### PR TITLE
Add CodeCommit CPP example codes

### DIFF
--- a/cpp/example_code/codecommit/CMakeLists.txt
+++ b/cpp/example_code/codecommit/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set (CMAKE_CXX_STANDARD 11)
+
+cmake_minimum_required(VERSION 3.2)
+project(codecommit-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "create_pull_request")
+list(APPEND EXAMPLES "create_repository")
+list(APPEND EXAMPLES "delete_branch")
+list(APPEND EXAMPLES "delete_repository")
+list(APPEND EXAMPLES "list_pull_requests")
+list(APPEND EXAMPLES "update_pull_request")
+list(APPEND EXAMPLES "update_repository")
+list(APPEND EXAMPLES "list_branches")
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-codecommit aws-cpp-sdk-core)
+endforeach()

--- a/cpp/example_code/codecommit/CMakeLists.txt
+++ b/cpp/example_code/codecommit/CMakeLists.txt
@@ -7,13 +7,12 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-set (CMAKE_CXX_STANDARD 11)
-
 cmake_minimum_required(VERSION 3.2)
 project(codecommit-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
-find_package(aws-sdk-cpp)
+find_package(AWSSDK REQUIRED COMPONENTS codecommit)
 
 set(EXAMPLES "")
 list(APPEND EXAMPLES "create_pull_request")

--- a/cpp/example_code/codecommit/create_pull_request.cpp
+++ b/cpp/example_code/codecommit/create_pull_request.cpp
@@ -1,0 +1,71 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/codecommit/CodeCommitClient.h>
+#include <aws/codecommit/model/CreatePullRequestRequest.h>
+#include <aws/codecommit/model/CreatePullRequestResult.h>
+#include <aws/codecommit/model/Target.h>
+#include <aws/core/utils/Outcome.h>
+#include <iostream>
+
+/**
+ * Creates a pull request based with title, description, repository name, source branch
+ * and destination branch name based on command line inputs
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 6)
+  {
+    std::cout << "Usage: create_pull_request <title> <description> <repository_name>"
+              << "<source_branch_name> <destination_branch_name>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String title(argv[1]);
+    Aws::String description(argv[2]);
+    Aws::String repository_name(argv[3]);
+    Aws::String source_branch_name(argv[4]);
+    Aws::String destination_branch_name(argv[5]);
+
+    Aws::CodeCommit::CodeCommitClient codecommit;
+
+    Aws::CodeCommit::Model::Target targets;
+    Aws::CodeCommit::Model::CreatePullRequestRequest cpr_req;
+
+    targets.SetRepositoryName(repository_name);
+    targets.SetSourceReference(source_branch_name);
+    targets.SetDestinationReference(destination_branch_name);
+
+    cpr_req.SetTitle(title);
+    cpr_req.SetDescription(description);
+    cpr_req.AddTargets(targets);
+
+    auto cpr_out = codecommit.CreatePullRequest(cpr_req);
+
+    if (cpr_out.IsSuccess())
+    {
+      std::cout << "Successfully created pull request " << std::endl;
+    }
+    else
+    {
+      std::cout << "Error creating pull request " << cpr_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/codecommit/create_repository.cpp
+++ b/cpp/example_code/codecommit/create_repository.cpp
@@ -1,0 +1,62 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/codecommit/CodeCommitClient.h>
+#include <aws/codecommit/model/CreateRepositoryRequest.h>
+#include <aws/codecommit/model/CreateRepositoryResult.h>
+#include <aws/codecommit/model/RepositoryMetadata.h>
+#include <iostream>
+
+/**
+ * Creates a repository based on command line inputs
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 3)
+  {
+    std::cout << "Usage: create_repository <repository_name> <repository_description>"
+              << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String repository_name(argv[1]);
+    Aws::String repository_description(argv[2]);
+
+    Aws::CodeCommit::CodeCommitClient codecommit;
+
+    Aws::CodeCommit::Model::CreateRepositoryRequest cr_req;
+
+    cr_req.SetRepositoryName(repository_name);
+    cr_req.SetRepositoryDescription(repository_description);
+
+    auto cr_out = codecommit.CreateRepository(cr_req);
+
+    if (cr_out.IsSuccess())
+    {
+      std::cout << "Successfully created repository with repository id:"
+                << cr_out.GetResult().GetRepositoryMetadata().GetRepositoryId() << std::endl;
+    }
+    else
+    {
+      std::cout << "Error creating repository" << cr_out.GetError().GetMessage()
+                << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/codecommit/delete_branch.cpp
+++ b/cpp/example_code/codecommit/delete_branch.cpp
@@ -1,0 +1,61 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/codecommit/CodeCommitClient.h>
+#include <aws/codecommit/model/DeleteBranchRequest.h>
+#include <aws/codecommit/model/DeleteBranchResult.h>
+#include <aws/codecommit/model/RepositoryMetadata.h>
+#include <iostream>
+
+/**
+ * Deletes a branch of repository based on command line inputs
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 3)
+  {
+    std::cout << "Usage: delete_branch <repository_name> <branch_name>"
+              << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String repository_name(argv[1]);
+    Aws::String branch_name(argv[2]);
+
+    Aws::CodeCommit::CodeCommitClient codecommit;
+
+    Aws::CodeCommit::Model::DeleteBranchRequest db_req;
+
+    db_req.SetRepositoryName(repository_name);
+    db_req.SetBranchName(branch_name);
+
+    auto db_out = codecommit.DeleteBranch(db_req);
+
+    if (db_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted branch from repository" << std::endl;
+    }
+    else
+    {
+      std::cout << "Error deleting branch" << db_out.GetError().GetMessage()
+                << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/codecommit/delete_repository.cpp
+++ b/cpp/example_code/codecommit/delete_repository.cpp
@@ -1,0 +1,60 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/codecommit/CodeCommitClient.h>
+#include <aws/codecommit/model/DeleteRepositoryRequest.h>
+#include <aws/codecommit/model/DeleteRepositoryResult.h>
+#include <iostream>
+
+/**
+ * Deletes a repository based on command line inputs
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_repository <repository_name>"
+              << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String repository_name(argv[1]);
+
+    Aws::CodeCommit::CodeCommitClient codecommit;
+
+    Aws::CodeCommit::Model::DeleteRepositoryRequest dr_req;
+
+    dr_req.SetRepositoryName(repository_name);
+
+    auto dr_out = codecommit.DeleteRepository(dr_req);
+
+    if (dr_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted repository with repository id:"
+                << dr_out.GetResult().GetRepositoryId()
+                << std::endl;
+    }
+    else
+    {
+      std::cout << "Error deleting repository" << dr_out.GetError().GetMessage()
+                << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/codecommit/list_branches.cpp
+++ b/cpp/example_code/codecommit/list_branches.cpp
@@ -1,0 +1,63 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/codecommit/CodeCommitClient.h>
+#include <aws/codecommit/model/ListBranchesRequest.h>
+#include <aws/codecommit/model/ListBranchesResult.h>
+#include <iostream>
+
+/**
+ * Lists branches of a repository based on command line inputs
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: list_branches <repository_name>"
+              << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String repository_name(argv[1]);
+
+    Aws::CodeCommit::CodeCommitClient codecommit;
+
+    Aws::CodeCommit::Model::ListBranchesRequest lb_req;
+
+    lb_req.SetRepositoryName(repository_name);
+
+    auto lb_out = codecommit.ListBranches(lb_req);
+
+    if (lb_out.IsSuccess())
+    {
+      std::cout << "Successfully listing branches names as: ";
+
+      for (auto val: lb_out.GetResult().GetBranches())
+      {
+        std::cout << " " << val;
+      }
+    }
+    else
+    {
+      std::cout << "Error listing branches." << lb_out.GetError().GetMessage()
+                << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/codecommit/list_pull_requests.cpp
+++ b/cpp/example_code/codecommit/list_pull_requests.cpp
@@ -1,0 +1,63 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/codecommit/CodeCommitClient.h>
+#include <aws/codecommit/model/ListPullRequestsRequest.h>
+#include <aws/codecommit/model/ListPullRequestsResult.h>
+#include <iostream>
+
+/**
+ * Lists pull requests of a repository based on command line inputs
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: list_pull_requests <repository_name>"
+              << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String repository_name(argv[1]);
+
+    Aws::CodeCommit::CodeCommitClient codecommit;
+
+    Aws::CodeCommit::Model::ListPullRequestsRequest lpr_req;
+
+    lpr_req.SetRepositoryName(repository_name);
+
+    auto lpr_out = codecommit.ListPullRequests(lpr_req);
+
+    if (lpr_out.IsSuccess())
+    {
+      std::cout << "Successfully listed pull requests with pull request ids as: ";
+
+      for (auto val: lpr_out.GetResult().GetPullRequestIds())
+      {
+        std::cout << " " << val;
+      }
+    }
+    else
+    {
+      std::cout << "Error getting pull requests" << lpr_out.GetError().GetMessage()
+                << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/codecommit/update_pull_request.cpp
+++ b/cpp/example_code/codecommit/update_pull_request.cpp
@@ -1,0 +1,89 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/codecommit/CodeCommitClient.h>
+#include <aws/codecommit/model/UpdatePullRequestDescriptionRequest.h>
+#include <aws/codecommit/model/UpdatePullRequestDescriptionResult.h>
+#include <aws/codecommit/model/UpdatePullRequestStatusRequest.h>
+#include <aws/codecommit/model/UpdatePullRequestStatusResult.h>
+#include <aws/codecommit/model/UpdatePullRequestTitleRequest.h>
+#include <aws/codecommit/model/UpdatePullRequestTitleRequest.h>
+#include <aws/codecommit/model/Target.h>
+#include <aws/core/utils/Outcome.h>
+#include <iostream>
+
+/**
+ * Updates pull request based on command line input.
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 5)
+  {
+    std::cout << "Usage: update_pull_request <pull_request_id> <pull_request_description>"
+                 "<pull_request_status> <pull_request_title>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String pull_request_id(argv[1]);
+    Aws::String pull_request_description(argv[2]);
+    Aws::String pull_request_status(argv[3]);
+    Aws::String pull_request_title(argv[4]);
+
+    Aws::CodeCommit::CodeCommitClient codecommit;
+
+    Aws::CodeCommit::Model::UpdatePullRequestDescriptionRequest uprd_req;
+    Aws::CodeCommit::Model::UpdatePullRequestStatusRequest uprs_req;
+    Aws::CodeCommit::Model::UpdatePullRequestTitleRequest uprt_req;
+
+    uprd_req.SetPullRequestId(pull_request_id);
+    uprd_req.SetDescription(pull_request_description);
+
+    uprs_req.SetPullRequestId(pull_request_id);
+    if (pull_request_status == "OPEN")
+    {
+      uprs_req.SetPullRequestStatus(Aws::CodeCommit::Model::PullRequestStatusEnum::OPEN);
+    }
+    if (pull_request_status == "CLOSED")
+    {
+      uprs_req.SetPullRequestStatus(Aws::CodeCommit::Model::PullRequestStatusEnum::CLOSED);
+    }
+    else
+    {
+      uprs_req.SetPullRequestStatus(Aws::CodeCommit::Model::PullRequestStatusEnum::NOT_SET);
+    }
+
+    uprt_req.SetPullRequestId(pull_request_id);
+    uprt_req.SetTitle(pull_request_title);
+
+    auto uprd_out = codecommit.UpdatePullRequestDescription(uprd_req);
+    auto uprs_out = codecommit.UpdatePullRequestStatus(uprs_req);
+    auto uprt_out = codecommit.UpdatePullRequestTitle(uprt_req);
+
+    if (uprd_out.IsSuccess() and uprs_out.IsSuccess() and uprt_out.IsSuccess())
+    {
+      std::cout << "Successfully updated pull request title, status and description."
+                << std::endl;
+    }
+    else
+    {
+      std::cout << "Error updating pull request."
+                << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/codecommit/update_repository.cpp
+++ b/cpp/example_code/codecommit/update_repository.cpp
@@ -1,0 +1,67 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/codecommit/CodeCommitClient.h>
+#include <aws/codecommit/model/UpdateRepositoryDescriptionRequest.h>
+#include <aws/codecommit/model/UpdateRepositoryNameRequest.h>
+#include <aws/core/utils/Outcome.h>
+#include <iostream>
+
+/**
+ * Updates repository based on command line input.
+ */
+
+int main(int argc, char ** argv)
+{
+  if (argc != 5)
+  {
+    std::cout << "Usage: update_repository <repository_old_name> <repository_new_name>"
+                 "<repository_description>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String repository_old_name(argv[1]);
+    Aws::String repository_new_name(argv[2]);
+    Aws::String repository_description(argv[3]);
+
+    Aws::CodeCommit::CodeCommitClient codecommit;
+
+    Aws::CodeCommit::Model::UpdateRepositoryDescriptionRequest urd_req;
+    Aws::CodeCommit::Model::UpdateRepositoryNameRequest urn_req;
+
+    urd_req.SetRepositoryName(repository_old_name);
+    urd_req.SetRepositoryDescription(repository_description);
+
+    urn_req.SetOldName(repository_old_name);
+    urn_req.SetNewName(repository_new_name);
+
+    auto urd_out = codecommit.UpdateRepositoryDescription(urd_req);
+    auto urn_out = codecommit.UpdateRepositoryName(urn_req);
+
+    if (urd_out.IsSuccess() and urn_out.IsSuccess())
+    {
+      std::cout << "Successfully updated repository."
+                << std::endl;
+    }
+    else
+    {
+      std::cout << "Error updating repository."
+                << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for CodeCommit Service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.