### PR TITLE
Fix dynamod db read item example

### DIFF
--- a/ruby/example_code/dynamodb/dynamodb_ruby_example_read_movies_item.rb
+++ b/ruby/example_code/dynamodb/dynamodb_ruby_example_read_movies_item.rb
@@ -23,8 +23,8 @@ key = {
 params = {
     table_name: 'Movies',
     key: {
-        year: year,
-        title: title
+        year: key[:year],
+        title: key[:title]
     }
 }
 


### PR DESCRIPTION
`year` and `title` are not defined anywhere. I believe `key[:year]` and
`key[:title]` were wanted instead.