### PR TITLE
Added Python ACM list_tags_for_certificate() example

### DIFF
--- a/python/example_code/acm/list_tags_for_certificate.py
+++ b/python/example_code/acm/list_tags_for_certificate.py
@@ -1,0 +1,25 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import boto3
+
+
+# Create ACM client
+acm = boto3.client('acm')
+
+# List certificate tags.
+response = acm.list_tags_for_certificate(
+    CertificateArn='arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012'
+)
+for tag in response['Tags']:
+    print(tag)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added Python ACM list_tags_for_certificate() example, API call does not support pagination.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
