### PR TITLE
Add ElastiCache CPP example codes

### DIFF
--- a/cpp/example_code/elasticache/CMakeLists.txt
+++ b/cpp/example_code/elasticache/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set (CMAKE_CXX_STANDARD 11)
+
+cmake_minimum_required(VERSION 3.2)
+project(elasticache-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "create_cache_cluster")
+list(APPEND EXAMPLES "delete_cache_cluster")
+list(APPEND EXAMPLES "modify_cache_cluster")
+list(APPEND EXAMPLES "add_tags_to_resource")
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-elasticache aws-cpp-sdk-core)
+endforeach()

--- a/cpp/example_code/elasticache/CMakeLists.txt
+++ b/cpp/example_code/elasticache/CMakeLists.txt
@@ -7,13 +7,12 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-set (CMAKE_CXX_STANDARD 11)
-
 cmake_minimum_required(VERSION 3.2)
 project(elasticache-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
-find_package(aws-sdk-cpp)
+find_package(AWSSDK REQUIRED COMPONENTS elasticache)
 
 set(EXAMPLES "")
 list(APPEND EXAMPLES "create_cache_cluster")

--- a/cpp/example_code/elasticache/add_tags_to_resource.cpp
+++ b/cpp/example_code/elasticache/add_tags_to_resource.cpp
@@ -1,0 +1,60 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/elasticache/ElastiCacheClient.h>
+#include <aws/elasticache/model/AddTagsToResourceRequest.h>
+#include <aws/elasticache/model/AddTagsToResourceResult.h>
+#include <aws/elasticache/model/Tag.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 3)
+  {
+    std::cout << "Usage: add_tags <resource_name> <tag_key> <tag_value>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String name(argv[1]);
+    Aws::String tag_key(argv[2]);
+    Aws::String tag_value(argv[3]);
+
+    Aws::ElastiCache::ElastiCacheClient elasticache;
+
+    Aws::ElastiCache::Model::AddTagsToResourceRequest attr_req;
+    Aws::ElastiCache::Model::Tags tags;
+
+    tags.SetKey(tag_key);
+    tags.SetValue(tag_value);
+
+    attr_req.SetResourceName(name);
+    attr_req.AddTags(tags);
+
+    auto attr_out = elasticache.AddTagsToResource(attr_req);
+
+    if (attr_out.IsSuccess())
+    {
+      std::cout << "Successfully added tags to resource" << std::endl;
+    }
+    else
+    {
+      std::cout << "Error adding tags" << attr_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/elasticache/add_tags_to_resource.cpp
+++ b/cpp/example_code/elasticache/add_tags_to_resource.cpp
@@ -34,7 +34,7 @@ int main(int argc, char ** argv)
     Aws::ElastiCache::ElastiCacheClient elasticache;
 
     Aws::ElastiCache::Model::AddTagsToResourceRequest attr_req;
-    Aws::ElastiCache::Model::Tags tags;
+    Aws::ElastiCache::Model::Tag tags;
 
     tags.SetKey(tag_key);
     tags.SetValue(tag_value);

--- a/cpp/example_code/elasticache/add_tags_to_resource.cpp
+++ b/cpp/example_code/elasticache/add_tags_to_resource.cpp
@@ -18,7 +18,7 @@
 
 int main(int argc, char ** argv)
 {
-  if (argc != 3)
+  if (argc != 4)
   {
     std::cout << "Usage: add_tags <resource_name> <tag_key> <tag_value>" << std::endl;
     return 1;

--- a/cpp/example_code/elasticache/create_cache_cluster.cpp
+++ b/cpp/example_code/elasticache/create_cache_cluster.cpp
@@ -18,9 +18,10 @@
 
 int main(int argc, char ** argv)
 {
-  if (argc != 2)
+  if (argc != 5)
   {
-    std::cout << "Usage: create_cache_cluster <cluster_id>" << std::endl;
+    std::cout << "Usage: create_cache_cluster <cluster_id> <engine> <cache_node_type>"
+                 "<num_cache_nodes>" << std::endl;
     return 1;
   }
 
@@ -28,12 +29,18 @@ int main(int argc, char ** argv)
   Aws::InitAPI(options);
   {
     Aws::String cluster_id(argv[1]);
+    Aws::String engine(argv[2]);
+    Aws::String cache_node_type(argv[3]);
+    int num_cache_nodes = Aws::Utils::StringUtils::ConvertToInt64(argv[4]);
 
     Aws::ElastiCache::ElastiCacheClient elasticache;
 
     Aws::ElastiCache::Model::CreateCacheClusterRequest ccc_req;
 
     ccc_req.SetCacheClusterId(cluster_id);
+    ccc_req.SetEngine(engine);
+    ccc_req.SetCacheNodeType(cache_node_type);
+    ccc_req.SetNumCacheNodes(num_cache_nodes);
 
     auto ccc_out = elasticache.CreateCacheCluster(ccc_req);
 

--- a/cpp/example_code/elasticache/create_cache_cluster.cpp
+++ b/cpp/example_code/elasticache/create_cache_cluster.cpp
@@ -1,0 +1,53 @@
+
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/elasticache/ElastiCacheClient.h>
+#include <aws/elasticache/model/CreateCacheClusterRequest.h>
+#include <aws/elasticache/model/CreateCacheClusterResult.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: create_cache_cluster <cluster_id>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String cluster_id(argv[1]);
+
+    Aws::ElastiCache::ElastiCacheClient elasticache;
+
+    Aws::ElastiCache::Model::CreateCacheClusterRequest ccc_req;
+
+    ccc_req.SetCacheClusterId(cluster_id);
+
+    auto ccc_out = elasticache.CreateCacheCluster(ccc_req);
+
+    if (ccc_out.IsSuccess())
+    {
+      std::cout << "Successfully created cache cluster" << std::endl;
+    }
+    else
+    {
+      std::cout << "Error creating cache cluster" << ccc_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/elasticache/delete_cache_cluster.cpp
+++ b/cpp/example_code/elasticache/delete_cache_cluster.cpp
@@ -1,0 +1,53 @@
+
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/elasticache/ElastiCacheClient.h>
+#include <aws/elasticache/model/DeleteCacheClusterRequest.h>
+#include <aws/elasticache/model/DeleteCacheClusterResult.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_cache_cluster <cluster_id>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String cluster_id(argv[1]);
+
+    Aws::ElastiCache::ElastiCacheClient elasticache;
+
+    Aws::ElastiCache::Model::DeleteCacheClusterRequest ccc_req;
+
+    ccc_req.SetCacheClusterId(cluster_id);
+
+    auto ccc_out = elasticache.DeleteCacheCluster(ccc_req);
+
+    if (ccc_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted cache cluster" << std::endl;
+    }
+    else
+    {
+      std::cout << "Error deleting cache cluster" << ccc_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/elasticache/modify_cache_cluster.cpp
+++ b/cpp/example_code/elasticache/modify_cache_cluster.cpp
@@ -1,0 +1,55 @@
+
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/elasticache/ElastiCacheClient.h>
+#include <aws/elasticache/model/ModifyCacheClusterRequest.h>
+#include <aws/elasticache/model/ModifyCacheClusterResult.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: modify_cache_cluster <cluster_id> <topic_arn>" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String cluster_id(argv[1]);
+    Aws::String topic_arn(argv[2]);
+
+    Aws::ElastiCache::ElastiCacheClient elasticache;
+
+    Aws::ElastiCache::Model::ModifyCacheClusterRequest mcc_req;
+
+    mcc_req.SetCacheClusterId(cluster_id);
+    mcc_req.SetNotificationTopicArn(topic_arn);
+
+    auto mcc_out = elasticache.ModifyCacheCluster(mcc_req);
+
+    if (mcc_out.IsSuccess())
+    {
+      std::cout << "Successfully modified cache cluster" << std::endl;
+    }
+    else
+    {
+      std::cout << "Error creating cache cluster" << mcc_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for ElastiCache Service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
