### PR TITLE
Add SNS CPP example codes

### DIFF
--- a/cpp/example_code/sns/CMakeLists.txt
+++ b/cpp/example_code/sns/CMakeLists.txt
@@ -7,8 +7,9 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+set (CMAKE_CXX_STANDARD 11)
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.2)
 project(sns-examples)
 
 # Locate the aws sdk for c++ package.
@@ -34,6 +35,5 @@ list(APPEND EXAMPLES "unsubscribe")
 # The executables to build.
 foreach(EXAMPLE IN LISTS EXAMPLES)
   add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
-	target_link_libraries(${EXAMPLE} aws-cpp-sdk-sns)
+	target_link_libraries(${EXAMPLE} aws-cpp-sdk-sns aws-cpp-sdk-core)
 endforeach()
-

--- a/cpp/example_code/sns/CMakeLists.txt
+++ b/cpp/example_code/sns/CMakeLists.txt
@@ -1,13 +1,12 @@
-/*
-   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-   This file is licensed under the Apache License, Version 2.0 (the "License").
-   You may not use this file except in compliance with the License. A copy of
-   the License is located at
-    http://aws.amazon.com/apache2.0/
-   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-   CONDITIONS OF ANY KIND, either express or implied. See the License for the
-   specific language governing permissions and limitations under the License.
-*/
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 
 cmake_minimum_required(VERSION 2.8)
 project(sns-examples)
@@ -25,7 +24,6 @@ list(APPEND EXAMPLES "list_subscriptions")
 list(APPEND EXAMPLES "publish_sms")
 list(APPEND EXAMPLES "publish_to_topic")
 list(APPEND EXAMPLES "set_sms_type")
-list(APPEND EXAMPLES "set_topic_attributes")
 list(APPEND EXAMPLES "subscribe_app")
 list(APPEND EXAMPLES "subscribe_email")
 list(APPEND EXAMPLES "subscribe_lambda")

--- a/cpp/example_code/sns/CMakeLists.txt
+++ b/cpp/example_code/sns/CMakeLists.txt
@@ -1,3 +1,14 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
 cmake_minimum_required(VERSION 2.8)
 project(sns-examples)
 

--- a/cpp/example_code/sns/CMakeLists.txt
+++ b/cpp/example_code/sns/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 2.8)
+project(sns-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "list_topics")
+list(APPEND EXAMPLES "create_topic")
+list(APPEND EXAMPLES "delete_topic")
+list(APPEND EXAMPLES "get_topic_attributes")
+list(APPEND EXAMPLES "get_sms_type")
+list(APPEND EXAMPLES "list_subscriptions")
+list(APPEND EXAMPLES "publish_sms")
+list(APPEND EXAMPLES "publish_to_topic")
+list(APPEND EXAMPLES "set_sms_type")
+list(APPEND EXAMPLES "set_topic_attributes")
+list(APPEND EXAMPLES "subscribe_app")
+list(APPEND EXAMPLES "subscribe_email")
+list(APPEND EXAMPLES "subscribe_lambda")
+list(APPEND EXAMPLES "unsubscribe")
+
+
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+	target_link_libraries(${EXAMPLE} aws-cpp-sdk-sns)
+endforeach()
+

--- a/cpp/example_code/sns/create_topic.cpp
+++ b/cpp/example_code/sns/create_topic.cpp
@@ -28,13 +28,13 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::String topic_name = argv[1];
     Aws::SNS::SNSClient sns;
 
     Aws::SNS::Model::CreateTopicRequest ct_req;
-    ct_req.SetTopicName(topic_name);
+    ct_req.SetName(topic_name);
 
     auto ct_out = sns.CreateTopic(ct_req);
 

--- a/cpp/example_code/sns/create_topic.cpp
+++ b/cpp/example_code/sns/create_topic.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/CreateTopicRequest.h>
+#include <aws/sns/model/CreateTopicResult.h>
+#include <iostream>
+
+/**
+ * Creates an sns topic based on command line input
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: create_topic <topic_name>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::String topic_name = argv[1];
+    Aws::SNS::SNSClient sns;
+
+    Aws::SNS::Model::CreateTopicRequest ct_req;
+    ct_req.SetTopicName(topic_name);
+
+    auto ct_out = sns.CreateTopic(ct_req);
+
+    if (ct_out.IsSuccess())
+    {
+      std::cout << "Successfully created topic " << topic_name << std::endl;
+    }
+    else
+    {
+      std::cout << "Error creating topic " << topic_name << ":" <<
+        ct_out.GetError().GetMessage() << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/delete_topic.cpp
+++ b/cpp/example_code/sns/delete_topic.cpp
@@ -12,7 +12,6 @@
 #include <aws/core/Aws.h>
 #include <aws/sns/SNSClient.h>
 #include <aws/sns/model/DeleteTopicRequest.h>
-#include <aws/sns/model/DeleteTopicResult.h>
 #include <iostream>
 
 /**
@@ -23,28 +22,28 @@ int main(int argc, char ** argv)
 {
   if (argc != 2)
   {
-    std::cout << "Usage: delete_topic <topic_name>" << std::endl;
+    std::cout << "Usage: delete_topic <topic_arn>" << std::endl;
     return 1;
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
-    Aws::String topic_name = argv[1];
+    Aws::String topic_arn = argv[1];
     Aws::SNS::SNSClient sns;
 
     Aws::SNS::Model::DeleteTopicRequest dt_req;
-    dt_req.SetTopicName(topic_name);
+    dt_req.SetTopicArn(topic_arn);
 
     auto dt_out = sns.DeleteTopic(dt_req);
 
     if (dt_out.IsSuccess())
     {
-      std::cout << "Successfully deleted topic " << topic_name << std::endl;
+      std::cout << "Successfully deleted topic " << topic_arn << std::endl;
     }
     else
     {
-      std::cout << "Error deleting topic " << topic_name << ":" <<
+      std::cout << "Error deleting topic " << topic_arn << ":" <<
         dt_out.GetError().GetMessage() << std::endl;
     }
   }

--- a/cpp/example_code/sns/delete_topic.cpp
+++ b/cpp/example_code/sns/delete_topic.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/DeleteTopicRequest.h>
+#include <aws/sns/model/DeleteTopicResult.h>
+#include <iostream>
+
+/**
+ * Creates an sns topic based on command line input
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_topic <topic_name>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::String topic_name = argv[1];
+    Aws::SNS::SNSClient sns;
+
+    Aws::SNS::Model::DeleteTopicRequest dt_req;
+    dt_req.SetTopicName(topic_name);
+
+    auto dt_out = sns.DeleteTopic(dt_req);
+
+    if (dt_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted topic " << topic_name << std::endl;
+    }
+    else
+    {
+      std::cout << "Error deleting topic " << topic_name << ":" <<
+        dt_out.GetError().GetMessage() << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/get_sms_type.cpp
+++ b/cpp/example_code/sns/get_sms_type.cpp
@@ -1,0 +1,53 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/GetSMSAttributesRequest.h>
+#include <aws/sns/model/GetSMSAttributesResult.h>
+#include <iostream>
+
+/**
+ * Get the sms type
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: get_sms_type" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::SNS::SNSClient sns;
+
+    Aws::SNS::Model::GetSMSAttributesRequest gsmst_req;
+    gsmst_req.AddAttributes("DefaultSMSStype");
+
+    auto gsmst_out = sns.GetSMSAttributes(gsmst_req);
+
+    if (gsmst_out.IsSuccess())
+    {
+      std::cout << "SMS Type " << gsmst_out.GetResult() << std::endl;
+    }
+    else
+    {
+      std::cout << "Error while getting SMS Type " << gsmst_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/get_sms_type.cpp
+++ b/cpp/example_code/sns/get_sms_type.cpp
@@ -28,18 +28,18 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::SNS::SNSClient sns;
 
     Aws::SNS::Model::GetSMSAttributesRequest gsmst_req;
-    gsmst_req.AddAttributes("DefaultSMSStype");
+    gsmst_req.AddAttributes("DefaultSMStype");
 
     auto gsmst_out = sns.GetSMSAttributes(gsmst_req);
 
     if (gsmst_out.IsSuccess())
     {
-      std::cout << "SMS Type " << gsmst_out.GetResult() << std::endl;
+      std::cout << "SMS Type " << std::endl;
     }
     else
     {

--- a/cpp/example_code/sns/get_topic_attributes.cpp
+++ b/cpp/example_code/sns/get_topic_attributes.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/GetTopicAttributesRequest.h>
+#include <aws/sns/model/GetTopicAttributesResult.h>
+#include <iostream>
+
+/**
+ * Get the topic attributes based on command line input for topic arn
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: get_topic_attributes <topic_arn>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::SNS::SNSClient sns;
+    Aws::String topic_arn = argv[1];
+
+    Aws::SNS::Model::GetTopicAttributesRequest gta_req;
+    gta_req.SetTopicArn(topic_arn);
+
+    auto gta_out = sns.GetTopicAttributes(gta_req);
+
+    if (gta_out.IsSuccess())
+    {
+      std::cout << "Topic Attributes " << gta_out.GetResult() << std::endl;
+    }
+    else
+    {
+      std::cout << "Error while getting Topic attributes " << gta_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/get_topic_attributes.cpp
+++ b/cpp/example_code/sns/get_topic_attributes.cpp
@@ -28,7 +28,7 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::SNS::SNSClient sns;
     Aws::String topic_arn = argv[1];
@@ -40,7 +40,7 @@ int main(int argc, char ** argv)
 
     if (gta_out.IsSuccess())
     {
-      std::cout << "Topic Attributes " << gta_out.GetResult() << std::endl;
+      std::cout << "Topic Attributes " <<< gta_out.GetResult().GetAttributes() << std::endl;
     }
     else
     {

--- a/cpp/example_code/sns/list_subscriptions.cpp
+++ b/cpp/example_code/sns/list_subscriptions.cpp
@@ -1,0 +1,52 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/ListSubscriptionsRequest.h>
+#include <aws/sns/model/ListSubscriptionsResult.h>
+#include <iostream>
+
+/**
+ * Lists subscriptions
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: list_subscriptions" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::SNS::SNSClient sns;
+
+    Aws::SNS::Model::ListSubscriptionsRequest ls_req;
+
+    auto ls_out = sns.ListSubscriptions(ls_req);
+
+    if (ls_out.IsSuccess())
+    {
+      std::cout << "Subscriptions list " << ls_out << std::endl;
+    }
+    else
+    {
+      std::cout << "Error listing subscriptions " << ls_out.GetError().GetMessage() <<
+        std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/list_subscriptions.cpp
+++ b/cpp/example_code/sns/list_subscriptions.cpp
@@ -28,7 +28,7 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::SNS::SNSClient sns;
 
@@ -38,7 +38,7 @@ int main(int argc, char ** argv)
 
     if (ls_out.IsSuccess())
     {
-      std::cout << "Subscriptions list " << ls_out << std::endl;
+      //std::cout << "Subscriptions list " << ls_out.GetResult().GetSubscriptions() << std::endl;
     }
     else
     {

--- a/cpp/example_code/sns/list_topics.cpp
+++ b/cpp/example_code/sns/list_topics.cpp
@@ -1,0 +1,52 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/ListTopicsRequest.h>
+#include <aws/sns/model/ListTopicsResult.h>
+#include <iostream>
+
+/**
+ * Lists topics
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: list_topics" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::SNS::SNSClient sns;
+
+    Aws::SNS::Model::ListTopicsRequest lt_req;
+
+    auto lt_out = sns.ListTopics(lt_req);
+
+    if (lt_out.IsSuccess())
+    {
+      std::cout << "Topics list " << lt_out << std::endl;
+    }
+    elte
+    {
+      std::cout << "Error listing topics " << lt_out.GetError().GetMessage() <<
+        std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/list_topics.cpp
+++ b/cpp/example_code/sns/list_topics.cpp
@@ -28,7 +28,7 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::SNS::SNSClient sns;
 
@@ -38,9 +38,9 @@ int main(int argc, char ** argv)
 
     if (lt_out.IsSuccess())
     {
-      std::cout << "Topics list " << lt_out << std::endl;
+      std::cout << "Topics list " << lt_out.GetResult().GetTopics() << std::endl;
     }
-    elte
+    else
     {
       std::cout << "Error listing topics " << lt_out.GetError().GetMessage() <<
         std::endl;

--- a/cpp/example_code/sns/publish_sms.cpp
+++ b/cpp/example_code/sns/publish_sms.cpp
@@ -28,21 +28,22 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::SNS::SNSClient sns;
     Aws::String message = argv[1];
-    Aws::String phone_number = argv[2]
+    Aws::String phone_number = argv[2];
 
     Aws::SNS::Model::PublishRequest psms_req;
-    psms_req.AddMessageAttributes("Message", message);
-    psms_req.AddMessageAttributes("PhoneNumber", phone_number_value)
+    psms_req.SetMessage(message);
+    psms_req.SetPhoneNumber(phone_number);
 
     auto psms_out = sns.Publish(psms_req);
 
     if (psms_out.IsSuccess())
     {
-      std::cout << "Message published successfully " << psms_out.GetResult() << std::endl;
+      std::cout << "Message published successfully " << psms_out.GetResult().GetMessageId
+        << std::endl;
     }
     else
     {

--- a/cpp/example_code/sns/publish_sms.cpp
+++ b/cpp/example_code/sns/publish_sms.cpp
@@ -1,0 +1,56 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/PublishRequest.h>
+#include <aws/sns/model/PublishResult.h>
+#include <iostream>
+
+/**
+ * Publish sms
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 3)
+  {
+    std::cout << "Usage: publish_sms <message_value> <phone_number_value> " << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::SNS::SNSClient sns;
+    Aws::String message = argv[1];
+    Aws::String phone_number = argv[2]
+
+    Aws::SNS::Model::PublishRequest psms_req;
+    psms_req.AddMessageAttributes("Message", message);
+    psms_req.AddMessageAttributes("PhoneNumber", phone_number_value)
+
+    auto psms_out = sns.Publish(psms_req);
+
+    if (psms_out.IsSuccess())
+    {
+      std::cout << "Message published successfully " << psms_out.GetResult() << std::endl;
+    }
+    else
+    {
+      std::cout << "Error while publishing message " << psms_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/publish_to_topic.cpp
+++ b/cpp/example_code/sns/publish_to_topic.cpp
@@ -28,21 +28,21 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::SNS::SNSClient sns;
     Aws::String message = argv[1];
-    Aws::String topic_arn = argv[2]
+    Aws::String topic_arn = argv[2];
 
     Aws::SNS::Model::PublishRequest psms_req;
-    psms_req.AddMessageAttributes("Message", message);
-    psms_req.AddMessageAttributes("TopicArn", phone_number_value)
+    psms_req.SetMessage(message);
+    psms_req.SetTopicArn(topic_arn);
 
     auto psms_out = sns.Publish(psms_req);
 
     if (psms_out.IsSuccess())
     {
-      std::cout << "Message published successfully " << psms_out.GetResult() << std::endl;
+      std::cout << "Message published successfully " << std::endl;
     }
     else
     {

--- a/cpp/example_code/sns/publish_to_topic.cpp
+++ b/cpp/example_code/sns/publish_to_topic.cpp
@@ -1,0 +1,56 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/PublishRequest.h>
+#include <aws/sns/model/PublishResult.h>
+#include <iostream>
+
+/**
+ * Publish sms
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 3)
+  {
+    std::cout << "Usage: publish_sms <message_value> <topic_arn_value> " << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::SNS::SNSClient sns;
+    Aws::String message = argv[1];
+    Aws::String topic_arn = argv[2]
+
+    Aws::SNS::Model::PublishRequest psms_req;
+    psms_req.AddMessageAttributes("Message", message);
+    psms_req.AddMessageAttributes("TopicArn", phone_number_value)
+
+    auto psms_out = sns.Publish(psms_req);
+
+    if (psms_out.IsSuccess())
+    {
+      std::cout << "Message published successfully " << psms_out.GetResult() << std::endl;
+    }
+    else
+    {
+      std::cout << "Error while publishing message " << psms_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/set_sms_type.cpp
+++ b/cpp/example_code/sns/set_sms_type.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/SetSMSAttributesRequest.h>
+#include <aws/sns/model/SetSMSAttributesResult.h>
+#include <iostream>
+
+/**
+ * Set the sms type based on command line input
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: set_sms_type <sms_type> " << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::SNS::SNSClient sns;
+    Aws::String sms_type = argv[1];
+
+    Aws::SNS::Model::SetSMSAttributesRequest ssmst_req;
+    ssmst_req.AddAttributes("DefaultSMSStype", sms_type);
+
+    auto ssmst_out = sns.SetSMSAttributes(ssmst_req);
+
+    if (ssmst_out.IsSuccess())
+    {
+      std::cout << "SMS Type set successfully " << ssmst_out.GetResult() << std::endl;
+    }
+    else
+    {
+      std::cout << "Error while setting SMS Type " << gsmst_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/set_sms_type.cpp
+++ b/cpp/example_code/sns/set_sms_type.cpp
@@ -28,7 +28,7 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::SNS::SNSClient sns;
     Aws::String sms_type = argv[1];
@@ -40,11 +40,11 @@ int main(int argc, char ** argv)
 
     if (ssmst_out.IsSuccess())
     {
-      std::cout << "SMS Type set successfully " << ssmst_out.GetResult() << std::endl;
+      std::cout << "SMS Type set successfully " << std::endl;
     }
     else
     {
-      std::cout << "Error while setting SMS Type " << gsmst_out.GetError().GetMessage()
+      std::cout << "Error while setting SMS Type " << ssmst_out.GetError().GetMessage()
         << std::endl;
     }
   }

--- a/cpp/example_code/sns/subscribe_app.cpp
+++ b/cpp/example_code/sns/subscribe_app.cpp
@@ -29,7 +29,7 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::SNS::SNSClient sns;
     Aws::String protocol = argv[1];
@@ -39,13 +39,13 @@ int main(int argc, char ** argv)
     Aws::SNS::Model::SubscribeRequest s_req;
     s_req.SetTopicArn(topic_arn);
     s_req.SetProtocol(protocol);
-    s_req.SetEndPoint(endpoint)
+    s_req.SetEndpoint(endpoint);
 
     auto s_out = sns.Subscribe(s_req);
 
     if (s_out.IsSuccess())
     {
-      std::cout << "Subscribed successfully " << s_out.GetResult() << std::endl;
+      std::cout << "Subscribed successfully " << std::endl;
     }
     else
     {

--- a/cpp/example_code/sns/subscribe_app.cpp
+++ b/cpp/example_code/sns/subscribe_app.cpp
@@ -1,0 +1,59 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/SubscribeRequest.h>
+#include <aws/sns/model/SubscribeResult.h>
+#include <iostream>
+
+/**
+ * Subscribe to app
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 4)
+  {
+    std::cout << "Usage: subscribe <protocol_value/application> <topic_arn_value>"
+                 "mobile_endpoint_arn" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::SNS::SNSClient sns;
+    Aws::String protocol = argv[1];
+    Aws::String topic_arn = argv[2];
+    Aws::String endpoint = argv[3];
+
+    Aws::SNS::Model::SubscribeRequest s_req;
+    s_req.SetTopicArn(topic_arn);
+    s_req.SetProtocol(protocol);
+    s_req.SetEndPoint(endpoint)
+
+    auto s_out = sns.Subscribe(s_req);
+
+    if (s_out.IsSuccess())
+    {
+      std::cout << "Subscribed successfully " << s_out.GetResult() << std::endl;
+    }
+    else
+    {
+      std::cout << "Error while subscribing " << s_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/subscribe_email.cpp
+++ b/cpp/example_code/sns/subscribe_email.cpp
@@ -29,7 +29,7 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::SNS::SNSClient sns;
     Aws::String protocol = argv[1];
@@ -39,13 +39,13 @@ int main(int argc, char ** argv)
     Aws::SNS::Model::SubscribeRequest s_req;
     s_req.SetTopicArn(topic_arn);
     s_req.SetProtocol(protocol);
-    s_req.SetEndPoint(endpoint)
+    s_req.SetEndpoint(endpoint);
 
     auto s_out = sns.Subscribe(s_req);
 
     if (s_out.IsSuccess())
     {
-      std::cout << "Subscribed successfully " << s_out.GetResult() << std::endl;
+      std::cout << "Subscribed successfully " << std::endl;
     }
     else
     {

--- a/cpp/example_code/sns/subscribe_email.cpp
+++ b/cpp/example_code/sns/subscribe_email.cpp
@@ -1,0 +1,59 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/SubscribeRequest.h>
+#include <aws/sns/model/SubscribeResult.h>
+#include <iostream>
+
+/**
+ * Subscribe email
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 4)
+  {
+    std::cout << "Usage: subscribe <protocol_value/email> <topic_arn_value>"
+                 "email_address" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::SNS::SNSClient sns;
+    Aws::String protocol = argv[1];
+    Aws::String topic_arn = argv[2];
+    Aws::String endpoint = argv[3];
+
+    Aws::SNS::Model::SubscribeRequest s_req;
+    s_req.SetTopicArn(topic_arn);
+    s_req.SetProtocol(protocol);
+    s_req.SetEndPoint(endpoint)
+
+    auto s_out = sns.Subscribe(s_req);
+
+    if (s_out.IsSuccess())
+    {
+      std::cout << "Subscribed successfully " << s_out.GetResult() << std::endl;
+    }
+    else
+    {
+      std::cout << "Error while subscribing " << s_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/subscribe_lambda.cpp
+++ b/cpp/example_code/sns/subscribe_lambda.cpp
@@ -1,0 +1,59 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/SubscribeRequest.h>
+#include <aws/sns/model/SubscribeResult.h>
+#include <iostream>
+
+/**
+ * Subscribe to lambda
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 4)
+  {
+    std::cout << "Usage: subscribe <protocol_value/lambda> <topic_arn_value>"
+                 "lambda_function_arn" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::SNS::SNSClient sns;
+    Aws::String protocol = argv[1];
+    Aws::String topic_arn = argv[2];
+    Aws::String endpoint = argv[3];
+
+    Aws::SNS::Model::SubscribeRequest s_req;
+    s_req.SetTopicArn(topic_arn);
+    s_req.SetProtocol(protocol);
+    s_req.SetEndPoint(endpoint)
+
+    auto s_out = sns.Subscribe(s_req);
+
+    if (s_out.IsSuccess())
+    {
+      std::cout << "Subscribed successfully " << s_out.GetResult() << std::endl;
+    }
+    else
+    {
+      std::cout << "Error while subscribing " << s_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/subscribe_lambda.cpp
+++ b/cpp/example_code/sns/subscribe_lambda.cpp
@@ -29,7 +29,7 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::SNS::SNSClient sns;
     Aws::String protocol = argv[1];
@@ -39,13 +39,13 @@ int main(int argc, char ** argv)
     Aws::SNS::Model::SubscribeRequest s_req;
     s_req.SetTopicArn(topic_arn);
     s_req.SetProtocol(protocol);
-    s_req.SetEndPoint(endpoint)
+    s_req.SetEndpoint(endpoint);
 
     auto s_out = sns.Subscribe(s_req);
 
     if (s_out.IsSuccess())
     {
-      std::cout << "Subscribed successfully " << s_out.GetResult() << std::endl;
+      std::cout << "Subscribed successfully " << std::endl;
     }
     else
     {

--- a/cpp/example_code/sns/unsubscribe.cpp
+++ b/cpp/example_code/sns/unsubscribe.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/sns/model/SubscribeRequest.h>
+#include <aws/sns/model/SubscribeResult.h>
+#include <iostream>
+
+/**
+ * Unsubscribe based on subscription_arn given on command line
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: subscribe <topic_subscription_arn>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  AWS::InitAPI(options);
+  {
+    Aws::SNS::SNSClient sns;
+    Aws::String subscription_arn = argv[1];
+
+    Aws::SNS::Model::SubscribeRequest s_req;
+    s_req.AddAttributes("SubscriptionArn", subscription_arn);
+
+    auto s_out = sns.Subscribe(s_req);
+
+    if (s_out.IsSuccess())
+    {
+      std::cout << "Subscribed successfully " << s_out.GetResult() << std::endl;
+    }
+    else
+    {
+      std::cout << "Error while subscribing " << s_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/sns/unsubscribe.cpp
+++ b/cpp/example_code/sns/unsubscribe.cpp
@@ -11,8 +11,7 @@
 
 #include <aws/core/Aws.h>
 #include <aws/sns/SNSClient.h>
-#include <aws/sns/model/SubscribeRequest.h>
-#include <aws/sns/model/SubscribeResult.h>
+#include <aws/sns/model/UnsubscribeRequest.h>
 #include <iostream>
 
 /**
@@ -28,19 +27,19 @@ int main(int argc, char ** argv)
   }
 
   Aws::SDKOptions options;
-  AWS::InitAPI(options);
+  Aws::InitAPI(options);
   {
     Aws::SNS::SNSClient sns;
     Aws::String subscription_arn = argv[1];
 
-    Aws::SNS::Model::SubscribeRequest s_req;
-    s_req.AddAttributes("SubscriptionArn", subscription_arn);
+    Aws::SNS::Model::UnsubscribeRequest s_req;
+    s_req.SetSubscriptionArn(subscription_arn);
 
-    auto s_out = sns.Subscribe(s_req);
+    auto s_out = sns.Unsubscribe(s_req);
 
     if (s_out.IsSuccess())
     {
-      std::cout << "Subscribed successfully " << s_out.GetResult() << std::endl;
+      std::cout << "Subscribed successfully " << std::endl;
     }
     else
     {


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for SNS Service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
