### PR TITLE
Adding missing AWS import in Go example

### DIFF
--- a/go/example_code/sqs/sqs_listqueues.go
+++ b/go/example_code/sqs/sqs_listqueues.go
@@ -17,6 +17,7 @@ package main
 import (
     "fmt"
 
+    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/sqs"
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add missing library import

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
