### PR TITLE
Add CloudTrail CPP example codes

### DIFF
--- a/cpp/example_code/cloudtrail/CMakeLists.txt
+++ b/cpp/example_code/cloudtrail/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set (CMAKE_CXX_STANDARD 11)
+
+cmake_minimum_required(VERSION 3.2)
+project(cloudtrail-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "create_trail")
+list(APPEND EXAMPLES "delete_trail")
+list(APPEND EXAMPLES "describe_trails")
+list(APPEND EXAMPLES "lookup_events")
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-cloudtrail aws-cpp-sdk-core)
+endforeach()
+

--- a/cpp/example_code/cloudtrail/create_trail.cpp
+++ b/cpp/example_code/cloudtrail/create_trail.cpp
@@ -1,0 +1,57 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/cloudtrail/CloudTrailClient.h>
+#include <aws/cloudtrail/model/CreateTrailRequest.h>
+#include <aws/cloudtrail/model/CreateTrailResult.h>
+#include <iostream>
+
+/**
+ * Creates a cloud trail on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 3)
+  {
+    std::cout << "Usage: create_trail <trail_name> <bucket_name>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String trail_name(argv[1]);
+    Aws::String bucket_name(argv[2]);
+
+    Aws::CloudTrail::CloudTrailClient ct;
+
+    Aws::CloudTrail::Model::CreateTrailRequest ct_req;
+    ct_req.SetName(trail_name);
+    ct_req.SetS3BucketName(bucket_name);
+
+    auto ct_out = ct.CreateTrail(ct_req);
+
+    if (ct_out.IsSuccess())
+    {
+      std::cout << "Successfully created cloud trail" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error creating cloud trail " << ct_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/cloudtrail/delete_trail.cpp
+++ b/cpp/example_code/cloudtrail/delete_trail.cpp
@@ -1,0 +1,55 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/cloudtrail/CloudTrailClient.h>
+#include <aws/cloudtrail/model/DeleteTrailRequest.h>
+#include <aws/cloudtrail/model/DeleteTrailResult.h>
+#include <iostream>
+
+/**
+ * Deletes a cloud trail on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_trail <trail_name>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String trail_name(argv[1]);
+
+    Aws::CloudTrail::CloudTrailClient ct;
+
+    Aws::CloudTrail::Model::DeleteTrailRequest dt_req;
+    dt_req.SetName(trail_name);
+
+    auto dt_out = ct.CreateTrail(ct_req);
+
+    if (dt_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted cloud trail" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error deleting cloud trail " << dt_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/cloudtrail/describe_trails.cpp
+++ b/cpp/example_code/cloudtrail/describe_trails.cpp
@@ -1,0 +1,58 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/cloudtrail/CloudTrailClient.h>
+#include <aws/cloudtrail/model/DescribeTrailsRequest.h>
+#include <aws/cloudtrail/model/DescribeTrailsResult.h>
+#include <iostream>
+
+/**
+ * Describes all cloud trails in a AWS region on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 3)
+  {
+    std::cout << "Usage: describe_trail";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+
+    Aws::CloudTrail::CloudTrailClient ct;
+
+    Aws::CloudTrail::Model::DescribeTrailsRequest dt_req;
+
+    auto dt_out = ct.DescribeTrails(dt_req);
+
+    if (dt_out.IsSuccess())
+    {
+      std::cout << "Successfully describing cloud trails:";
+
+      for (auto val: dt_out.GetResult().GetTrailList())
+      {
+        std::cout << val << std::endl;
+      }
+    }
+
+    else
+    {
+      std::cout << "Error describing cloud trails" << dt_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/cloudtrail/lookup_events.cpp
+++ b/cpp/example_code/cloudtrail/lookup_events.cpp
@@ -1,0 +1,58 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/cloudtrail/CloudTrailClient.h>
+#include <aws/cloudtrail/model/LookupEventsRequest.h>
+#include <aws/cloudtrail/model/LookupEventsResult.h>
+#include <iostream>
+
+/**
+ * Look up Cloud Trail events based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 1)
+  {
+    std::cout << "Usage: lookup_events";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+
+    Aws::CloudTrail::CloudTrailClient ct;
+
+    Aws::CloudTrail::Model::LookupEventsRequest le_req;
+
+    auto le_out = ct.LookupEvents(le_req);
+
+    if (le_out.IsSuccess())
+    {
+      std::cout << "Successfully looking up cloudtrail events:";
+
+      for (auto val: le_out.GetResult().GetEvents())
+      {
+        std::cout << " " << val << std::endl;
+      }
+    }
+
+    else
+    {
+      std::cout << "Error looking up cloudtrail events" << le_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for CloudTrail Service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.