### PR TITLE
Fixed usage of undefined variable email_address in Ruby example

### DIFF
--- a/ruby/example_code/ses/ses_send_email.rb
+++ b/ruby/example_code/ses/ses_send_email.rb
@@ -83,7 +83,7 @@ begin
     # configuration_set_name: configsetname,
   )
 
-  puts 'Email sent to ' + email_address
+  puts 'Email sent to ' + recipient
 
 
 # If something goes wrong, display an error message.


### PR DESCRIPTION
*Description of changes:*

Replaced it by the defined variable `recipient`, allow the example to run without errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
