### PR TITLE
Set CMAKE_CXX_STANDARD as 11 in cmake.

### DIFF
--- a/cpp/example_code/cloudtrail/CMakeLists.txt
+++ b/cpp/example_code/cloudtrail/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(cloudtrail-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS cloudtrail)

--- a/cpp/example_code/cloudwatch/CMakeLists.txt
+++ b/cpp/example_code/cloudwatch/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(cloudwatch-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS monitoring events logs)

--- a/cpp/example_code/dynamodb/CMakeLists.txt
+++ b/cpp/example_code/dynamodb/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(dynamodb-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS dynamodb)

--- a/cpp/example_code/ebs/CMakeLists.txt
+++ b/cpp/example_code/ebs/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(ebs-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS elasticbeanstalk ec2)

--- a/cpp/example_code/ec2/CMakeLists.txt
+++ b/cpp/example_code/ec2/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(ec2-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS ec2)

--- a/cpp/example_code/glacier/CMakeLists.txt
+++ b/cpp/example_code/glacier/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(glacier-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS glacier)

--- a/cpp/example_code/guardduty/CMakeLists.txt
+++ b/cpp/example_code/guardduty/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(guardduty-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS guardduty)

--- a/cpp/example_code/iam/CMakeLists.txt
+++ b/cpp/example_code/iam/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(iam-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS iam)

--- a/cpp/example_code/kinesis/CMakeLists.txt
+++ b/cpp/example_code/kinesis/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(kinesis-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS kinesis)

--- a/cpp/example_code/lambda/CMakeLists.txt
+++ b/cpp/example_code/lambda/CMakeLists.txt
@@ -12,6 +12,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(lambda-example)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS lambda)

--- a/cpp/example_code/redshift/CMakeLists.txt
+++ b/cpp/example_code/redshift/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(redshift-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS redshift)

--- a/cpp/example_code/s3/CMakeLists.txt
+++ b/cpp/example_code/s3/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(s3-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS s3)

--- a/cpp/example_code/s3encryption/CMakeLists.txt
+++ b/cpp/example_code/s3encryption/CMakeLists.txt
@@ -12,6 +12,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(s3Encryption)
+set (CMAKE_CXX_STANDARD 11)
 
 find_package(AWSSDK REQUIRED COMPONENTS s3-encryption)
 

--- a/cpp/example_code/ses/CMakeLists.txt
+++ b/cpp/example_code/ses/CMakeLists.txt
@@ -7,13 +7,12 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-set (CMAKE_CXX_STANDARD 11)
-
 cmake_minimum_required(VERSION 3.2)
 project(ses-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
-find_package(aws-sdk-cpp)
+find_package(AWSSDK REQUIRED COMPONENTS email)
 
 set(EXAMPLES "")
 list(APPEND EXAMPLES "create_template")

--- a/cpp/example_code/sns/CMakeLists.txt
+++ b/cpp/example_code/sns/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(sns-examples)
+set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS sns)

--- a/cpp/example_code/sqs/CMakeLists.txt
+++ b/cpp/example_code/sqs/CMakeLists.txt
@@ -9,6 +9,8 @@
 
 cmake_minimum_required(VERSION 3.2)
 project(sqs-examples)
+set (CMAKE_CXX_STANDARD 11)
+
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS sqs)
 


### PR DESCRIPTION
*Description of changes:*
Add `set (CMAKE_CXX_STANDARD 11)` for all CMAKEs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
