### PR TITLE
Update to ec2-ruby-example-create-instance.rb

### DIFF
--- a/ruby/example_code/ec2/ec2-ruby-example-create-instance.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-create-instance.rb
@@ -38,10 +38,10 @@ instance = ec2.create_instances({
 })
 
 # Wait for the instance to be created, running, and passed status checks
-ec2.client.wait_until(:instance_status_ok, {instance_ids: [instance[0].id]})
+ec2.client.wait_until(:instance_status_ok, {instance_ids: instance.map(&:id)})
 
 # Name the instance 'MyGroovyInstance' and give it the Group tag 'MyGroovyGroup'
 instance.create_tags({ tags: [{ key: 'Name', value: 'MyGroovyInstance' }, { key: 'Group', value: 'MyGroovyGroup' }]})
 
-puts instance.id
-puts instance.public_ip_address
+puts instance.map(&:id)[0]
+puts instance.map(&:public_ip_address)[0]


### PR DESCRIPTION
getting deprecation of instance[#index]; appears that pulling the key via map doesn't cause the warning.
nor am I able to use instance.#collection_item

Another note not apart of the request is that tags can be added via tag_specifications but not shown here.