### PR TITLE
Fixed bad URL in code comments. Minor changes to Python SMTP code example

### DIFF
--- a/dotnet/example_code/Pinpoint/pinpoint_send_email_message_api.cs
+++ b/dotnet/example_code/Pinpoint/pinpoint_send_email_message_api.cs
@@ -36,7 +36,7 @@ namespace PinpointEmailSendMessageAPI
     {
         // The AWS Region that you want to use to send the email. For a list of
         // AWS Regions where the Amazon Pinpoint API is available, see 
-        // https://alpha-docs-aws.amazon.com/pinpoint/latest/apireference/
+        // https://docs.aws.amazon.com/pinpoint/latest/apireference/
         static string region = "us-west-2";
 
         // The "From" address. This address has to be verified in Amazon Pinpoint 

--- a/dotnet/example_code/Pinpoint/pinpoint_send_sms_message_api.cs
+++ b/dotnet/example_code/Pinpoint/pinpoint_send_sms_message_api.cs
@@ -36,7 +36,7 @@ namespace SendMessage
     {
         // The AWS Region that you want to use to send the message. For a list of
         // AWS Regions where the Amazon Pinpoint API is available, see
-        // https://alpha-docs-aws.amazon.com/pinpoint/latest/apireference/
+        // https://docs.aws.amazon.com/pinpoint/latest/apireference/
         private static readonly string region = "us-east-1";
 
         // The phone number or short code to send the message from. The phone number
@@ -67,7 +67,7 @@ namespace SendMessage
 
         // The sender ID to use when sending the message. Support for sender ID
         // varies by country or region. For more information, see
-        // https://alpha-docs-aws.amazon.com/pinpoint/latest/userguide/channels-sms-countries.html
+        // https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-sms-countries.html
         private static readonly string senderId = "mySenderId";
 
         public static void Main(string[] args)

--- a/javascript/example_code/pinpoint-email/pinpoint_send_email_message_email_api.js
+++ b/javascript/example_code/pinpoint-email/pinpoint_send_email_message_email_api.js
@@ -29,7 +29,7 @@ var AWS = require('aws-sdk');
 
 // The AWS Region that you want to use to send the email. For a list of
 // AWS Regions where the Amazon Pinpoint Email API is available, see
-// https://alpha-docs-aws.amazon.com//pinpoint-email/latest/APIReference
+// https://docs.aws.amazon.com//pinpoint-email/latest/APIReference
 var aws_region = "us-west-2";
 
 // The "From" address. This address has to be verified in Amazon Pinpoint

--- a/javascript/example_code/pinpoint/pinpoint_send_email_message_api.js
+++ b/javascript/example_code/pinpoint/pinpoint_send_email_message_api.js
@@ -29,7 +29,7 @@ const AWS = require('aws-sdk');
 
 // The AWS Region that you want to use to send the email. For a list of
 // AWS Regions where the Amazon Pinpoint API is available, see
-// https://alpha-docs-aws.amazon.com/pinpoint/latest/apireference/
+// https://docs.aws.amazon.com/pinpoint/latest/apireference/
 const aws_region = "us-west-2"
 
 // The "From" address. This address has to be verified in Amazon Pinpoint

--- a/javascript/example_code/pinpoint/pinpoint_send_sms_message_api.js
+++ b/javascript/example_code/pinpoint/pinpoint_send_sms_message_api.js
@@ -29,7 +29,7 @@ var AWS = require('aws-sdk');
 
 // The AWS Region that you want to use to send the message. For a list of
 // AWS Regions where the Amazon Pinpoint API is available, see
-// https://alpha-docs-aws.amazon.com/pinpoint/latest/apireference/.
+// https://docs.aws.amazon.com/pinpoint/latest/apireference/.
 var aws_region = "us-east-1";
 
 // The phone number or short code to send the message from. The phone number
@@ -61,7 +61,7 @@ var registeredKeyword = "myKeyword";
 
 // The sender ID to use when sending the message. Support for sender ID
 // varies by country or region. For more information, see
-// https://alpha-docs-aws.amazon.com/pinpoint/latest/userguide/channels-sms-countries.html
+// https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-sms-countries.html
 var senderId = "MySenderID";
 
 // Specify that you're using a shared credentials file, and optionally specify

--- a/python/example_code/pinpoint/pinpoint_send_email_smtp.py
+++ b/python/example_code/pinpoint/pinpoint_send_email_smtp.py
@@ -21,7 +21,6 @@
 # snippet-start:[pinpoint.python.pinpoint_send_email_smtp.complete]
 
 import smtplib
-import email.utils
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
@@ -119,7 +118,6 @@ try:
         #Uncomment the next line to send SMTP server responses to stdout
         #server.set_debuglevel(1)
         server.sendmail(SENDER, RECIPIENT, msg.as_string())
-        server.quit()
 except Exception as e:
     print ("Error: ", e)
 else:


### PR DESCRIPTION
awsdocs-14607, awsdocs-14605, awsdocs-14604

Removed some unnecessary code from code example that shows how to send email through the Pinpoint SMTP interface using Python. Fixed some broken URLs that were found in the comments for Pinpoint .NET and Java samples.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
