### PR TITLE
Fix typo in S3ObjectOperations.java

### DIFF
--- a/javav2/example_code/s3/src/main/java/com/example/s3/S3ObjectOperations.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/S3ObjectOperations.java
@@ -67,7 +67,7 @@ public class S3ObjectOperations {
         		.maxKeys(2)
         		.build();
         
-        ListObjectsV2Paginator listRes = s3.listObjectsV2Iterable(listReq);
+        ListObjectsV2Iterable listRes = s3.listObjectsV2Paginator(listReq);
         // Dealing with ListObjectsV2Response pages
         listRes.stream()
                  .flatMap(r -> r.contents().stream())


### PR DESCRIPTION
fix typo by switching method's name and var's type