### PR TITLE
Add CodeBuild CPP example codes

### DIFF
--- a/cpp/example_code/codebuild/CMakeLists.txt
+++ b/cpp/example_code/codebuild/CMakeLists.txt
@@ -7,13 +7,12 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-set (CMAKE_CXX_STANDARD 11)
-
 cmake_minimum_required(VERSION 3.2)
 project(codebuild-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
-find_package(aws-sdk-cpp)
+find_package(AWSSDK REQUIRED COMPONENTS codebuild)
 
 set(EXAMPLES "")
 list(APPEND EXAMPLES "build_project")

--- a/cpp/example_code/codebuild/CMakeLists.txt
+++ b/cpp/example_code/codebuild/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set (CMAKE_CXX_STANDARD 11)
+
+cmake_minimum_required(VERSION 3.2)
+project(codebuild-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "build_project")
+list(APPEND EXAMPLES "list_builds")
+list(APPEND EXAMPLES "list_projects")
+
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-codebuild aws-cpp-sdk-core)
+endforeach()

--- a/cpp/example_code/codebuild/build_project.cpp
+++ b/cpp/example_code/codebuild/build_project.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/codebuild/CodeBuildClient.h>
+#include <aws/codebuild/model/StartBuildRequest.h>
+#include <aws/codebuild/model/StartBuildResult.h>
+#include <iostream>
+
+/**
+ * Starts the project build based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: build_project <project_name>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String project_name(argv[1]);
+    Aws::CodeBuild::CodeBuildClient codebuild;
+
+    Aws::CodeBuild::Model::StartBuildRequest sb_req;
+    sb_req.SetProjectName(project_name);
+
+    auto sb_out = codebuild.StartBuild(sb_req);
+
+    if (sb_out.IsSuccess())
+    {
+      std::cout << "Successfully started build" << std::endl;
+    }
+
+    else
+    {
+      std::cout << "Error starting build" << sb_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/codebuild/build_project.cpp
+++ b/cpp/example_code/codebuild/build_project.cpp
@@ -10,6 +10,7 @@
 */
 
 #include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
 #include <aws/codebuild/CodeBuildClient.h>
 #include <aws/codebuild/model/StartBuildRequest.h>
 #include <aws/codebuild/model/StartBuildResult.h>

--- a/cpp/example_code/codebuild/list_builds.cpp
+++ b/cpp/example_code/codebuild/list_builds.cpp
@@ -10,6 +10,8 @@
 */
 
 #include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/core/utils/StringUtils.h>
 #include <aws/codebuild/CodeBuildClient.h>
 #include <aws/codebuild/model/ListBuildsRequest.h>
 #include <aws/codebuild/model/ListBuildsResult.h>
@@ -31,12 +33,24 @@ int main(int argc, char **argv)
   Aws::SDKOptions options;
   Aws::InitAPI(options);
   {
-    Aws::String sort_order_type(argv[1]);
     Aws::CodeBuild::CodeBuildClient codebuild;
 
     Aws::CodeBuild::Model::ListBuildsRequest lb_req;
     Aws::CodeBuild::Model::BatchGetBuildsRequest bgb_req;
-    lb_req.SetSortOrder(sort_order_type);
+
+    if (Aws::Utils::StringUtils::CaselessCompare(argv[1], "ASCENDING"))
+    {
+      lb_req.SetSortOrder(Aws::CodeBuild::Model::SortOrderType::ASCENDING);
+    }
+    else if(Aws::Utils::StringUtils::CaselessCompare(argv[1], "DESCENDING"))
+    {
+      lb_req.SetSortOrder(Aws::CodeBuild::Model::SortOrderType::DESCENDING);
+    }
+    else
+    {
+      lb_req.SetSortOrder(Aws::CodeBuild::Model::SortOrderType::NOT_SET);
+    }
+
 
     auto lb_out = codebuild.ListBuilds(lb_req);
 

--- a/cpp/example_code/codebuild/list_builds.cpp
+++ b/cpp/example_code/codebuild/list_builds.cpp
@@ -1,0 +1,71 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/codebuild/CodeBuildClient.h>
+#include <aws/codebuild/model/ListBuildsRequest.h>
+#include <aws/codebuild/model/ListBuildsResult.h>
+#include <aws/codebuild/model/BatchGetBuildsRequest.h>
+#include <aws/codebuild/model/BatchGetBuildsResult.h>
+#include <iostream>
+
+/**
+ * Gets the list of builds and information about each build based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: list_builds <sort_order_type>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String sort_order_type(argv[1]);
+    Aws::CodeBuild::CodeBuildClient codebuild;
+
+    Aws::CodeBuild::Model::ListBuildsRequest lb_req;
+    Aws::CodeBuild::Model::BatchGetBuildsRequest bgb_req;
+    lb_req.SetSortOrder(sort_order_type);
+
+    auto lb_out = codebuild.ListBuilds(lb_req);
+
+    if (lb_out.IsSuccess())
+    {
+      std::cout << "Information about each build:" << std::endl;
+      for (auto val : lb_out.GetResult().GetIds())
+      {
+        bgb_req.SetIds(val);
+        auto bgb_out = codebuild.BatchGetBuilds(bgb_req);
+
+        if (bgb_out.IsSuccess())
+        {
+          for (auto val: bgb_out.GetResult().GetBuilds())
+          {
+            std::cout << val << std::endl;
+          }
+        }
+
+      }
+    }
+
+    else
+    {
+      std::cout << "Error listing builds" << lb_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/codebuild/list_projects.cpp
+++ b/cpp/example_code/codebuild/list_projects.cpp
@@ -1,0 +1,70 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/codebuild/CodeBuildClient.h>
+#include <aws/codebuild/model/ListProjectsRequest.h>
+#include <aws/codebuild/model/ListProjectsResult.h>
+#include <iostream>
+
+/**
+ * Gets the list of projects based on command line input
+ */
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: list_projects <sort_order_type>";
+    return 1;
+  }
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String sort_order_type(argv[1]);
+    Aws::CodeBuild::CodeBuildClient codebuild;
+
+    Aws::CodeBuild::Model::ListProjectsRequest lp_req;
+
+    if (sort_order_type == "ASCENDING")
+    {
+      lp_req.SetSortOrder(Aws::CodeBuild::Model::SortOrderType::ASCENDING);
+    }
+    else if (sort_order_type == "DESCENDING")
+    {
+      lp_req.SetSortOrder(Aws::CodeBuild::Model::SortOrderType::DESCENDING);
+    }
+    else
+    {
+      lp_req.SetSortOrder(Aws::CodeBuild::Model::SortOrderType::NOT_SET);
+    }
+
+    auto lp_out = codebuild.ListProjects(lp_req);
+
+    if (lp_out.IsSuccess())
+    {
+      std::cout << "Successfully listing projects";
+      for (auto val : lp_out.GetResult().GetProjects())
+      {
+        cout << " " << val << std::endl;
+      }
+    }
+
+    else
+    {
+      std::cout << "Error listing projects" << lp_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/codebuild/list_projects.cpp
+++ b/cpp/example_code/codebuild/list_projects.cpp
@@ -10,6 +10,7 @@
 */
 
 #include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
 #include <aws/codebuild/CodeBuildClient.h>
 #include <aws/codebuild/model/ListProjectsRequest.h>
 #include <aws/codebuild/model/ListProjectsResult.h>
@@ -54,7 +55,7 @@ int main(int argc, char **argv)
       std::cout << "Successfully listing projects";
       for (auto val : lp_out.GetResult().GetProjects())
       {
-        cout << " " << val << std::endl;
+        std::cout << " " << val << std::endl;
       }
     }
 


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for CodeBuild Service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.