### PR TITLE
Add EFS CPP example codes

### DIFF
--- a/cpp/example_code/efs/CMakeLists.txt
+++ b/cpp/example_code/efs/CMakeLists.txt
@@ -25,5 +25,5 @@ list(APPEND EXAMPLES "create_mount_target")
 # The executables to build.
 foreach(EXAMPLE IN LISTS EXAMPLES)
   add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
-  target_link_libraries(${EXAMPLE} aws-cpp-sdk-efs aws-cpp-sdk-core)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-elasticfilesystem aws-cpp-sdk-core)
 endforeach()

--- a/cpp/example_code/efs/CMakeLists.txt
+++ b/cpp/example_code/efs/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set (CMAKE_CXX_STANDARD 11)
+
+cmake_minimum_required(VERSION 3.2)
+project(efs-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "create_file_system")
+list(APPEND EXAMPLES "delete_file_system")
+list(APPEND EXAMPLES "update_file_system")
+list(APPEND EXAMPLES "create_mount_target")
+
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-efs aws-cpp-sdk-core)
+endforeach()

--- a/cpp/example_code/efs/CMakeLists.txt
+++ b/cpp/example_code/efs/CMakeLists.txt
@@ -7,13 +7,13 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-set (CMAKE_CXX_STANDARD 11)
-
 cmake_minimum_required(VERSION 3.2)
 project(efs-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
-find_package(aws-sdk-cpp)
+find_package(AWSSDK REQUIRED COMPONENTS efs)
+set (CMAKE_CXX_STANDARD 11)
 
 set(EXAMPLES "")
 list(APPEND EXAMPLES "create_file_system")

--- a/cpp/example_code/efs/create_file_system.cpp
+++ b/cpp/example_code/efs/create_file_system.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/elasticfilesystem/EFSClient.h>
+#include <aws/elasticfilesystem/model/CreateFileSystemRequest.h>
+#include <aws/elasticfilesystem/model/CreateFileSystemResult.h>
+#include <iostream>
+
+/**
+ * Creates file system based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: create_file_system <creation_token>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String creation_token(argv[1]);
+    Aws::EFS::EFSClient efs;
+
+    Aws::EFS::Model::CreateFileSystemRequest cfs_req;
+
+    cfs_req.SetCreationToken(creation_token);
+    auto cfs_out = efs.CreateFileSystem(cfs_req);
+
+    if (cfs_out.IsSuccess())
+    {
+      std::cout << "Successfully created file system " << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error creating file system " << cfs_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/efs/create_file_system.cpp
+++ b/cpp/example_code/efs/create_file_system.cpp
@@ -10,6 +10,7 @@
 */
 
 #include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
 #include <aws/elasticfilesystem/EFSClient.h>
 #include <aws/elasticfilesystem/model/CreateFileSystemRequest.h>
 #include <aws/elasticfilesystem/model/CreateFileSystemResult.h>

--- a/cpp/example_code/efs/create_mount_target.cpp
+++ b/cpp/example_code/efs/create_mount_target.cpp
@@ -1,0 +1,57 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/elasticfilesystem/EFSClient.h>
+#include <aws/elasticfilesystem/model/CreateMountTargetRequest.h>
+#include <aws/elasticfilesystem/model/CreateMountTargetResult.h>
+#include <iostream>
+
+/**
+ * Creates mount target based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 3)
+  {
+    std::cout << "Usage: create_mount_target <file_system_id> <subnet_id>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String file_system_id(argv[1]);
+    Aws::String subnet_id(argv[2]);
+    Aws::EFS::EFSClient efs;
+
+    Aws::EFS::Model::CreateMountTargetRequest cmt_req;
+
+    cmt_req.SetFileSystemId(file_system_id);
+    cmt_req.SetSubnetId(subnet_id);
+
+    auto cmt_out = efs.CreateMountTarget(cmt_req);
+
+    if (cmt_out.IsSuccess())
+    {
+      std::cout << "Successfully created mount target " << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error creating mount target" << cmt_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/efs/create_mount_target.cpp
+++ b/cpp/example_code/efs/create_mount_target.cpp
@@ -10,6 +10,7 @@
 */
 
 #include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
 #include <aws/elasticfilesystem/EFSClient.h>
 #include <aws/elasticfilesystem/model/CreateMountTargetRequest.h>
 #include <aws/elasticfilesystem/model/CreateMountTargetResult.h>

--- a/cpp/example_code/efs/delete_file_system.cpp
+++ b/cpp/example_code/efs/delete_file_system.cpp
@@ -1,0 +1,55 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/elasticfilesystem/EFSClient.h>
+#include <aws/elasticfilesystem/model/DeleteFileSystemRequest.h>
+#include <aws/elasticfilesystem/model/DeleteFileSystemResult.h>
+#include <iostream>
+
+/**
+ * Deletes file system based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_file_system <file_system_id>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String file_system_id(argv[1]);
+    Aws::EFS::EFSClient efs;
+
+    Aws::EFS::Model::DeleteFileSystemRequest dfs_req;
+
+    dfs_req.SetFileSystemId(file_system_id);
+
+    auto dfs_out = efs.DeleteFileSystem(dfs_req);
+
+    if (dfs_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted file system " << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error deleting file system " << dfs_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/efs/delete_file_system.cpp
+++ b/cpp/example_code/efs/delete_file_system.cpp
@@ -10,9 +10,9 @@
 */
 
 #include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
 #include <aws/elasticfilesystem/EFSClient.h>
 #include <aws/elasticfilesystem/model/DeleteFileSystemRequest.h>
-#include <aws/elasticfilesystem/model/DeleteFileSystemResult.h>
 #include <iostream>
 
 /**

--- a/cpp/example_code/efs/update_file_system.cpp
+++ b/cpp/example_code/efs/update_file_system.cpp
@@ -10,6 +10,7 @@
 */
 
 #include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
 #include <aws/elasticfilesystem/EFSClient.h>
 #include <aws/elasticfilesystem/model/UpdateFileSystemRequest.h>
 #include <aws/elasticfilesystem/model/UpdateFileSystemResult.h>

--- a/cpp/example_code/efs/update_file_system.cpp
+++ b/cpp/example_code/efs/update_file_system.cpp
@@ -1,0 +1,69 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/elasticfilesystem/EFSClient.h>
+#include <aws/elasticfilesystem/model/UpdateFileSystemRequest.h>
+#include <aws/elasticfilesystem/model/UpdateFileSystemResult.h>
+#include <iostream>
+
+/**
+ * Update file system based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 3)
+  {
+    std::cout << "Usage: update_file_system <file_system_id> <thorughput_mode>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String file_system_id(argv[1]);
+    Aws::String throughput_mode(argv[2]);
+    Aws::EFS::EFSClient efs;
+
+    Aws::EFS::Model::UpdateFileSystemRequest ufs_req;
+
+    if (throughput_mode == "bursting")
+    {
+      ufs_req.SetThroughputMode(Aws::EFS::Model::ThroughputMode::bursting);
+    }
+    else if (throughput_mode == "provisioned")
+    {
+      ufs_req.SetThroughputMode(Aws::EFS::Model::ThroughputMode::provisioned);
+    }
+    else
+    {
+      ufs_req.SetThroughputMode(Aws::EFS::Model::ThroughputMode::NOT_SET);
+    }
+
+    ufs_req.SetFileSystemId(file_system_id);
+
+    auto ufs_out = efs.UpdateFileSystem(ufs_req);
+
+    if (ufs_out.IsSuccess())
+    {
+      std::cout << "Successfully updated file system " << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error updating file system " << ufs_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for EFS Service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.