### PR TITLE
Fix broken audio component reload.

### DIFF
--- a/javascript/example_code/browserstart/polly.html
+++ b/javascript/example_code/browserstart/polly.html
@@ -67,10 +67,11 @@
             // Create presigned URL of synthesized speech file
             signer.getSynthesizeSpeechUrl(speechParams, function(error, url) {
             if (error) {
-            document.getElementById('result').innerHTML = error;
+                document.getElementById('result').innerHTML = error;
             } else {
-            audioSource.src = url;
-            document.getElementById('result').innerHTML = "Speech ready to play.";
+                document.getElementById('audioSource').src = url;
+                document.getElementById('audioPlayback').load();
+                document.getElementById('result').innerHTML = "Speech ready to play.";
             }
           });
         }


### PR DESCRIPTION
This example didn't work from Chrome/Safari. Audio source url was changed properly, but the whole component was not reloaded afterwards, making play not working.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
