### PR TITLE
Mavenize Download User Doc example

### DIFF
--- a/java/example_code/workdocs/download-user-doc/pom.xml
+++ b/java/example_code/workdocs/download-user-doc/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>aws.example</groupId>
+  <artifactId>aws-workdocs-examples</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0</version>
+  <name>Amazon WorkDocs Examples</name>
+  <url>http://maven.apache.org</url>
+  <properties>
+     <maven.compiler.source>1.8</maven.compiler.source>
+     <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bom</artifactId>
+        <version>1.11.106</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-workdocs</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/java/example_code/workdocs/download-user-doc/src/main/java/aws/example/workdocs/DownloadUserDoc.java
+++ b/java/example_code/workdocs/download-user-doc/src/main/java/aws/example/workdocs/DownloadUserDoc.java
@@ -1,3 +1,5 @@
+package aws.example.workdocs;
+
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
@@ -25,9 +27,9 @@ import com.amazonaws.services.workdocs.model.InitiateDocumentVersionUploadResult
 import com.amazonaws.services.workdocs.model.UploadMetadata;
 import com.amazonaws.services.workdocs.model.User;
 
-public class download_user_doc {
+public class DownloadUserDoc {
 
-	private static String get_user_folder(AmazonWorkDocs workDocs, String orgId, String user) throws Exception {
+	private static String getUserFolder(AmazonWorkDocs workDocs, String orgId, String user) throws Exception {
 		String user_folder = "";
 		List<User> wdUsers = new ArrayList<>();
 		DescribeUsersRequest request = new DescribeUsersRequest();
@@ -62,12 +64,12 @@ public class download_user_doc {
 		return user_folder;
 	}
 
-	private static Map<String, String> get_doc_info(AmazonWorkDocs workDocs, String orgId, String user, String docName) throws Exception {
+	private static Map<String, String> getDocInfo(AmazonWorkDocs workDocs, String orgId, String user, String docName) throws Exception {
 		// Java code: http://docs.aws.amazon.com/workdocs/latest/developerguide/download-documents.html
 		Map<String, String> map = new HashMap<String, String>();
-		String folderId = get_user_folder(workDocs, orgId, user);
+		String folderId = getUserFolder(workDocs, orgId, user);
 
-        if (folderId == "") {
+        if ("".equals(folderId)) {
             System.out.println("Could not get user folder");
         } else {
 
@@ -93,7 +95,7 @@ public class download_user_doc {
 		return map;
 	}
 
-	private static String get_download_doc_url(AmazonWorkDocs workDocs, String docId, String versionId, String doc) {
+	private static String getDownloadDocUrl(AmazonWorkDocs workDocs, String docId, String versionId, String doc) {
 		GetDocumentVersionRequest request = new GetDocumentVersionRequest();
 		request.setDocumentId(docId);
 		request.setVersionId(versionId);
@@ -107,7 +109,7 @@ public class download_user_doc {
 		// Create default client
 		AmazonWorkDocs workDocs = AmazonWorkDocsClientBuilder.defaultClient();
 
-        // Set to the OrganizationId of your WorkDocs site.
+		// Set to the OrganizationId of your WorkDocs site.
 		String orgId = "d-123456789c";
 
 		// Set to the email address of a real user
@@ -116,10 +118,15 @@ public class download_user_doc {
 		// Set to the name of the doc
 		String workdocsName = "test.txt";
 
-        // Set to the full path to the doc
-		String saveDocFullName = "C:\\test.txt";
+		// Set to the full path to the doc
+		String saveDocFullName;
+		if(System.getProperty("os.name").contains("win")) {
+		  saveDocFullName = "C:\\test.txt";
+		} else {
+		  saveDocFullName = "/tmp/test.txt";
+		}
 
-		Map<String, String> map = get_doc_info(workDocs, orgId, userEmail, workdocsName);
+		Map<String, String> map = getDocInfo(workDocs, orgId, userEmail, workdocsName);
 
 		if (map.isEmpty()) {
 			System.out.println("Could not get info about workdoc " + workdocsName);
@@ -129,12 +136,12 @@ public class download_user_doc {
 		String doc_id = map.get("doc_id");
 		String version_id = map.get("version_id");
 
-		if (doc_id == "" || version_id == "") {
+		if ("".equals(doc_id) || "".equals(version_id)) {
 			System.out.println("Could not get info about workdoc " + workdocsName);
 			return;
 		}
 
-		String downloadUrl = get_download_doc_url(workDocs, doc_id, version_id, workdocsName);
+		String downloadUrl = getDownloadDocUrl(workDocs, doc_id, version_id, workdocsName);
 
 		GetDocumentVersionRequest request = new GetDocumentVersionRequest();
 		request.setDocumentId(doc_id);
@@ -143,13 +150,12 @@ public class download_user_doc {
 
 		// Get doc from provided URL
 		URL doc_url = new URL(downloadUrl);
-        URLConnection url_conn = doc_url.openConnection();
+		URLConnection url_conn = doc_url.openConnection();
 
 		final Path destination = Paths.get(saveDocFullName);
 
 		try (final InputStream in = url_conn.getInputStream();) {
 		    Files.copy(in, destination);
-
 		    System.out.println("Downloaded " + workdocsName + " to: "+ saveDocFullName);
 		}
 	}


### PR DESCRIPTION
*Description of changes:* 

In the readme, you mention Maven is available, but the workdocs examples are not mavenized. As such, I will mavenize each example. Most notable changes:

* The dir structure has changed to the default Maven structure
* *pom.xml* has been added such that Maven can build the example
* Fixed whitespace issues
* Fixed naming conventions in the Java class name
* Fixed naming conventions in method names
* Made it Windows independent
* Fixed bug, where String is compared using the `==` sign, which is incorrect, and may lead to buggy behavior. 

Projects can be build by simply issuing `mvn clean package`, as is in the readme. After this PR is merged, I'll gladly Mavenize the rest of the examples.

Thoughts? 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
