### PR TITLE
Add SES CPP example codes

### DIFF
--- a/cpp/example_code/ses/CMakeLists.txt
+++ b/cpp/example_code/ses/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set (CMAKE_CXX_STANDARD 11)
+
+cmake_minimum_required(VERSION 3.2)
+project(ses-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "create_template")
+list(APPEND EXAMPLES "create_receipt_filter")
+list(APPEND EXAMPLES "create_receipt_rule")
+list(APPEND EXAMPLES "create_receipt_rule_set")
+list(APPEND EXAMPLES "delete_identity")
+list(APPEND EXAMPLES "delete_receipt_filter")
+list(APPEND EXAMPLES "delete_receipt_rule")
+list(APPEND EXAMPLES "delete_receipt_rule_set")
+list(APPEND EXAMPLES "delete_template")
+list(APPEND EXAMPLES "get_template")
+list(APPEND EXAMPLES "list_identities")
+list(APPEND EXAMPLES "send_email")
+list(APPEND EXAMPLES "send_templated_email")
+list(APPEND EXAMPLES "update_template")
+list(APPEND EXAMPLES "verify_email_identity")
+
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-email aws-cpp-sdk-core)
+endforeach()
+

--- a/cpp/example_code/ses/create_receipt_filter.cpp
+++ b/cpp/example_code/ses/create_receipt_filter.cpp
@@ -1,0 +1,66 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/CreateReceiptFilterRequest.h>
+#include <aws/email/model/CreateReceiptFilterResult.h>
+#include <aws/email/model/ReceiptFilterPolicy.h>
+#include <aws/email/model/ReceiptFilter.h>
+#include <aws/email/model/ReceiptIpFilter.h>
+#include <iostream>
+
+/**
+ * Creates an ses receipt filter based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 4)
+  {
+    std::cout << "Usage: create_template <receipt_filter_name> <cidr_value> <receipt_filter_policy_val>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String receipt_filter_name = argv[1];
+    Aws::String cidr_value = argv[2];
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::CreateReceiptFilterRequest crf_req;
+    Aws::SES::Model::ReceiptFilter receipt_filter;
+    Aws::SES::Model::ReceiptIpFilter receipt_ip_filter;
+
+    receipt_ip_filter.SetCidr(cidr_value);
+
+    receipt_filter.SetName(receipt_filter_name);
+    receipt_filter.SetIpFilter(receipt_ip_filter);
+
+    crf_req.SetFilter(receipt_filter);
+
+    auto ct_out = ses.CreateReceiptFilter(crf_req);
+
+    if (ct_out.IsSuccess())
+    {
+      std::cout << "Successfully created receipt filter " << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error creating receipt filter " << ct_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/create_receipt_rule.cpp
+++ b/cpp/example_code/ses/create_receipt_rule.cpp
@@ -1,0 +1,100 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/CreateReceiptRuleRequest.h>
+#include <aws/email/model/CreateReceiptRuleResult.h>
+#include <aws/email/model/ReceiptRule.h>
+#include <aws/email/model/ReceiptAction.h>
+#include <aws/email/model/TlsPolicy.h>
+#include <aws/email/model/S3Action.h>
+#include <iostream>
+
+/**
+ * Creates an ses receipt filter based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 7)
+  {
+    std::cout << "Usage: create_receipt_rule <s3_bucket_name> <s3_object_key_prefix>"
+      "<rule_name> <rule_set_name> <tls_policy_val> <receipients_value>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String s3_bucket_name(argv[1]);
+    Aws::String s3_object_key_prefix(argv[2]);
+
+    for (int i = 6; i < argc; ++i)
+    {
+      const Aws::String arg(argv[i]);
+    }
+    Aws::String rule_name(argv[3]);
+    Aws::String rule_set_name(argv[4]);
+    Aws::String tls_policy_val(argv[5]);
+
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::CreateReceiptRuleRequest crr_req;
+    Aws::SES::Model::ReceiptRule receipt_rule;
+    Aws::SES::Model::ReceiptAction receipt_actions;
+    Aws::SES::Model::S3Action s3_action;
+
+    if (tls_policy_val == "Require")
+    {
+      receipt_rule.SetTlsPolicy(Aws::SES::Model::TlsPolicy::Require);
+    }
+    else if (tls_policy_val == "Optional")
+    {
+      receipt_rule.SetTlsPolicy(Aws::SES::Model::TlsPolicy::Optional);
+    }
+    else
+    {
+      receipt_rule.SetTlsPolicy(Aws::SES::Model::TlsPolicy::NOT_SET);
+    }
+
+    s3_action.SetBucketName(s3_bucket_name);
+    s3_action.SetObjectKeyPrefix(s3_object_key_prefix);
+
+    receipt_actions.SetS3Action(s3_action);
+
+    receipt_rule.SetName(rule_name);
+
+    for (int i = 6; i < argc; ++i)
+    {
+      receipt_rule.AddRecipients(argv[i]);
+    }
+    receipt_rule.SetActions(receipt_actions);
+
+    crr_req.SetRuleSetName(rule_set_name);
+    crr_req.SetRule(receipt_rule);
+
+    auto crr_out = ses.CreateReceiptRule(crr_req);
+
+    if (crr_out.IsSuccess())
+    {
+      std::cout << "Successfully created receipt rule" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error creating receipt rule" << crr_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/create_receipt_rule_set.cpp
+++ b/cpp/example_code/ses/create_receipt_rule_set.cpp
@@ -1,0 +1,56 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/CreateReceiptRuleSetRequest.h>
+#include <aws/email/model/CreateReceiptRuleSetResult.h>
+#include <iostream>
+
+/**
+ * Creates an ses receipt filter based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: create_receipt_rule_set <rule_set_name>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String rule_set_name(argv[1]);
+
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::CreateReceiptRuleSetRequest crrs_req;
+
+    crrs_req.SetRuleSetName(rule_set_name);
+
+    auto crrs_out = ses.CreateReceiptRuleSet(crrs_req);
+
+    if (crrs_out.IsSuccess())
+    {
+      std::cout << "Successfully created receipt rule set" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error creating receipt rule set" << crrs_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/create_template.cpp
+++ b/cpp/example_code/ses/create_template.cpp
@@ -1,0 +1,65 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/CreateTemplateRequest.h>
+#include <aws/email/model/CreateTemplateResult.h>
+#include <aws/email/model/Template.h>
+#include <iostream>
+
+/**
+ * Creates an ses template based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: create_template <template_name> <html_content> <subject_line> <text_content>";
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String template_name = argv[1];
+    Aws::String html_name = argv[2];
+    Aws::String subject_line = argv[3];
+    Aws::String text_content = argv[4];
+
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::CreateTemplateRequest ct_req;
+    Aws::SES::Model::Template template_var;
+
+    template_var.SetTemplateName(template_name);
+    template_var.SetHtmlPart(html_name);
+    template_var.SetSubjectPart(subject_line);
+
+    ct_req.SetTemplate(template_var);
+
+    auto ct_out = ses.CreateTemplate(ct_req);
+
+    if (ct_out.IsSuccess())
+    {
+      std::cout << "Successfully create template " << template_name << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error creating template " << ct_out.GetError().GetMessage() << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/delete_identity.cpp
+++ b/cpp/example_code/ses/delete_identity.cpp
@@ -1,0 +1,55 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/DeleteIdentityRequest.h>
+#include <iostream>
+
+/**
+ * Creates an ses receipt filter based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_identity <identity>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String identity(argv[1]);
+
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::DeleteIdentityRequest di_req;
+
+    di_req.SetIdentity(identity);
+
+    auto di_out = ses.DeleteIdentity(di_req);
+
+    if (di_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted identity" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error deleting identity" << di_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/delete_receipt_filter.cpp
+++ b/cpp/example_code/ses/delete_receipt_filter.cpp
@@ -1,0 +1,52 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is drfstributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/DeleteReceiptFilterRequest.h>
+#include <aws/email/model/DeleteReceiptFilterResult.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_receipt_filter <filter_name>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String filter_name(argv[1]);
+
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::DeleteReceiptFilterRequest drf_req;
+
+    drf_req.SetFilterName(filter_name);
+
+    auto drf_out = ses.DeleteReceiptFilter(drf_req);
+
+    if (drf_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted receipt filter request" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error deleting receipt filter request" << drf_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/delete_receipt_rule.cpp
+++ b/cpp/example_code/ses/delete_receipt_rule.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is drrstributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/DeleteReceiptRuleRequest.h>
+#include <aws/email/model/DeleteReceiptRuleResult.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  if (argc != 3)
+  {
+    std::cout << "Usage: delete_receipt_rule <rule_name> <rule_set_name>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String rule_name(argv[1]);
+    Aws::String rule_set_name(argv[2]);
+
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::DeleteReceiptRuleRequest drr_req;
+
+    drr_req.SetRuleName(rule_name);
+    drr_req.SetRuleSetName(rule_set_name);
+
+    auto drr_out = ses.DeleteReceiptRule(drr_req);
+
+    if (drr_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted receipt rule" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error deleting receipt rule" << drr_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/delete_receipt_rule_set.cpp
+++ b/cpp/example_code/ses/delete_receipt_rule_set.cpp
@@ -1,0 +1,52 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is drrsstributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/DeleteReceiptRuleSetRequest.h>
+#include <aws/email/model/DeleteReceiptRuleSetResult.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_receipt_rule_set <rule_set_name>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String rule_set_name(argv[1]);
+
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::DeleteReceiptRuleSetRequest drrs_req;
+
+    drrs_req.SetRuleSetName(rule_set_name);
+
+    auto drrs_out = ses.DeleteReceiptRuleSet(drrs_req);
+
+    if (drrs_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted receipt rule set" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error deleting receipt rule set" << drrs_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/delete_template.cpp
+++ b/cpp/example_code/ses/delete_template.cpp
@@ -1,0 +1,52 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is dtstributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/DeleteTemplateRequest.h>
+#include <aws/email/model/DeleteTemplateResult.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_template_request <template_name>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String template_name(argv[1]);
+
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::DeleteTemplateRequest dt_req;
+
+    dt_req.SetTemplateName(template_name);
+
+    auto dt_out = ses.DeleteTemplate(dt_req);
+
+    if (dt_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted template" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error deleting template" << dt_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/get_template.cpp
+++ b/cpp/example_code/ses/get_template.cpp
@@ -1,0 +1,52 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is gtstributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/GetTemplateRequest.h>
+#include <aws/email/model/GetTemplateResult.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: get_template <template_name>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String template_name(argv[1]);
+
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::GetTemplateRequest gt_req;
+
+    gt_req.SetTemplateName(template_name);
+
+    auto gt_out = ses.GetTemplate(gt_req);
+
+    if (gt_out.IsSuccess())
+    {
+      std::cout << "Successfully get template" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error getting template" << gt_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/list_identities.cpp
+++ b/cpp/example_code/ses/list_identities.cpp
@@ -1,0 +1,65 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is dtstributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/ListIdentitiesRequest.h>
+#include <aws/email/model/ListIdentitiesResult.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: list_identities <identity_type>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::ListIdentitiesRequest li_req;
+
+    if (argv[1] == "EmailAddress")
+    {
+      li_req.SetIdentityType(Aws::SES::Model::IdentityType::EmailAddress);
+    }
+    else if (argv[1] == "Domain")
+    {
+      li_req.SetIdentityType(Aws::SES::Model::IdentityType::Domain);
+    }
+    else
+    {
+      li_req.SetIdentityType(Aws::SES::Model::IdentityType::NOT_SET);
+    }
+
+    auto li_out = ses.ListIdentities(li_req);
+
+    if (li_out.IsSuccess())
+    {
+      std::cout << "List of identities:";
+      for (auto identities: li_out.GetResult().GetIdentities())
+      {
+        std::cout << " " << identities << std::endl;
+      }
+    }
+
+    else
+    {
+      std::cout << "Error listing identities" << li_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/list_receipt_filters.cpp
+++ b/cpp/example_code/ses/list_receipt_filters.cpp
@@ -1,0 +1,48 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affilrfates. All Rights Reserved.
+   This file is lrfcensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in complrfance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is dtstributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implrfed. See the License for the
+   specific language governing permissions and lrfmitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/ListReceiptFiltersRequest.h>
+#include <aws/email/model/ListReceiptFiltersResponse.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  if (argc != 1)
+  {
+    std::cout << "Usage: lrfst_receipt_filters";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::SES::SES::Client ses;
+
+    Aws::SES::Model::ListReceiptFiltersRequest lrf_req;
+
+    auto lrf_out = ses.ListReceiptFilters(lrf_req);
+
+    if (lrf_out.IsSuccess())
+    {
+      std::cout << "Successfully list receipt filters" << lrf_out.GetResult().GetFilters() << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error listing receipt filters" << lrf_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/send_email.cpp
+++ b/cpp/example_code/ses/send_email.cpp
@@ -1,0 +1,92 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/SendEmailRequest.h>
+#include <aws/email/model/SendEmailResult.h>
+#include <aws/email/model/Destination.h>
+#include <aws/email/model/Message.h>
+#include <aws/email/model/Body.h>
+#include <aws/email/model/Content.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  if (argc != 6)
+  {
+    std::cout << "Usage: send_email <message_body_html_data> <message_body_text_data>"
+      "<message_subject_data> <sender_email_address> <cc_address> <reply_to_address>"
+      "<to_addresses>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String message_body_html_data(argv[1]);
+    Aws::String message_body_text_data(argv[2]);
+    Aws::String message_subject_data(argv[3]);
+    Aws::String sender_email_address(argv[4]);
+    Aws::String cc_address(argv[5]);
+    Aws::String reply_to_address(argv[6]);
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::SendEmailRequest se_req;
+    Aws::SES::Model::Destination destination;
+    Aws::SES::Model::Message message;
+    Aws::SES::Model::Body message_body;
+    Aws::SES::Model::Content message_body_text;
+    Aws::SES::Model::Content message_body_html;
+    Aws::SES::Model::Content message_subject;
+
+
+    destination.AddCcAddresses(cc_address);
+    for (int i = 6; i < argc; ++i)
+    {
+      destination.AddToAddresses(argv[i]);
+    }
+
+    message_body_html.SetData(message_body_html_data);
+    message_body_html.SetCharset("UTF-8");
+    message_body_text.SetData(message_body_text_data);
+    message_body_text.SetCharset("UTF-8");
+    message_subject.SetData(message_subject_data);
+    message_subject.SetCharset("UTF-8");
+
+    message_body.SetText(message_body_text);
+    message_body.SetHtml(message_body_html);
+
+    message.SetBody(message_body);
+    message.SetSubject(message_subject);
+
+    se_req.SetDestination(destination);
+    se_req.SetMessage(message);
+    se_req.SetSource(sender_email_address);
+    se_req.AddReplyToAddresses(reply_to_address);
+
+    auto se_out = ses.SendEmail(se_req);
+
+    if (se_out.IsSuccess())
+    {
+      std::cout << "Successfully sent GetMessage " << se_out.GetResult().GetMessageId()
+        << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error creating receipt filter " << se_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/send_templated_email.cpp
+++ b/cpp/example_code/ses/send_templated_email.cpp
@@ -1,0 +1,70 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/SendTemplatedEmailRequest.h>
+#include <aws/email/model/SendTemplatedEmailResult.h>
+#include <aws/email/model/Destination.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  if (argc != 6)
+  {
+    std::cout << "Usage: send_templated_email <template_name> <template_data>"
+      "<sender_email_address> <cc_address> <reply_to_address> <to_addresses>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String template_name(argv[1]);
+    Aws::String template_data(argv[2]);
+    Aws::String sender_email_address(argv[3]);
+    Aws::String cc_address(argv[4]);
+    Aws::String reply_to_address(argv[5]);
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::SendTemplatedEmailRequest ste_req;
+    Aws::SES::Model::Destination destination;
+
+    destination.AddCcAddresses(cc_address);
+
+    for (int i = 6; i < argc; ++i)
+    {
+      destination.AddToAddresses(argv[i]);
+    }
+
+    ste_req.SetDestination(destination);
+    ste_req.SetTemplate(template_name);
+    ste_req.SetTemplateData(template_data);
+    ste_req.SetSource(sender_email_address);
+    ste_req.AddReplyToAddresses(reply_to_address);
+
+    auto ste_out = ses.SendTemplatedEmail(ste_req);
+
+    if (ste_out.IsSuccess())
+    {
+      std::cout << "Successfully sent templated message " << ste_out.GetResult().GetMessageId()
+        << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error sending templated message " << ste_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/update_template.cpp
+++ b/cpp/example_code/ses/update_template.cpp
@@ -1,0 +1,62 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/UpdateTemplateRequest.h>
+#include <aws/email/model/UpdateTemplateResult.h>
+#include <aws/email/model/Template.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  if (argc != 6)
+  {
+    std::cout << "Usage: update_template <template_name> <html_content>"
+      "<subject_line> <text_content>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String template_name(argv[1]);
+    Aws::String html_content(argv[2]);
+    Aws::String subject_line(argv[3]);
+    Aws::String text_content(argv[4]);
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::Template template_values;
+    Aws::SES::Model::UpdateTemplateRequest ut_req;
+
+    template_values.SetTemplateName(template_name);
+    template_values.SetSubjectPart(subject_line);
+    template_values.SetHtmlPart(html_content);
+    template_values.SetTextPart(text_content);
+
+    ut_req.SetTemplate(template_values);
+
+    auto ut_out = ses.UpdateTemplate(ut_req);
+
+    if (ut_out.IsSuccess())
+    {
+      std::cout << "Successfully updated template" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error updating template" << ut_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ses/verify_email_identity.cpp
+++ b/cpp/example_code/ses/verify_email_identity.cpp
@@ -1,0 +1,51 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/email/SESClient.h>
+#include <aws/email/model/VerifyEmailIdentityRequest.h>
+#include <aws/email/model/VerifyEmailIdentityResult.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: verify_email_address <email_address>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String email_address(argv[1]);
+    Aws::SES::SESClient ses;
+
+    Aws::SES::Model::VerifyEmailIdentityRequest vea_req;
+
+    vea_req.SetEmailAddress(email_address);
+
+    auto vea_out = ses.VerifyEmailIdentity(vea_req);
+
+    if (vea_out.IsSuccess())
+    {
+      std::cout << "Email verification initiated" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error initiating email verification" << vea_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for SES Service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.