### PR TITLE
Trim Container Name Argument in Java example

### DIFF
--- a/java/example_code/mediastore/src/main/java/aws/example/mediastore/CreateContainer.java
+++ b/java/example_code/mediastore/src/main/java/aws/example/mediastore/CreateContainer.java
@@ -61,7 +61,7 @@ public class CreateContainer
     public static Container createContainer(String name) {
         final AWSMediaStore mediastore = AWSMediaStoreClientBuilder.defaultClient();
         final CreateContainerRequest request = new CreateContainerRequest()
-            .withContainerName(name);
+            .withContainerName(name.trim());
         try {
             final CreateContainerResult result = mediastore.createContainer(request);
             return result.getContainer();

--- a/java/example_code/mediastore/src/main/java/aws/example/mediastore/ListItems.java
+++ b/java/example_code/mediastore/src/main/java/aws/example/mediastore/ListItems.java
@@ -87,7 +87,7 @@ public class ListItems
     public static String getContainerEndpoint(String name) {
         final AWSMediaStore mediastore = AWSMediaStoreClientBuilder.defaultClient();
         final DescribeContainerRequest request = new DescribeContainerRequest()
-            .withContainerName(name);
+            .withContainerName(name.trim());
         try {
             final DescribeContainerResult result = mediastore.describeContainer(request);
             return result.getContainer().getEndpoint();

--- a/java/example_code/mediastore/src/main/java/aws/example/mediastore/PutObject.java
+++ b/java/example_code/mediastore/src/main/java/aws/example/mediastore/PutObject.java
@@ -100,7 +100,7 @@ public class PutObject
     public static String getContainerEndpoint(String name) {
         final AWSMediaStore mediastore = AWSMediaStoreClientBuilder.defaultClient();
         final DescribeContainerRequest request = new DescribeContainerRequest()
-            .withContainerName(name);
+            .withContainerName(name.trim());
         try {
             final DescribeContainerResult result = mediastore.describeContainer(request);
             return result.getContainer().getEndpoint();


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Trimmed container name arguments of `createContainer()` and `getContainerEndpoint()` methods in mediastore example classes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
