### PR TITLE
Add StorageGateway CPP example codes

### DIFF
--- a/cpp/example_code/storage gateway/CMakeLists.txt
+++ b/cpp/example_code/storage gateway/CMakeLists.txt
@@ -7,13 +7,12 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-set (CMAKE_CXX_STANDARD 11)
-
 cmake_minimum_required(VERSION 3.2)
 project(sg-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
-find_package(aws-sdk-cpp)
+find_package(AWSSDK REQUIRED COMPONENTS sg)
 
 set(EXAMPLES "")
 list(APPEND EXAMPLES "create_nfs_file_share")

--- a/cpp/example_code/storage gateway/CMakeLists.txt
+++ b/cpp/example_code/storage gateway/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set (CMAKE_CXX_STANDARD 11)
+
+cmake_minimum_required(VERSION 3.2)
+project(sg-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "create_nfs_file_share")
+list(APPEND EXAMPLES "list_file_share")
+list(APPEND EXAMPLES "start_gateway")
+list(APPEND EXAMPLES "describe_gateway_information")
+list(APPEND EXAMPLES "describe_smb_settings")
+list(APPEND EXAMPLES "delete_volume")
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-storagegateway aws-cpp-sdk-core)
+endforeach()
+

--- a/cpp/example_code/storage gateway/create_nfs_file_share.cpp
+++ b/cpp/example_code/storage gateway/create_nfs_file_share.cpp
@@ -1,0 +1,58 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/storagegateway/StorageGatewayClient.h>
+#include <aws/storagegateway/model/CreateNFSFileShareRequest.h>
+#include <aws/storagegateway/model/CreateNFSFileShareResult.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 5)
+  {
+    std::cout << "Usage: create_nfs_file_share <gateway_arn> <client_token> <location_arn> <role>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String gateway_arn(argv[1]);
+    Aws::String client_token(argv[2]);
+    Aws::String location_arn(argv[3]);
+    Aws::String role(argv[4]);
+
+    Aws::StorageGateway::StorageGatewayClient storagegateway;
+
+    Aws::StorageGateway::Model::CreateNFSFileShareRequest cnfsfs_req;
+
+    cnfsfs.SetGatewayARN(gateway_arn);
+    cnfsfs.SetRole(role);
+    cnfsfs.SetLocationARN(location_arn);
+    cnfsfs.AddClientList(client_token);
+
+    auto cnfsfs_out = storagegateway.CreateNFSFileShare(cnfsfs_req);
+
+    if (cnfsfs_out.IsSuccess())
+    {
+      std::cout << "Successfully created NFS File share" << std::endl;
+    }
+    else
+    {
+      std::cout << "Error creating NFS File share" << cnfsfs_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/storage gateway/delete_volume.cpp
+++ b/cpp/example_code/storage gateway/delete_volume.cpp
@@ -1,0 +1,52 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/storagegateway/StorageGatewayClient.h>
+#include <aws/storagegateway/model/DeleteVolumeRequest.h>
+#include <aws/storagegateway/model/DeleteVolumeResult.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_volume <volume_arn>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String volume_arn(argv[1]);
+
+    Aws::StorageGateway::StorageGatewayClient storagegateway;
+
+    Aws::StorageGateway::Model::DeleteVolumeRequest dv_req;
+
+    dv.SetVolumeARN(gateway_arn);
+
+    auto dv_out = storagegateway.CreateNFSFileShare(dv_req);
+
+    if (dv_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted volume arn." << std::endl;
+    }
+    else
+    {
+      std::cout << "Error deleting volume arn." << dv_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/storage gateway/describe_gateway_information.cpp
+++ b/cpp/example_code/storage gateway/describe_gateway_information.cpp
@@ -1,0 +1,55 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/storagegateway/StorageGatewayClient.h>
+#include <aws/storagegateway/model/DescribeGatewayRequest.h>
+#include <aws/storagegateway/model/DescribeGatewayResult.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: describe_gateway <gateway_arn>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String gateway_arn(argv[1]);
+
+    Aws::StorageGateway::StorageGatewayClient sg;
+
+    Aws::StorageGateway::Model::DescribeGatewayRequest dgi_req;
+
+    sg.SetGatewayARN(gateway_arn);
+
+    auto dgi_out = storagegatway.DescribeGateway(dgi_req);
+
+    if (dgi_out.IsSuccess())
+    {
+      std::cout << "Successfully describing gateway as:";
+      std::cout << " " << dgi_out.GetResult().GetGatewayId();
+      std::cout << " " << dgi_out.GetResult().GetGatewayName();
+      std::cout << std::endl;
+    }
+    else
+    {
+      std::cout << "Error describing gateway" << dgi_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/storage gateway/describe_smb_settings.cpp
+++ b/cpp/example_code/storage gateway/describe_smb_settings.cpp
@@ -1,0 +1,56 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/storagegateway/StorageGatewayClient.h>
+#include <aws/storagegateway/model/DescribeSMBSettingsRequest.h>
+#include <aws/storagegateway/model/DescribeSMBSettingsResult.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: describe_smb_settings <gateway_arn>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String gateway_arn(argv[1]);
+
+    Aws::StorageGateway::StorageGatewayClient sg;
+
+    Aws::StorageGateway::Model::DescribeSMBSettingsRequest dsmbs_req;
+
+    sg.SetGatewayARN(gateway_arn);
+
+    auto dsmbs_out = storagegatway.DescribeGateway(dsmbs_req);
+
+    if (dsmbs_out.IsSuccess())
+    {
+      std::cout << "Successfully describing SMB settings as:";
+      for (auto val : dsmbs_out.GetResult().GetSMBFileShareInfoList())
+      {
+        cout << " " << val;
+      }
+    }
+    else
+    {
+      std::cout << "Error describing SMB settings." << dsmbs_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/storage gateway/list_file_shares.cpp
+++ b/cpp/example_code/storage gateway/list_file_shares.cpp
@@ -1,0 +1,56 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/storagegateway/StorageGatewayClient.h>
+#include <aws/storagegateway/model/ListFileSharesRequest.h>
+#include <aws/storagegateway/model/ListFileSharesResult.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: list_file_shares <gateway_arn>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String gateway_arn(argv[1]);
+
+    Aws::StorageGateway::StorageGatewayClient storagegateway;
+
+    Aws::StorageGateway::Model::ListFileSharesRequest lfs_req;
+
+    storagegateway.SetGatewayARN(gateway_arn);
+
+    auto lfs_out = storagegateway.ListFileShares(lfs_req);
+
+    if (lfs_out.IsSuccess())
+    {
+      std::cout << "Successfully listing file shares";
+      for (auto val: lfs_out.GetResult().GetFileShareInfoList())
+      {
+        cout << " " << val;
+      }
+    }
+    else
+    {
+      std::cout << "Error listing File share" << lfs_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/storage gateway/start_gateway.cpp
+++ b/cpp/example_code/storage gateway/start_gateway.cpp
@@ -1,0 +1,52 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/storagegateway/StorageGatewayClient.h>
+#include <aws/storagegateway/model/StartGatewayRequest.h>
+#include <aws/storagegateway/model/StartGatewayResult.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: start_gateway <gateway_arn>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String gateway_arn(argv[1]);
+
+    Aws::StorageGateway::StorageGatewayClient sg;
+
+    Aws::StorageGateway::Model::StartGatewayRequest sg_req;
+
+    sg.SetGatewayARN(gateway_arn);
+
+    auto sg_out = storagegatway.StartGateway(sg_req);
+
+    if (sg_out.IsSuccess())
+    {
+      std::cout << "Successfully started gateway." << std::endl;
+    }
+    else
+    {
+      std::cout << "Error starting gateway." << sg_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for StorageGateway service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.