### PR TITLE
Use the intended variable and fix typo in the intended variable

### DIFF
--- a/php/example_code/ses/Send_Email.php
+++ b/php/example_code/ses/Send_Email.php
@@ -36,14 +36,14 @@ $html_body = '<h1>AWS Amazon Simple Email Service Test Email</h1>' .
 $subject = 'Amazon SES test (AWS SDK for PHP)';
 $plaintext_body = 'This email was send with Amazon SES using the AWS SDK for PHP.';
 $sender_email = 'email_address';
-$recipeint_emails = ['email_address'];
+$recipient_emails = ['email_address'];
 $char_set = 'UTF-8';
 $configuration_set = 'ConfigSet';
 
 try {
     $result = $SesClient->sendEmail([
         'Destination' => [
-            'ToAddresses' => $verified_recipeint_emails,
+            'ToAddresses' => $recipient_emails,
         ],
         'ReplyToAddresses' => [$sender_email],
         'Source' => $sender_email,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The example code in php/example_code/ses/Send_Email.php didn't work as the $verified_recipeint_emails was undefined and the $recipeint_emails wasn't used. This MR makes it work.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
