### PR TITLE
Add Glacier CPP example codes

### DIFF
--- a/cpp/example_code/glacier/CMakeLists.txt
+++ b/cpp/example_code/glacier/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set (CMAKE_CXX_STANDARD 11)
+
+cmake_minimum_required(VERSION 3.2)
+project(glacier-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "create_vault")
+list(APPEND EXAMPLES "upload_archive")
+
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-glacier aws-cpp-sdk-core)
+endforeach()

--- a/cpp/example_code/glacier/create_vault.cpp
+++ b/cpp/example_code/glacier/create_vault.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/glacier/GlacierClient.h>
+#include <aws/glacier/model/CreateVaultRequest.h>
+#include <aws/glacier/model/CreateVaultResult.h>
+#include <iostream>
+
+/**
+ * Creates a glacier vault based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: create_vault <vault_name>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String vault_name(argv[1]);
+    Aws::Glacier::GlacierClient glacier;
+
+    Aws::Glacier::Model::CreateVaultRequest cv_req;
+    cv_req.SetVaultName(vault_name);
+
+    auto cv_out = glacier.CreateVault(cv_req);
+
+    if (cv_out.IsSuccess())
+    {
+      std::cout << "Successfully created vault" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error creating vault" << cv_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/glacier/upload_archive.cpp
+++ b/cpp/example_code/glacier/upload_archive.cpp
@@ -1,0 +1,61 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/glacier/GlacierClient.h>
+#include <aws/glacier/model/UploadArchiveRequest.h>
+#include <aws/glacier/model/UploadArchiveResult.h>
+#include <iostream>
+
+/**
+ * Uploads archives based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 4)
+  {
+    std::cout << "Usage: upload_archive <vault_name> <account_id> <archive_description>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String vault_name(argv[1]);
+    Aws::String account_id(argv[2]);
+    Aws::String archive_description(argv[3]);
+
+    Aws::Glacier::GlacierClient glacier;
+
+    Aws::Glacier::Model::CreateVaultRequest ua_req;
+    ua_req.SetVaultName(vault_name);
+    ua_req.SetAccountId(account_id);
+    ua_req.SetArchiveDescription(archive_description);
+
+
+    auto ua_out = ses.UploadArchive(ua_req);
+
+    if (ua_out.IsSuccess())
+    {
+      std::cout << "Successfully upload archive with archive id: " << ua_out.GetResult().GetArchiveId()
+        << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error upload archive" << ua_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for Glacier Service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
