### PR TITLE
Fix typo on example secretsmanager resource policy

### DIFF
--- a/iam_policies/secretsmanager/asm-resource-policy-grant-only-gsv-to-mateo.json
+++ b/iam_policies/secretsmanager/asm-resource-policy-grant-only-gsv-to-mateo.json
@@ -3,7 +3,7 @@
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": {"AWS": arn:aws:iam::123456789012:user/mateo" },
+            "Principal": {"AWS": "arn:aws:iam::123456789012:user/mateo" },
             "Action": "secretsmanager:GetSecretValue",
             "Resource": "*"
         }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
