### PR TITLE
Add example for Go extending SDK for context.Context

### DIFF
--- a/go/example_code/extending_sdk/request_context.go
+++ b/go/example_code/extending_sdk/request_context.go
@@ -1,0 +1,22 @@
+/*
+   Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// SQS ReceiveMessage
+	params := &sqs.ReceiveMessageInput{ ... }
+	req, resp := s.ReceiveMessageRequest(params)
+	req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
+	err := req.Send()


### PR DESCRIPTION
Adds an example for using the Golang's `context.Context with the AWS SDK for Go.

Related to awsdocs/aws-go-developer-guide#1