### PR TITLE
Update S3 encryption example for C++

### DIFF
--- a/cpp/example_code/s3encryption/CMakeLists.txt
+++ b/cpp/example_code/s3encryption/CMakeLists.txt
@@ -12,18 +12,21 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(s3Encryption)
+set(CMAKE_CXX_STANDARD 17) # The SDK is built with C++11, but the application can use a later standard
 
-find_package(aws-sdk-cpp)
+find_package(aws-cpp-sdk-s3-encryption)
 
+if (WIN32)
 # Link to shared libraries.
 add_definitions(-DUSE_IMPORT_EXPORT)
+endif()
 
 if (APPLE)
     add_definitions(-DUNDER_MACOS)
 endif()
 
 add_executable(s3Encryption s3Encryption.cpp)
-target_link_libraries(s3Encryption aws-cpp-sdk-s3)
-target_link_libraries(s3Encryption aws-cpp-sdk-s3-encryption)
-
-MESSAGE( STATUS "CMAKE_INCLUDE_PATH: " ${CMAKE_INCLUDE_PATH} )
+target_link_libraries(s3Encryption
+    aws-cpp-sdk-s3-encryption
+    aws-cpp-sdk-s3
+    aws-cpp-sdk-core)


### PR DESCRIPTION
The current example has a few problems. Namely:
1. The CMake script is missing dependencies, which makes the example broken
1. The CMake script does not specify the C++ standard which makes the example broken when used with compilers that do not default to C++11 or later.
1. The code is out of sync with the latest SDK changes.

I've also gone ahead and changed a few things to make the code more idiomatic. In particular logging errors.