### PR TITLE
Add AWS Elemental MediaStore Java examples

### DIFF
--- a/java/example_code/mediastore/Makefile
+++ b/java/example_code/mediastore/Makefile
@@ -1,0 +1,7 @@
+all: target/aws-mediastore-examples-1.0.jar
+
+target/aws-mediastore-examples-1.0.jar: src/main/java/aws/example/mediastore/*.java
+	mvn package
+
+clean:
+	mvn clean

--- a/java/example_code/mediastore/pom.xml
+++ b/java/example_code/mediastore/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>aws.example.mediastore</groupId>
+  <artifactId>aws-mediastore-examples</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0</version>
+  <name>AWS Elemental MediaStore Examples</name>
+  <url>http://maven.apache.org</url>
+  <properties>
+     <maven.compiler.source>1.8</maven.compiler.source>
+     <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bom</artifactId>
+        <version>1.11.360</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-mediastore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-mediastoredata</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/java/example_code/mediastore/run_example.sh
+++ b/java/example_code/mediastore/run_example.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [[ -z $* ]] ; then
+    echo 'Supply the name of one of the example classes as an argument.'
+    echo 'If there are arguments to the class, put them in quotes after the class name.'
+    exit 1
+fi
+export CLASSPATH=target/aws-mediastore-examples-1.0.jar
+export className=$1
+echo "## Running $className..."
+shift
+echo "## arguments $@..."
+mvn exec:java -Dexec.mainClass="aws.example.mediastore.$className" -Dexec.args="$@" -Dexec.cleanupDaemonThreads=false

--- a/java/example_code/mediastore/src/main/java/aws/example/mediastore/CreateContainer.java
+++ b/java/example_code/mediastore/src/main/java/aws/example/mediastore/CreateContainer.java
@@ -1,0 +1,66 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+package aws.example.mediastore;
+import com.amazonaws.services.mediastore.AWSMediaStore;
+import com.amazonaws.services.mediastore.AWSMediaStoreClientBuilder;
+import com.amazonaws.services.mediastore.model.Container;
+import com.amazonaws.services.mediastore.model.CreateContainerRequest;
+import com.amazonaws.services.mediastore.model.CreateContainerResult;
+import com.amazonaws.services.mediastore.model.AWSMediaStoreException;
+
+/**
+ * Create an AWS Elemental MediaStore container.
+ *
+ * This code expects that you have AWS credentials set up per:
+ * http://docs.aws.amazon.com/java-sdk/latest/developer-guide/setup-credentials.html
+ */
+public class CreateContainer
+{
+    public static void main(String[] args)
+    {
+        final String USAGE = "\n" +
+            "CreateContainer - create an AWS Elemental MediaStore container\n\n" +
+            "Usage: CreateContainer <name>\n\n" +
+            "Where:\n" +
+            "  name - the name of the container to create.\n";
+
+        if (args.length < 1) {
+            System.out.println(USAGE);
+            System.exit(1);
+        }
+
+        final String name = args[0];
+
+        System.out.format("\nCreating MediaStore container: %s\n", name);
+        final Container c = createContainer(name);
+        if (c == null) {
+            System.out.println("Error creating container!\n");
+        } else {
+            System.out.println("Done!\n");
+        }
+    }
+
+    public static Container createContainer(String name) {
+        final AWSMediaStore mediastore = AWSMediaStoreClientBuilder.defaultClient();
+        final CreateContainerRequest request = new CreateContainerRequest()
+            .withContainerName(name);
+        try {
+            final CreateContainerResult result = mediastore.createContainer(request);
+            return result.getContainer();
+        } catch (AWSMediaStoreException e) {
+            System.err.println(e.getErrorMessage());
+        }
+        return null;
+    }
+}

--- a/java/example_code/mediastore/src/main/java/aws/example/mediastore/ListContainers.java
+++ b/java/example_code/mediastore/src/main/java/aws/example/mediastore/ListContainers.java
@@ -1,0 +1,40 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+package aws.example.mediastore;
+import com.amazonaws.services.mediastore.AWSMediaStore;
+import com.amazonaws.services.mediastore.AWSMediaStoreClientBuilder;
+import com.amazonaws.services.mediastore.model.Container;
+import com.amazonaws.services.mediastore.model.ListContainersRequest;
+import com.amazonaws.services.mediastore.model.ListContainersResult;
+import java.util.List;
+
+/**
+ * List your AWS Elemental MediaStore containers.
+ *
+ * This code expects that you have AWS credentials set up per:
+ * http://docs.aws.amazon.com/java-sdk/latest/developer-guide/setup-credentials.html
+ */
+public class ListContainers
+{
+    public static void main(String[] args)
+    {
+        final AWSMediaStore mediastore = AWSMediaStoreClientBuilder.defaultClient();
+        final ListContainersResult result = mediastore.listContainers(new ListContainersRequest());
+        final List<Container> containers = result.getContainers();
+        System.out.println("Your AWS Elemental MediaStore containers are:");
+        for (Container b : containers) {
+            System.out.println("* " + b.getName());
+        }
+    }
+}

--- a/java/example_code/mediastore/src/main/java/aws/example/mediastore/ListItems.java
+++ b/java/example_code/mediastore/src/main/java/aws/example/mediastore/ListItems.java
@@ -1,0 +1,92 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+package aws.example.mediastore;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.amazonaws.services.mediastore.AWSMediaStore;
+import com.amazonaws.services.mediastore.AWSMediaStoreClientBuilder;
+import com.amazonaws.services.mediastore.model.DescribeContainerRequest;
+import com.amazonaws.services.mediastore.model.DescribeContainerResult;
+import com.amazonaws.services.mediastore.model.AWSMediaStoreException;
+import com.amazonaws.services.mediastoredata.AWSMediaStoreData;
+import com.amazonaws.services.mediastoredata.AWSMediaStoreDataClientBuilder;
+import com.amazonaws.services.mediastoredata.model.Item;
+import com.amazonaws.services.mediastoredata.model.ListItemsRequest;
+import com.amazonaws.services.mediastoredata.model.ListItemsResult;
+import java.util.List;
+
+/**
+ * List objects and folders within an AWS Elemental MediaStore container.
+ *
+ * This code expects that you have AWS credentials set up per:
+ * http://docs.aws.amazon.com/java-sdk/latest/developer-guide/setup-credentials.html
+ */
+public class ListItems
+{
+    public static void main(String[] args)
+    {
+        final String USAGE = "\n" +
+            "To run this example, supply the name of a container and an optional path!\n" +
+            "\n" +
+            "Ex: ListItems <container-name> [path]\n";
+
+        if (args.length < 1) {
+            System.out.println(USAGE);
+            System.exit(1);
+        }
+
+        final String containerName = args[0];
+        String path = "";
+        if (args.length > 1) {
+            path = args[1];
+        }
+
+        System.out.format("Objects in MediaStore container %s, path '%s':\n", containerName, path);
+
+        final String endpoint = getContainerEndpoint(containerName);
+        if (endpoint == null || endpoint.isEmpty()) {
+            System.err.println("Could not determine container endpoint!");
+            System.exit(1);
+        }
+
+        final String region = new DefaultAwsRegionProviderChain().getRegion();
+        final EndpointConfiguration endpointConfig = new EndpointConfiguration(endpoint, region);
+
+        final AWSMediaStoreData mediastoredata = AWSMediaStoreDataClientBuilder
+            .standard()
+            .withEndpointConfiguration(endpointConfig)
+            .build();
+        final ListItemsRequest request = new ListItemsRequest()
+            .withPath(path);
+
+        ListItemsResult result = mediastoredata.listItems(request);
+        List<Item> items = result.getItems();
+        for (Item i: items) {
+            System.out.printf("* (%s)\t%s\n", i.getType(), i.getName());
+        }
+    }
+
+    public static String getContainerEndpoint(String name) {
+        final AWSMediaStore mediastore = AWSMediaStoreClientBuilder.defaultClient();
+        final DescribeContainerRequest request = new DescribeContainerRequest()
+            .withContainerName(name);
+        try {
+            final DescribeContainerResult result = mediastore.describeContainer(request);
+            return result.getContainer().getEndpoint();
+        } catch (AWSMediaStoreException e) {
+            System.err.println(e.getErrorMessage());
+        }
+        return null;
+    }
+}

--- a/java/example_code/mediastore/src/main/java/aws/example/mediastore/PutObject.java
+++ b/java/example_code/mediastore/src/main/java/aws/example/mediastore/PutObject.java
@@ -1,0 +1,105 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+package aws.example.mediastore;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.amazonaws.services.mediastore.AWSMediaStore;
+import com.amazonaws.services.mediastore.AWSMediaStoreClientBuilder;
+import com.amazonaws.services.mediastore.model.DescribeContainerRequest;
+import com.amazonaws.services.mediastore.model.DescribeContainerResult;
+import com.amazonaws.services.mediastore.model.AWSMediaStoreException;
+import com.amazonaws.services.mediastoredata.AWSMediaStoreData;
+import com.amazonaws.services.mediastoredata.AWSMediaStoreDataClientBuilder;
+import com.amazonaws.services.mediastoredata.model.PutObjectRequest;
+import com.amazonaws.services.mediastoredata.model.PutObjectResult;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+
+/**
+ * Upload a file to an AWS Elemental MediaStore container.
+ *
+ * This code expects that you have AWS credentials set up per:
+ * http://docs.aws.amazon.com/java-sdk/latest/developer-guide/setup-credentials.html
+ */
+public class PutObject
+{
+    public static void main(String[] args)
+    {
+        final String USAGE = "\n" +
+            "To run this example, supply the name of a container and a file to\n" +
+            "upload to it.\n" +
+            "\n" +
+            "Ex: PutObject <container-name> <file-path>\n";
+
+        if (args.length < 2) {
+            System.out.println(USAGE);
+            System.exit(1);
+        }
+
+        final String containerName = args[0];
+        final String filePath = args[1];
+
+        System.out.format("Uploading %s to MediaStore container %s...\n", filePath, containerName);
+
+        try (final InputStream is = new FileInputStream(filePath)) {
+            final PutObjectResult result = putObject(containerName, filePath, is);
+            System.out.printf("Saved object: %s\n", result);
+            System.out.println("Done!");
+        } catch (IOException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
+    }
+
+    public static PutObjectResult putObject(String containerName, String filePath, InputStream body) throws IOException {
+        final String endpoint = getContainerEndpoint(containerName);
+        if (endpoint == null || endpoint.isEmpty()) {
+            System.err.println("Could not determine container endpoint!");
+            System.exit(1);
+        }
+        final String region = new DefaultAwsRegionProviderChain().getRegion();
+        final EndpointConfiguration endpointConfig = new EndpointConfiguration(endpoint, region);
+
+        final AWSMediaStoreData mediastoredata = AWSMediaStoreDataClientBuilder
+            .standard()
+            .withEndpointConfiguration(endpointConfig)
+            .build();
+        final PutObjectRequest request = new PutObjectRequest()
+            .withContentType("application/octet-stream")
+            .withBody(body)
+            .withPath(filePath);
+
+        try {
+            return mediastoredata.putObject(request);
+        } catch (AWSMediaStoreException e) {
+            System.err.println(e.getErrorMessage());
+            System.exit(1);
+        }
+        return null;
+    }
+
+    public static String getContainerEndpoint(String name) {
+        final AWSMediaStore mediastore = AWSMediaStoreClientBuilder.defaultClient();
+        final DescribeContainerRequest request = new DescribeContainerRequest()
+            .withContainerName(name);
+        try {
+            final DescribeContainerResult result = mediastore.describeContainer(request);
+            return result.getContainer().getEndpoint();
+        } catch (AWSMediaStoreException e) {
+            System.err.println(e.getErrorMessage());
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Basic examples to demonstrate basic flows:
- Create and list containers;
- Upload objects and list items (objects and folders).

The examples were based off and follow the same standards as the examples for other services.

Disclaimer: I work on the AWS Elemental MediaStore team.