### PR TITLE
Correct Go SDK sample service client

### DIFF
--- a/go/example_code/ecs/update_deployment_with_setters.go
+++ b/go/example_code/ecs/update_deployment_with_setters.go
@@ -12,9 +12,9 @@
    specific language governing permissions and limitations under the License.
 */
 
-resp, err := svc.UpdateService((&ec2.UpdateServiceInput{}).
+resp, err := svc.UpdateService((&ecs.UpdateServiceInput{}).
 	SetService("myService").
-	SetDeploymentConfiguration((&ec2.DeploymentConfiguration{}).
+	SetDeploymentConfiguration((&ecs.DeploymentConfiguration{}).
 		SetMinimumHealthyPrecent(80),
 	),
 )


### PR DESCRIPTION
The service should be `ecs` for the setter example not `ec2`.