### PR TITLE
Generate credential report in Python

### DIFF
--- a/python/example_code/iam/generate_credential_report.py
+++ b/python/example_code/iam/generate_credential_report.py
@@ -1,0 +1,23 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import boto3
+
+
+# Create IAM client
+client = boto3.client('iam')
+
+# Generate credentials report of all users in account
+response = client.generate_credential_report()
+
+print(response)

--- a/python/example_code/iam/get_account_authorization_details
+++ b/python/example_code/iam/get_account_authorization_details
@@ -1,0 +1,20 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import boto3
+
+# Create IAM client
+iam = boto3.client('iam')
+
+account_details = iam.get_account_authorization_details()
+print(account_details)


### PR DESCRIPTION
example code to generate the credentials report. The print statement should actually be taken off as this script should just be generating the report not actually getting it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
