### PR TITLE
[aws-sdk java][s3] Rewritten s3 object initialization

### DIFF
--- a/java/example_code/s3/src/main/java/aws/example/s3/CopyObject.java
+++ b/java/example_code/s3/src/main/java/aws/example/s3/CopyObject.java
@@ -13,7 +13,7 @@
 */
 package aws.example.s3;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.AmazonServiceException;
 
 /**
@@ -43,7 +43,7 @@ public class CopyObject
 
         System.out.format("Copying object %s from bucket %s to %s\n",
                 object_key, from_bucket, to_bucket);
-        final AmazonS3 s3 = new AmazonS3Client();
+        final AmazonS3 s3 = AmazonS3ClientBuilder.defaultClient();
         try {
             s3.copyObject(from_bucket, object_key, to_bucket, object_key);
         } catch (AmazonServiceException e) {


### PR DESCRIPTION
Changed `s3` object initialization to latest  `AmazonS3ClientBuilder#defaultClient()` from deprecated way. Documentation already updated [here](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/examples-s3-buckets.html)