### PR TITLE
Add get_console_output script to retrieve instance console output

### DIFF
--- a/python/example_code/ec2/get_console_output.py
+++ b/python/example_code/ec2/get_console_output.py
@@ -1,0 +1,40 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import boto3
+
+import sys
+
+def get_console_output(instance_id):
+    """
+    Using EC2 GetConsoleOutput API according
+        https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetConsoleOutput.html
+    """
+    ec2 = boto3.resource('ec2')
+    ec2_instance = ec2.Instance(instance_id)
+    json_output = ec2_instance.console_output()
+
+    return json_output.get('Output', '')
+
+def main():
+    if len(sys.argv) == 1:
+        print("Usage: {0} <instance-id>".format(sys.argv[0]))
+        sys.exit(1)
+
+    instance_id = sys.argv[1]
+    output = get_console_output(instance_id)
+    print(output)
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
*Description of changes:*

This change add a `boto3` python example to retrieve the EC2 console output using the EC2 REST API function [GetConsoleOutput](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetConsoleOutput.html) 

It's similar to the `get-console-output` command using [awscli](https://github.com/aws/aws-cli/) below:

```
aws ec2 get-console-output --instance-id <instance-id> | jq '.Output'
```

Done for [Hacktoberfest](https://hacktoberfest.digitalocean.com/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
