### PR TITLE
Add GuardDuty CPP example codes

### DIFF
--- a/cpp/example_code/guardduty/CMakeLists.txt
+++ b/cpp/example_code/guardduty/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set (CMAKE_CXX_STANDARD 11)
+
+cmake_minimum_required(VERSION 3.2)
+project(guardduty-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "list_detectors")
+list(APPEND EXAMPLES "list_findings_with_finding_criteria")
+
+
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-guardduty aws-cpp-sdk-core)
+endforeach()
+

--- a/cpp/example_code/guardduty/list_detectors.cpp
+++ b/cpp/example_code/guardduty/list_detectors.cpp
@@ -1,0 +1,59 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/guardduty/GuardDutyClient.h>
+#include <aws/guardduty/model/ListDetectorsRequest.h>
+#include <aws/guardduty/model/ListDetectorsResult.h>
+#include <iostream>
+
+/*
+ * Lists GuardDuty detectors in the current AWS region.
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 1)
+  {
+    std::cout << "Usage: list_detectors" << std::endl;
+
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::GuardDuty::GuardDutyClient gd;
+
+    Aws::GuardDuty::Model::ListDetectorsRequest ld_req;
+
+    auto ld_out = gd.ListDetectors(ld_req);
+
+    if (ld_out.IsSuccess())
+    {
+      std::cout << "Successfully listing the detectors:";
+
+      for (auto val: ld_out.GetResult().GetDetectorIds())
+      {
+        std::cout << " " << val << std::endl;
+      }
+    }
+    else
+    {
+      std::cout << "Error listing the detectors " << ld_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}
+

--- a/cpp/example_code/guardduty/list_findings_with_finding_criteria.cpp
+++ b/cpp/example_code/guardduty/list_findings_with_finding_criteria.cpp
@@ -1,0 +1,66 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/guardduty/GuardDutyClient.h>
+#include <aws/guardduty/model/ListFindingsRequest.h>
+#include <aws/guardduty/model/ListFindingsResult.h>
+#include <aws/guardduty/model/FindingCriteria.h>
+#include <aws/guardduty/model/Condition.h>
+#include <iostream>
+
+/*
+ * List all GuardDuty Findings that match the specified FindingCriteria.
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: list_findings_with_finding_criteria <detector_id> <condition_val>"
+      "<criteria_val>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String detector_id(argv[1]);
+    Aws::String condition_val(argv[2]);
+    Aws::String criteria_val(argv[3]);
+
+    Aws::GuardDuty::Condition condition;
+    Aws::GuardDuty::GuardDutyClient gd;
+    Aws::GuardDuty::Model::ListFindingsRequest lffc_req;
+    Aws::GuardDuty::Model::FindingCriteria finding_criteria;
+
+    condition.AddEq(condition_val);
+    finding_criteria.AddCriterion(criteria_val, condition);
+    lffc_req.SetDetectorId(detector_id);
+    lffc_req.SetFindingCriteria(finding_criteria);
+    lffc_req.SetMaxResults(10);
+
+    auto lffc_out = gd.ListFindingsRequest(lffc_req);
+
+    if (lffc_out.IsSuccess())
+    {
+      std::cout << "Successfully listing the findings";
+    }
+    else
+    {
+      std::cout << "Error listing the findings " << lffc_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for GuardDuty Service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.