### PR TITLE
reformat to PEP-8 guidelines and add missing __future__ import

### DIFF
--- a/python/example_code/cloudfront/list_distributions.py
+++ b/python/example_code/cloudfront/list_distributions.py
@@ -11,8 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import boto3
+from __future__ import print_function
 
+import boto3
 
 # Create CloudFront client
 cf = boto3.client('cloudfront')
@@ -20,13 +21,16 @@ cf = boto3.client('cloudfront')
 # List distributions
 print("\nCloudFront Distributions:\n")
 distributions=cf.list_distributions()
+
 if distributions['DistributionList']['Quantity'] > 0:
-  for distribution in distributions['DistributionList']['Items']:
-    print("Domain: " + distribution['DomainName'])
-    print("Distribution Id: " + distribution['Id'])
-    print("Certificate Source: " + distribution['ViewerCertificate']['CertificateSource'])
-    if (distribution['ViewerCertificate']['CertificateSource'] == "acm"):
-      print("Certificate: " + distribution['ViewerCertificate']['Certificate'])
-    print("")
-else:    
-  print("Error - No CloudFront Distributions Detected.")
+    for distribution in distributions['DistributionList']['Items']:
+        print("Domain: {}".format(distribution['DomainName']))
+        print("Distribution Id: {}".format(distribution['Id']))
+        print("Certificate Source: {}".format(distribution['ViewerCertificate']['CertificateSource']))
+
+        if distribution['ViewerCertificate']['CertificateSource'] == "acm":
+              print("Certificate: {}".format(distribution['ViewerCertificate']['Certificate']))
+
+        print("")
+else:
+    print("Error - No CloudFront Distributions Detected.")

--- a/python/example_code/cloudfront/list_distributions_paginator.py
+++ b/python/example_code/cloudfront/list_distributions_paginator.py
@@ -11,24 +11,28 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import boto3
+from __future__ import print_function
 
+import boto3
 
 # Create CloudFront client
 cf = boto3.client('cloudfront')
 
 # List distributions with the pagination interface
 print("\nCloudFront Distributions:\n")
+
 paginator = cf.get_paginator('list_distributions')
-for distributionlist in paginator.paginate():
-  if distributionlist['DistributionList']['Quantity'] > 0:
-    for distribution in distributionlist['DistributionList']['Items']:
-      #print(distribution)
-      print("Domain: " + distribution['DomainName'])
-      print("Distribution Id: " + distribution['Id'])
-      print("Certificate Source: " + distribution['ViewerCertificate']['CertificateSource'])
-      if (distribution['ViewerCertificate']['CertificateSource'] == "acm"):
-        print("Certificate ARN: " + distribution['ViewerCertificate']['Certificate'])
-      print("")
-  else:    
-    print("Error - No CloudFront Distributions Detected.")
+
+for distribution_list in paginator.paginate():
+    if distribution_list['DistributionList']['Quantity'] > 0:
+        for distribution in distribution_list['DistributionList']['Items']:
+            print("Domain: {}".format(distribution['DomainName']))
+            print("Distribution Id: {}".format(distribution['Id']))
+            print("Certificate Source: {}".format(distribution['ViewerCertificate']['CertificateSource']))
+
+            if distribution['ViewerCertificate']['CertificateSource'] == "acm":
+                print("Certificate ARN: {}".format(distribution['ViewerCertificate']['Certificate']))
+
+            print("")
+    else:
+        print("Error - No CloudFront Distributions Detected.")


### PR DESCRIPTION
*Description of changes:*

Reformatted Python CloudFront examples to match PEP-8, and include `__future__` imports for Python versions 2.5 and lower.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
