### PR TITLE
Add Neptune CPP example codes

### DIFF
--- a/cpp/example_code/neptune/CMakeLists.txt
+++ b/cpp/example_code/neptune/CMakeLists.txt
@@ -7,13 +7,12 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-set (CMAKE_CXX_STANDARD 11)
-
 cmake_minimum_required(VERSION 3.2)
 project(neptune-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
-find_package(aws-sdk-cpp)
+find_package(AWSSDK REQUIRED COMPONENTS neptune)
 
 set(EXAMPLES "")
 list(APPEND EXAMPLES "create_db_cluster")

--- a/cpp/example_code/neptune/CMakeLists.txt
+++ b/cpp/example_code/neptune/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set (CMAKE_CXX_STANDARD 11)
+
+cmake_minimum_required(VERSION 3.2)
+project(neptune-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "create_db_cluster")
+list(APPEND EXAMPLES "delete_db_cluster")
+list(APPEND EXAMPLES "modify_db_cluster")
+list(APPEND EXAMPLES "describe_db_clusters")
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-neptune aws-cpp-sdk-core)
+endforeach()

--- a/cpp/example_code/neptune/create_db_cluster.cpp
+++ b/cpp/example_code/neptune/create_db_cluster.cpp
@@ -1,0 +1,55 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/neptune/NeptuneClient.h>
+#include <aws/neptune/model/CreateDBClusterRequest.h>
+#include <aws/neptune/model/CreateDBClusterResult.h>
+#include <iostream>
+
+/**
+ * Creates a Neptune db cluster based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: create_db_cluster <db_cluster_identifier>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String db_cluster_identifier(argv[1]);
+    Aws::Neptune::NeptuneClient neptune;
+
+    Aws::Neptune::Model::CreateDBClusterRequest cdbc_req;
+    cdbc_req.SetDBClusterIdentifier(db_cluster_identifier);
+    cdbc_req.SetEngine("neptune");
+
+    auto cdbc_out = neptune.CreateDBCluster(cdbc_req);
+
+    if (cdbc_out.IsSuccess())
+    {
+      std::cout << "Successfully created neptune db cluster " << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error creating neptune db cluster " << cdbc_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/neptune/delete_db_cluster.cpp
+++ b/cpp/example_code/neptune/delete_db_cluster.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/neptune/NeptuneClient.h>
+#include <aws/neptune/model/DeleteDBClusterRequest.h>
+#include <aws/neptune/model/DeleteDBClusterResult.h>
+#include <iostream>
+
+/**
+ * Deletes a Neptune db cluster based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_db_cluster <db_cluster_identifier>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String db_cluster_identifier(argv[1]);
+    Aws::Neptune::NeptuneClient neptune;
+
+    Aws::Neptune::Model::DeleteDBClusterRequest ddbc_req;
+    ddbc_req.SetDBClusterIdentifier(db_cluster_identifier);
+
+    auto ddbc_out = neptune.DeleteDBCluster(ddbc_req);
+
+    if (ddbc_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted neptune db cluster " << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error deleting neptune db cluster " << ddbc_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/neptune/describe_db_clusters.cpp
+++ b/cpp/example_code/neptune/describe_db_clusters.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
 
       for (auto val: ddbc_out.GetResult().GetDBClusters())
       {
-        std::cout << " " << val << std::endl;
+        std::cout << " " << val.GetDBClusterIdentifier() << std::endl;
       }
     }
 

--- a/cpp/example_code/neptune/describe_db_clusters.cpp
+++ b/cpp/example_code/neptune/describe_db_clusters.cpp
@@ -1,0 +1,57 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/neptune/NeptuneClient.h>
+#include <aws/neptune/model/DescribeDBClustersRequest.h>
+#include <aws/neptune/model/DescribeDBClustersResult.h>
+#include <iostream>
+
+/**
+ * Describes Neptune db cluster based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 1)
+  {
+    std::cout << "Usage: describe_db_cluster";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::Neptune::NeptuneClient neptune;
+
+    Aws::Neptune::Model::DescribeDBClustersRequest ddbc_req;
+
+    auto ddbc_out = neptune.DescribeDBClusters(ddbc_req);
+
+    if (ddbc_out.IsSuccess())
+    {
+      std::cout << "Successfully described db clusters request:";
+
+      for (auto val: ddbc_out.GetResult().GetDBClusters())
+      {
+        std::cout << " " << val << std::endl;
+      }
+    }
+
+    else
+    {
+      std::cout << "Error describing neptune db clusters " << ddbc_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/neptune/modify_db_cluster.cpp
+++ b/cpp/example_code/neptune/modify_db_cluster.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/neptune/NeptuneClient.h>
+#include <aws/neptune/model/ModifyDBClusterRequest.h>
+#include <aws/neptune/model/ModifyDBClusterResult.h>
+#include <iostream>
+
+/**
+ * Modifies a Neptune db cluster based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: modify_db_cluster <db_cluster_identifier>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String db_cluster_identifier(argv[1]);
+    Aws::Neptune::NeptuneClient neptune;
+
+    Aws::Neptune::Model::ModifyDBClusterRequest mdbc_req;
+    mdbc_req.SetDBClusterIdentifier(db_cluster_identifier);
+
+    auto mdbc_out = neptune.ModifyDBCluster(mdbc_req);
+
+    if (mdbc_out.IsSuccess())
+    {
+      std::cout << "Successfully modified neptune db cluster " << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error modifying neptune db cluster " << mdbc_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for Neptune Service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.