### PR TITLE
Enhance README for the Java section

### DIFF
--- a/java/README.rst
+++ b/java/README.rst
@@ -75,10 +75,15 @@ Running the examples
 
 To run these examples, you'll need the AWS SDK for Java libraries in your ``CLASSPATH``::
 
-    export CLASSPATH=/path/to/aws-java-sdk/lib/*:/path/to/aws-java-sdk/third-party/lib/*
+    On Unix, run open the command line and execute:
+    export CLASSPATH="/path/to/aws-java-sdk/lib/*:/path/to/aws-java-sdk/third-party/lib/*:$CLASSPATH"
+
+    On Windows, open cmd and execute:
+    set CLASSPATH="path/to/aws-java-sdk/lib/*;path/to/aws-java-sdk/third-party/lib/*;%CLASSPATH%"
 
 Where ``/path/to/aws-java-sdk`` is the path to where you extracted the AWS Java SDK download (it
-contains the ``lib`` and ``third-party/lib`` directories).
+contains the ``lib`` and ``third-party/lib`` directories). For example, the path can be
+``/tmp/aws-java-sdk``, or ``C:\aws-java-sdk``.
 
 Once you set the ``CLASSPATH``, you can run a particular example like this::
 


### PR DESCRIPTION
*Description of changes:*

The Java section needs some improvements. For starters, I'm adding a windows-specific exports for the readme. Most notably:

* Unix uses _export_ to set environment variables, Windows uses _set_
* Unix classpath is divided by _:_, Windows classpath is divided by _;_
* Added example of classpath for each platform

Feel free to ask for corrections.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
