### PR TITLE
Moving S3 Java and Ruby code samples to the AWS code catalog

### DIFF
--- a/java/example_code/s3/src/main/java/CORS.java
+++ b/java/example_code/s3/src/main/java/CORS.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[CORS.java demonstrates how to set, get, and delete S3 bucket cross-origin resource sharing configurations.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Bucket cors]
+// snippet-keyword:[PUT Bucket cors]
+// snippet-keyword:[DELETE Bucket cors]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.cors.complete]
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.BucketCrossOriginConfiguration;
+import com.amazonaws.services.s3.model.CORSRule;
+
+public class CORS {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+
+        // Create two CORS rules.
+        List<CORSRule.AllowedMethods> rule1AM = new ArrayList<CORSRule.AllowedMethods>();
+        rule1AM.add(CORSRule.AllowedMethods.PUT);
+        rule1AM.add(CORSRule.AllowedMethods.POST);
+        rule1AM.add(CORSRule.AllowedMethods.DELETE);
+        CORSRule rule1 = new CORSRule().withId("CORSRule1").withAllowedMethods(rule1AM)
+                .withAllowedOrigins(Arrays.asList(new String[] { "http://*.example.com" }));
+
+        List<CORSRule.AllowedMethods> rule2AM = new ArrayList<CORSRule.AllowedMethods>();
+        rule2AM.add(CORSRule.AllowedMethods.GET);
+        CORSRule rule2 = new CORSRule().withId("CORSRule2").withAllowedMethods(rule2AM)
+                .withAllowedOrigins(Arrays.asList(new String[] { "*" })).withMaxAgeSeconds(3000)
+                .withExposedHeaders(Arrays.asList(new String[] { "x-amz-server-side-encryption" }));
+
+        List<CORSRule> rules = new ArrayList<CORSRule>();
+        rules.add(rule1);
+        rules.add(rule2);
+
+        // Add the rules to a new CORS configuration.
+        BucketCrossOriginConfiguration configuration = new BucketCrossOriginConfiguration();
+        configuration.setRules(rules);
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+            
+            // Add the configuration to the bucket.
+            s3Client.setBucketCrossOriginConfiguration(bucketName, configuration);
+    
+            // Retrieve and display the configuration.
+            configuration = s3Client.getBucketCrossOriginConfiguration(bucketName);
+            printCORSConfiguration(configuration);
+    
+            // Add another new rule.
+            List<CORSRule.AllowedMethods> rule3AM = new ArrayList<CORSRule.AllowedMethods>();
+            rule3AM.add(CORSRule.AllowedMethods.HEAD);
+            CORSRule rule3 = new CORSRule().withId("CORSRule3").withAllowedMethods(rule3AM)
+                    .withAllowedOrigins(Arrays.asList(new String[] { "http://www.example.com" }));
+    
+            rules = configuration.getRules();
+            rules.add(rule3);
+            configuration.setRules(rules);
+            s3Client.setBucketCrossOriginConfiguration(bucketName, configuration);
+    
+            // Verify that the new rule was added by checking the number of rules in the configuration.
+            configuration = s3Client.getBucketCrossOriginConfiguration(bucketName);
+            System.out.println("Expected # of rules = 3, found " + configuration.getRules().size());
+    
+            // Delete the configuration.
+            s3Client.deleteBucketCrossOriginConfiguration(bucketName);
+            System.out.println("Removed CORS configuration.");
+    
+            // Retrieve and display the configuration to verify that it was
+            // successfully deleted.
+            configuration = s3Client.getBucketCrossOriginConfiguration(bucketName);
+            printCORSConfiguration(configuration);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+
+    private static void printCORSConfiguration(BucketCrossOriginConfiguration configuration) {
+        if (configuration == null) {
+            System.out.println("Configuration is null.");
+        } else {
+            System.out.println("Configuration has " + configuration.getRules().size() + " rules\n");
+
+            for (CORSRule rule : configuration.getRules()) {
+                System.out.println("Rule ID: " + rule.getId());
+                System.out.println("MaxAgeSeconds: " + rule.getMaxAgeSeconds());
+                System.out.println("AllowedMethod: " + rule.getAllowedMethods());
+                System.out.println("AllowedOrigins: " + rule.getAllowedOrigins());
+                System.out.println("AllowedHeaders: " + rule.getAllowedHeaders());
+                System.out.println("ExposeHeader: " + rule.getExposedHeaders());
+                System.out.println();
+            }
+        }
+    }
+}
+
+// snippet-end:[s3.java.cors.complete]

--- a/java/example_code/s3/src/main/java/CopyObjectSingleOperation.java
+++ b/java/example_code/s3/src/main/java/CopyObjectSingleOperation.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[CopyObjectSingleOperation.java demonstrates how to perform a simple copy of an S3 object within a single bucket.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.copy_object_single_operation.complete]
+
+import java.io.IOException;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+
+public class CopyObjectSingleOperation {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String sourceKey = "*** Source object key *** ";
+        String destinationKey = "*** Destination object key ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Copy the object into a new object in the same bucket.
+            CopyObjectRequest copyObjRequest = new CopyObjectRequest(bucketName, sourceKey, bucketName, destinationKey);
+            s3Client.copyObject(copyObjRequest);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client  
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.copy_object_single_operation.complete]

--- a/java/example_code/s3/src/main/java/CreateBucket.java
+++ b/java/example_code/s3/src/main/java/CreateBucket.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[CreateBucket.java demonstrates how to create a new S3 bucket.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Bucket]
+// snippet-keyword:[HEAD Bucket]
+// snippet-keyword:[GET Bucket location]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.create_bucket.complete]
+
+import java.io.IOException;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CreateBucketRequest;
+import com.amazonaws.services.s3.model.GetBucketLocationRequest;
+
+public class CreateBucket {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            if (!s3Client.doesBucketExistV2(bucketName)) {
+                // Because the CreateBucketRequest object doesn't specify a region, the
+                // bucket is created in the region specified in the client.
+                s3Client.createBucket(new CreateBucketRequest(bucketName));
+                
+                // Verify that the bucket was created by retrieving it and checking its location.
+                String bucketLocation = s3Client.getBucketLocation(new GetBucketLocationRequest(bucketName));
+                System.out.println("Bucket location: " + bucketLocation);
+            }
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it and returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.create_bucket.complete]

--- a/java/example_code/s3/src/main/java/CreateBucketWithACL.java
+++ b/java/example_code/s3/src/main/java/CreateBucketWithACL.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[CreateBucketWithACL.java demonstrates how to create a bucket with a canned ACL and how to modify a bucket's ACL grants.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Bucket acl]
+// snippet-keyword:[PUT Bucket acl]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.create_bucket_with_acl.complete]
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.CanonicalGrantee;
+import com.amazonaws.services.s3.model.CreateBucketRequest;
+import com.amazonaws.services.s3.model.EmailAddressGrantee;
+import com.amazonaws.services.s3.model.Grant;
+import com.amazonaws.services.s3.model.GroupGrantee;
+import com.amazonaws.services.s3.model.Permission;
+
+public class CreateBucketWithACL {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String userEmailForReadPermission = "*** user@example.com ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Create a bucket with a canned ACL. This ACL will be replaced by the setBucketAcl()
+            // calls below. It is included here for demonstration purposes.
+            CreateBucketRequest createBucketRequest = new CreateBucketRequest(bucketName, clientRegion)
+                    .withCannedAcl(CannedAccessControlList.LogDeliveryWrite);
+            s3Client.createBucket(createBucketRequest);
+    
+            // Create a collection of grants to add to the bucket.
+            ArrayList<Grant> grantCollection = new ArrayList<Grant>();
+            
+            // Grant the account owner full control.
+            Grant grant1 = new Grant(new CanonicalGrantee(s3Client.getS3AccountOwner().getId()), Permission.FullControl);
+            grantCollection.add(grant1);
+    
+            // Grant the LogDelivery group permission to write to the bucket.
+            Grant grant2 = new Grant(GroupGrantee.LogDelivery, Permission.Write);
+            grantCollection.add(grant2);
+    
+            // Save grants by replacing all current ACL grants with the two we just created.
+            AccessControlList bucketAcl = new AccessControlList();
+            bucketAcl.grantAllPermissions(grantCollection.toArray(new Grant[0]));
+            s3Client.setBucketAcl(bucketName, bucketAcl);
+            
+            // Retrieve the bucket's ACL, add another grant, and then save the new ACL.
+            AccessControlList newBucketAcl = s3Client.getBucketAcl(bucketName);
+            Grant grant3 = new Grant(new EmailAddressGrantee(userEmailForReadPermission), Permission.Read);
+            newBucketAcl.grantAllPermissions(grant3);
+            s3Client.setBucketAcl(bucketName, newBucketAcl);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it and returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.create_bucket_with_acl.complete]

--- a/java/example_code/s3/src/main/java/CrossRegionReplication.java
+++ b/java/example_code/s3/src/main/java/CrossRegionReplication.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[CrossRegionReplication.java demonstrates how to set and get cross-region replication rules.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Bucket replication]
+// snippet-keyword:[GET Bucket replication]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.cross_region_replication.complete]
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.BucketReplicationConfiguration;
+import com.amazonaws.services.s3.model.ReplicationDestinationConfig;
+import com.amazonaws.services.s3.model.ReplicationRule;
+import com.amazonaws.services.s3.model.ReplicationRuleStatus;
+import com.amazonaws.services.s3.model.StorageClass;
+
+public class CrossRegionReplication {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String accountId = "*** Account ID ***";
+        String roleName = "*** Role name ***";
+        String sourceBucketName = "*** Source bucket name ***";
+        String destBucketName = "*** Destination bucket name ***";
+        String prefix = "Tax/";
+        
+        String roleARN = String.format("arn:aws:iam::%s:role/%s", accountId, roleName);
+        String destinationBucketARN = "arn:aws:s3:::" + destBucketName;
+   
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Create the replication rule.
+            List<ReplicationFilterPredicate> andOperands = new ArrayList<ReplicationFilterPredicate>();
+            andOperands.add(new ReplicationPrefixPredicate("prefix"));
+
+            
+            Map<String, ReplicationRule> replicationRules = new HashMap<String, ReplicationRule>();
+            replicationRules.put("ReplicationRule1",
+                                 new ReplicationRule()
+                                     .withPriority(0)
+                                     .withStatus(ReplicationRuleStatus.Enabled)
+                                     .withDeleteMarkerReplication(new DeleteMarkerReplication().withStatus(DeleteMarkerReplicationStatus.DISABLED))
+                                     .withFilter(new ReplicationFilter().withPredicate(new ReplicationAndOperator(andOperands)))
+                                     .withDestinationConfig(new ReplicationDestinationConfig()
+                                                                     .withBucketARN(destinationBucketARN)
+                                                                     .withStorageClass(StorageClass.Standard)));
+            
+            // Save the replication rule to the source bucket.
+            s3Client.setBucketReplicationConfiguration(sourceBucketName,
+                                                       new BucketReplicationConfiguration()
+                                                               .withRoleARN(roleARN)
+                                                               .withRules(replicationRules));
+    
+            // Retrieve the replication configuration and verify that the configuration
+            // matches the rule we just set.
+            BucketReplicationConfiguration replicationConfig = s3Client.getBucketReplicationConfiguration(sourceBucketName);
+            ReplicationRule rule = replicationConfig.getRule("ReplicationRule1");
+            System.out.println("Retrieved destination bucket ARN: " + rule.getDestinationConfig().getBucketARN());
+            System.out.println("Retrieved source-bucket replication rule prefix: " + rule.getPrefix());
+            System.out.println("Retrieved source-bucket replication rule status: " + rule.getStatus());
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.cross_region_replication.complete]

--- a/java/example_code/s3/src/main/java/DeleteBucket.java
+++ b/java/example_code/s3/src/main/java/DeleteBucket.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[DeleteBucket.java demonstrates how to empty and then delete an S3 bucket.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[DELETE Bucket]
+// snippet-keyword:[GET Bucket]
+// snippet-keyword:[DELETE Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.delete_bucket.complete]
+
+import java.util.Iterator;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ListVersionsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.services.s3.model.S3VersionSummary;
+import com.amazonaws.services.s3.model.VersionListing;
+
+public class DeleteBucket {
+
+    public static void main(String[] args) {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+    
+            // Delete all objects from the bucket. This is sufficient
+            // for unversioned buckets. For versioned buckets, when you attempt to delete objects, Amazon S3 inserts
+            // delete markers for all objects, but doesn't delete the object versions.
+            // To delete objects from versioned buckets, delete all of the object versions before deleting
+            // the bucket (see below for an example).
+            ObjectListing objectListing = s3Client.listObjects(bucketName);
+            while (true) {
+                Iterator<S3ObjectSummary> objIter = objectListing.getObjectSummaries().iterator();
+                while (objIter.hasNext()) {
+                    s3Client.deleteObject(bucketName, objIter.next().getKey());
+                }
+    
+                // If the bucket contains many objects, the listObjects() call
+                // might not return all of the objects in the first listing. Check to
+                // see whether the listing was truncated. If so, retrieve the next page of objects 
+                // and delete them.
+                if (objectListing.isTruncated()) {
+                    objectListing = s3Client.listNextBatchOfObjects(objectListing);
+                } else {
+                    break;
+                }
+            }
+    
+            // Delete all object versions (required for versioned buckets).
+            VersionListing versionList = s3Client.listVersions(new ListVersionsRequest().withBucketName(bucketName));
+            while (true) {
+                Iterator<S3VersionSummary> versionIter = versionList.getVersionSummaries().iterator();
+                while (versionIter.hasNext()) {
+                    S3VersionSummary vs = versionIter.next();
+                    s3Client.deleteVersion(bucketName, vs.getKey(), vs.getVersionId());
+                }
+    
+                if (versionList.isTruncated()) {
+                    versionList = s3Client.listNextBatchOfVersions(versionList);
+                } else {
+                    break;
+                }
+            }
+    
+            // After all objects and object versions are deleted, delete the bucket.
+            s3Client.deleteBucket(bucketName);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client couldn't
+            // parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.delete_bucket.complete]

--- a/java/example_code/s3/src/main/java/DeleteMultipleObjectsNonVersionedBucket.java
+++ b/java/example_code/s3/src/main/java/DeleteMultipleObjectsNonVersionedBucket.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[DeleteMultipleObjectsNonVersionedBucket.java demonstrates how to delete multiple S3 objects from a non-versioned bucket.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[DELETE Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.delete_multiple_objects_non_versioned_bucket.complete]
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
+import com.amazonaws.services.s3.model.DeleteObjectsResult;
+
+public class DeleteMultipleObjectsNonVersionedBucket {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Upload three sample objects.
+            ArrayList<KeyVersion> keys = new ArrayList<KeyVersion>();
+            for (int i = 0; i < 3; i++) {
+                String keyName = "delete object example " + i;
+                s3Client.putObject(bucketName, keyName, "Object number " + i + " to be deleted.");
+                keys.add(new KeyVersion(keyName));
+            }
+            System.out.println(keys.size() + " objects successfully created.");
+    
+            // Delete the sample objects.
+            DeleteObjectsRequest multiObjectDeleteRequest = new DeleteObjectsRequest(bucketName)
+                                                                    .withKeys(keys)
+                                                                    .withQuiet(false);
+    
+            // Verify that the objects were deleted successfully.
+            DeleteObjectsResult delObjRes = s3Client.deleteObjects(multiObjectDeleteRequest);
+            int successfulDeletes = delObjRes.getDeletedObjects().size();
+            System.out.println(successfulDeletes + " objects successfully deleted.");
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.delete_multiple_objects_non_versioned_bucket.complete]

--- a/java/example_code/s3/src/main/java/DeleteMultipleObjectsVersionEnabledBucket.java
+++ b/java/example_code/s3/src/main/java/DeleteMultipleObjectsVersionEnabledBucket.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[DeleteMultipleObjectsVersionEnabledBucket.java demonstrates how to delete S3 object versions and remove delete markers from objects in versioned S3 buckets.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[DELETE Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.delete_multiple_objects_version_enabled_bucket.complete]
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.BucketVersioningConfiguration;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
+import com.amazonaws.services.s3.model.DeleteObjectsResult;
+import com.amazonaws.services.s3.model.DeleteObjectsResult.DeletedObject;
+import com.amazonaws.services.s3.model.PutObjectResult;
+
+public class DeleteMultipleObjectsVersionEnabledBucket {
+    private static AmazonS3 S3_CLIENT;
+    private static String VERSIONED_BUCKET_NAME;
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        VERSIONED_BUCKET_NAME = "*** Bucket name ***";
+        
+        try {
+            S3_CLIENT = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Check to make sure that the bucket is versioning-enabled.
+            String bucketVersionStatus = S3_CLIENT.getBucketVersioningConfiguration(VERSIONED_BUCKET_NAME).getStatus();
+            if(!bucketVersionStatus.equals(BucketVersioningConfiguration.ENABLED)) {
+                System.out.printf("Bucket %s is not versioning-enabled.", VERSIONED_BUCKET_NAME);
+            }
+            else {
+                // Upload and delete sample objects, using specific object versions.
+                uploadAndDeleteObjectsWithVersions();
+        
+                // Upload and delete sample objects without specifying version IDs.
+                // Amazon S3 creates a delete marker for each object rather than deleting
+                // specific versions.
+                DeleteObjectsResult unversionedDeleteResult = uploadAndDeleteObjectsWithoutVersions();
+        
+                // Remove the delete markers placed on objects in the non-versioned create/delete method.
+                multiObjectVersionedDeleteRemoveDeleteMarkers(unversionedDeleteResult);
+            }
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+
+    private static void uploadAndDeleteObjectsWithVersions() {
+        System.out.println("Uploading and deleting objects with versions specified.");
+
+        // Upload three sample objects.
+        ArrayList<KeyVersion> keys = new ArrayList<KeyVersion>();
+        for (int i = 0; i < 3; i++) {
+            String keyName = "delete object without version ID example " + i;
+            PutObjectResult putResult = S3_CLIENT.putObject(VERSIONED_BUCKET_NAME, keyName,
+                    "Object number " + i + " to be deleted.");
+            // Gather the new object keys with version IDs.
+            keys.add(new KeyVersion(keyName, putResult.getVersionId()));
+        }
+
+        // Delete the specified versions of the sample objects.
+        DeleteObjectsRequest multiObjectDeleteRequest = new DeleteObjectsRequest(VERSIONED_BUCKET_NAME)
+                .withKeys(keys)
+                .withQuiet(false);
+
+        // Verify that the object versions were successfully deleted.
+        DeleteObjectsResult delObjRes = S3_CLIENT.deleteObjects(multiObjectDeleteRequest);
+        int successfulDeletes = delObjRes.getDeletedObjects().size();
+        System.out.println(successfulDeletes + " objects successfully deleted");
+    }
+
+    private static DeleteObjectsResult uploadAndDeleteObjectsWithoutVersions() {
+        System.out.println("Uploading and deleting objects with no versions specified.");
+
+        // Upload three sample objects.
+        ArrayList<KeyVersion> keys = new ArrayList<KeyVersion>();
+        for (int i = 0; i < 3; i++) {
+            String keyName = "delete object with version ID example " + i;
+            S3_CLIENT.putObject(VERSIONED_BUCKET_NAME, keyName, "Object number " + i + " to be deleted.");
+            // Gather the new object keys without version IDs.
+            keys.add(new KeyVersion(keyName));
+        }
+
+        // Delete the sample objects without specifying versions.
+        DeleteObjectsRequest multiObjectDeleteRequest = new DeleteObjectsRequest(VERSIONED_BUCKET_NAME).withKeys(keys)
+                .withQuiet(false);
+
+        // Verify that delete markers were successfully added to the objects.
+        DeleteObjectsResult delObjRes = S3_CLIENT.deleteObjects(multiObjectDeleteRequest);
+        int successfulDeletes = delObjRes.getDeletedObjects().size();
+        System.out.println(successfulDeletes + " objects successfully marked for deletion without versions.");
+        return delObjRes;
+    }
+
+    private static void multiObjectVersionedDeleteRemoveDeleteMarkers(DeleteObjectsResult response) {
+        List<KeyVersion> keyList = new ArrayList<KeyVersion>();
+        for (DeletedObject deletedObject : response.getDeletedObjects()) {
+            // Note that the specified version ID is the version ID for the delete marker.
+            keyList.add(new KeyVersion(deletedObject.getKey(), deletedObject.getDeleteMarkerVersionId()));
+        }
+        // Create a request to delete the delete markers.
+        DeleteObjectsRequest deleteRequest = new DeleteObjectsRequest(VERSIONED_BUCKET_NAME).withKeys(keyList);
+
+        // Delete the delete markers, leaving the objects intact in the bucket.
+        DeleteObjectsResult delObjRes = S3_CLIENT.deleteObjects(deleteRequest);
+        int successfulDeletes = delObjRes.getDeletedObjects().size();
+        System.out.println(successfulDeletes + " delete markers successfully deleted");
+    }
+}
+
+// snippet-end:[s3.java.delete_multiple_objects_version_enabled_bucket.complete]

--- a/java/example_code/s3/src/main/java/DeleteObjectNonVersionedBucket.java
+++ b/java/example_code/s3/src/main/java/DeleteObjectNonVersionedBucket.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[DeleteObjectNonVersionedBucket.java demonstrates how to delete an S3 object from a non-versioned bucket.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[DELETE Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.delete_object_non_versioned_bucket.complete]
+
+import java.io.IOException;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+
+public class DeleteObjectNonVersionedBucket {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String keyName = "*** Key name ****";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            s3Client.deleteObject(new DeleteObjectRequest(bucketName, keyName));
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.delete_object_non_versioned_bucket.complete]

--- a/java/example_code/s3/src/main/java/DeleteObjectVersionEnabledBucket.java
+++ b/java/example_code/s3/src/main/java/DeleteObjectVersionEnabledBucket.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[DeleteObjectVersionEnabledBucket.java demonstrates how to delete an S3 object version from a version-enabled bucket.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[DELETE Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.delete_object_version_enabled_bucket.complete]
+
+import java.io.IOException;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.BucketVersioningConfiguration;
+import com.amazonaws.services.s3.model.DeleteVersionRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+
+public class DeleteObjectVersionEnabledBucket {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String keyName = "*** Key name ****";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Check to ensure that the bucket is versioning-enabled.
+            String bucketVersionStatus = s3Client.getBucketVersioningConfiguration(bucketName).getStatus();
+            if(!bucketVersionStatus.equals(BucketVersioningConfiguration.ENABLED)) {
+                System.out.printf("Bucket %s is not versioning-enabled.", bucketName);
+            }
+            else {
+                // Add an object.
+                PutObjectResult putResult = s3Client.putObject(bucketName, keyName, "Sample content for deletion example.");
+                System.out.printf("Object %s added to bucket %s\n", keyName, bucketName);
+        
+                // Delete the version of the object that we just created.
+                System.out.println("Deleting versioned object " + keyName);
+                s3Client.deleteVersion(new DeleteVersionRequest(bucketName, keyName, putResult.getVersionId()));
+                System.out.printf("Object %s, version %s deleted\n", keyName, putResult.getVersionId());
+            }
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.delete_object_version_enabled_bucket.complete]

--- a/java/example_code/s3/src/main/java/DualStackEndpoints.java
+++ b/java/example_code/s3/src/main/java/DualStackEndpoints.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[DualStackEndpoints.java demonstrates how to create an S3 client with dual-stack endpoints enabled.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Bucket]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.dual_stack_endpoints.complete]
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+public class DualStackEndpoints {
+
+    public static void main(String[] args) {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+
+        try {
+            // Create an Amazon S3 client with dual-stack endpoints enabled.
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .withDualstackEnabled(true)
+                    .build();
+
+            s3Client.listObjects(bucketName);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.dual_stack_endpoints.complete]

--- a/java/example_code/s3/src/main/java/EnableNotificationOnABucket.java
+++ b/java/example_code/s3/src/main/java/EnableNotificationOnABucket.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[EnableNotificationsOnABucket.java demonstrates how to configure an S3 bucket to work with Amazon Simple Notification Service and Simple Queue Service.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Bucket notification]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.enable_notification_on_a_bucket.complete]
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.BucketNotificationConfiguration;
+import com.amazonaws.services.s3.model.TopicConfiguration;
+import com.amazonaws.services.s3.model.QueueConfiguration;
+import com.amazonaws.services.s3.model.S3Event;
+import com.amazonaws.services.s3.model.SetBucketNotificationConfigurationRequest;
+
+public class EnableNotificationOnABucket {
+
+    public static void main(String[] args) throws IOException {
+        String bucketName = "*** Bucket name ***";
+        String clientRegion = "*** Client region ***";
+        String snsTopicARN = "*** SNS Topic ARN ***";
+        String sqsQueueARN = "*** SQS Queue ARN ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+            BucketNotificationConfiguration notificationConfiguration = new BucketNotificationConfiguration();
+
+            // Add an SNS topic notification.
+            notificationConfiguration.addConfiguration("snsTopicConfig",
+                    new TopicConfiguration(snsTopicARN, EnumSet.of(S3Event.ObjectCreated)));
+
+            // Add an SQS queue notification.
+            notificationConfiguration.addConfiguration("sqsQueueConfig",
+                    new QueueConfiguration(sqsQueueARN, EnumSet.of(S3Event.ObjectCreated)));
+            
+            // Create the notification configuration request and set the bucket notification configuration.
+            SetBucketNotificationConfigurationRequest request = new SetBucketNotificationConfigurationRequest(
+                    bucketName, notificationConfiguration);
+            s3Client.setBucketNotificationConfiguration(request);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+//snippet-end:[s3.java.enable_notification_on_a_bucket.complete]

--- a/java/example_code/s3/src/main/java/GeneratePresignedURL.java
+++ b/java/example_code/s3/src/main/java/GeneratePresignedURL.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[GeneratePresignedURL.java demonstrates how to generate a presigned URL with the S3 Java SDK.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.generate_presigned_url.complete]
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.HttpMethod;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+
+public class GeneratePresignedURL {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String objectKey = "*** Object key ***";
+
+        try {            
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withRegion(clientRegion)
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .build();
+    
+            // Set the presigned URL to expire after one hour.
+            java.util.Date expiration = new java.util.Date();
+            long expTimeMillis = expiration.getTime();
+            expTimeMillis += 1000 * 60 * 60;
+            expiration.setTime(expTimeMillis);
+
+            // Generate the presigned URL.
+            System.out.println("Generating pre-signed URL.");
+            GeneratePresignedUrlRequest generatePresignedUrlRequest = 
+                    new GeneratePresignedUrlRequest(bucketName, objectKey)
+                    .withMethod(HttpMethod.GET)
+                    .withExpiration(expiration);
+            URL url = s3Client.generatePresignedUrl(generatePresignedUrlRequest);
+    
+            System.out.println("Pre-Signed URL: " + url.toString());
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.generate_presigned_url.complete]

--- a/java/example_code/s3/src/main/java/GeneratePresignedUrlAndUploadObject.java
+++ b/java/example_code/s3/src/main/java/GeneratePresignedUrlAndUploadObject.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[GeneratePresignedUrlAndUploadObject.java demonstrates how to generate a presigned URL with the S3 Java SDK and use the URL to upload an object.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.generate_presigned_url_and_upload_object.complete]
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.HttpMethod;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.S3Object;
+
+public class GeneratePresignedUrlAndUploadObject {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String objectKey = "*** Object key ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+    
+            // Set the pre-signed URL to expire after one hour.
+            java.util.Date expiration = new java.util.Date();
+            long expTimeMillis = expiration.getTime();
+            expTimeMillis += 1000 * 60 * 60;
+            expiration.setTime(expTimeMillis);
+
+            // Generate the pre-signed URL.
+            System.out.println("Generating pre-signed URL.");
+            GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, objectKey)
+                    .withMethod(HttpMethod.PUT)
+                    .withExpiration(expiration);
+            URL url = s3Client.generatePresignedUrl(generatePresignedUrlRequest);
+            
+            // Create the connection and use it to upload the new object using the pre-signed URL.
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setDoOutput(true);
+            connection.setRequestMethod("PUT");
+            OutputStreamWriter out = new OutputStreamWriter(connection.getOutputStream());
+            out.write("This text uploaded as an object via presigned URL.");
+            out.close();
+    
+            // Check the HTTP response code. To complete the upload and make the object available, 
+            // you must interact with the connection object in some way.
+            connection.getResponseCode();
+            System.out.println("HTTP response code: " + connection.getResponseCode());
+    
+            // Check to make sure that the object was uploaded successfully.
+            S3Object object = s3Client.getObject(bucketName, objectKey);
+            System.out.println("Object " + object.getKey() + " created in bucket " + object.getBucketName());
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client  
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.generate_presigned_url_and_upload_object.complete]

--- a/java/example_code/s3/src/main/java/GetObject.java
+++ b/java/example_code/s3/src/main/java/GetObject.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[GetObject.java demonstrates several ways to retrieve an entire or partial S3 object.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.get_object.complete]
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ResponseHeaderOverrides;
+import com.amazonaws.services.s3.model.S3Object;
+
+public class GetObject {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String key = "*** Object key ***";
+
+        S3Object fullObject = null, objectPortion = null, headerOverrideObject = null;
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withRegion(clientRegion)
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .build();
+
+            // Get an object and print its contents.
+            System.out.println("Downloading an object");
+            fullObject = s3Client.getObject(new GetObjectRequest(bucketName, key));
+            System.out.println("Content-Type: " + fullObject.getObjectMetadata().getContentType());
+            System.out.println("Content: ");
+            displayTextInputStream(fullObject.getObjectContent());
+            
+            // Get a range of bytes from an object and print the bytes.
+            GetObjectRequest rangeObjectRequest = new GetObjectRequest(bucketName, key)
+                                                        .withRange(0,9);
+            objectPortion = s3Client.getObject(rangeObjectRequest);
+            System.out.println("Printing bytes retrieved.");
+            displayTextInputStream(objectPortion.getObjectContent());
+            
+            // Get an entire object, overriding the specified response headers, and print the object's content.
+            ResponseHeaderOverrides headerOverrides = new ResponseHeaderOverrides()
+                                                            .withCacheControl("No-cache")
+                                                            .withContentDisposition("attachment; filename=example.txt");
+            GetObjectRequest getObjectRequestHeaderOverride = new GetObjectRequest(bucketName, key)
+                                                            .withResponseHeaders(headerOverrides);
+            headerOverrideObject = s3Client.getObject(getObjectRequestHeaderOverride);
+            displayTextInputStream(headerOverrideObject.getObjectContent());
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+        finally {
+            // To ensure that the network connection doesn't remain open, close any open input streams.
+            if(fullObject != null) {
+                fullObject.close();
+            }
+            if(objectPortion != null) {
+                objectPortion.close();
+            }
+            if(headerOverrideObject != null) {
+                headerOverrideObject.close();
+            }
+        }
+    }
+
+    private static void displayTextInputStream(InputStream input) throws IOException {
+        // Read the text input stream one line at a time and display each line.
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+        String line = null;
+        while ((line = reader.readLine()) != null) {
+            System.out.println(line);
+        }
+        System.out.println();
+    }
+}
+
+// snippet-end:[s3.java.get_object.complete]

--- a/java/example_code/s3/src/main/java/HighLevelAbortMultipartUpload.java
+++ b/java/example_code/s3/src/main/java/HighLevelAbortMultipartUpload.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[HighLevelAbortMultipartUpload.java demonstrates how to abort a multipart upload to S3 using the TransferManager class.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[DELETE Multipart upload]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.high_level_abort_multipart_upload.complete]
+
+import java.util.Date;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+
+public class HighLevelAbortMultipartUpload {
+
+    public static void main(String[] args) {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withRegion(clientRegion)
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .build();
+            TransferManager tm = TransferManagerBuilder.standard()
+                    .withS3Client(s3Client)
+                    .build();
+            
+            // sevenDays is the duration of seven days in milliseconds.
+            long sevenDays = 1000 * 60 * 60 * 24 * 7;
+            Date oneWeekAgo = new Date(System.currentTimeMillis() - sevenDays);
+            tm.abortMultipartUploads(bucketName, oneWeekAgo);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client couldn't 
+            // parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.high_level_abort_multipart_upload.complete]

--- a/java/example_code/s3/src/main/java/HighLevelMultipartUpload.java
+++ b/java/example_code/s3/src/main/java/HighLevelMultipartUpload.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[HighLevelMultipartUpload.java demonstrates how to upload a file to S3 using the TransferManager class.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.high_level_multipart_upload.complete]
+
+import java.io.File;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import com.amazonaws.services.s3.transfer.Upload;
+
+public class HighLevelMultipartUpload {
+
+    public static void main(String[] args) throws Exception {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String keyName = "*** Object key ***";
+        String filePath = "*** Path for file to upload ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withRegion(clientRegion)
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .build();
+            TransferManager tm = TransferManagerBuilder.standard()
+                    .withS3Client(s3Client)
+                    .build();
+            
+            // TransferManager processes all transfers asynchronously,
+            // so this call returns immediately.
+            Upload upload = tm.upload(bucketName, keyName, new File(filePath));
+            System.out.println("Object upload started");
+    
+            // Optionally, wait for the upload to finish before continuing.
+            upload.waitForCompletion();
+            System.out.println("Object upload complete");
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.high_level_multipart_upload.complete]

--- a/java/example_code/s3/src/main/java/HighLevelTrackMultipartUpload.java
+++ b/java/example_code/s3/src/main/java/HighLevelTrackMultipartUpload.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[HighLevelTrackMultipartUpload.java demonstrates how to upload a file to S3 and monitor the upload using the TransferManager class.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.high_level_track_multipart_upload.complete]
+
+import java.io.File;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.event.ProgressEvent;
+import com.amazonaws.event.ProgressListener;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import com.amazonaws.services.s3.transfer.Upload;
+
+public class HighLevelTrackMultipartUpload {
+
+    public static void main(String[] args) throws Exception {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String keyName = "*** Object key ***";
+        String filePath = "*** Path to file to upload ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withRegion(clientRegion)
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .build();
+            TransferManager tm = TransferManagerBuilder.standard()
+                                .withS3Client(s3Client)
+                                .build();
+            PutObjectRequest request = new PutObjectRequest(bucketName, keyName, new File(filePath));
+            
+            // To receive notifications when bytes are transferred, add a  
+            // ProgressListener to your request.
+            request.setGeneralProgressListener(new ProgressListener() {
+                public void progressChanged(ProgressEvent progressEvent) {
+                    System.out.println("Transferred bytes: " + progressEvent.getBytesTransferred());
+                    }
+            });
+            // TransferManager processes all transfers asynchronously,
+            // so this call returns immediately.
+            Upload upload = tm.upload(request);
+    
+            // Optionally, you can wait for the upload to finish before continuing.
+            upload.waitForCompletion();
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client 
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.high_level_track_multipart_upload.complete]

--- a/java/example_code/s3/src/main/java/LifecycleConfiguration.java
+++ b/java/example_code/s3/src/main/java/LifecycleConfiguration.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[LifecycleConfiguration.java demonstrates how to set and get S3 bucket lifecycle configurations.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Bucket lifecycle]
+// snippet-keyword:[PUT Bucket lifecycle]
+// snippet-keyword:[DELETE Bucket lifecycle]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.lifecycle_configuration.complete]
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration.Transition;
+import com.amazonaws.services.s3.model.StorageClass;
+import com.amazonaws.services.s3.model.Tag;
+import com.amazonaws.services.s3.model.lifecycle.LifecycleAndOperator;
+import com.amazonaws.services.s3.model.lifecycle.LifecycleFilter;
+import com.amazonaws.services.s3.model.lifecycle.LifecyclePrefixPredicate;
+import com.amazonaws.services.s3.model.lifecycle.LifecycleTagPredicate;
+
+public class LifecycleConfiguration {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        
+        // Create a rule to archive objects with the "glacierobjects/" prefix to Glacier immediately.
+        BucketLifecycleConfiguration.Rule rule1 = new BucketLifecycleConfiguration.Rule()
+                .withId("Archive immediately rule")
+                .withFilter(new LifecycleFilter(new LifecyclePrefixPredicate("glacierobjects/")))
+                .addTransition(new Transition().withDays(0).withStorageClass(StorageClass.Glacier))
+                .withStatus(BucketLifecycleConfiguration.ENABLED);
+
+        // Create a rule to transition objects to the Standard-Infrequent Access storage class 
+        // after 30 days, then to Glacier after 365 days. Amazon S3 will delete the objects after 3650 days.
+        // The rule applies to all objects with the tag "archive" set to "true". 
+        BucketLifecycleConfiguration.Rule rule2 = new BucketLifecycleConfiguration.Rule()
+                .withId("Archive and then delete rule")
+                .withFilter(new LifecycleFilter(new LifecycleTagPredicate(new Tag("archive", "true"))))
+                .addTransition(new Transition().withDays(30).withStorageClass(StorageClass.StandardInfrequentAccess))
+                .addTransition(new Transition().withDays(365).withStorageClass(StorageClass.Glacier))
+                .withExpirationInDays(3650)
+                .withStatus(BucketLifecycleConfiguration.ENABLED);
+
+        // Add the rules to a new BucketLifecycleConfiguration.
+        BucketLifecycleConfiguration configuration = new BucketLifecycleConfiguration()
+                .withRules(Arrays.asList(rule1, rule2));
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Save the configuration.
+            s3Client.setBucketLifecycleConfiguration(bucketName, configuration);
+    
+            // Retrieve the configuration.
+            configuration = s3Client.getBucketLifecycleConfiguration(bucketName);
+    
+            // Add a new rule with both a prefix predicate and a tag predicate.
+            configuration.getRules().add(new BucketLifecycleConfiguration.Rule().withId("NewRule")
+                    .withFilter(new LifecycleFilter(new LifecycleAndOperator(
+                            Arrays.asList(new LifecyclePrefixPredicate("YearlyDocuments/"),
+                                          new LifecycleTagPredicate(new Tag("expire_after", "ten_years"))))))
+                    .withExpirationInDays(3650)
+                    .withStatus(BucketLifecycleConfiguration.ENABLED));
+    
+            // Save the configuration.
+            s3Client.setBucketLifecycleConfiguration(bucketName, configuration);
+    
+            // Retrieve the configuration.
+            configuration = s3Client.getBucketLifecycleConfiguration(bucketName);
+    
+            // Verify that the configuration now has three rules.
+            configuration = s3Client.getBucketLifecycleConfiguration(bucketName);
+            System.out.println("Expected # of rules = 3; found: " + configuration.getRules().size());
+    
+            // Delete the configuration.
+            s3Client.deleteBucketLifecycleConfiguration(bucketName);
+    
+            // Verify that the configuration has been deleted by attempting to retrieve it.
+            configuration = s3Client.getBucketLifecycleConfiguration(bucketName);
+            String s = (configuration == null) ? "No configuration found." : "Configuration found.";
+            System.out.println(s);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.lifecycle_configuration.complete]

--- a/java/example_code/s3/src/main/java/ListKeys.java
+++ b/java/example_code/s3/src/main/java/ListKeys.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[ListKeys.java demonstrates how to retrieve and iterate through a list of the keys contained in an S3 bucket.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Bucket v2]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.list_keys.complete]
+
+import java.io.IOException;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+public class ListKeys {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        
+        try {    
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+    
+            System.out.println("Listing objects");
+    
+            // maxKeys is set to 2 to demonstrate the use of
+            // ListObjectsV2Result.getNextContinuationToken()
+            ListObjectsV2Request req = new ListObjectsV2Request().withBucketName(bucketName).withMaxKeys(2);
+            ListObjectsV2Result result;
+
+            do {
+                result = s3Client.listObjectsV2(req);
+    
+                for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
+                    System.out.printf(" - %s (size: %d)\n", objectSummary.getKey(), objectSummary.getSize());
+                }
+                // If there are more than maxKeys keys in the bucket, get a continuation token
+                // and list the next objects.
+                String token = result.getNextContinuationToken();
+                System.out.println("Next Continuation Token: " + token);
+                req.setContinuationToken(token);
+            } while (result.isTruncated());
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.list_keys.complete]

--- a/java/example_code/s3/src/main/java/ListKeysVersioningEnabledBucket.java
+++ b/java/example_code/s3/src/main/java/ListKeysVersioningEnabledBucket.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[ListKeysVersioningEnabledBucket.java demonstrates how to list object versions in a version-enabled S3 bucket.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Bucket]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.list_keys_versioning_enabled_bucket.complete]
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ListVersionsRequest;
+import com.amazonaws.services.s3.model.S3VersionSummary;
+import com.amazonaws.services.s3.model.VersionListing;
+
+public class ListKeysVersioningEnabledBucket {
+
+    public static void main(String[] args) {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                                    .withCredentials(new ProfileCredentialsProvider())
+                                    .withRegion(clientRegion)
+                                    .build();
+            
+            // Retrieve the list of versions. If the bucket contains more versions
+            // than the specified maximum number of results, Amazon S3 returns
+            // one page of results per request.
+            ListVersionsRequest request = new ListVersionsRequest()
+                .withBucketName(bucketName)
+                .withMaxResults(2);
+            VersionListing versionListing = s3Client.listVersions(request); 
+            int numVersions = 0, numPages = 0;
+            while(true) {
+                numPages++;
+                for (S3VersionSummary objectSummary : 
+                    versionListing.getVersionSummaries()) {
+                    System.out.printf("Retrieved object %s, version %s\n", 
+                                            objectSummary.getKey(), 
+                                            objectSummary.getVersionId());
+                    numVersions++;
+                }
+                // Check whether there are more pages of versions to retrieve. If
+                // there are, retrieve them. Otherwise, exit the loop.
+                if(versionListing.isTruncated()) {
+                    versionListing = s3Client.listNextBatchOfVersions(versionListing);
+                }
+                else {
+                    break;
+                }
+            }
+            System.out.println(numVersions + " object versions retrieved in " + numPages + " pages");
+         } 
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.list_keys_versioning_enabled_bucket.complete]

--- a/java/example_code/s3/src/main/java/ListMultipartUploads.java
+++ b/java/example_code/s3/src/main/java/ListMultipartUploads.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[ListMultipartUploads.java demonstrates how to list all in-progress multipart uploads.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[List Multipart Uploads]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.list_multipart_uploads.complete]
+
+import java.util.List;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ListMultipartUploadsRequest;
+import com.amazonaws.services.s3.model.MultipartUpload;
+import com.amazonaws.services.s3.model.MultipartUploadListing;
+
+public class ListMultipartUploads {
+
+    public static void main(String[] args) {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Retrieve a list of all in-progress multipart uploads.
+            ListMultipartUploadsRequest allMultipartUploadsRequest = new ListMultipartUploadsRequest(bucketName);
+            MultipartUploadListing multipartUploadListing = s3Client.listMultipartUploads(allMultipartUploadsRequest);
+            List<MultipartUpload> uploads = multipartUploadListing.getMultipartUploads();
+            
+            // Display information about all in-progress multipart uploads.
+            System.out.println(uploads.size() + " multipart upload(s) in progress.");
+            for (MultipartUpload u : uploads) {
+                System.out.println("Upload in progress: Key = \"" + u.getKey() + "\", id = " + u.getUploadId());
+            }
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client  
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.list_multipart_uploads.complete]

--- a/java/example_code/s3/src/main/java/LowLevelAbortMultipartUpload.java
+++ b/java/example_code/s3/src/main/java/LowLevelAbortMultipartUpload.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[LowLevelAbortMultipartUpload.java demonstrates how to abort an in-progress multipart upload.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[Abort Multipart Upload]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.low_level_abort_multipart_upload.complete]
+
+import java.util.List;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.ListMultipartUploadsRequest;
+import com.amazonaws.services.s3.model.MultipartUpload;
+import com.amazonaws.services.s3.model.MultipartUploadListing;
+
+public class LowLevelAbortMultipartUpload {
+
+    public static void main(String[] args) {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withRegion(clientRegion)
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .build();
+
+            // Find all in-progress multipart uploads.
+            ListMultipartUploadsRequest allMultipartUploadsRequest = new ListMultipartUploadsRequest(bucketName);
+            MultipartUploadListing multipartUploadListing = s3Client.listMultipartUploads(allMultipartUploadsRequest);
+    
+            List<MultipartUpload> uploads = multipartUploadListing.getMultipartUploads();
+            System.out.println("Before deletions, " + uploads.size() + " multipart uploads in progress.");
+
+            // Abort each upload.
+            for (MultipartUpload u : uploads) {
+                System.out.println("Upload in progress: Key = \"" + u.getKey() + "\", id = " + u.getUploadId());    
+                s3Client.abortMultipartUpload(new AbortMultipartUploadRequest(bucketName, u.getKey(), u.getUploadId()));
+                System.out.println("Upload deleted: Key = \"" + u.getKey() + "\", id = " + u.getUploadId());
+            }
+    
+            // Verify that all in-progress multipart uploads have been aborted.
+            multipartUploadListing = s3Client.listMultipartUploads(allMultipartUploadsRequest);
+            uploads = multipartUploadListing.getMultipartUploads();
+            System.out.println("After aborting uploads, " + uploads.size() + " multipart uploads in progress.");
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.low_level_abort_multipart_upload.complete]

--- a/java/example_code/s3/src/main/java/LowLevelMultipartCopy.java
+++ b/java/example_code/s3/src/main/java/LowLevelMultipartCopy.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[LowLevelMultipartCopy.java demonstrates how to perform a multipart upload of an S3 object.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[Initiate Multipart Upload]
+// snippet-keyword:[Upload Part]
+// snippet-keyword:[Complete Multipart Upload]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.low_level_multipart_copy.complete]
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.*;
+import com.amazonaws.services.s3.model.*;
+
+public class LowLevelMultipartCopy {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String sourceBucketName = "*** Source bucket name ***";
+        String sourceObjectKey = "*** Source object key ***";
+        String destBucketName = "*** Target bucket name ***";
+        String destObjectKey = "*** Target object key ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Initiate the multipart upload.
+            InitiateMultipartUploadRequest initRequest = new InitiateMultipartUploadRequest(destBucketName, destObjectKey);
+            InitiateMultipartUploadResult initResult = s3Client.initiateMultipartUpload(initRequest);
+    
+            // Get the object size to track the end of the copy operation.
+            GetObjectMetadataRequest metadataRequest = new GetObjectMetadataRequest(sourceBucketName, sourceObjectKey);
+            ObjectMetadata metadataResult = s3Client.getObjectMetadata(metadataRequest);
+            long objectSize = metadataResult.getContentLength();
+    
+            // Copy the object using 5 MB parts.
+            long partSize = 5 * 1024 * 1024;
+            long bytePosition = 0;
+            int partNum = 1;
+            List<CopyPartResult> copyResponses = new ArrayList<CopyPartResult>();
+            while (bytePosition < objectSize) {
+                // The last part might be smaller than partSize, so check to make sure
+                // that lastByte isn't beyond the end of the object.
+                long lastByte = Math.min(bytePosition + partSize - 1, objectSize - 1);
+                
+                // Copy this part.
+                CopyPartRequest copyRequest = new CopyPartRequest()
+                        .withSourceBucketName(sourceBucketName)
+                        .withSourceKey(sourceObjectKey)
+                        .withDestinationBucketName(destBucketName)
+                        .withDestinationKey(destObjectKey)
+                        .withUploadId(initResult.getUploadId())
+                        .withFirstByte(bytePosition)
+                        .withLastByte(lastByte)
+                        .withPartNumber(partNum++);
+                copyResponses.add(s3Client.copyPart(copyRequest));
+                bytePosition += partSize;
+            }
+    
+            // Complete the upload request to concatenate all uploaded parts and make the copied object available.
+            CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+                                                                        destBucketName,
+                                                                        destObjectKey, 
+                                                                        initResult.getUploadId(),
+                                                                        getETags(copyResponses));
+            s3Client.completeMultipartUpload(completeRequest);
+            System.out.println("Multipart copy complete.");
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client  
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+
+    // This is a helper function to construct a list of ETags.
+    private static List<PartETag> getETags(List<CopyPartResult> responses) {
+        List<PartETag> etags = new ArrayList<PartETag>();
+        for (CopyPartResult response : responses) {
+            etags.add(new PartETag(response.getPartNumber(), response.getETag()));
+        }
+        return etags;
+    }
+}
+
+// snippet-end:[s3.java.low_level_multipart_copy.complete]

--- a/java/example_code/s3/src/main/java/LowLevelMultipartUpload.java
+++ b/java/example_code/s3/src/main/java/LowLevelMultipartUpload.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[LowLevelMultipartUpload.java demonstrates how to use the low-level APIs to upload an object to S3 in multiple parts.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[Initiate Multipart Upload]
+// snippet-keyword:[Upload Part]
+// snippet-keyword:[Complete Multipart Upload]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.low_level_multipart_upload.complete]
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+
+public class LowLevelMultipartUpload {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String keyName = "*** Key name ***";
+        String filePath = "*** Path to file to upload ***";
+        
+        File file = new File(filePath);
+        long contentLength = file.length();
+        long partSize = 5 * 1024 * 1024; // Set part size to 5 MB. 
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                                    .withRegion(clientRegion)
+                                    .withCredentials(new ProfileCredentialsProvider())
+                                    .build();
+                       
+            // Create a list of ETag objects. You retrieve ETags for each object part uploaded,
+            // then, after each individual part has been uploaded, pass the list of ETags to 
+            // the request to complete the upload.
+            List<PartETag> partETags = new ArrayList<PartETag>();
+
+            // Initiate the multipart upload.
+            InitiateMultipartUploadRequest initRequest = new InitiateMultipartUploadRequest(bucketName, keyName);
+            InitiateMultipartUploadResult initResponse = s3Client.initiateMultipartUpload(initRequest);
+
+            // Upload the file parts.
+            long filePosition = 0;
+            for (int i = 1; filePosition < contentLength; i++) {
+                // Because the last part could be less than 5 MB, adjust the part size as needed.
+                partSize = Math.min(partSize, (contentLength - filePosition));
+
+                // Create the request to upload a part.
+                UploadPartRequest uploadRequest = new UploadPartRequest()
+                        .withBucketName(bucketName)
+                        .withKey(keyName)
+                        .withUploadId(initResponse.getUploadId())
+                        .withPartNumber(i)
+                        .withFileOffset(filePosition)
+                        .withFile(file)
+                        .withPartSize(partSize);
+
+                // Upload the part and add the response's ETag to our list.
+                UploadPartResult uploadResult = s3Client.uploadPart(uploadRequest);
+                partETags.add(uploadResult.getPartETag());
+
+                filePosition += partSize;
+            }
+
+            // Complete the multipart upload.
+            CompleteMultipartUploadRequest compRequest = new CompleteMultipartUploadRequest(bucketName, keyName,
+                    initResponse.getUploadId(), partETags);
+            s3Client.completeMultipartUpload(compRequest);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.low_level_multipart_upload.complete]

--- a/java/example_code/s3/src/main/java/MakingRequests.java
+++ b/java/example_code/s3/src/main/java/MakingRequests.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[MakingRequests.java demonstrates how to make basic requests against Amazon S3 resources.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Bucket]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.making_requests.complete]
+
+import java.io.IOException;
+import java.util.List;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+public class MakingRequests {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+    
+            // Get a list of objects in the bucket, two at a time, and 
+            // print the name and size of each object.
+            ListObjectsRequest listRequest = new ListObjectsRequest().withBucketName(bucketName).withMaxKeys(2);
+            ObjectListing objects = s3Client.listObjects(listRequest);
+            while(true) {
+                List<S3ObjectSummary> summaries = objects.getObjectSummaries();
+                for(S3ObjectSummary summary : summaries) {
+                    System.out.printf("Object \"%s\" retrieved with size %d\n", summary.getKey(), summary.getSize());
+                }
+                if(objects.isTruncated()) {
+                    objects = s3Client.listNextBatchOfObjects(objects);
+                }
+                else {
+                    break;
+                }
+            }
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.making_requests.complete]

--- a/java/example_code/s3/src/main/java/MakingRequestsWithFederatedTempCredentials.java
+++ b/java/example_code/s3/src/main/java/MakingRequestsWithFederatedTempCredentials.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[MakingRequestsWithFederatedTempCredentials.java demonstrates how to make requests against Amazon S3 using federated temporary credentials.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Bucket]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.making_requests_with_federated_temp_credentials.complete]
+
+import java.io.IOException;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Resource;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.auth.policy.Statement.Effect;
+import com.amazonaws.auth.policy.actions.S3Actions;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.amazonaws.services.securitytoken.model.Credentials;
+import com.amazonaws.services.securitytoken.model.GetFederationTokenRequest;
+import com.amazonaws.services.securitytoken.model.GetFederationTokenResult;
+import com.amazonaws.services.s3.model.ObjectListing;
+
+public class MakingRequestsWithFederatedTempCredentials {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Specify bucket name ***";
+        String federatedUser = "*** Federated user name ***";
+        String resourceARN = "arn:aws:s3:::" + bucketName;
+
+        try {
+            AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder
+                    .standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+            
+            GetFederationTokenRequest getFederationTokenRequest = new GetFederationTokenRequest();
+            getFederationTokenRequest.setDurationSeconds(7200);
+            getFederationTokenRequest.setName(federatedUser);
+            
+            // Define the policy and add it to the request.
+            Policy policy = new Policy();
+            policy.withStatements(new Statement(Effect.Allow)
+                    .withActions(S3Actions.ListObjects)
+                    .withResources(new Resource(resourceARN)));
+            getFederationTokenRequest.setPolicy(policy.toJson());
+            
+            // Get the temporary security credentials.
+            GetFederationTokenResult federationTokenResult = stsClient.getFederationToken(getFederationTokenRequest);
+            Credentials sessionCredentials = federationTokenResult.getCredentials();
+    
+            // Package the session credentials as a BasicSessionCredentials
+            // object for an Amazon S3 client object to use.
+            BasicSessionCredentials basicSessionCredentials = new BasicSessionCredentials(
+                                                                    sessionCredentials.getAccessKeyId(), 
+                                                                    sessionCredentials.getSecretAccessKey(),
+                                                                    sessionCredentials.getSessionToken());
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                                    .withCredentials(new AWSStaticCredentialsProvider(basicSessionCredentials))
+                                    .withRegion(clientRegion)
+                                    .build();
+    
+            // To verify that the client works, send a listObjects request using 
+            // the temporary security credentials.
+            ObjectListing objects = s3Client.listObjects(bucketName);
+            System.out.println("No. of Objects = " + objects.getObjectSummaries().size());
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.making_requests_with_federated_temp_credentials.complete]

--- a/java/example_code/s3/src/main/java/MakingRequestsWithIAMTempCredentials.java
+++ b/java/example_code/s3/src/main/java/MakingRequestsWithIAMTempCredentials.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[MakingRequestsWithIAMTempCredentials.java demonstrates how to assume an IAM role temporarily and use it to make requests against Amazon S3.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Bucket]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.making_requests_with_IAM_temp_credentials.complete]
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+import com.amazonaws.services.securitytoken.model.Credentials;
+import com.amazonaws.services.securitytoken.model.GetSessionTokenRequest;
+import com.amazonaws.services.securitytoken.model.GetSessionTokenResult;
+
+public class MakingRequestsWithIAMTempCredentials {
+    public static void main(String[] args) {
+        String clientRegion = "*** Client region ***";
+        String roleARN = "*** ARN for role to be assumed ***";
+        String roleSessionName = "*** Role session name ***";
+        String bucketName = "*** Bucket name ***";
+
+        try {
+            // Creating the STS client is part of your trusted code. It has
+            // the security credentials you use to obtain temporary security credentials.
+            AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
+                                                    .withCredentials(new ProfileCredentialsProvider())
+                                                    .withRegion(clientRegion)
+                                                    .build();
+
+            // Assume the IAM role. Note that you cannot assume the role of an AWS root account;
+            // Amazon S3 will deny access. You must use credentials for an IAM user or an IAM role.
+            AssumeRoleRequest roleRequest = new AssumeRoleRequest()
+                                                    .withRoleArn(roleARN)
+                                                    .withRoleSessionName(roleSessionName);
+            stsClient.assumeRole(roleRequest);
+
+            // Start a session.
+            GetSessionTokenRequest getSessionTokenRequest = new GetSessionTokenRequest();
+            // The duration can be set to more than 3600 seconds only if temporary
+            // credentials are requested by an IAM user rather than an account owner.
+            getSessionTokenRequest.setDurationSeconds(7200);
+            GetSessionTokenResult sessionTokenResult = stsClient.getSessionToken(getSessionTokenRequest);
+            Credentials sessionCredentials = sessionTokenResult.getCredentials();
+
+            // Package the temporary security credentials as a BasicSessionCredentials object 
+            // for an Amazon S3 client object to use.
+            BasicSessionCredentials basicSessionCredentials = new BasicSessionCredentials(
+                    sessionCredentials.getAccessKeyId(), sessionCredentials.getSecretAccessKey(),
+                    sessionCredentials.getSessionToken());
+
+            // Provide temporary security credentials so that the Amazon S3 client 
+			// can send authenticated requests to Amazon S3. You create the client 
+			// using the basicSessionCredentials object.
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                                    .withCredentials(new AWSStaticCredentialsProvider(basicSessionCredentials))
+                                    .withRegion(clientRegion)
+                                    .build();
+
+            // Verify that assuming the role worked and the permissions are set correctly
+            // by getting a set of object keys from the bucket.
+            ObjectListing objects = s3Client.listObjects(bucketName);
+            System.out.println("No. of Objects: " + objects.getObjectSummaries().size());
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.making_requests_with_IAM_temp_credentials.complete]

--- a/java/example_code/s3/src/main/java/ManagingObjectTags.java
+++ b/java/example_code/s3/src/main/java/ManagingObjectTags.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[ManagingObjectTags.java demonstrates how to set, get, and replace an S3 object's tags.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Object tagging]
+// snippet-keyword:[PUT Object tagging]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.managing_object_tags.complete]
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.*;
+
+public class ManagingObjectTags {
+
+    public static void main(String[] args) {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String keyName = "*** Object key ***";
+        String filePath = "*** File path ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Create an object, add two new tags, and upload the object to Amazon S3.
+            PutObjectRequest putRequest = new PutObjectRequest(bucketName, keyName, new File(filePath));
+            List<Tag> tags = new ArrayList<Tag>();
+            tags.add(new Tag("Tag 1", "This is tag 1"));
+            tags.add(new Tag("Tag 2", "This is tag 2"));
+            putRequest.setTagging(new ObjectTagging(tags));
+            PutObjectResult putResult = s3Client.putObject(putRequest);
+    
+            // Retrieve the object's tags.
+            GetObjectTaggingRequest getTaggingRequest = new GetObjectTaggingRequest(bucketName, keyName);
+            GetObjectTaggingResult getTagsResult = s3Client.getObjectTagging(getTaggingRequest);
+    
+            // Replace the object's tags with two new tags.
+            List<Tag> newTags = new ArrayList<Tag>();
+            newTags.add(new Tag("Tag 3", "This is tag 3"));
+            newTags.add(new Tag("Tag 4", "This is tag 4"));
+            s3Client.setObjectTagging(new SetObjectTaggingRequest(bucketName, keyName, new ObjectTagging(newTags)));
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.managing_object_tags.complete]

--- a/java/example_code/s3/src/main/java/ModifyACLExistingObject.java
+++ b/java/example_code/s3/src/main/java/ModifyACLExistingObject.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[ModifyACLExistingObject.java demonstrates how to retrieve, modify, and set the ACL grants for an S3 object.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Object acl]
+// snippet-keyword:[PUT Object acl]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.modify_acl_existing_object.complete]
+
+import java.io.IOException;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.CanonicalGrantee;
+import com.amazonaws.services.s3.model.EmailAddressGrantee;
+import com.amazonaws.services.s3.model.Permission;
+
+public class ModifyACLExistingObject {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String keyName = "*** Key name ***";
+        String emailGrantee = "*** user@example.com ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Get the existing object ACL that we want to modify.
+            AccessControlList acl = s3Client.getObjectAcl(bucketName, keyName);
+            
+            // Clear the existing list of grants.
+            acl.getGrantsAsList().clear();
+            
+            // Grant a sample set of permissions, using the existing ACL owner for Full Control permissions.
+            acl.grantPermission(new CanonicalGrantee(acl.getOwner().getId()), Permission.FullControl);
+            acl.grantPermission(new EmailAddressGrantee(emailGrantee), Permission.WriteAcp);
+    
+            // Save the modified ACL back to the object.
+            s3Client.setObjectAcl(bucketName, keyName, acl);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.modify_acl_existing_object.complete]

--- a/java/example_code/s3/src/main/java/RestoreArchivedObject.java
+++ b/java/example_code/s3/src/main/java/RestoreArchivedObject.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[RestoreArchivedObject.java demonstrates how to restore an S3 object temporarily from a Glacier archive.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[POST Object restore]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.restore_archived_object.complete]
+
+import java.io.IOException;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.RestoreObjectRequest;
+
+public class RestoreArchivedObject {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String keyName = "*** Object key ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Create and submit a request to restore an object from Glacier for two days.
+            RestoreObjectRequest requestRestore = new RestoreObjectRequest(bucketName, keyName, 2);
+            s3Client.restoreObjectV2(requestRestore);
+    
+            // Check the restoration status of the object.
+            ObjectMetadata response = s3Client.getObjectMetadata(bucketName, keyName);
+            Boolean restoreFlag = response.getOngoingRestore();
+            System.out.format("Restoration status: %s.\n",
+                    restoreFlag ? "in progress" : "not in progress (finished or failed)");
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.restore_archived_object.complete]

--- a/java/example_code/s3/src/main/java/S3ClientSideEncryptionAsymmetricMasterKey.java
+++ b/java/example_code/s3/src/main/java/S3ClientSideEncryptionAsymmetricMasterKey.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[S3ClientSideEncryptionAsymmetricMasterKey.java demonstrates how to upload and download encrypted objects using S3 with a client-side asymmetric master key.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Object]
+// snippet-keyword:[GET Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.s3_client_side_encryption_asymmetric_master_key.complete]
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3EncryptionClientBuilder;
+import com.amazonaws.services.s3.model.EncryptionMaterials;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.StaticEncryptionMaterialsProvider;
+import com.amazonaws.util.IOUtils;
+
+public class S3ClientSideEncryptionAsymmetricMasterKey {
+
+    public static void main(String[] args) throws Exception {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String objectKeyName = "*** Key name ***";
+        String rsaKeyDir = System.getProperty("java.io.tmpdir");
+        String publicKeyName = "public.key";
+        String privateKeyName = "private.key";
+
+        // Generate a 1024-bit RSA key pair.
+        KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
+        keyGenerator.initialize(1024, new SecureRandom());
+        KeyPair origKeyPair = keyGenerator.generateKeyPair();
+
+        // To see how it works, save and load the key pair to and from the file system.
+        saveKeyPair(rsaKeyDir, publicKeyName, privateKeyName, origKeyPair);
+        KeyPair keyPair = loadKeyPair(rsaKeyDir, publicKeyName, privateKeyName, "RSA");
+
+        try {
+            // Create the encryption client.
+            EncryptionMaterials encryptionMaterials = new EncryptionMaterials(keyPair);
+            AmazonS3 s3EncryptionClient = AmazonS3EncryptionClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withEncryptionMaterials(new StaticEncryptionMaterialsProvider(encryptionMaterials))
+                    .withRegion(clientRegion)
+                    .build();
+    
+            // Create a new object.
+            byte[] plaintext = "S3 Object Encrypted Using Client-Side Asymmetric Master Key.".getBytes();
+            S3Object object = new S3Object();
+            object.setKey(objectKeyName);
+            object.setObjectContent(new ByteArrayInputStream(plaintext));
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(plaintext.length);
+
+            // Upload the object. The encryption client automatically encrypts it.
+            PutObjectRequest putRequest = new PutObjectRequest(bucketName, 
+                                                               object.getKey(), 
+                                                               object.getObjectContent(),
+                                                               metadata);
+            s3EncryptionClient.putObject(putRequest);
+    
+            // Download and decrypt the object.
+            S3Object downloadedObject = s3EncryptionClient.getObject(bucketName, object.getKey());
+            byte[] decrypted = IOUtils.toByteArray(downloadedObject.getObjectContent());
+    
+            // Verify that the data that you downloaded is the same as the original data.
+            System.out.println("Plaintext: " + new String(plaintext));
+            System.out.println("Decrypted text: " + new String(decrypted));
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+
+    private static void saveKeyPair(String dir, 
+                                   String publicKeyName, 
+                                   String privateKeyName, 
+                                   KeyPair keyPair) throws IOException {
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        // Write the public key to the specified file.
+        X509EncodedKeySpec x509EncodedKeySpec = new X509EncodedKeySpec(publicKey.getEncoded());
+        FileOutputStream publicKeyOutputStream = new FileOutputStream(dir + File.separator + publicKeyName);
+        publicKeyOutputStream.write(x509EncodedKeySpec.getEncoded());
+        publicKeyOutputStream.close();
+
+        // Write the private key to the specified file.
+        PKCS8EncodedKeySpec pkcs8EncodedKeySpec = new PKCS8EncodedKeySpec(privateKey.getEncoded());
+        FileOutputStream privateKeyOutputStream = new FileOutputStream(dir + File.separator + privateKeyName);
+        privateKeyOutputStream.write(pkcs8EncodedKeySpec.getEncoded());
+        privateKeyOutputStream.close();
+    }
+
+    private static KeyPair loadKeyPair(String dir,
+                                      String publicKeyName,
+                                      String privateKeyName,
+                                      String algorithm)
+            throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+        // Read the public key from the specified file.
+        File publicKeyFile = new File(dir + File.separator + publicKeyName);
+        FileInputStream publicKeyInputStream = new FileInputStream(publicKeyFile);
+        byte[] encodedPublicKey = new byte[(int) publicKeyFile.length()];
+        publicKeyInputStream.read(encodedPublicKey);
+        publicKeyInputStream.close();
+
+        // Read the private key from the specified file.
+        File privateKeyFile = new File(dir + File.separator + privateKeyName);
+        FileInputStream privateKeyInputStream = new FileInputStream(privateKeyFile);
+        byte[] encodedPrivateKey = new byte[(int) privateKeyFile.length()];
+        privateKeyInputStream.read(encodedPrivateKey);
+        privateKeyInputStream.close();
+
+        // Convert the keys into a key pair.
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm);
+        X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(encodedPublicKey);
+        PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
+
+        PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(encodedPrivateKey);
+        PrivateKey privateKey = keyFactory.generatePrivate(privateKeySpec);
+
+        return new KeyPair(publicKey, privateKey);
+    }
+}
+
+// snippet-end:[s3.java.s3_client_side_encryption_asymmetric_master_key.complete]

--- a/java/example_code/s3/src/main/java/S3ClientSideEncryptionSymMasterKey.java
+++ b/java/example_code/s3/src/main/java/S3ClientSideEncryptionSymMasterKey.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[S3ClientSideEncryptionSymMasterKey.java demonstrates how to upload and download encrypted objects using S3 with a client-side symmetric master key.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Object]
+// snippet-keyword:[GET Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.s3_client_side_encryption_sym_master_key.complete]
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3EncryptionClientBuilder;
+import com.amazonaws.services.s3.model.EncryptionMaterials;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.StaticEncryptionMaterialsProvider;
+
+public class S3ClientSideEncryptionSymMasterKey {
+
+    public static void main(String[] args) throws Exception {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String objectKeyName = "*** Object key name ***";
+        String masterKeyDir = System.getProperty("java.io.tmpdir");
+        String masterKeyName = "secret.key";
+
+        // Generate a symmetric 256-bit AES key.
+        KeyGenerator symKeyGenerator = KeyGenerator.getInstance("AES");
+        symKeyGenerator.init(256);
+        SecretKey symKey = symKeyGenerator.generateKey();
+
+        // To see how it works, save and load the key to and from the file system.
+        saveSymmetricKey(masterKeyDir, masterKeyName, symKey);
+        symKey = loadSymmetricAESKey(masterKeyDir, masterKeyName, "AES");
+
+        try {
+            // Create the Amazon S3 encryption client.
+            EncryptionMaterials encryptionMaterials = new EncryptionMaterials(symKey);
+            AmazonS3 s3EncryptionClient = AmazonS3EncryptionClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withEncryptionMaterials(new StaticEncryptionMaterialsProvider(encryptionMaterials))
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Upload a new object. The encryption client automatically encrypts it.
+            byte[] plaintext = "S3 Object Encrypted Using Client-Side Symmetric Master Key.".getBytes();
+            s3EncryptionClient.putObject(new PutObjectRequest(bucketName, 
+                                                            objectKeyName, 
+                                                            new ByteArrayInputStream(plaintext), 
+                                                            new ObjectMetadata()));
+    
+            // Download and decrypt the object.
+            S3Object downloadedObject = s3EncryptionClient.getObject(bucketName, objectKeyName);
+            byte[] decrypted = com.amazonaws.util.IOUtils.toByteArray(downloadedObject.getObjectContent());
+    
+            // Verify that the data that you downloaded is the same as the original data.
+            System.out.println("Plaintext: " + new String(plaintext));
+            System.out.println("Decrypted text: " + new String(decrypted));
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+
+    private static void saveSymmetricKey(String masterKeyDir, String masterKeyName, SecretKey secretKey) throws IOException {
+        X509EncodedKeySpec x509EncodedKeySpec = new X509EncodedKeySpec(secretKey.getEncoded());
+        FileOutputStream keyOutputStream = new FileOutputStream(masterKeyDir + File.separator + masterKeyName);
+        keyOutputStream.write(x509EncodedKeySpec.getEncoded());
+        keyOutputStream.close();
+    }
+
+    private static SecretKey loadSymmetricAESKey(String masterKeyDir, String masterKeyName, String algorithm)
+            throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
+        // Read the key from the specified file.
+        File keyFile = new File(masterKeyDir + File.separator + masterKeyName);
+        FileInputStream keyInputStream = new FileInputStream(keyFile);
+        byte[] encodedPrivateKey = new byte[(int) keyFile.length()];
+        keyInputStream.read(encodedPrivateKey);
+        keyInputStream.close();
+
+        // Reconstruct and return the master key.
+        return new SecretKeySpec(encodedPrivateKey, "AES");
+    }
+}
+
+// snippet-end:[s3.java.s3_client_side_encryption_sym_master_key.complete]

--- a/java/example_code/s3/src/main/java/ServerSideEncryptionCopyObjectUsingHLwithSSEC.java
+++ b/java/example_code/s3/src/main/java/ServerSideEncryptionCopyObjectUsingHLwithSSEC.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[ServerSideEncryptionCopyObjectUsingHLwithSSEC.java demonstrates how to perform various operations with the high-level TransferManager class using S3 server-side encryption with a customer-generated encryption key.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.server_side_encryption_copy_object_using_hl_with_sse_c.complete]
+
+import java.io.File;
+import java.security.SecureRandom;
+
+import javax.crypto.KeyGenerator;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.SSECustomerKey;
+import com.amazonaws.services.s3.transfer.Copy;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import com.amazonaws.services.s3.transfer.Upload;
+
+public class ServerSideEncryptionCopyObjectUsingHLwithSSEC {
+
+    public static void main(String[] args) throws Exception {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String fileToUpload = "*** File path ***";
+        String keyName = "*** New object key name ***";
+        String targetKeyName = "*** Key name for object copy ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                                    .withRegion(clientRegion)
+                                    .withCredentials(new ProfileCredentialsProvider())
+                                    .build();
+            TransferManager tm = TransferManagerBuilder.standard()
+                                    .withS3Client(s3Client)
+                                    .build();
+
+            // Create an object from a file.
+            PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, keyName, new File(fileToUpload));
+    
+            // Create an encryption key.
+            KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+            keyGenerator.init(256, new SecureRandom());
+            SSECustomerKey sseCustomerEncryptionKey = new SSECustomerKey(keyGenerator.generateKey());
+    
+            // Upload the object. TransferManager uploads asynchronously, so this call returns immediately.
+            putObjectRequest.setSSECustomerKey(sseCustomerEncryptionKey);
+            Upload upload = tm.upload(putObjectRequest);
+            
+            // Optionally, wait for the upload to finish before continuing.
+            upload.waitForCompletion();
+            System.out.println("Object created.");
+    
+            // Copy the object and store the copy using SSE-C with a new key.
+            CopyObjectRequest copyObjectRequest = new CopyObjectRequest(bucketName, keyName, bucketName, targetKeyName);
+            SSECustomerKey sseTargetObjectEncryptionKey = new SSECustomerKey(keyGenerator.generateKey());
+            copyObjectRequest.setSourceSSECustomerKey(sseCustomerEncryptionKey);
+            copyObjectRequest.setDestinationSSECustomerKey(sseTargetObjectEncryptionKey);
+    
+            // Copy the object. TransferManager copies asynchronously, so this call returns immediately.
+            Copy copy = tm.copy(copyObjectRequest);
+            
+            // Optionally, wait for the upload to finish before continuing.
+            copy.waitForCompletion();
+            System.out.println("Copy complete.");
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.server_side_encryption_copy_object_using_hl_with_sse_c.complete]

--- a/java/example_code/s3/src/main/java/ServerSideEncryptionUsingClientSideEncryptionKey.java
+++ b/java/example_code/s3/src/main/java/ServerSideEncryptionUsingClientSideEncryptionKey.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[ServerSideEncryptionUsingClientSideEncryptionKey.java demonstrates how to perform various operations with S3 using server-side encryption with a customer-provided encryption key.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Object]
+// snippet-keyword:[PUT Object]
+// snippet-keyword:[HEAD Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.server_side_encryption_using_client_side_encryption_key.complete]
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import javax.crypto.KeyGenerator;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.services.s3.model.SSECustomerKey;
+
+public class ServerSideEncryptionUsingClientSideEncryptionKey {
+    private static SSECustomerKey SSE_KEY;
+    private static AmazonS3 S3_CLIENT;
+    private static KeyGenerator KEY_GENERATOR;
+
+    public static void main(String[] args) throws IOException, NoSuchAlgorithmException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String keyName = "*** Key name ***";
+        String uploadFileName = "*** File path ***";
+        String targetKeyName = "*** Target key name ***";
+        
+        // Create an encryption key.
+        KEY_GENERATOR = KeyGenerator.getInstance("AES");
+        KEY_GENERATOR.init(256, new SecureRandom());
+        SSE_KEY = new SSECustomerKey(KEY_GENERATOR.generateKey());
+
+        try {
+            S3_CLIENT = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withRegion(clientRegion)
+                    .build();
+
+            // Upload an object.
+            uploadObject(bucketName, keyName, new File(uploadFileName));
+    
+            // Download the object.
+            downloadObject(bucketName, keyName);
+    
+            // Verify that the object is properly encrypted by attempting to retrieve it
+            // using the encryption key.
+            retrieveObjectMetadata(bucketName, keyName);
+    
+            // Copy the object into a new object that also uses SSE-C.
+            copyObject(bucketName, keyName, targetKeyName);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+
+    private static void uploadObject(String bucketName, String keyName, File file) {
+        PutObjectRequest putRequest = new PutObjectRequest(bucketName, keyName, file).withSSECustomerKey(SSE_KEY);
+        S3_CLIENT.putObject(putRequest);
+        System.out.println("Object uploaded");
+    }
+
+    private static void downloadObject(String bucketName, String keyName) throws IOException {
+        GetObjectRequest getObjectRequest = new GetObjectRequest(bucketName, keyName).withSSECustomerKey(SSE_KEY);
+        S3Object object = S3_CLIENT.getObject(getObjectRequest);
+
+        System.out.println("Object content: ");
+        displayTextInputStream(object.getObjectContent());
+    }
+
+    private static void retrieveObjectMetadata(String bucketName, String keyName) {
+        GetObjectMetadataRequest getMetadataRequest = new GetObjectMetadataRequest(bucketName, keyName)
+                                                                .withSSECustomerKey(SSE_KEY);
+        ObjectMetadata objectMetadata = S3_CLIENT.getObjectMetadata(getMetadataRequest);
+        System.out.println("Metadata retrieved. Object size: " + objectMetadata.getContentLength());
+    }
+    
+    private static void copyObject(String bucketName, String keyName, String targetKeyName)
+            throws NoSuchAlgorithmException {
+        // Create a new encryption key for target so that the target is saved using SSE-C.
+        SSECustomerKey newSSEKey = new SSECustomerKey(KEY_GENERATOR.generateKey());
+
+        CopyObjectRequest copyRequest = new CopyObjectRequest(bucketName, keyName, bucketName, targetKeyName)
+                .withSourceSSECustomerKey(SSE_KEY)
+				.withDestinationSSECustomerKey(newSSEKey);
+
+        S3_CLIENT.copyObject(copyRequest);
+        System.out.println("Object copied");
+    }
+
+    private static void displayTextInputStream(S3ObjectInputStream input) throws IOException {
+        // Read one line at a time from the input stream and display each line.
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            System.out.println(line);
+        }
+        System.out.println();
+    }
+}
+
+// snippet-end:[s3.java.server_side_encryption_using_client_side_encryption_key.complete]

--- a/java/example_code/s3/src/main/java/SpecifyServerSideEncryption.java
+++ b/java/example_code/s3/src/main/java/SpecifyServerSideEncryption.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[SpecifyServerSideEncryption.java demonstrates how to upload an object using S3 server-side encryption.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.specify_server_side_encryption.complete]
+
+import java.io.ByteArrayInputStream;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.internal.SSEResultBase;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.CopyObjectResult;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+
+public class SpecifyServerSideEncryption {
+
+    public static void main(String[] args) {
+           String clientRegion = "*** Client region ***";
+           String bucketName = "*** Bucket name ***";
+           String keyNameToEncrypt = "*** Key name for an object to upload and encrypt ***";
+           String keyNameToCopyAndEncrypt = "*** Key name for an unencrypted object to be encrypted by copying ***";
+           String copiedObjectKeyName = "*** Key name for the encrypted copy of the unencrypted object ***";
+           
+           try {
+               AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                                       .withRegion(clientRegion)
+                                       .withCredentials(new ProfileCredentialsProvider())
+                                       .build();
+           
+               // Upload an object and encrypt it with SSE.
+               uploadObjectWithSSEEncryption(s3Client, bucketName, keyNameToEncrypt);
+               
+               // Upload a new unencrypted object, then change its encryption state
+               // to encrypted by making a copy.
+               changeSSEEncryptionStatusByCopying(s3Client, 
+                                                  bucketName, 
+                                                  keyNameToCopyAndEncrypt, 
+                                                  copiedObjectKeyName);
+           }
+           catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+
+    private static void uploadObjectWithSSEEncryption(AmazonS3 s3Client, String bucketName, String keyName) {
+        String objectContent = "Test object encrypted with SSE";
+                
+        // Specify server-side encryption.
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(objectContent.length());
+        objectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+        PutObjectRequest putRequest = new PutObjectRequest(bucketName, 
+                                                           keyName, 
+                                                           new ByteArrayInputStream(objectContent.getBytes()), 
+                                                           objectMetadata);
+
+        // Upload the object and check its encryption status.
+        PutObjectResult putResult = s3Client.putObject(putRequest);
+        System.out.println("Object \"" + keyName + "\" uploaded with SSE.");
+        printEncryptionStatus(putResult);
+    }
+    
+    private static void changeSSEEncryptionStatusByCopying(AmazonS3 s3Client, 
+                                                           String bucketName, 
+                                                           String sourceKey,
+                                                           String destKey) {
+        // Upload a new, unencrypted object.
+        PutObjectResult putResult = s3Client.putObject(bucketName, sourceKey, "Object example to encrypt by copying");
+        System.out.println("Unencrypted object \"" + sourceKey + "\" uploaded.");
+        printEncryptionStatus(putResult);
+        
+        // Make a copy of the object and use server-side encryption when storing the copy.
+        CopyObjectRequest request = new CopyObjectRequest(bucketName,
+                                                          sourceKey,
+                                                          bucketName,
+                                                          destKey);
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+        request.setNewObjectMetadata(objectMetadata);
+        
+        // Perform the copy operation and display the copy's encryption status.
+        CopyObjectResult response = s3Client.copyObject(request);
+        System.out.println("Object \"" + destKey + "\" uploaded with SSE.");
+        printEncryptionStatus(response);
+        
+        // Delete the original, unencrypted object, leaving only the encrypted copy in Amazon S3.
+        s3Client.deleteObject(bucketName, sourceKey);
+        System.out.println("Unencrypted object \"" + sourceKey + "\" deleted.");
+    }
+    
+    private static void printEncryptionStatus(SSEResultBase response) {
+        String encryptionStatus = response.getSSEAlgorithm();
+        if(encryptionStatus == null) {
+            encryptionStatus = "Not encrypted with SSE"; 
+        }
+        System.out.println("Object encryption status is: " + encryptionStatus);
+    }
+}
+
+// snippet-end:[s3.java.specify_server_side_encryption.complete]

--- a/java/example_code/s3/src/main/java/TransferAcceleration.java
+++ b/java/example_code/s3/src/main/java/TransferAcceleration.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[TransferAcceleration.java demonstrates how to enable and use transfer acceleration with Amazon S3.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Bucket accelerate]
+// snippet-keyword:[GET Bucket accelerate]
+// snippet-keyword:[PUT Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.transfer_acceleration.complete]
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.BucketAccelerateConfiguration;
+import com.amazonaws.services.s3.model.BucketAccelerateStatus;
+import com.amazonaws.services.s3.model.GetBucketAccelerateConfigurationRequest;
+import com.amazonaws.services.s3.model.SetBucketAccelerateConfigurationRequest;
+
+public class TransferAcceleration {
+    public static void main(String[] args) {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String keyName = "*** Key name ***";
+        
+        try {
+            // Create an Amazon S3 client that is configured to use the accelerate endpoint.
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withRegion(clientRegion)
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .enableAccelerateMode()
+                    .build();
+
+            // Enable Transfer Acceleration for the specified bucket.
+            s3Client.setBucketAccelerateConfiguration(
+                    new SetBucketAccelerateConfigurationRequest(bucketName,
+                                                                new BucketAccelerateConfiguration(
+                                                                        BucketAccelerateStatus.Enabled)));
+    
+            // Verify that transfer acceleration is enabled for the bucket.
+            String accelerateStatus = s3Client.getBucketAccelerateConfiguration(
+                                                    new GetBucketAccelerateConfigurationRequest(bucketName))
+                                              .getStatus();
+            System.out.println("Bucket accelerate status: " + accelerateStatus);
+            
+            // Upload a new object using the accelerate endpoint.
+            s3Client.putObject(bucketName, keyName, "Test object for transfer acceleration");
+            System.out.println("Object \"" + keyName + "\" uploaded with transfer acceleration.");
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.transfer_acceleration.complete]

--- a/java/example_code/s3/src/main/java/UploadObject.java
+++ b/java/example_code/s3/src/main/java/UploadObject.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[UploadObject.java demonstrates how to perform a basic object upload using Amazon S3.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.upload_object.complete]
+
+import java.io.File;
+import java.io.IOException;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+public class UploadObject {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String stringObjKeyName = "*** String object key name ***";
+        String fileObjKeyName = "*** File object key name ***";
+        String fileName = "*** Path to file to upload ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withRegion(clientRegion)
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .build();
+        
+            // Upload a text string as a new object.
+            s3Client.putObject(bucketName, stringObjKeyName, "Uploaded String Object");
+            
+            // Upload a file as a new object with ContentType and title specified.
+            PutObjectRequest request = new PutObjectRequest(bucketName, fileObjKeyName, new File(fileName));
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType("plain/text");
+            metadata.addUserMetadata("x-amz-meta-title", "someTitle");
+            request.setMetadata(metadata);
+            s3Client.putObject(request);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.upload_object.complete]

--- a/java/example_code/s3/src/main/java/UploadObjectKMSKey.java
+++ b/java/example_code/s3/src/main/java/UploadObjectKMSKey.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[UploadObjectKMSKey.java demonstrates how to upload and download S3 objects using a KMS key.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[GET Object]
+// snippet-keyword:[PUT Object]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.upload_object_kms_key.complete]
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.regions.RegionUtils;
+import com.amazonaws.services.kms.AWSKMS;
+import com.amazonaws.services.kms.AWSKMSClientBuilder;
+import com.amazonaws.services.kms.model.CreateKeyResult;
+import com.amazonaws.services.s3.AmazonS3Encryption;
+import com.amazonaws.services.s3.AmazonS3EncryptionClientBuilder;
+import com.amazonaws.services.s3.model.CryptoConfiguration;
+import com.amazonaws.services.s3.model.KMSEncryptionMaterialsProvider;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+
+public class UploadObjectKMSKey {
+
+    public static void main(String[] args) throws IOException {
+        String bucketName = "*** Bucket name ***";
+        String keyName = "*** Object key name ***";
+        String clientRegion = "*** Client region ***";
+        String kms_cmk_id = "*** AWS KMS customer master key ID ***";
+        int readChunkSize = 4096;
+
+        try {
+            // Optional: If you don't have a KMS key (or need another one),
+            // create one. This example creates a key with AWS-created
+            // key material.
+            AWSKMS kmsClient = AWSKMSClientBuilder.standard()
+                                    .withCredentials(new ProfileCredentialsProvider())
+                                    .withRegion(clientRegion)
+                                    .build();
+            CreateKeyResult keyResult = kmsClient.createKey();
+            kms_cmk_id = keyResult.getKeyMetadata().getKeyId();
+    
+             // Create the encryption client.
+            KMSEncryptionMaterialsProvider materialProvider = new KMSEncryptionMaterialsProvider(kms_cmk_id);
+            CryptoConfiguration cryptoConfig = new CryptoConfiguration()
+                    .withAwsKmsRegion(RegionUtils.getRegion(clientRegion));
+            AmazonS3Encryption encryptionClient = AmazonS3EncryptionClientBuilder.standard()
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .withEncryptionMaterials(materialProvider)
+                    .withCryptoConfiguration(cryptoConfig)
+                    .withRegion(clientRegion).build();
+    
+            // Upload an object using the encryption client.
+            String origContent = "S3 Encrypted Object Using KMS-Managed Customer Master Key.";
+            int origContentLength = origContent.length();
+            encryptionClient.putObject(bucketName, keyName, origContent);
+    
+            // Download the object. The downloaded object is still encrypted.
+            S3Object downloadedObject = encryptionClient.getObject(bucketName, keyName);
+            S3ObjectInputStream input = downloadedObject.getObjectContent();
+    
+            // Decrypt and read the object and close the input stream.
+            byte[] readBuffer = new byte[readChunkSize];
+            ByteArrayOutputStream baos = new ByteArrayOutputStream(readChunkSize);
+            int bytesRead = 0;
+            int decryptedContentLength = 0;
+    
+            while ((bytesRead = input.read(readBuffer)) != -1) {
+                baos.write(readBuffer, 0, bytesRead);
+                decryptedContentLength += bytesRead;
+            }
+            input.close();
+    
+            // Verify that the original and decrypted contents are the same size.
+            System.out.println("Original content length: " + origContentLength);
+            System.out.println("Decrypted content length: " + decryptedContentLength);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+}
+
+// snippet-end:[s3.java.upload_object_kms_key.complete]

--- a/java/example_code/s3/src/main/java/WebsiteConfiguration.java
+++ b/java/example_code/s3/src/main/java/WebsiteConfiguration.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/
+
+// snippet-sourcedescription:[WebsiteConfiguration.java demonstrates how to set, get, and delete S3 bucket website configurations.]
+// snippet-service:[s3]
+// snippet-keyword:[Java]
+// snippet-keyword:[Amazon S3]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[PUT Bucket website]
+// snippet-keyword:[GET Bucket website]
+// snippet-keyword:[DELETE Bucket website]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-01-28]
+// snippet-sourceauthor:[AWS]
+// snippet-start:[s3.java.website_configuration.complete]
+
+import java.io.IOException;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.BucketWebsiteConfiguration;
+
+public class WebsiteConfiguration {
+
+    public static void main(String[] args) throws IOException {
+        String clientRegion = "*** Client region ***";
+        String bucketName = "*** Bucket name ***";
+        String indexDocName = "*** Index document name ***";
+        String errorDocName = "*** Error document name ***";
+
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withRegion(clientRegion)
+                    .withCredentials(new ProfileCredentialsProvider())
+                    .build();
+
+            // Print the existing website configuration, if it exists.
+            printWebsiteConfig(s3Client, bucketName);
+    
+            // Set the new website configuration.
+            s3Client.setBucketWebsiteConfiguration(bucketName, new BucketWebsiteConfiguration(indexDocName, errorDocName));
+    
+            // Verify that the configuration was set properly by printing it.
+            printWebsiteConfig(s3Client, bucketName);
+    
+            // Delete the website configuration.
+            s3Client.deleteBucketWebsiteConfiguration(bucketName);
+    
+            // Verify that the website configuration was deleted by printing it.
+            printWebsiteConfig(s3Client, bucketName);
+        }
+        catch(AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process 
+            // it, so it returned an error response.
+            e.printStackTrace();
+        }
+        catch(SdkClientException e) {
+            // Amazon S3 couldn't be contacted for a response, or the client
+            // couldn't parse the response from Amazon S3.
+            e.printStackTrace();
+        }
+    }
+
+    private static void printWebsiteConfig(AmazonS3 s3Client, String bucketName) {
+        System.out.println("Website configuration: ");
+        BucketWebsiteConfiguration bucketWebsiteConfig = s3Client.getBucketWebsiteConfiguration(bucketName);
+        if (bucketWebsiteConfig == null) {
+            System.out.println("No website config.");
+        } else {
+            System.out.println("Index doc: " + bucketWebsiteConfig.getIndexDocumentSuffix());
+            System.out.println("Error doc: " + bucketWebsiteConfig.getErrorDocument());
+        }
+    }
+}
+
+// snippet-end:[s3.java.website_configuration.complete]

--- a/ruby/example_code/s3/auth_federation_token_request_test.rb
+++ b/ruby/example_code/s3/auth_federation_token_request_test.rb
@@ -1,0 +1,144 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and limitations under the License.
+#**
+
+
+# snippet-sourcedescription:[auth_federation_token_request_test.rb allows a federated user with a limited set of permissions to lists keys in the specified bucket.] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
+# snippet-keyword:[GET Bucket, GET Object, GET Keys]
+# snippet-sourcetype:[full-example]
+# snippet-sourcedate:[YYYY-MM-DD]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.auth_federation_token_request_test.rb]
+
+require 'aws-sdk-s3'
+require 'aws-sdk-iam'
+
+USAGE = << DOC
+
+Usage: federated_create_bucket_policy.rb -b BUCKET -u USER [-r REGION] [-d] [-h]
+
+  Creates a federated policy for USER to list items in BUCKET for one hour.
+
+  BUCKET is required and must already exist.
+
+  USER is required and if not found, is created.
+
+  If REGION is not supplied, defaults to us-west-2.
+
+  -d gives you extra (debugging) information.
+
+  -h displays this message and quits.
+
+DOC
+
+$debug = false
+
+def print_debug(s)
+  if $debug
+    puts s
+  end
+end
+
+def get_user(region, user_name, create)
+  user = nil
+  iam = Aws::IAM::Client.new(region: 'us-west-2')
+  
+begin
+  user = iam.create_user(user_name: user_name)
+  iam.wait_until(:user_exists, user_name: user_name)
+  print_debug("Created new user #{user_name}")
+rescue Aws::IAM::Errors::EntityAlreadyExists
+  print_debug("Found user #{user_name} in region #{region}")
+end
+end
+
+# main
+region = 'us-west-2'
+user_name = ''
+bucket_name = ''
+
+i = 0
+
+while i &lt; ARGV.length
+  case ARGV[i]
+
+    when '-b'
+      i += 1
+      bucket_name = ARGV[i]
+
+    when '-u'
+      i += 1
+      user_name = ARGV[i]
+
+    when '-r'
+      i += 1
+
+      region = ARGV[i]
+
+    when '-d'
+      puts 'Debugging enabled'
+      $debug = true
+
+    when '-h'
+      puts USAGE
+      exit 0
+
+    else
+      puts 'Unrecognized option: ' + ARGV[i]
+      puts USAGE
+      exit 1
+
+  end
+
+  i += 1
+end
+
+if bucket_name == ''
+  puts 'You must supply a bucket name'
+  puts USAGE
+  exit 1
+end
+
+if user_name == ''
+  puts 'You must supply a user name'
+  puts USAGE
+  exit 1
+end
+
+#Identify the IAM user we allow to list Amazon S3 bucket items for an hour.
+user = get_user(region, user_name, true)
+
+# Create a new STS client and get temporary credentials.
+sts = Aws::STS::Client.new(region: region)
+
+creds = sts.get_federation_token({
+  duration_seconds: 3600,
+  name: user_name,
+  policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Action\":\"s3:ListBucket\",\"Resource\":\"arn:aws:s3:::#{bucket_name}\"}]}",
+})
+
+# Create an Amazon S3 resource with temporary credentials.
+s3 = Aws::S3::Resource.new(region: region, credentials: creds)
+
+puts "Contents of '%s':" % bucket_name
+puts '  Name => GUID'
+
+ s3.bucket(bucket_name).objects.limit(50).each do |obj|
+      puts "  #{obj.key} => #{obj.etag}"
+end
+# snippet-end:[s3.ruby.auth_federation_token_request_test.rb]

--- a/ruby/example_code/s3/auth_federation_token_request_test.rb
+++ b/ruby/example_code/s3/auth_federation_token_request_test.rb
@@ -11,8 +11,6 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-
-
 # snippet-sourcedescription:[auth_federation_token_request_test.rb allows a federated user with a limited set of permissions to lists keys in the specified bucket.] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
@@ -20,17 +18,15 @@
 # snippet-keyword:[Code Sample]
 # snippet-keyword:[GET Bucket, GET Object, GET Keys]
 # snippet-sourcetype:[full-example]
-# snippet-sourcedate:[YYYY-MM-DD]
+# snippet-sourcedate:[2019-02-11]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.auth_federation_token_request_test.rb]
-
 require 'aws-sdk-s3'
 require 'aws-sdk-iam'
 
-USAGE = << DOC
+USAGE = <<DOC
 
-Usage: federated_create_bucket_policy.rb -b BUCKET -u USER [-r REGION] [-d] [-h]
+Usage: ruby auth_federation_token_request_test.rb -b BUCKET -u USER [-r REGION] [-d] [-h]
 
   Creates a federated policy for USER to list items in BUCKET for one hour.
 
@@ -46,35 +42,40 @@ Usage: federated_create_bucket_policy.rb -b BUCKET -u USER [-r REGION] [-d] [-h]
 
 DOC
 
-$debug = false
-
-def print_debug(s)
-  if $debug
+def print_debug(debug, s)
+  if debug
     puts s
   end
 end
 
-def get_user(region, user_name, create)
-  user = nil
+# Get the user if they exist, otherwise create them
+def get_user(region, user_name, debug)
   iam = Aws::IAM::Client.new(region: 'us-west-2')
   
-begin
-  user = iam.create_user(user_name: user_name)
-  iam.wait_until(:user_exists, user_name: user_name)
-  print_debug("Created new user #{user_name}")
-rescue Aws::IAM::Errors::EntityAlreadyExists
-  print_debug("Found user #{user_name} in region #{region}")
-end
+  # See if user exists
+  user = iam.user(user_name)
+ 
+  # If user does not exist, create them
+  if user == nil
+    user = iam.create_user(user_name: user_name)
+    iam.wait_until(:user_exists, user_name: user_name)
+    print_debug(debug, "Created new user #{user_name}")
+  else
+    print_debug(debug, "Found user #{user_name} in region #{region}")
+  end
+ 
+ user
 end
 
 # main
 region = 'us-west-2'
 user_name = ''
 bucket_name = ''
+debug = false
 
 i = 0
 
-while i &lt; ARGV.length
+while i < ARGV.length
   case ARGV[i]
 
     when '-b'
@@ -92,7 +93,7 @@ while i &lt; ARGV.length
 
     when '-d'
       puts 'Debugging enabled'
-      $debug = true
+      debug = true
 
     when '-h'
       puts USAGE
@@ -102,7 +103,7 @@ while i &lt; ARGV.length
       puts 'Unrecognized option: ' + ARGV[i]
       puts USAGE
       exit 1
-
+   
   end
 
   i += 1
@@ -120,8 +121,8 @@ if user_name == ''
   exit 1
 end
 
-#Identify the IAM user we allow to list Amazon S3 bucket items for an hour.
-user = get_user(region, user_name, true)
+# Identify the IAM user we allow to list Amazon S3 bucket items for an hour.
+user = get_user(region, user_name, debug)
 
 # Create a new STS client and get temporary credentials.
 sts = Aws::STS::Client.new(region: region)
@@ -138,7 +139,12 @@ s3 = Aws::S3::Resource.new(region: region, credentials: creds)
 puts "Contents of '%s':" % bucket_name
 puts '  Name => GUID'
 
- s3.bucket(bucket_name).objects.limit(50).each do |obj|
-      puts "  #{obj.key} => #{obj.etag}"
+begin
+  s3.bucket(bucket_name).objects.limit(50).each do |obj|
+    puts "  #{obj.key} => #{obj.etag}"
+  end
+rescue Exception => ex
+  puts 'Caught exception accessing bucket ' +  bucket_name + ':'
+  puts ex.message
 end
 # snippet-end:[s3.ruby.auth_federation_token_request_test.rb]

--- a/ruby/example_code/s3/auth_request_object_keys.rb
+++ b/ruby/example_code/s3/auth_request_object_keys.rb
@@ -1,0 +1,48 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and limitations under the License.
+#**
+
+
+# snippet-sourcedescription:[auth_request_object_keysuses the credentials in a shared AWS credentials file on a local computer to authenticate a request to get all of the object key names in a specific bucket.] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
+# snippet-keyword:[GET Bucket]
+# snippet-sourcetype:[full-example]
+# snippet-sourcedate:[2019-01-28]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.auth_request_object_keys.rb]
+
+# This snippet example does the following:
+# Creates an instance of the Aws::S3::Resource class. 
+# Makes a request to Amazon S3 by enumerating objects in a bucket using the bucket method of Aws::S3::Resource. 
+# The client generates the necessary signature value from the credentials in the AWS credentials file on your computer, 
+# and includes it in the request it sends to Amazon S3.
+# Prints the array of object key names to the terminal.
+# The credentials that are used for this example come from a local AWS credentials file on the computer that is running this application. 
+# The credentials are for an IAM user who can list objects in the bucket that the user specifies when they run the application.
+
+# Use the Amazon S3 modularized gem for version 3 of the AWS Ruby SDK.
+require 'aws-sdk-s3'
+
+# Get an Amazon S3 resource.
+s3 = Aws::S3::Resource.new(region: 'us-west-2')
+
+# Create an array of up to the first 100 object keynames in the bucket.
+bucket = s3.bucket('example_bucket').objects.collect(&:key)
+
+# Print the array to the terminal.
+puts bucket
+# snippet-end:[s3.ruby.auth_request_object_keys.rb]

--- a/ruby/example_code/s3/auth_request_object_keys.rb
+++ b/ruby/example_code/s3/auth_request_object_keys.rb
@@ -11,9 +11,7 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-
-
-# snippet-sourcedescription:[auth_request_object_keysuses the credentials in a shared AWS credentials file on a local computer to authenticate a request to get all of the object key names in a specific bucket.] 
+# snippet-sourcedescription:[auth_request_object_keys.rb uses the credentials in a shared AWS credentials file on a local computer to authenticate a request to get all of the object key names in a specific bucket.] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
 # snippet-keyword:[Amazon S3]
@@ -22,9 +20,7 @@
 # snippet-sourcetype:[full-example]
 # snippet-sourcedate:[2019-01-28]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.auth_request_object_keys.rb]
-
 # This snippet example does the following:
 # Creates an instance of the Aws::S3::Resource class. 
 # Makes a request to Amazon S3 by enumerating objects in a bucket using the bucket method of Aws::S3::Resource. 

--- a/ruby/example_code/s3/auth_request_test.rb
+++ b/ruby/example_code/s3/auth_request_test.rb
@@ -1,0 +1,80 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and limitations under the License.
+#**
+
+
+# snippet-sourcedescription:[auth_request_test.rb uses the credentials in a  shared AWS credentials file on a local computer to authenticate a request to get all of the object key names  in a specific bucket.] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
+# snippet-keyword:[GET Bucket]
+# snippet-sourcetype:[full-example]
+# snippet-sourcedate:[2019-01-28]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.auth_request_test.rb]
+
+# This snippet example does the following:
+# Creates an instance of the Aws::S3::Resource class. 
+# Makes a request to Amazon S3 by enumerating objects in a bucket using the bucket method of Aws::S3::Resource. 
+# The client generates the necessary signature value from the credentials in the AWS credentials file on your computer, 
+# and includes it in the request it sends to Amazon S3.
+# Prints the array of object key names to the terminal.
+# The credentials that are used for this example come from a local AWS credentials file on the computer that is running this application. 
+# The credentials are for an IAM user who can list objects in the bucket that the user specifies when they run the application.
+
+# Use the Amazon S3 modularized gem for version 3 of the AWS Ruby SDK.
+require 'aws-sdk-s3'
+
+# Usage: ruby auth_request_test.rb list BUCKET
+
+# Set the name of the bucket on which the operations are performed.
+# This argument is required
+bucket_name = nil
+
+# The operation to perform on the bucket.
+operation = 'list' # default
+operation = ARGV[0] if (ARGV.length > 0)
+
+if ARGV.length > 1
+  bucket_name = ARGV[1]
+else
+  exit 1
+end
+
+# Get an Amazon S3 resource.
+s3 = Aws::S3::Resource.new(region: 'us-west-2')
+
+# Get the bucket by name.
+bucket = s3.bucket(bucket_name)
+
+case operation
+
+when 'list'
+  if bucket.exists?
+    # Enumerate the bucket contents and object etags.
+    puts "Contents of '%s':" % bucket_name
+    puts '  Name => GUID'
+
+    bucket.objects.limit(50).each do |obj|
+      puts "  #{obj.key} => #{obj.etag}"
+    end
+  else
+    puts "The bucket '%s' does not exist!" % bucket_name
+  end
+
+else
+  puts "Unknown operation: '%s'! Only list is supported." % operation
+end
+# snippet-end:[s3.ruby.auth_request_test.rb]

--- a/ruby/example_code/s3/auth_request_test.rb
+++ b/ruby/example_code/s3/auth_request_test.rb
@@ -11,8 +11,6 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-
-
 # snippet-sourcedescription:[auth_request_test.rb uses the credentials in a  shared AWS credentials file on a local computer to authenticate a request to get all of the object key names  in a specific bucket.] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
@@ -20,11 +18,9 @@
 # snippet-keyword:[Code Sample]
 # snippet-keyword:[GET Bucket]
 # snippet-sourcetype:[full-example]
-# snippet-sourcedate:[2019-01-28]
+# snippet-sourcedate:[2019-02-11]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.auth_request_test.rb]
-
 # This snippet example does the following:
 # Creates an instance of the Aws::S3::Resource class. 
 # Makes a request to Amazon S3 by enumerating objects in a bucket using the bucket method of Aws::S3::Resource. 
@@ -37,11 +33,8 @@
 # Use the Amazon S3 modularized gem for version 3 of the AWS Ruby SDK.
 require 'aws-sdk-s3'
 
-# Usage: ruby auth_request_test.rb list BUCKET
-
-# Set the name of the bucket on which the operations are performed.
-# This argument is required
-bucket_name = nil
+# Usage: ruby auth_request_test.rb OPERATION BUCKET
+# Currently only the list operation is supported
 
 # The operation to perform on the bucket.
 operation = 'list' # default

--- a/ruby/example_code/s3/auth_session_token_request_test.rb
+++ b/ruby/example_code/s3/auth_session_token_request_test.rb
@@ -1,0 +1,151 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and limitations under the License.
+#**
+
+
+# snippet-sourcedescription:[auth_session_token_request_test.rb creates a temporary user to list the items in a specified bucket for one hour. To use this example, you must have AWS credentials that have the necessary permissions to create new AWS Security Token Service (AWS STS) clients, and list Amaazon S3 buckets using temporary security credentials] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
+# snippet-keyword:[PUT Bucket]
+# snippet-sourcetype:[full-example]
+# snippet-sourcedate:[2019-01-28]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.auth_session_token_request_test.rb]
+
+# This snippet example does the following:
+# The following Ruby example creates a temporary user to list the items in a specified bucket
+# for one hour. To use this example, you must have AWS credentials that have the necessary
+# permissions to create new AWS Security Token Service (AWS STS) clients, and list Amaazon S3 buckets using temporary security credentials 
+# using your AWS account security credentials, the temporary security credentials are valid for only one hour. You can
+# specify session duration only if you use &IAM; user credentials to request a session.
+
+require 'aws-sdk-core'
+require 'aws-sdk-s3'
+require 'aws-sdk-iam'
+
+
+USAGE = <<DOC
+
+Usage: assumerole_create_bucket_policy.rb -b BUCKET -u USER [-r REGION] [-d] [-h]
+
+  Assumes a role for USER to list items in BUCKET for one hour.
+
+  BUCKET is required and must already exist.
+
+  USER is required and if not found, is created.
+
+  If REGION is not supplied, defaults to us-west-2.
+
+  -d gives you extra (debugging) information.
+
+  -h displays this message and quits.
+
+DOC
+
+$debug = false
+
+def print_debug(s)
+  if $debug
+    puts s
+  end
+end
+
+def get_user(region, user_name, create)
+  user = nil
+  iam = Aws::IAM::Client.new(region: 'us-west-2')
+  
+begin
+  user = iam.create_user(user_name: user_name)
+  iam.wait_until(:user_exists, user_name: user_name)
+  print_debug("Created new user #{user_name}")
+rescue Aws::IAM::Errors::EntityAlreadyExists
+  print_debug("Found user #{user_name} in region #{region}")
+end
+end
+
+# main
+region = 'us-west-2'
+user_name = ''
+bucket_name = ''
+
+i = 0
+
+while i &lt; ARGV.length
+  case ARGV[i]
+
+    when '-b'
+      i += 1
+      bucket_name = ARGV[i]
+
+    when '-u'
+      i += 1
+      user_name = ARGV[i]
+
+    when '-r'
+      i += 1
+
+      region = ARGV[i]
+
+    when '-d'
+      puts 'Debugging enabled'
+      $debug = true
+
+    when '-h'
+      puts USAGE
+      exit 0
+
+    else
+      puts 'Unrecognized option: ' + ARGV[i]
+      puts USAGE
+      exit 1
+
+  end
+
+  i += 1
+end
+
+if bucket_name == ''
+  puts 'You must supply a bucket name'
+  puts USAGE
+  exit 1
+end
+
+if user_name == ''
+  puts 'You must supply a user name'
+  puts USAGE
+  exit 1
+end
+
+#Identify the IAM user that is allowed to list Amazon S3 bucket items for an hour.
+user = get_user(region, user_name, true)
+
+# Create a new Amazon STS client and get temporary credentials. This uses a role that was already created.
+creds = Aws::AssumeRoleCredentials.new(
+  client: Aws::STS::Client.new(region: region),
+  role_arn: "arn:aws:iam::111122223333:role/assumedrolelist",
+  role_session_name: "assumerole-s3-list"
+)
+
+# Create an Amazon S3 resource with temporary credentials.
+s3 = Aws::S3::Resource.new(region: region, credentials: creds)
+
+puts "Contents of '%s':" % bucket_name
+puts '  Name => GUID'
+
+ s3.bucket(bucket_name).objects.limit(50).each do |obj|
+      puts "  #{obj.key} => #{obj.etag}"
+end
+# snippet-end:[s3.ruby.auth_session_token_request_test.rb]

--- a/ruby/example_code/s3/auth_session_token_request_test.rb
+++ b/ruby/example_code/s3/auth_session_token_request_test.rb
@@ -11,8 +11,6 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-
-
 # snippet-sourcedescription:[auth_session_token_request_test.rb creates a temporary user to list the items in a specified bucket for one hour. To use this example, you must have AWS credentials that have the necessary permissions to create new AWS Security Token Service (AWS STS) clients, and list Amaazon S3 buckets using temporary security credentials] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
@@ -20,11 +18,9 @@
 # snippet-keyword:[Code Sample]
 # snippet-keyword:[PUT Bucket]
 # snippet-sourcetype:[full-example]
-# snippet-sourcedate:[2019-01-28]
+# snippet-sourcedate:[2019-02-11]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.auth_session_token_request_test.rb]
-
 # This snippet example does the following:
 # The following Ruby example creates a temporary user to list the items in a specified bucket
 # for one hour. To use this example, you must have AWS credentials that have the necessary
@@ -35,7 +31,6 @@
 require 'aws-sdk-core'
 require 'aws-sdk-s3'
 require 'aws-sdk-iam'
-
 
 USAGE = <<DOC
 
@@ -55,31 +50,36 @@ Usage: assumerole_create_bucket_policy.rb -b BUCKET -u USER [-r REGION] [-d] [-h
 
 DOC
 
-$debug = false
-
-def print_debug(s)
-  if $debug
+def print_debug(debug, s)
+  if debug
     puts s
   end
 end
 
-def get_user(region, user_name, create)
-  user = nil
-  iam = Aws::IAM::Client.new(region: 'us-west-2')
-  
-begin
-  user = iam.create_user(user_name: user_name)
-  iam.wait_until(:user_exists, user_name: user_name)
-  print_debug("Created new user #{user_name}")
-rescue Aws::IAM::Errors::EntityAlreadyExists
-  print_debug("Found user #{user_name} in region #{region}")
-end
+# Get the user if they exist, otherwise create them
+def get_user(region, user_name, debug)
+  iam = Aws::IAM::Resource.new(region: region)
+
+  # See if user exists
+  user = iam.user(user_name)
+
+  # If user does not exist, create them
+  if user == nil
+    user = iam.create_user(user_name: user_name)
+    iam.wait_until(:user_exists, user_name: user_name)
+    print_debug(debug, "Created new user #{user_name}")
+  else
+    print_debug(debug, "Found user #{user_name} in region #{region}")
+  end
+
+  user
 end
 
 # main
 region = 'us-west-2'
 user_name = ''
 bucket_name = ''
+debug = false
 
 i = 0
 
@@ -101,7 +101,7 @@ while i &lt; ARGV.length
 
     when '-d'
       puts 'Debugging enabled'
-      $debug = true
+      debug = true
 
     when '-h'
       puts USAGE
@@ -130,22 +130,27 @@ if user_name == ''
 end
 
 #Identify the IAM user that is allowed to list Amazon S3 bucket items for an hour.
-user = get_user(region, user_name, true)
+user = get_user(region, user_name, debug)
 
 # Create a new Amazon STS client and get temporary credentials. This uses a role that was already created.
-creds = Aws::AssumeRoleCredentials.new(
-  client: Aws::STS::Client.new(region: region),
-  role_arn: "arn:aws:iam::111122223333:role/assumedrolelist",
-  role_session_name: "assumerole-s3-list"
-)
+begin
+  creds = Aws::AssumeRoleCredentials.new(
+    client: Aws::STS::Client.new(region: region),
+    role_arn: "arn:aws:iam::111122223333:role/assumedrolelist",
+    role_session_name: "assumerole-s3-list"
+  )
 
-# Create an Amazon S3 resource with temporary credentials.
-s3 = Aws::S3::Resource.new(region: region, credentials: creds)
+  # Create an Amazon S3 resource with temporary credentials.
+  s3 = Aws::S3::Resource.new(region: region, credentials: creds)
 
-puts "Contents of '%s':" % bucket_name
-puts '  Name => GUID'
+  puts "Contents of '%s':" % bucket_name
+  puts '  Name => GUID'
 
- s3.bucket(bucket_name).objects.limit(50).each do |obj|
-      puts "  #{obj.key} => #{obj.etag}"
+  s3.bucket(bucket_name).objects.limit(50).each do |obj|
+    puts "  #{obj.key} => #{obj.etag}"
+  end
+ rescue Exception => ex
+  puts 'Caught exception accessing bucket ' +  bucket_name + ':'
+  puts ex.message
 end
 # snippet-end:[s3.ruby.auth_session_token_request_test.rb]

--- a/ruby/example_code/s3/copy_object_between_buckets.rb
+++ b/ruby/example_code/s3/copy_object_between_buckets.rb
@@ -1,0 +1,38 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and limitations under the License.
+#**
+
+
+# snippet-sourcedescription:[copy_object_between_buckets demonstrates the preceding tasks using the "copy_object" method to copy an object from one bucket to another.] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
+# snippet-keyword:[COPY object]
+# snippet-sourcetype:[full-example]
+# snippet-sourcedate:[2019-01-28]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.copy_object_between_buckets.rb]
+require 'aws-sdk-s3'
+
+source_bucket_name = '*** Provide bucket name ***'
+target_bucket_name = '*** Provide bucket name ***'
+source_key = '*** Provide source key ***'
+target_key = '*** Provide target key ***'
+
+s3 = Aws::S3::Client.new(region: 'us-west-2')
+s3.copy_object({bucket: target_bucket_name, copy_source: source_bucket_name + '/' + source_key, key: target_key})
+
+puts "Copying file #{source_key} to #{target_key}."
+# snippet-end:[s3.ruby.copy_object_between_buckets.rb]

--- a/ruby/example_code/s3/copy_object_between_buckets.rb
+++ b/ruby/example_code/s3/copy_object_between_buckets.rb
@@ -11,8 +11,6 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-
-
 # snippet-sourcedescription:[copy_object_between_buckets demonstrates the preceding tasks using the "copy_object" method to copy an object from one bucket to another.] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
@@ -20,9 +18,8 @@
 # snippet-keyword:[Code Sample]
 # snippet-keyword:[COPY object]
 # snippet-sourcetype:[full-example]
-# snippet-sourcedate:[2019-01-28]
+# snippet-sourcedate:[2019-02-11]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.copy_object_between_buckets.rb]
 require 'aws-sdk-s3'
 
@@ -31,8 +28,13 @@ target_bucket_name = '*** Provide bucket name ***'
 source_key = '*** Provide source key ***'
 target_key = '*** Provide target key ***'
 
-s3 = Aws::S3::Client.new(region: 'us-west-2')
-s3.copy_object({bucket: target_bucket_name, copy_source: source_bucket_name + '/' + source_key, key: target_key})
+begin
+  s3 = Aws::S3::Client.new(region: 'us-west-2')
+  s3.copy_object({bucket: target_bucket_name, copy_source: source_bucket_name + '/' + source_key, key: target_key})
+rescue Exception => ex
+  puts 'Caught exception copying object ' +  source_key + ' from bucket ' + source_bucket_name + ' to bucket ' + target_bucket_name + ' as ' + target_key + ':'
+  puts ex.message
+end
 
-puts "Copying file #{source_key} to #{target_key}."
+puts 'Copied ' +  source_key + ' from bucket ' + source_bucket_name + ' to bucket ' + target_bucket_name + ' as ' + target_key
 # snippet-end:[s3.ruby.copy_object_between_buckets.rb]

--- a/ruby/example_code/s3/copy_object_encrypt_copy.rb
+++ b/ruby/example_code/s3/copy_object_encrypt_copy.rb
@@ -1,0 +1,38 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and limitations under the License.
+#**
+
+# snippet-sourcedescription:[copy_object_encrypt_copy.rb demonstrates how to copy an object and encrypt the copy.] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
+# snippet-keyword:[COPY Object]
+# snippet-sourcetype:[full-example]
+# snippet-sourcedate:[2019-01-28]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.copy_object_encrypt_copy.rb]
+require 'aws-sdk-s3'
+
+regionName = 'us-west-2' 
+encryptionType = 'AES256'
+
+s3 = Aws::S3::Resource.new(region:regionName)
+bucket1 = s3.bucket('source-bucket-name')
+bucket2 = s3.bucket('target-bucket-name')
+obj1 = bucket1.object('Bucket1Key')
+obj2 = bucket2.object('Bucket2Key')
+ 
+obj1.copy_to(obj2, :server_side_encryption => encryptionType)
+# snippet-end:[s3.ruby.copy_object_encrypt_copy.rb]

--- a/ruby/example_code/s3/copy_object_encrypt_copy.rb
+++ b/ruby/example_code/s3/copy_object_encrypt_copy.rb
@@ -11,7 +11,6 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-
 # snippet-sourcedescription:[copy_object_encrypt_copy.rb demonstrates how to copy an object and encrypt the copy.] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
@@ -21,7 +20,6 @@
 # snippet-sourcetype:[full-example]
 # snippet-sourcedate:[2019-01-28]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.copy_object_encrypt_copy.rb]
 require 'aws-sdk-s3'
 

--- a/ruby/example_code/s3/create_bucket_snippet.rb
+++ b/ruby/example_code/s3/create_bucket_snippet.rb
@@ -1,0 +1,31 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and lim2019itations under the License.
+#**
+
+# snippet-sourcedescription:[create_bucket_snippet creates a bucket programmatically by using the AWS SDK for Ruby.] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
+# snippet-keyword:[CREATE Bucket]
+# snippet-sourcetype:[snippet]
+# snippet-sourcedate:[2019-01-28]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.create_bucket_snippet.rb]
+
+require 'aws-sdk-s3'
+	        
+s3 = Aws::S3::Client.new(region: 'us-west-2')
+s3.create_bucket(bucket: 'bucket-name')
+# snippet-end:[s3.ruby.create_bucket_snippet.rb]

--- a/ruby/example_code/s3/create_bucket_snippet.rb
+++ b/ruby/example_code/s3/create_bucket_snippet.rb
@@ -11,7 +11,6 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and lim2019itations under the License.
 #**
-
 # snippet-sourcedescription:[create_bucket_snippet creates a bucket programmatically by using the AWS SDK for Ruby.] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
@@ -21,9 +20,7 @@
 # snippet-sourcetype:[snippet]
 # snippet-sourcedate:[2019-01-28]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.create_bucket_snippet.rb]
-
 require 'aws-sdk-s3'
 	        
 s3 = Aws::S3::Client.new(region: 'us-west-2')

--- a/ruby/example_code/s3/determine_object_encryption_state.rb
+++ b/ruby/example_code/s3/determine_object_encryption_state.rb
@@ -11,8 +11,6 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-
-
 # snippet-sourcedescription:[determine_object_encryption_state.rb shows how to determine the encryption state of an existing object.] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
@@ -20,9 +18,8 @@
 # snippet-keyword:[Code Sample]
 # snippet-keyword:[GET server_side_encryption Object]
 # snippet-sourcetype:[full-example]
-# snippet-sourcedate:[2019-01-28]
+# snippet-sourcedate:[2019-02-11]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.determine_object_encryption_state.rb]
 # Determine server-side encryption of an object.
 require 'aws-sdk-s3'

--- a/ruby/example_code/s3/determine_object_encryption_state.rb
+++ b/ruby/example_code/s3/determine_object_encryption_state.rb
@@ -1,0 +1,38 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and limitations under the License.
+#**
+
+
+# snippet-sourcedescription:[determine_object_encryption_state.rb shows how to determine the encryption state of an existing object.] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
+# snippet-keyword:[GET server_side_encryption Object]
+# snippet-sourcetype:[full-example]
+# snippet-sourcedate:[2019-01-28]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.determine_object_encryption_state.rb]
+# Determine server-side encryption of an object.
+require 'aws-sdk-s3'
+
+regionName = 'us-west-2' 
+bucketName='bucket-name'
+key = 'key' '
+
+s3 = Aws::S3::Resource.new(region:regionName)
+enc = s3.bucket(bucketName).object(key).server_side_encryption
+enc_state = (enc != nil) ? enc : "not set"
+puts "Encryption state is #{enc_state}."
+# snippet-end:[s3.ruby.determine_object_encryption_state.rb]

--- a/ruby/example_code/s3/s3_encrypt_file_upload.rb
+++ b/ruby/example_code/s3/s3_encrypt_file_upload.rb
@@ -1,0 +1,38 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and limitations under the License.
+#**
+
+# snippet-sourcedescription:[s3_encrypt_file_upload.rb demonstrates how to specify that a file uploaded to Amazon S3 be encrypted at rest.] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
+# snippet-keyword:[ENCRYPT UPLOAD File]
+# snippet-sourcetype:[full-example]
+# snippet-sourcedate:[2019-01-28]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.s3_encrypt_file_upload.rb]
+# The following example demonstrates how to specify that a file uploaded to Amazon S3 be encrypted at rest.
+require 'aws-sdk-s3' 
+
+regionName = 'us-west-2' 
+bucketName = 'my-bucket' 
+key = 'key' 
+filePath = 'local/path/to/file'
+encryptionType = 'AES256'
+
+s3 = Aws::S3::Resource.new(region:regionName) 
+obj = s3.bucket(bucketName).object(key) 
+obj.upload_file(filePath, :server_side_encryption => encryptionType)
+# snippet-end:[s3.ruby.s3_encrypt_file_upload.rb]

--- a/ruby/example_code/s3/s3_encrypt_file_upload.rb
+++ b/ruby/example_code/s3/s3_encrypt_file_upload.rb
@@ -11,7 +11,6 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-
 # snippet-sourcedescription:[s3_encrypt_file_upload.rb demonstrates how to specify that a file uploaded to Amazon S3 be encrypted at rest.] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
@@ -19,9 +18,8 @@
 # snippet-keyword:[Code Sample]
 # snippet-keyword:[ENCRYPT UPLOAD File]
 # snippet-sourcetype:[full-example]
-# snippet-sourcedate:[2019-01-28]
+# snippet-sourcedate:[2019-02-11]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.s3_encrypt_file_upload.rb]
 # The following example demonstrates how to specify that a file uploaded to Amazon S3 be encrypted at rest.
 require 'aws-sdk-s3' 

--- a/ruby/example_code/s3/upload_files_using_managed_file_uploader.rb
+++ b/ruby/example_code/s3/upload_files_using_managed_file_uploader.rb
@@ -11,8 +11,6 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-
-
 # snippet-sourcedescription:[upload_files_using_managed_file_uploader uses a managed file uploader, which makes it easy to upload files of any size from disk.] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
@@ -22,7 +20,6 @@
 # snippet-sourcetype:[full-example]
 # snippet-sourcedate:[2019-01-28]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.upload_files_using_managed_file_uploader.rb]
 require 'aws-sdk-s3'
 

--- a/ruby/example_code/s3/upload_files_using_managed_file_uploader.rb
+++ b/ruby/example_code/s3/upload_files_using_managed_file_uploader.rb
@@ -1,0 +1,32 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and limitations under the License.
+#**
+
+
+# snippet-sourcedescription:[upload_files_using_managed_file_uploader uses a managed file uploader, which makes it easy to upload files of any size from disk.] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
+# snippet-keyword:[UPLOAD file]
+# snippet-sourcetype:[full-example]
+# snippet-sourcedate:[2019-01-28]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.upload_files_using_managed_file_uploader.rb]
+require 'aws-sdk-s3'
+
+s3 = Aws::S3::Resource.new(region:'us-west-2')
+obj = s3.bucket('bucket-name').object('key')
+obj.upload_file('/path/to/source/file')
+# snippet-end:[s3.ruby.upload_files_using_managed_file_uploader.rb]

--- a/ruby/example_code/s3/upload_files_using_put_object_method.rb
+++ b/ruby/example_code/s3/upload_files_using_put_object_method.rb
@@ -1,0 +1,39 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and limitations under the License.
+#**
+
+
+# snippet-sourcedescription:[upload_files_using_put_object_method.rb shows how to upload an object using the #put method of Amazon S3 object. This is useful if the object is a string or an I/O object that is not a file on disk.] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
+# snippet-keyword:[PUT Object]
+# snippet-sourcetype:[full-example]
+# snippet-sourcedate:[2019-01-28]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.upload_files_using_put_object_method.rb]
+  require 'aws-sdk-s3'
+
+  s3 = Aws::S3::Resource.new(region:'us-west-2')
+  obj = s3.bucket('bucket-name').object('key')
+
+# string data
+  obj.put(body: 'Hello World!')
+
+# I/O object
+  File.open('/path/to/source.file', 'rb') do |file|
+  obj.put(body: file)
+  end
+# snippet-end:[s3.ruby.upload_files_using_put_object_method.rb]

--- a/ruby/example_code/s3/upload_files_using_put_object_method.rb
+++ b/ruby/example_code/s3/upload_files_using_put_object_method.rb
@@ -11,8 +11,6 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-
-
 # snippet-sourcedescription:[upload_files_using_put_object_method.rb shows how to upload an object using the #put method of Amazon S3 object. This is useful if the object is a string or an I/O object that is not a file on disk.] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
@@ -20,20 +18,16 @@
 # snippet-keyword:[Code Sample]
 # snippet-keyword:[PUT Object]
 # snippet-sourcetype:[full-example]
-# snippet-sourcedate:[2019-01-28]
+# snippet-sourcedate:[2019-02-11]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.upload_files_using_put_object_method.rb]
-  require 'aws-sdk-s3'
+require 'aws-sdk-s3'
 
-  s3 = Aws::S3::Resource.new(region:'us-west-2')
-  obj = s3.bucket('bucket-name').object('key')
-
-# string data
-  obj.put(body: 'Hello World!')
+s3 = Aws::S3::Resource.new(region:'us-west-2')
+obj = s3.bucket('bucket-name').object('key')
 
 # I/O object
-  File.open('/path/to/source.file', 'rb') do |file|
+File.open('/path/to/source.file', 'rb') do |file|
   obj.put(body: file)
-  end
+end
 # snippet-end:[s3.ruby.upload_files_using_put_object_method.rb]

--- a/ruby/example_code/s3/upload_object_presigned_url.rb
+++ b/ruby/example_code/s3/upload_object_presigned_url.rb
@@ -1,0 +1,52 @@
+#**
+ #* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #*
+ #* This file is licensed under the Apache License, Version 2.0 (the "License").
+ #* You may not use this file except in compliance with the License. A copy of
+ #* the License is located at
+ #*
+ #* http://aws.amazon.com/apache2.0/
+ #*
+ #* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ #* specific language governing permissions and limitations under the License.
+#**
+
+
+# snippet-sourcedescription:[create_bucket.rb allows anyone with the presigned URL can upload an object by using the AWS SDK for Ruby.] 
+# snippet-service:[s3]
+# snippet-keyword:[Ruby]
+# snippet-keyword:[Amazon S3]
+# snippet-keyword:[PUT Bucket, Presigned URL]
+# snippet-keyword:[Upload-presigned-url]
+# snippet-sourcetype:[snippet]
+# snippet-sourcedate:[2019-01-28]
+# snippet-sourceauthor:[AWS]
+
+# snippet-start:[s3.ruby.upload_object_presigned_url.rb]
+#Uploading an object using a presigned URL for SDK for Ruby - Version 3.
+
+require 'aws-sdk-s3'
+require 'net/http'
+
+s3 = Aws::S3::Resource.new(region:'us-west-2')
+
+obj = s3.bucket('BucketName').object('KeyName')
+# Replace BucketName with the name of your bucket.
+# Replace KeyName with the name of the object you are creating or replacing.
+
+url = URI.parse(obj.presigned_url(:put))
+
+body = "Hello World!"
+# This is the contents of your object. In this case, it's a simple string.
+
+Net::HTTP.start(url.host) do |http|
+  http.send_request("PUT", url.request_uri, body, {
+# This is required, or Net::HTTP will add a default unsigned content-type.
+    "content-type" => "",
+  })
+end
+
+puts obj.get.body.read
+# This will print out the contents of your object to the terminal window.
+# snippet-end:[s3.ruby.upload_object_presigned_url.rb]

--- a/ruby/example_code/s3/upload_object_presigned_url.rb
+++ b/ruby/example_code/s3/upload_object_presigned_url.rb
@@ -15,6 +15,7 @@
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
 # snippet-keyword:[Amazon S3]
+# snippet-keyword:[Code Sample]
 # snippet-keyword:[PUT Bucket, Presigned URL]
 # snippet-keyword:[Upload-presigned-url]
 # snippet-sourcetype:[snippet]

--- a/ruby/example_code/s3/upload_object_presigned_url.rb
+++ b/ruby/example_code/s3/upload_object_presigned_url.rb
@@ -11,8 +11,6 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-
-
 # snippet-sourcedescription:[create_bucket.rb allows anyone with the presigned URL can upload an object by using the AWS SDK for Ruby.] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
@@ -20,9 +18,8 @@
 # snippet-keyword:[PUT Bucket, Presigned URL]
 # snippet-keyword:[Upload-presigned-url]
 # snippet-sourcetype:[snippet]
-# snippet-sourcedate:[2019-01-28]
+# snippet-sourcedate:[2019-02-11]
 # snippet-sourceauthor:[AWS]
-
 # snippet-start:[s3.ruby.upload_object_presigned_url.rb]
 #Uploading an object using a presigned URL for SDK for Ruby - Version 3.
 


### PR DESCRIPTION
Moving S3 Java and Ruby code samples to code catalog.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license