### PR TITLE
Updated a Pinpoint example, added a new SES example--Java and Python

### DIFF
--- a/java/example_code/pinpoint/pinpoint_create_endpoint.java
+++ b/java/example_code/pinpoint/pinpoint_create_endpoint.java
@@ -31,71 +31,71 @@ import java.util.Arrays;
 
 public class AddExampleEndpoint {
 
-public static void main(String[] args) {
-
-final String USAGE = "\n" +
-	"AddExampleEndpoint - Adds an example endpoint to an Amazon Pinpoint application." +
-	"Usage: AddExampleEndpoint <applicationId>" +
-	"Where:\n" +
-	"  applicationId - The ID of the Amazon Pinpoint application to add the example " +
-	"endpoint to.";
-
-if (args.length < 1) {
-    System.out.println(USAGE);
-    System.exit(1);
-}
-
-String applicationId = args[0];
-
-// The device token assigned to the user's device by Apple Push Notification service (APNs).
-String deviceToken = "1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t1u2v3w4x5y6z7a8b9c0d1e2f";
-
-// Initializes an endpoint definition with channel type and address.
-EndpointRequest wangXiulansIphoneEndpoint = new EndpointRequest()
-	.withChannelType(ChannelType.APNS)
-	.withAddress(deviceToken);
-
-// Adds custom attributes to the endpoint.
-wangXiulansIphoneEndpoint.addAttributesEntry("interests", Arrays.asList(
-	"technology",
-	"music",
-	"travel"));
-
-// Adds custom metrics to the endpoint.
-wangXiulansIphoneEndpoint.addMetricsEntry("technology_interest_level", 9.0);
-wangXiulansIphoneEndpoint.addMetricsEntry("music_interest_level", 6.0);
-wangXiulansIphoneEndpoint.addMetricsEntry("travel_interest_level", 4.0);
-
-// Adds standard demographic attributes.
-wangXiulansIphoneEndpoint.setDemographic(new EndpointDemographic()
-	.withAppVersion("1.0")
-	.withMake("apple")
-	.withModel("iPhone")
-	.withModelVersion("8")
-	.withPlatform("ios")
-	.withPlatformVersion("11.3.1")
-	.withTimezone("America/Los_Angeles"));
-
-// Adds standard location attributes.
-wangXiulansIphoneEndpoint.setLocation(new EndpointLocation()
-	.withCountry("US")
-	.withCity("Seattle")
-	.withPostalCode("98121")
-	.withLatitude(47.61)
-	.withLongitude(-122.33));
-
-// Initializes the Amazon Pinpoint client.
-AmazonPinpoint pinpointClient = AmazonPinpointClientBuilder.standard()
-	.withRegion(Regions.US_EAST_1).build();
-
-// Updates or creates the endpoint with Amazon Pinpoint.
-UpdateEndpointResult result = pinpointClient.updateEndpoint(new UpdateEndpointRequest()
-	.withApplicationId(applicationId)
-	.withEndpointId("example_endpoint")
-	.withEndpointRequest(wangXiulansIphoneEndpoint));
-
-System.out.format("Update endpoint result: %s\n", result.getMessageBody().getMessage());
-
-}
+	public static void main(String[] args) {
+	
+		final String USAGE = "\n" +
+			"AddExampleEndpoint - Adds an example endpoint to an Amazon Pinpoint application." +
+			"Usage: AddExampleEndpoint <applicationId>" +
+			"Where:\n" +
+			"  applicationId - The ID of the Amazon Pinpoint application to add the example " +
+			"endpoint to.";
+		
+		if (args.length < 1) {
+		    System.out.println(USAGE);
+		    System.exit(1);
+		}
+		
+		String applicationId = args[0];
+		
+		// The device token assigned to the user's device by Apple Push Notification service (APNs).
+		String deviceToken = "1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t1u2v3w4x5y6z7a8b9c0d1e2f";
+		
+		// Initializes an endpoint definition with channel type and address.
+		EndpointRequest wangXiulansIphoneEndpoint = new EndpointRequest()
+			.withChannelType(ChannelType.APNS)
+			.withAddress(deviceToken);
+		
+		// Adds custom attributes to the endpoint.
+		wangXiulansIphoneEndpoint.addAttributesEntry("interests", Arrays.asList(
+			"technology",
+			"music",
+			"travel"));
+		
+		// Adds custom metrics to the endpoint.
+		wangXiulansIphoneEndpoint.addMetricsEntry("technology_interest_level", 9.0);
+		wangXiulansIphoneEndpoint.addMetricsEntry("music_interest_level", 6.0);
+		wangXiulansIphoneEndpoint.addMetricsEntry("travel_interest_level", 4.0);
+		
+		// Adds standard demographic attributes.
+		wangXiulansIphoneEndpoint.setDemographic(new EndpointDemographic()
+			.withAppVersion("1.0")
+			.withMake("apple")
+			.withModel("iPhone")
+			.withModelVersion("8")
+			.withPlatform("ios")
+			.withPlatformVersion("11.3.1")
+			.withTimezone("America/Los_Angeles"));
+		
+		// Adds standard location attributes.
+		wangXiulansIphoneEndpoint.setLocation(new EndpointLocation()
+			.withCountry("US")
+			.withCity("Seattle")
+			.withPostalCode("98121")
+			.withLatitude(47.61)
+			.withLongitude(-122.33));
+		
+		// Initializes the Amazon Pinpoint client.
+		AmazonPinpoint pinpointClient = AmazonPinpointClientBuilder.standard()
+			.withRegion(Regions.US_EAST_1).build();
+		
+		// Updates or creates the endpoint with Amazon Pinpoint.
+		UpdateEndpointResult result = pinpointClient.updateEndpoint(new UpdateEndpointRequest()
+			.withApplicationId(applicationId)
+			.withEndpointId("example_endpoint")
+			.withEndpointRequest(wangXiulansIphoneEndpoint));
+		
+		System.out.format("Update endpoint result: %s\n", result.getMessageBody().getMessage());
+	
+	}
 }
 // snippet-end:[pinpoint.java.pinpoint_create_endpoint.complete]

--- a/python/example_code/ses/ses_generate_smtp_credentials.py
+++ b/python/example_code/ses/ses_generate_smtp_credentials.py
@@ -1,0 +1,68 @@
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# snippet-sourcedescription:[ses_generate_smtp_credentials.py demonstrates how to convert an IAM Secret Access Key into a password that you can use to connect to the Amazon SES SMTP interface.]
+# snippet-service:[ses]
+# snippet-keyword:[python]
+# snippet-keyword:[Amazon SES]
+# snippet-keyword:[Code Sample]
+# snippet-sourcetype:[full-example]
+# snippet-sourcedate:[2019-02-06]
+# snippet-sourceauthor:[AWS]
+# snippet-start:[ses.python.ses_generate_smtp_credentials.complete]
+
+#!/usr/bin/env python3
+
+import hmac
+import hashlib
+import base64
+import argparse
+
+# Values that are required to calculate the signature. These values should
+# never change.
+DATE = "11111111"
+SERVICE = "ses"
+MESSAGE = "SendRawEmail"
+TERMINAL = "aws4_request"
+VERSION = 0x04
+
+def sign(key, msg):
+    return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
+
+def calculateKey(secretAccessKey, region):
+    signature = sign(("AWS4" + secretAccessKey).encode('utf-8'), DATE)
+    signature = sign(signature, region)
+    signature = sign(signature, SERVICE)
+    signature = sign(signature, TERMINAL)
+    signature = sign(signature, MESSAGE)
+    signatureAndVersion = bytes([VERSION]) + signature
+    smtpPassword = base64.b64encode(signatureAndVersion)
+    print(smtpPassword.decode('utf-8'))
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert a Secret Access Key for an IAM user to an SMTP password.')
+    parser.add_argument('--secret',
+            help='The Secret Access Key that you want to convert.',
+            required=True,
+            action="store")
+    parser.add_argument('--region',
+            help='The name of the AWS Region that the SMTP password will be used in.',
+            required=True,
+            choices=['us-east-1','us-west-2','eu-west-1'],
+            action="store")
+    args = parser.parse_args()
+
+    calculateKey(args.secret,args.region)
+
+main()
+
+# snippet-end:[ses.python.ses_generate_smtp_credentials.complete]


### PR DESCRIPTION
Added a code example for converting an IAM Secret Access Key to a password that you can use to sign in to the Amazon SES SMTP interfacee. Fixed broken indentation in Pinpoint create an endpoint example.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.