### PR TITLE
Add AWS SDK for Go API setters examples

### DIFF
--- a/go/example_code/ec2/update_deployment_with_setters.go
+++ b/go/example_code/ec2/update_deployment_with_setters.go
@@ -1,0 +1,20 @@
+/*
+   Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+resp, err := svc.UpdateService((&ec2.UpdateServiceInput{}).
+	SetService("myService").
+	SetDeploymentConfiguration((&ec2.DeploymentConfiguration{}).
+		SetMinimumHealthyPrecent(80),
+	),
+)

--- a/go/example_code/s3/put_object_with_setters.go
+++ b/go/example_code/s3/put_object_with_setters.go
@@ -1,0 +1,20 @@
+/*
+   Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+resp, err := svc.PutObject((&s3.PutObject{}).
+	SetBucket("myBucket").
+	SetKey("myKey").
+	SetBody(strings.NewReader("object body")).
+	SetWebsiteRedirectLocation("https://example.com/something"),
+)


### PR DESCRIPTION
Adds doc examples for aws/aws-sdk-go#918 change.