### PR TITLE
Change a wrong value

### DIFF
--- a/javascript/example_code/cognito/cognito_getcreds.html
+++ b/javascript/example_code/cognito/cognito_getcreds.html
@@ -30,7 +30,7 @@
 
 var getIdParams = {
 IdentityPoolId: IDENTITY_POOL_ID,
-AccountId: AWS_ACCOUNT_ID
+AccountId: ACCOUNT_ID
 };
 
 var cognitoidentity = new AWS.CognitoIdentity({apiVersion: '2014-06-30'});


### PR DESCRIPTION
Fix #227

Rename a value of an `AccountId` key form `AWS_ACCOUNT_ID` to `ACCOUNT_ID`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
