### PR TITLE
Added Python enable_guardduty example, creates and or enables Amazon …

### DIFF
--- a/php/example_code/s3/MultipartUplodadStream.php
+++ b/php/example_code/s3/MultipartUplodadStream.php
@@ -22,7 +22,7 @@ require 'vendor/autoload.php';
 
 use Aws\S3\S3Client;
 use Aws\Exception\AwsException;
-use Aws\S3\MultipartCopy;
+use Aws\S3\MultipartUploader;
 use Aws\Exception\MultipartUploadException;
 
 // Create a S3Client
@@ -59,5 +59,5 @@ do {
 //snippet-keyword:[Amazon S3]
 //snippet-service:[s3]
 //snippet-sourcetype:[full-example]
-//snippet-sourcedate:[2018-09-20]
+//snippet-sourcedate:[2019-01-02]
 //snippet-sourceauthor:[jschwarzwalder (AWS)]

--- a/python/example_code/guardduty/create_detector.py
+++ b/python/example_code/guardduty/create_detector.py
@@ -1,0 +1,47 @@
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#snippet-start:[guardduty.python.create_detector.complete]
+import boto3
+
+def create_detector(client):
+    client.create_detector();
+
+region='us-east-1'
+
+# Create GuardDuty client
+gd = boto3.client(
+    service_name='guardduty',
+    region_name=region
+    )
+
+#Get the GuardDuty Detector for the current AWS Region
+detector=gd.list_detectors()
+if len(detector['DetectorIds']) > 0:
+    detector_id = detector['DetectorIds'][0]
+    print('Detector exists in Region ' + region + ' Detector Id: ' + detector_id)
+else:
+    print('GuardDuty Detector does not exist in Region ' + region)
+    print('Creating Detector in ' + region + ' ...')
+    create_detector(gd)
+
+#snippet-end:[guardduty.python.create_detector.complete]
+#snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+#snippet-sourcedescription:[create_detector.py creates Amazon GuardDuty Detector in specified Region.]
+#snippet-keyword:[Python]
+#snippet-keyword:[AWS SDK for Python (Boto3)]
+#snippet-keyword:[Code Sample]
+#snippet-keyword:[Amazon GuardDuty]
+#snippet-service:[guardduty]
+#snippet-sourcetype:[full-example]
+#snippet-sourcedate:[2019-01-02]
+#snippet-sourceauthor:[walkerk1980]

--- a/python/example_code/guardduty/enable_guardduty.py
+++ b/python/example_code/guardduty/enable_guardduty.py
@@ -1,0 +1,67 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import boto3
+
+regions_to_enable='us-east-1 us-west-2'
+
+def create_detector(client):
+    client.create_detector();
+
+def enable_detector(client, detector):
+    client.update_detector(
+        DetectorId=detector,
+        Enable=True
+    )
+try:
+    for region in regions_to_enable.split():
+    # Create GuardDuty client
+    gd = boto3.client(
+        service_name='guardduty',
+        region_name=region
+    )
+    
+    #Get the GuardDuty Detector for the current AWS Region
+    detector=gd.list_detectors()
+    if len(detector['DetectorIds']) > 0:
+        detector_id = detector['DetectorIds'][0]
+        print('Detector exists in Region ' + region + ' Detector Id: ' + detector_id)
+    else:
+        print('GuardDuty Detector does not exist in Region ' + region)
+        print('Creating Detector in ' + region + ' ...')
+        create_detector(client=gd)
+    
+    detector=gd.list_detectors()
+    if len(detector['DetectorIds']) > 0:
+        detector_id = detector['DetectorIds'][0]
+        detector_details = gd.get_detector(DetectorId=detector_id)
+        detector_status = detector_details['Status']
+        print('Detector ID ' + detector_id + ' in Region ' + region + ' is ' + detector_status)
+        if detector_status == 'DISABLED':
+            print('Enabling Detector ' + detector_id + ' in ' + region + ' ...')
+            enable_detector(client=gd,detector=detector_id)
+    else:
+        print('GuardDuty Detector does not exist in Region ' + region)
+except Exception as e:
+    print(e)
+
+#snippet-end:[guardduty.python.enable_guardduty.complete]
+#snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+#snippet-sourcedescription:[enable_guardduty.py creates and or enables Amazon GuardDuty in the specified Regions.]
+#snippet-keyword:[Python]
+#snippet-keyword:[AWS SDK for Python (Boto3)]
+#snippet-keyword:[Code Sample]
+#snippet-keyword:[Amazon GuardDuty]
+#snippet-service:[guardduty]
+#snippet-sourcetype:[full-example]
+#snippet-sourcedate:[2019-01-02]
+#snippet-sourceauthor:[walkerk1980]

--- a/python/example_code/guardduty/enable_guardduty.py
+++ b/python/example_code/guardduty/enable_guardduty.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -22,13 +22,14 @@ def enable_detector(client, detector):
         DetectorId=detector,
         Enable=True
     )
+
 try:
     for region in regions_to_enable.split():
-    # Create GuardDuty client
-    gd = boto3.client(
-        service_name='guardduty',
-        region_name=region
-    )
+        # Create GuardDuty client
+        gd = boto3.client(
+            service_name='guardduty',
+            region_name=region
+        )
     
     #Get the GuardDuty Detector for the current AWS Region
     detector=gd.list_detectors()
@@ -54,7 +55,7 @@ try:
 except Exception as e:
     print(e)
 
-#snippet-end:[guardduty.python.enable_guardduty.complete]
+#snippet-start:[guardduty.python.enable_guardduty.complete]
 #snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 #snippet-sourcedescription:[enable_guardduty.py creates and or enables Amazon GuardDuty in the specified Regions.]
 #snippet-keyword:[Python]

--- a/python/example_code/iam/create_role.py
+++ b/python/example_code/iam/create_role.py
@@ -1,0 +1,71 @@
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License. 
+# snippet-start:[iam.python.create_user.complete]
+
+# Requires boto3 1.9.72
+import boto3, json
+
+# Create IAM client
+iam = boto3.client('iam')
+
+path='/'
+role_name='TestRole1'
+description='A test Role'
+
+trust_policy={
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+
+tags=[
+    {
+        'Key': 'Environment',
+        'Value': 'Production'
+    }
+]
+
+try:
+    response = iam.create_role(
+        Path=path,
+        RoleName=role_name,
+        AssumeRolePolicyDocument=json.dumps(trust_policy),
+        Description=description,
+        MaxSessionDuration=3600,
+        Tags=tags
+    )
+
+    print(response)
+except Exception as e:
+    print(e)
+
+#snippet-start:[iam.python.create_role.complete]
+#snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+#snippet-sourcedescription:[create_role.py demonstrates how to create an IAM Role.]
+#snippet-keyword:[Python]
+#snippet-keyword:[AWS SDK for Python (Boto3)]
+#snippet-keyword:[Code Sample]
+#snippet-keyword:[AWS Identity and Access Management (IAM)]
+#snippet-service:[iam]
+#snippet-sourcetype:[full-example]
+#snippet-sourcedate:[2019-01-02]
+#snippet-sourceauthor:[walkerk1980]
+

--- a/python/example_code/iam/tag_role.py
+++ b/python/example_code/iam/tag_role.py
@@ -1,0 +1,55 @@
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+# 
+# snippet-start:[iam.python.tag_role.complete]
+
+# Requires boto3 1.9.72
+import boto3
+
+
+# Create IAM client
+iam = boto3.client('iam')
+
+role_name='AccountantRole1'
+
+tags=[
+    {
+        'Key': 'Department',
+        'Value': 'Accounting'
+    },
+    {
+        'Key': 'Environment',
+        'Value': 'Production'
+    }
+]
+
+try:
+    response = iam.tag_role(
+        Tags=tags,
+        RoleName=role_name
+    )
+    print(response)
+except Exception as e:
+    print(e)
+    
+#snippet-end[iam.python.tag_role.complete]
+#snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+#snippet-sourcedescription:[tag_role.py demonstrates how to Tag an IAM Role.]
+#snippet-keyword:[Python]
+#snippet-keyword:[AWS SDK for Python (Boto3)]
+#snippet-keyword:[Code Sample]
+#snippet-keyword:[AWS Identity and Access Management (IAM)]
+#snippet-service:[iam]
+#snippet-sourcetype:[full-example]
+#snippet-sourcedate:[2019-01-02]
+#snippet-sourceauthor:[walkerk1980]


### PR DESCRIPTION
…GuardDuty in the specified Regions

*Issue #, if available:*

*Description of changes:*
 Added Python enable_guardduty example, creates and or enables Amazon GuardDuty in the specified Regions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
