### PR TITLE
Add EBS CPP example codes

### DIFF
--- a/cpp/example_code/ebs/CMakeLists.txt
+++ b/cpp/example_code/ebs/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set (CMAKE_CXX_STANDARD 11)
+
+cmake_minimum_required(VERSION 3.2)
+project(ebs-examples)
+
+# Locate the aws sdk for c++ package.
+find_package(aws-sdk-cpp)
+
+set(EXAMPLES "")
+list(APPEND EXAMPLES "describe_volumes")
+list(APPEND EXAMPLES "attach_volume")
+list(APPEND EXAMPLES "create_volume")
+list(APPEND EXAMPLES "delete_volume")
+
+# The executables to build.
+foreach(EXAMPLE IN LISTS EXAMPLES)
+  add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+  target_link_libraries(${EXAMPLE} aws-cpp-sdk-ec2 aws-cpp-sdk-core)
+endforeach()

--- a/cpp/example_code/ebs/attach_volume.cpp
+++ b/cpp/example_code/ebs/attach_volume.cpp
@@ -1,0 +1,58 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/ec2/EC2Client.h>
+#include <aws/ec2/model/AttachVolumeRequest.h>
+#include <aws/ec2/model/AttachVolumeResponse.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 4)
+  {
+    std::cout << "Usage: attach_volume <device_name> <instance_id> <volume_id>"
+              << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String device_name(argv[1]);
+    Aws::String instance_id(argv[2]);
+    Aws::String volume_id(argv[3]);
+
+    Aws::EC2::EC2Client ec2;
+
+    Aws::EC2::Model::AttachVolumeRequest av_req;
+
+    av_req.SetDevice(device_name);
+    av_req.SetInstanceId(instance_id);
+    av_req.SetVolumeId(volume_id);
+
+    auto av_out = ec2.AttachVolume(av_req);
+
+    if (av_out.IsSuccess())
+    {
+      std::cout << "Successfully attached volume at: " << av_out.GetResult().GetAttachTime()
+                << std::endl;
+    }
+    else
+    {
+      std::cout << "Error describing volumes" << av_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ebs/create_volume.cpp
+++ b/cpp/example_code/ebs/create_volume.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/ec2/EC2Client.h>
+#include <aws/ec2/model/CreateVolumeRequest.h>
+#include <aws/ec2/model/CreateVolumeResponse.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: create_volume <az>"
+              << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String az(argv[1]);
+
+    Aws::EC2::EC2Client ec2;
+
+    Aws::EC2::Model::CreateVolumeRequest av_req;
+
+    av_req.SetAvailabilityZone(az);
+
+    auto av_out = ec2.CreateVolume(av_req);
+
+    if (av_out.IsSuccess())
+    {
+      std::cout << "Successfully create volume at: " << av_out.GetResult().GetCreateTime()
+                << " with volume id: " << av_out.GetResult().GetVolumeId() << std::endl;
+    }
+    else
+    {
+      std::cout << "Error creating volume." << av_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ebs/delete_volume.cpp
+++ b/cpp/example_code/ebs/delete_volume.cpp
@@ -1,0 +1,52 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/ec2/EC2Client.h>
+#include <aws/ec2/model/DeleteVolumeRequest.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2)
+  {
+    std::cout << "Usage: delete_volume <volume_id>"
+              << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::String volume_id(argv[1]);
+
+    Aws::EC2::EC2Client ec2;
+
+    Aws::EC2::Model::DeleteVolumeRequest dv_req;
+
+    dv_req.SetVolumeId(volume_id);
+
+    auto dv_out = ec2.DeleteVolume(dv_req);
+
+    if (dv_out.IsSuccess())
+    {
+      std::cout << "Successfully deleted volume. " << std::endl;
+    }
+    else
+    {
+      std::cout << "Error deleting volume." << dv_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}

--- a/cpp/example_code/ebs/describe_volumes.cpp
+++ b/cpp/example_code/ebs/describe_volumes.cpp
@@ -1,0 +1,56 @@
+/*
+   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+    http://aws.amazon.com/apache2.0/
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+#include <aws/core/Aws.h>
+#include <aws/ec2/EC2Client.h>
+#include <aws/ec2/model/DescribeVolumesRequest.h>
+#include <aws/ec2/model/DescribeVolumesResponse.h>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 1)
+  {
+    std::cout << "Usage: describe_volumes" << std::endl;
+    return 1;
+  }
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  {
+    Aws::EC2::EC2Client ec2;
+
+    Aws::EC2::Model::DescribeVolumesRequest dv_req;
+
+    dv_req.SetResourceName(name);
+    dv_req.AddTags(tags);
+
+    auto dv_out = ec2.DescribeVolumes(dv_req);
+
+    if (dv_out.IsSuccess())
+    {
+      std::cout << "Successfully describing volumes as:";
+      for (auto val: dv_out.GetResult().GetVolumes())
+      {
+        std::cout << " " << val;
+      }
+      std::cout << std::endl;
+    }
+    else
+    {
+      std::cout << "Error describing volumes" << dv_out.GetError().GetMessage()
+        << std::endl;
+    }
+  }
+
+  Aws::ShutdownAPI(options);
+  return 0;
+}


### PR DESCRIPTION
ref https://github.com/awsdocs/aws-doc-sdk-examples/issues/187.

This adds example codes for EBS service using CPP SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.