### PR TITLE
Update C++ SDK examples to make it build with C++ SDK.

### DIFF
--- a/cpp/example_code/codebuild/list_builds.cpp
+++ b/cpp/example_code/codebuild/list_builds.cpp
@@ -62,25 +62,20 @@ int main(int argc, char **argv)
       lb_req.SetSortOrder(Aws::CodeBuild::Model::SortOrderType::NOT_SET);
     }
 
-
     auto lb_out = codebuild.ListBuilds(lb_req);
 
     if (lb_out.IsSuccess())
     {
       std::cout << "Information about each build:" << std::endl;
-      for (auto val : lb_out.GetResult().GetIds())
+      bgb_req.SetIds(lb_out.GetResult().GetIds());
+      auto bgb_out = codebuild.BatchGetBuilds(bgb_req);
+
+      if (bgb_out.IsSuccess())
       {
-        bgb_req.SetIds(val);
-        auto bgb_out = codebuild.BatchGetBuilds(bgb_req);
-
-        if (bgb_out.IsSuccess())
+        for (auto val: bgb_out.GetResult().GetBuilds())
         {
-          for (auto val: bgb_out.GetResult().GetBuilds())
-          {
-            std::cout << val << std::endl;
-          }
+          std::cout << val.GetId() << std::endl;
         }
-
       }
     }
 

--- a/cpp/example_code/codecommit/update_pull_request.cpp
+++ b/cpp/example_code/codecommit/update_pull_request.cpp
@@ -83,7 +83,7 @@ int main(int argc, char ** argv)
     auto uprs_out = codecommit.UpdatePullRequestStatus(uprs_req);
     auto uprt_out = codecommit.UpdatePullRequestTitle(uprt_req);
 
-    if (uprd_out.IsSuccess() and uprs_out.IsSuccess() and uprt_out.IsSuccess())
+    if (uprd_out.IsSuccess() && uprs_out.IsSuccess() && uprt_out.IsSuccess())
     {
       std::cout << "Successfully updated pull request title, status and description."
                 << std::endl;

--- a/cpp/example_code/codecommit/update_repository.cpp
+++ b/cpp/example_code/codecommit/update_repository.cpp
@@ -61,7 +61,7 @@ int main(int argc, char ** argv)
     auto urd_out = codecommit.UpdateRepositoryDescription(urd_req);
     auto urn_out = codecommit.UpdateRepositoryName(urn_req);
 
-    if (urd_out.IsSuccess() and urn_out.IsSuccess())
+    if (urd_out.IsSuccess() && urn_out.IsSuccess())
     {
       std::cout << "Successfully updated repository."
                 << std::endl;

--- a/cpp/example_code/efs/CMakeLists.txt
+++ b/cpp/example_code/efs/CMakeLists.txt
@@ -12,7 +12,7 @@ project(efs-examples)
 set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
-find_package(AWSSDK REQUIRED COMPONENTS efs)
+find_package(AWSSDK REQUIRED COMPONENTS elasticfilesystem)
 
 set(EXAMPLES "")
 list(APPEND EXAMPLES "create_file_system")

--- a/cpp/example_code/s3/put_object_unicode.cpp
+++ b/cpp/example_code/s3/put_object_unicode.cpp
@@ -9,7 +9,7 @@
 //snippet-sourceauthor:[tapasweni-pathak]
 
 
-﻿/*
+/*
 Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/cpp/example_code/storage_gateway/CMakeLists.txt
+++ b/cpp/example_code/storage_gateway/CMakeLists.txt
@@ -12,11 +12,11 @@ project(sg-examples)
 set (CMAKE_CXX_STANDARD 11)
 
 # Locate the aws sdk for c++ package.
-find_package(AWSSDK REQUIRED COMPONENTS sg)
+find_package(AWSSDK REQUIRED COMPONENTS storagegateway)
 
 set(EXAMPLES "")
 list(APPEND EXAMPLES "create_nfs_file_share")
-list(APPEND EXAMPLES "list_file_share")
+list(APPEND EXAMPLES "list_file_shares")
 list(APPEND EXAMPLES "start_gateway")
 list(APPEND EXAMPLES "describe_gateway_information")
 list(APPEND EXAMPLES "describe_smb_settings")

--- a/cpp/example_code/storage_gateway/create_nfs_file_share.cpp
+++ b/cpp/example_code/storage_gateway/create_nfs_file_share.cpp
@@ -24,6 +24,7 @@
 #include <aws/storagegateway/StorageGatewayClient.h>
 #include <aws/storagegateway/model/CreateNFSFileShareRequest.h>
 #include <aws/storagegateway/model/CreateNFSFileShareResult.h>
+#include <aws/core/utils/Outcome.h>
 #include <iostream>
 
 int main(int argc, char ** argv)
@@ -46,10 +47,10 @@ int main(int argc, char ** argv)
 
     Aws::StorageGateway::Model::CreateNFSFileShareRequest cnfsfs_req;
 
-    cnfsfs.SetGatewayARN(gateway_arn);
-    cnfsfs.SetRole(role);
-    cnfsfs.SetLocationARN(location_arn);
-    cnfsfs.AddClientList(client_token);
+    cnfsfs_req.SetGatewayARN(gateway_arn);
+    cnfsfs_req.SetRole(role);
+    cnfsfs_req.SetLocationARN(location_arn);
+    cnfsfs_req.AddClientList(client_token);
 
     auto cnfsfs_out = storagegateway.CreateNFSFileShare(cnfsfs_req);
 

--- a/cpp/example_code/storage_gateway/delete_volume.cpp
+++ b/cpp/example_code/storage_gateway/delete_volume.cpp
@@ -24,6 +24,7 @@
 #include <aws/storagegateway/StorageGatewayClient.h>
 #include <aws/storagegateway/model/DeleteVolumeRequest.h>
 #include <aws/storagegateway/model/DeleteVolumeResult.h>
+#include <aws/core/utils/Outcome.h>
 #include <iostream>
 
 int main(int argc, char ** argv)
@@ -43,9 +44,9 @@ int main(int argc, char ** argv)
 
     Aws::StorageGateway::Model::DeleteVolumeRequest dv_req;
 
-    dv.SetVolumeARN(gateway_arn);
+    dv_req.SetVolumeARN(volume_arn);
 
-    auto dv_out = storagegateway.CreateNFSFileShare(dv_req);
+    auto dv_out = storagegateway.DeleteVolume(dv_req);
 
     if (dv_out.IsSuccess())
     {

--- a/cpp/example_code/storage_gateway/describe_gateway_information.cpp
+++ b/cpp/example_code/storage_gateway/describe_gateway_information.cpp
@@ -22,8 +22,9 @@
 
 #include <aws/core/Aws.h>
 #include <aws/storagegateway/StorageGatewayClient.h>
-#include <aws/storagegateway/model/DescribeGatewayRequest.h>
-#include <aws/storagegateway/model/DescribeGatewayResult.h>
+#include <aws/storagegateway/model/DescribeGatewayInformationRequest.h>
+#include <aws/storagegateway/model/DescribeGatewayInformationResult.h>
+#include <aws/core/utils/Outcome.h>
 #include <iostream>
 
 int main(int argc, char ** argv)
@@ -39,13 +40,13 @@ int main(int argc, char ** argv)
   {
     Aws::String gateway_arn(argv[1]);
 
-    Aws::StorageGateway::StorageGatewayClient sg;
+    Aws::StorageGateway::StorageGatewayClient storagegatway;
 
-    Aws::StorageGateway::Model::DescribeGatewayRequest dgi_req;
+    Aws::StorageGateway::Model::DescribeGatewayInformationRequest dgi_req;
 
-    sg.SetGatewayARN(gateway_arn);
+    dgi_req.SetGatewayARN(gateway_arn);
 
-    auto dgi_out = storagegatway.DescribeGateway(dgi_req);
+    auto dgi_out = storagegatway.DescribeGatewayInformation(dgi_req);
 
     if (dgi_out.IsSuccess())
     {

--- a/cpp/example_code/storage_gateway/describe_smb_settings.cpp
+++ b/cpp/example_code/storage_gateway/describe_smb_settings.cpp
@@ -24,6 +24,7 @@
 #include <aws/storagegateway/StorageGatewayClient.h>
 #include <aws/storagegateway/model/DescribeSMBSettingsRequest.h>
 #include <aws/storagegateway/model/DescribeSMBSettingsResult.h>
+#include <aws/core/utils/Outcome.h>
 #include <iostream>
 
 int main(int argc, char ** argv)
@@ -39,20 +40,20 @@ int main(int argc, char ** argv)
   {
     Aws::String gateway_arn(argv[1]);
 
-    Aws::StorageGateway::StorageGatewayClient sg;
+    Aws::StorageGateway::StorageGatewayClient storagegatway;
 
     Aws::StorageGateway::Model::DescribeSMBSettingsRequest dsmbs_req;
 
-    sg.SetGatewayARN(gateway_arn);
+    dsmbs_req.SetGatewayARN(gateway_arn);
 
-    auto dsmbs_out = storagegatway.DescribeGateway(dsmbs_req);
+    auto dsmbs_out = storagegatway.DescribeSMBSettings(dsmbs_req);
 
     if (dsmbs_out.IsSuccess())
     {
       std::cout << "Successfully describing SMB settings as:";
-      for (auto val : dsmbs_out.GetResult().GetSMBFileShareInfoList())
+      for (auto val : dsmbs_out.GetResult().GetDomainName())
       {
-        cout << " " << val;
+        std::cout << " " << val;
       }
     }
     else

--- a/cpp/example_code/storage_gateway/list_file_shares.cpp
+++ b/cpp/example_code/storage_gateway/list_file_shares.cpp
@@ -24,6 +24,7 @@
 #include <aws/storagegateway/StorageGatewayClient.h>
 #include <aws/storagegateway/model/ListFileSharesRequest.h>
 #include <aws/storagegateway/model/ListFileSharesResult.h>
+#include <aws/core/utils/Outcome.h>
 #include <iostream>
 
 int main(int argc, char ** argv)
@@ -43,16 +44,16 @@ int main(int argc, char ** argv)
 
     Aws::StorageGateway::Model::ListFileSharesRequest lfs_req;
 
-    storagegateway.SetGatewayARN(gateway_arn);
+    lfs_req.SetGatewayARN(gateway_arn);
 
     auto lfs_out = storagegateway.ListFileShares(lfs_req);
 
     if (lfs_out.IsSuccess())
     {
       std::cout << "Successfully listing file shares";
-      for (auto val: lfs_out.GetResult().GetFileShareInfoList())
+      for (auto fileShareInfo: lfs_out.GetResult().GetFileShareInfoList())
       {
-        cout << " " << val;
+        std::cout << " " << fileShareInfo.GetFileShareId();
       }
     }
     else

--- a/cpp/example_code/storage_gateway/start_gateway.cpp
+++ b/cpp/example_code/storage_gateway/start_gateway.cpp
@@ -24,6 +24,7 @@
 #include <aws/storagegateway/StorageGatewayClient.h>
 #include <aws/storagegateway/model/StartGatewayRequest.h>
 #include <aws/storagegateway/model/StartGatewayResult.h>
+#include <aws/core/utils/Outcome.h>
 #include <iostream>
 
 int main(int argc, char ** argv)
@@ -39,11 +40,11 @@ int main(int argc, char ** argv)
   {
     Aws::String gateway_arn(argv[1]);
 
-    Aws::StorageGateway::StorageGatewayClient sg;
+    Aws::StorageGateway::StorageGatewayClient storagegateway;
 
     Aws::StorageGateway::Model::StartGatewayRequest sg_req;
 
-    sg.SetGatewayARN(gateway_arn);
+    sg_req.SetGatewayARN(gateway_arn);
 
     auto sg_out = storagegateway.StartGateway(sg_req);
 


### PR DESCRIPTION
*Description of changes:*
Build these examples with C++ SDK, fix several issues, including:
1. logical `and` is not defined in msvc without `#include <ciso646>`, using `&&` instead.
2. some service library names are incorrect.
3. `#include <aws/core/utils/Outcome.h>` to fix "incomplete type" issue.
4. typos

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
