### PR TITLE
Python list users

### DIFF
--- a/python/example_code/iam/list_users.py
+++ b/python/example_code/iam/list_users.py
@@ -11,13 +11,14 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+# Import the AWS SDK for python
 import boto3
 
+# List users with the IAM service resource
+resource = boto3.resource('iam')
 
-# Create IAM client
-iam = boto3.client('iam')
-
-# List users with the pagination interface
-paginator = iam.get_paginator('list_users')
-for response in paginator.paginate():
-    print(response)
+for user in resource.users.all():
+    print("User {} created on {}".format(
+        user.user_name, 
+        user.create_date)
+    )

--- a/python/example_code/iam/list_users.py
+++ b/python/example_code/iam/list_users.py
@@ -22,3 +22,18 @@ for user in resource.users.all():
         user.user_name, 
         user.create_date)
     )
+
+
+# List users with the IAM client
+client = boto3.client('iam')
+
+done = False
+while(not done):
+    for user in client.list_users()['Users']:
+        print("User {} created on {}".format(
+            user['UserName'], 
+            user['CreateDate']
+        )
+    )
+    if not client.list_users()['IsTruncated']:
+        done = True

--- a/python/example_code/iam/list_users.py
+++ b/python/example_code/iam/list_users.py
@@ -14,7 +14,8 @@
 # Import the AWS SDK for python
 import boto3
 
-# List users with the IAM service resource
+
+# Option 1: List users with the IAM service resource
 resource = boto3.resource('iam')
 
 for user in resource.users.all():
@@ -24,7 +25,7 @@ for user in resource.users.all():
     )
 
 
-# List users with the IAM client
+# Option 2: List users with the IAM client
 client = boto3.client('iam')
 
 done = False


### PR DESCRIPTION
I've added examples for both the Service Resource and the Client usage to list IAM users in `list_users.py`. 

Does this make any sense or would you prefer single examples per file? Let me know if you like this approach. Then I would start migrating the other examples as well.