### PR TITLE
Fixed Go examples; rewrote Go DynamoDB examples

### DIFF
--- a/go/example_code/cloudformation/CfnCreateStack.go
+++ b/go/example_code/cloudformation/CfnCreateStack.go
@@ -30,7 +30,6 @@ import (
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/cloudformation"
 
-    "flag"
     "fmt"
     "os"
 )

--- a/go/example_code/cloudformation/CfnDeleteStack.go
+++ b/go/example_code/cloudformation/CfnDeleteStack.go
@@ -30,7 +30,6 @@ import (
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/cloudformation"
 
-    "flag"
     "fmt"
     "os"
 )

--- a/go/example_code/cloudformation/CfnListStacks.go
+++ b/go/example_code/cloudformation/CfnListStacks.go
@@ -29,7 +29,6 @@ import (
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/cloudformation"
 
-    "flag"
     "fmt"
     "os"
 )

--- a/go/example_code/cloudtrail/create_trail.go
+++ b/go/example_code/cloudtrail/create_trail.go
@@ -141,6 +141,6 @@ func main() {
         os.Exit(1)
     }
 
-    fmt.Println("Created the trail", trailName, "for bucket", bucketName, "in region", regionName)
+    fmt.Println("Created the trail", trailName, "for bucket", bucketName)
 }
 

--- a/go/example_code/cloudtrail/delete_trail.go
+++ b/go/example_code/cloudtrail/delete_trail.go
@@ -55,7 +55,7 @@ func main() {
     // Create CloudTrail client
     svc := cloudtrail.New(sess)
 
-    _, err = svc.DeleteTrail(&cloudtrail.DeleteTrailInput{Name: trailNamePtr})
+    _, err = svc.DeleteTrail(&cloudtrail.DeleteTrailInput{Name: aws.String(trailName)})
     if err != nil {
         fmt.Println("Got error calling CreateTrail:")
         fmt.Println(err.Error())

--- a/go/example_code/cloudtrail/lookup_events.go
+++ b/go/example_code/cloudtrail/lookup_events.go
@@ -38,7 +38,7 @@ import (
 func main() {
     // Trail name required
     var trailName string
-    flag.StringVar(&trailname, "n", "", "The name of the trail")
+    flag.StringVar(&trailName, "n", "", "The name of the trail")
 
     // Option to show event
     var showEvent bool
@@ -73,12 +73,9 @@ func main() {
     fmt.Println("")
 
     for _, event := range resp.Events {
-        if showEvents {
-            fmt.Println("Event:")
-            fmt.Println(aws.StringValue(event.CloudTrailEvent))
-            fmt.Println("")
-        }
-
+        fmt.Println("Event:")
+        fmt.Println(aws.StringValue(event.CloudTrailEvent))
+        fmt.Println("")
         fmt.Println("Name    ", aws.StringValue(event.EventName))
         fmt.Println("ID:     ", aws.StringValue(event.EventId))
         fmt.Println("Time:   ", aws.TimeValue(event.EventTime))

--- a/go/example_code/cloudwatch/CloudWatchGetLogEvents.go
+++ b/go/example_code/cloudwatch/CloudWatchGetLogEvents.go
@@ -25,10 +25,10 @@
 package main
 
 import (
+    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 
-    "flag"
     "fmt"
     "os"
 )
@@ -44,8 +44,8 @@ func main() {
     // in LOG-GROUP-NAME:
     resp, err := svc.GetLogEvents(&cloudwatchlogs.GetLogEventsInput{
         Limit:         aws.Int64(100),
-        LogGroupName:  aws.String(LOG-GROUP-NAME),
-        LogStreamName: aws.String(LOG-STREAM-NAME),
+        LogGroupName:  aws.String("LOG-GROUP-NAME"),
+        LogStreamName: aws.String("LOG-STREAM-NAME"),
     })
     if err != nil {
         fmt.Println("Got error getting log events:")
@@ -53,7 +53,7 @@ func main() {
         os.Exit(1)
     }
 
-    fmt.Println("Event messages for stream "+logStream+" in log group "+logGroup+":")
+    fmt.Println("Event messages for stream LOG-STREAM-NAME in log group LOG-GROUP-NAME:")
 
     gotToken := ""
     nextToken := ""

--- a/go/example_code/cloudwatch/delete_alarms.go
+++ b/go/example_code/cloudwatch/delete_alarms.go
@@ -21,29 +21,39 @@
    CONDITIONS OF ANY KIND, either express or implied. See the License for the
    specific language governing permissions and limitations under the License.
 */
+package main
 
-sess, err := session.NewSession()
-if err != nil {
-    fmt.Println("failed to create session,", err)
-    return
-}
+import (
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/cloudwatch"
 
-svc := cloudwatch.New(sess)
+    "fmt"
+)
 
-params := &cloudwatch.DeleteAlarmsInput{
-    AlarmNames: []*string{
-        aws.String("AlarmName"),
+func main() {
+    sess, err := session.NewSession()
+    if err != nil {
+        fmt.Println("failed to create session,", err)
+            return
+        }
+
+    svc := cloudwatch.New(sess)
+
+    params := &cloudwatch.DeleteAlarmsInput{
+        AlarmNames: []*string{
+            aws.String("AlarmName"),
         // More values...
-    },
-}
-resp, err := svc.DeleteAlarms(params)
+    }}
 
-if err != nil {
-    // Print the error, cast err to awserr.Error to get the Code and
-    // Message from an error.
-    fmt.Println(err.Error())
-    return
-}
+    resp, err := svc.DeleteAlarms(params)
+    if err != nil {
+        // Print the error, cast err to awserr.Error to get the Code and
+        // Message from an error.
+        fmt.Println(err.Error())
+        return
+    }
 
-// Pretty-print the response data.
-fmt.Println(resp)
+    // Pretty-print the response data.
+    fmt.Println(resp)
+}

--- a/go/example_code/cloudwatch/describe_alarm_history.go
+++ b/go/example_code/cloudwatch/describe_alarm_history.go
@@ -26,7 +26,7 @@ package main
 import (
     "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go_/service/cloudwatch"
+    "github.com/aws/aws-sdk-go/service/cloudwatch"
 
     "fmt"
     "os"

--- a/go/example_code/cloudwatch/describe_alarms.go
+++ b/go/example_code/cloudwatch/describe_alarms.go
@@ -24,7 +24,6 @@
 package main
 
 import (
-    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/cloudwatch"
 

--- a/go/example_code/cloudwatch/describe_alarms_for_metric.go
+++ b/go/example_code/cloudwatch/describe_alarms_for_metric.go
@@ -21,38 +21,49 @@
    CONDITIONS OF ANY KIND, either express or implied. See the License for the
    specific language governing permissions and limitations under the License.
 */
+package main
 
-sess, err := session.NewSession()
-if err != nil {
-    fmt.Println("failed to create session,", err)
-    return
-}
+import (
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/cloudwatch"
 
-svc := cloudwatch.New(sess)
+    "fmt"
+)
 
-params := &cloudwatch.DescribeAlarmsForMetricInput{
-    MetricName: aws.String("MetricName"), // Required
-    Namespace:  aws.String("Namespace"),  // Required
-    Dimensions: []*cloudwatch.Dimension{
-        { // Required
-            Name:  aws.String("DimensionName"),  // Required
-            Value: aws.String("DimensionValue"), // Required
+func main() {
+    sess, err := session.NewSession()
+    if err != nil {
+        fmt.Println("failed to create session,", err)
+        return
+    }
+
+    svc := cloudwatch.New(sess)
+
+    params := &cloudwatch.DescribeAlarmsForMetricInput{
+        MetricName: aws.String("MetricName"), // Required
+        Namespace:  aws.String("Namespace"),  // Required
+        Dimensions: []*cloudwatch.Dimension{
+            { // Required
+                Name:  aws.String("DimensionName"),  // Required
+                Value: aws.String("DimensionValue"), // Required
+            },
+            // More values...
         },
-        // More values...
-    },
-    ExtendedStatistic: aws.String("ExtendedStatistic"),
-    Period:            aws.Int64(1),
-    Statistic:         aws.String("Statistic"),
-    Unit:              aws.String("StandardUnit"),
-}
-resp, err := svc.DescribeAlarmsForMetric(params)
+        ExtendedStatistic: aws.String("ExtendedStatistic"),
+        Period:            aws.Int64(1),
+        Statistic:         aws.String("Statistic"),
+        Unit:              aws.String("StandardUnit"),
+    }
 
-if err != nil {
-    // Print the error, cast err to awserr.Error to get the Code and
-    // Message from an error.
-    fmt.Println(err.Error())
-    return
-}
+    resp, err := svc.DescribeAlarmsForMetric(params)
+    if err != nil {
+        // Print the error, cast err to awserr.Error to get the Code and
+        // Message from an error.
+        fmt.Println(err.Error())
+        return
+    }
 
-// Pretty-print the response data.
-fmt.Println(resp)
+    // Pretty-print the response data.
+    fmt.Println(resp)
+}

--- a/go/example_code/cloudwatch/disable_alarm.go
+++ b/go/example_code/cloudwatch/disable_alarm.go
@@ -25,6 +25,7 @@
 package main
 
 import (
+    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/cloudwatch"
 

--- a/go/example_code/codebuild/cb_build_project.go
+++ b/go/example_code/codebuild/cb_build_project.go
@@ -52,8 +52,7 @@ func main() {
     svc := codebuild.New(sess)
 
     // Build the project
-    _, err := svc.StartBuild(&codebuild.StartBuildInput{ProjectName: aws.String(project)})
-
+    _, err = svc.StartBuild(&codebuild.StartBuildInput{ProjectName: aws.String(project)})
     if err != nil {
         fmt.Println("Got error building project: ", err)
         os.Exit(1)

--- a/go/example_code/cognito/CognitoListUserPools.go
+++ b/go/example_code/cognito/CognitoListUserPools.go
@@ -29,7 +29,6 @@ import (
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 
-    "flag"
     "fmt"
     "os"
 )

--- a/go/example_code/dynamodb/DynamoDBCreateItem.go
+++ b/go/example_code/dynamodb/DynamoDBCreateItem.go
@@ -1,0 +1,102 @@
+// snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+// snippet-sourceauthor:[Doug-AWS]
+// snippet-sourcedescription:[DynamoDBCreateItem.go creates an item in an Amazon DynamoDB table.]
+// snippet-keyword:[Amazon DynamoDB]
+// snippet-keyword:[PutItem function]
+// snippet-keyword:[Go]
+// snippet-service:[dynamodb]
+// snippet-keyword:[Code Sample]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-03-19]
+/*
+   Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+// snippet-start:[dynamodb.go.create_item]
+package main
+
+// snippet-start:[dynamodb.go.create_item.imports]
+import (
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/dynamodb"
+    "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+
+    "fmt"
+    "os"
+    "strconv"
+)
+// snippet-end:[dynamodb.go.create_item.imports]
+
+// snippet-start:[dynamodb.go.create_item.struct]
+// Create struct to hold info about new item
+type Item struct {
+    Year   int
+    Title  string
+    Plot   string
+    Rating float64
+}
+// snippet-end:[dynamodb.go.create_item.struct]
+
+func main() {
+    // snippet-start:[dynamodb.go.create_item.session]
+    // Initialize a session that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and region from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
+
+    // Create DynamoDB client
+    svc := dynamodb.New(sess)
+    // snippet-end:[dynamodb.go.create_item.session]
+
+    // snippet-start:[dynamodb.go.create_item.assign_struct]
+    item := Item{
+        Year:   2015,
+        Title:  "The Big New Movie",
+        Plot:   "Nothing happens at all.",
+        Rating: 0.0,
+    }
+
+    av, err := dynamodbattribute.MarshalMap(item)
+    if err != nil {
+        fmt.Println("Got error marshalling new movie item:")
+        fmt.Println(err.Error())
+        os.Exit(1)
+    }
+    // snippet-end:[dynamodb.go.create_item.assign_struct]
+
+    // snippet-start:[dynamodb.go.create_item.call]
+    // Create item in table Movies
+    movieName := "The Big New Movie"
+    movieYear := 2015
+    tableName := "Movies"
+
+    input := &dynamodb.PutItemInput{
+        Item:      av,
+        TableName: aws.String(tableName),
+    }
+
+    _, err = svc.PutItem(input)
+    if err != nil {
+        fmt.Println("Got error calling PutItem:")
+        fmt.Println(err.Error())
+        os.Exit(1)
+    }
+
+    year := strconv.Itoa(movieYear)
+
+    fmt.Println("Successfully added '" + movieName + "' (" + year + ") to table " + tableName)
+    // snippet-end:[dynamodb.go.create_item.call]
+}
+// snippet-end:[dynamodb.go.create_item]

--- a/go/example_code/dynamodb/DynamoDBCreateTable.go
+++ b/go/example_code/dynamodb/DynamoDBCreateTable.go
@@ -1,0 +1,93 @@
+// snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+// snippet-sourceauthor:[Doug-AWS]
+// snippet-sourcedescription:[DynamoDBCreateTable.go create an Amazon DynamoDB table.]
+// snippet-keyword:[Amazon DynamoDB]
+// snippet-keyword:[CreateTable function]
+// snippet-keyword:[Go]
+// snippet-service:[dynamodb]
+// snippet-keyword:[Code Sample]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-03-18]
+/*
+   Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+// snippet-start:[dynamodb.go.create_table]
+package main
+
+// snippet-start:[dynamodb.go.create_table.imports]
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+
+	"fmt"
+	"os"
+)
+// snippet-end:[dynamodb.go.create_table.imports]
+
+func main() {
+	// snippet-start:[dynamodb.go.create_table.session]
+	// Initialize a session that the SDK will use to load
+	// credentials from the shared credentials file ~/.aws/credentials
+	// and region from the shared configuration file ~/.aws/config.
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+
+	// Create DynamoDB client
+	svc := dynamodb.New(sess)
+	// snippet-end:[dynamodb.go.create_table.session]
+
+	// snippet-start:[dynamodb.go.create_table.call]
+	// Create table Movies
+	tableName := "Movies"
+
+	input := &dynamodb.CreateTableInput{
+		AttributeDefinitions: []*dynamodb.AttributeDefinition{
+			{
+				AttributeName: aws.String("Year"),
+				AttributeType: aws.String("N"),
+			},
+			{
+				AttributeName: aws.String("Title"),
+				AttributeType: aws.String("S"),
+			},
+		},
+		KeySchema: []*dynamodb.KeySchemaElement{
+			{
+				AttributeName: aws.String("Year"),
+				KeyType:       aws.String("HASH"),
+			},
+			{
+				AttributeName: aws.String("Title"),
+				KeyType:       aws.String("RANGE"),
+			},
+		},
+		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+			ReadCapacityUnits:  aws.Int64(10),
+			WriteCapacityUnits: aws.Int64(10),
+		},
+		TableName: aws.String(tableName),
+	}
+
+	_, err := svc.CreateTable(input)
+	if err != nil {
+		fmt.Println("Got error calling CreateTable:")
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	fmt.Println("Created the table", tableName)
+	// snippet-end:[dynamodb.go.create_table.call]
+}
+// snippet-end:[dynamodb.go.create_table]

--- a/go/example_code/dynamodb/DynamoDBDeleteItem.go
+++ b/go/example_code/dynamodb/DynamoDBDeleteItem.go
@@ -1,0 +1,77 @@
+// snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+// snippet-sourceauthor:[Doug-AWS]
+// snippet-sourcedescription:[DynamoDBDeleteItem.go deletes an item from an Amazon DynamoDB table.]
+// snippet-keyword:[Amazon DynamoDB]
+// snippet-keyword:[DeleteItem function]
+// snippet-keyword:[Go]
+// snippet-service:[dynamodb]
+// snippet-keyword:[Code Sample]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-03-19]
+/*
+   Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+// snippet-start:[dynamodb.go.delete_item]
+package main
+
+// snippet-start:[dynamodb.go.delete_item.imports]
+import (
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/dynamodb"
+
+    "fmt"
+)
+// snippet-end:[dynamodb.go.delete_item.imports]
+
+func main() {
+    // snippet-start:[dynamodb.go.delete_item.session]
+    // Initialize a session that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and region from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
+
+    // Create DynamoDB client
+    svc := dynamodb.New(sess)
+    // snippet-end:[dynamodb.go.delete_item.session]
+
+    // snippet-start:[dynamodb.go.delete_item.call]
+    tableName := "Movies"
+    movieName := "The Big New Movie"
+    movieYear := "2015"
+
+    input := &dynamodb.DeleteItemInput{
+        Key: map[string]*dynamodb.AttributeValue{
+            "Year": {
+                N: aws.String(movieYear),
+            },
+            "Title": {
+                S: aws.String(movieName),
+            },
+        },
+        TableName: aws.String(tableName),
+    }
+
+    _, err := svc.DeleteItem(input)
+    if err != nil {
+        fmt.Println("Got error calling DeleteItem")
+        fmt.Println(err.Error())
+        return
+    }
+
+    fmt.Println("Deleted '" + movieName + "' (" + movieYear + ") from table " + tableName)
+    // snippet-start:[dynamodb.go.delete_item.call]
+}
+// snippet-end:[dynamodb.go.delete_item]

--- a/go/example_code/dynamodb/DynamoDBDeleteItem.go
+++ b/go/example_code/dynamodb/DynamoDBDeleteItem.go
@@ -72,6 +72,6 @@ func main() {
     }
 
     fmt.Println("Deleted '" + movieName + "' (" + movieYear + ") from table " + tableName)
-    // snippet-start:[dynamodb.go.delete_item.call]
+    // snippet-end:[dynamodb.go.delete_item.call]
 }
 // snippet-end:[dynamodb.go.delete_item]

--- a/go/example_code/dynamodb/DynamoDBListTables.go
+++ b/go/example_code/dynamodb/DynamoDBListTables.go
@@ -1,0 +1,68 @@
+// snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+// snippet-sourceauthor:[Doug-AWS]
+// snippet-sourcedescription:[DynamoDBListTables.go lists your Amazon DynamoDB tables.]
+// snippet-keyword:[Amazon DynamoDB]
+// snippet-keyword:[ListTables function]
+// snippet-keyword:[Go]
+// snippet-service:[dynamodb]
+// snippet-keyword:[Code Sample]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-03-18]
+/*
+   Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+// snippet-start:[dynamodb.go.list_tables]
+package main
+
+// snippet-start:[dynamodb.go.list_tables.imports]
+import (
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/dynamodb"
+
+    "fmt"
+    "os"
+)
+// snippet-end:[dynamodb.go.list_tables.imports]
+
+func main() {
+    // snippet-start:[dynamodb.go.list_tables.session]
+    // Initialize a session that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and region from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
+
+    // Create DynamoDB client
+    svc := dynamodb.New(sess)
+    // snippet-end:[dynamodb.go.list_tables.session]
+
+    // snippet-start:[dynamodb.go.list_tables.call]
+    // Get the list of tables
+    result, err := svc.ListTables(&dynamodb.ListTablesInput{})
+    if err != nil {
+        fmt.Println(err)
+        os.Exit(1)
+    }
+
+    fmt.Println("Tables:")
+    fmt.Println("")
+
+    for _, n := range result.TableNames {
+        fmt.Println(*n)
+    }
+
+    fmt.Println("")
+    // snippet-end:[dynamodb.go.list_tables.call]
+}
+// snippet-end:[dynamodb.go.list_tables]

--- a/go/example_code/dynamodb/DynamoDBLoadItems.go
+++ b/go/example_code/dynamodb/DynamoDBLoadItems.go
@@ -1,0 +1,114 @@
+// snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+// snippet-sourceauthor:[Doug-AWS]
+// snippet-sourcedescription:[DynamoDBLoadItems.go adds items from a JSON file to an Amazon DynamoDB table.]
+// snippet-keyword:[Amazon DynamoDB]
+// snippet-keyword:[PutItem function]
+// snippet-keyword:[Go]
+// snippet-service:[dynamodb]
+// snippet-keyword:[Code Sample]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-03-19]
+/*
+   Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+// snippet-start:[dynamodb.go.load_items]
+package main
+
+// snippet-start:[dynamodb.go.load_items.imports]
+import (
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/dynamodb"
+    "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+
+    "encoding/json"
+    "fmt"
+    "io/ioutil"
+    "os"
+    "strconv"
+)
+// snippet-end:[dynamodb.go.load_items.imports]
+
+// snippet-start:[dynamodb.go.load_items.struct]
+// Create struct to hold info about new item
+type Item struct {
+    Year   int
+    Title  string
+    Plot   string
+    Rating float64
+}
+// snippet-end:[dynamodb.go.load_items.struct]
+
+// snippet-start:[dynamodb.go.load_items.func]
+// Get table items from JSON file
+func getItems() []Item {
+    raw, err := ioutil.ReadFile("./movie_data.json")
+    if err != nil {
+        fmt.Println(err.Error())
+        os.Exit(1)
+    }
+
+    var items []Item
+    json.Unmarshal(raw, &items)
+    return items
+}
+// snippet-end:[dynamodb.go.load_items.func]
+
+func main() {
+    // snippet-start:[dynamodb.go.load_items.session]
+    // Initialize a session that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and region from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
+
+    // Create DynamoDB client
+    svc := dynamodb.New(sess)
+    // snippet-end:[dynamodb.go.load_items.session]
+
+    // snippet-start:[dynamodb.go.load_items.call]
+    // Get table items from movie_data.json
+    items := getItems()
+
+    // Add each item to Movies table:
+    tableName := "Movies"
+
+    for _, item := range items {
+        av, err := dynamodbattribute.MarshalMap(item)
+        if err != nil {
+            fmt.Println("Got error marshalling map:")
+            fmt.Println(err.Error())
+            os.Exit(1)
+        }
+
+        // Create item in table Movies
+        input := &dynamodb.PutItemInput{
+            Item:      av,
+            TableName: aws.String(tableName),
+        }
+
+        _, err = svc.PutItem(input)
+        if err != nil {
+            fmt.Println("Got error calling PutItem:")
+            fmt.Println(err.Error())
+            os.Exit(1)
+        }
+
+        year := strconv.Itoa(item.Year)
+
+        fmt.Println("Successfully added '" + item.Title + "' (" + year + ") to table " + tableName)
+        // snippet-start:[dynamodb.go.load_items.call]
+    }
+}
+// snippet-end:[dynamodb.go.load_items]

--- a/go/example_code/dynamodb/DynamoDBLoadItems.go
+++ b/go/example_code/dynamodb/DynamoDBLoadItems.go
@@ -108,7 +108,7 @@ func main() {
         year := strconv.Itoa(item.Year)
 
         fmt.Println("Successfully added '" + item.Title + "' (" + year + ") to table " + tableName)
-        // snippet-start:[dynamodb.go.load_items.call]
+        // snippet-end:[dynamodb.go.load_items.call]
     }
 }
 // snippet-end:[dynamodb.go.load_items]

--- a/go/example_code/dynamodb/DynamoDBReadItem.go
+++ b/go/example_code/dynamodb/DynamoDBReadItem.go
@@ -1,0 +1,103 @@
+// snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+// snippet-sourceauthor:[Doug-AWS]
+// snippet-sourcedescription:[DynamoDBReadItem.go gets an item from an Amazon DynamoDB table.]
+// snippet-keyword:[Amazon DynamoDB]
+// snippet-keyword:[GetItem function]
+// snippet-keyword:[Go]
+// snippet-service:[dynamodb]
+// snippet-keyword:[Code Sample]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-03-19]
+/*
+   Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+// snippet-start:[dynamodb.go.read_item]
+package main
+
+// snippet-start:[dynamodb.go.read_item.imports]
+import (
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/dynamodb"
+    "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+
+    "fmt"
+)
+// snippet-end:[dynamodb.go.read_item.imports]
+
+// snippet-start:[dynamodb.go.read_item.struct]
+// Create struct to hold info about new item
+type Item struct {
+    Year   int
+    Title  string
+    Plot   string
+    Rating float64
+}
+// snippet-end:[dynamodb.go.read_item.struct]
+
+func main() {
+    // snippet-start:[dynamodb.go.read_item.session]
+    // Initialize a session that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and region from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
+
+    // Create DynamoDB client
+    svc := dynamodb.New(sess)
+    // snippet-end:[dynamodb.go.read_item.session]
+
+    // snippet-start:[dynamodb.go.read_item.call]
+    tableName := "Movies"
+    movieName := "The Big New Movie"
+    movieYear := "2015"
+
+    result, err := svc.GetItem(&dynamodb.GetItemInput{
+        TableName: aws.String(tableName),
+        Key: map[string]*dynamodb.AttributeValue{
+            "Year": {
+                N: aws.String(movieYear),
+            },
+            "Title": {
+                S: aws.String(movieName),
+            },
+        },
+    })
+    if err != nil {
+        fmt.Println(err.Error())
+        return
+    }
+    // snippet-end:[dynamodb.go.read_item.call]
+
+    // snippet-start:[dynamodb.go.read_item.unmarshall]
+    item := Item{}
+
+    err = dynamodbattribute.UnmarshalMap(result.Item, &item)
+    if err != nil {
+        panic(fmt.Sprintf("Failed to unmarshal Record, %v", err))
+    }
+
+    if item.Title == "" {
+        fmt.Println("Could not find '" + movieName + "' (" + movieYear + ")")
+        return
+    }
+
+    fmt.Println("Found item:")
+    fmt.Println("Year:  ", item.Year)
+    fmt.Println("Title: ", item.Title)
+    fmt.Println("Plot:  ", item.Plot)
+    fmt.Println("Rating:", item.Rating)
+    // snippet-end:[dynamodb.go.read_item.unmarshall]
+}
+// snippet-end:[dynamodb.go.read_item]

--- a/go/example_code/dynamodb/DynamoDBScanItems.go
+++ b/go/example_code/dynamodb/DynamoDBScanItems.go
@@ -1,0 +1,138 @@
+// snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+// snippet-sourceauthor:[Doug-AWS]
+// snippet-sourcedescription:[DynamoDBScanItems.go gets items from and Amazon DymanoDB table using the Expression Builder package.]
+// snippet-keyword:[Amazon DynamoDB]
+// snippet-keyword:[Scan function]
+// snippet-keyword:[Expression Builder]
+// snippet-keyword:[Go]
+// snippet-service:[dynamodb]
+// snippet-keyword:[Code Sample]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-03-19]
+/*
+   Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+// snippet-start:[dynamodb.go.scan_items]
+package main
+
+// snippet-start:[dynamodb.go.scan_items.imports]
+import (
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/dynamodb"
+    "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+    "github.com/aws/aws-sdk-go/service/dynamodb/expression"
+
+    "fmt"
+    "os"
+)
+// snippet-end:[dynamodb.go.scan_items.imports]
+
+// snippet-start:[dynamodb.go.scan_items.struct]
+// Create struct to hold info about new item
+type Item struct {
+    Year   int
+    Title  string
+    Plot   string
+    Rating float64
+}
+// snippet-end:[dynamodb.go.scan_items.struct]
+
+// Get the movies with a minimum rating of 8.0 in 2011
+func main() {
+    // snippet-start:[dynamodb.go.scan_items.session]
+    // Initialize a session that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and region from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
+
+    // Create DynamoDB client
+    svc := dynamodb.New(sess)
+    // snippet-end:[dynamodb.go.scan_items.session]
+
+    // snippet-start:[dynamodb.go.scan_items.vars]
+    tableName := "Movies"
+    minRating := 4.0
+    year := 2013
+    // snippet-end:[dynamodb.go.scan_items.vars]
+
+    // snippet-start:[dynamodb.go.scan_items.expr]
+    // Create the Expression to fill the input struct with.
+    // Get all movies in that year; we'll pull out those with a higher rating later
+    filt := expression.Name("Year").Equal(expression.Value(year))
+
+    // Or we could get by ratings and pull out those with the right year later
+    //    filt := expression.Name("info.rating").GreaterThan(expression.Value(min_rating))
+
+    // Get back the title, year, and rating
+    proj := expression.NamesList(expression.Name("Title"), expression.Name("Year"), expression.Name("Rating"))
+
+    expr, err := expression.NewBuilder().WithFilter(filt).WithProjection(proj).Build()
+    if err != nil {
+        fmt.Println("Got error building expression:")
+        fmt.Println(err.Error())
+        os.Exit(1)
+    }
+    // snippet-end:[dynamodb.go.scan_items.expr]
+
+    // snippet-start:[dynamodb.go.scan_items.call]
+    // Build the query input parameters
+    params := &dynamodb.ScanInput{
+        ExpressionAttributeNames:  expr.Names(),
+        ExpressionAttributeValues: expr.Values(),
+        FilterExpression:          expr.Filter(),
+        ProjectionExpression:      expr.Projection(),
+        TableName:                 aws.String(tableName),
+    }
+
+    // Make the DynamoDB Query API call
+    result, err := svc.Scan(params)
+    if err != nil {
+        fmt.Println("Query API call failed:")
+        fmt.Println((err.Error()))
+        os.Exit(1)
+    }
+    // snippet-end:[dynamodb.go.scan_items.call]
+
+    // snippet-start:[dynamodb.go.scan_items.process]
+    numItems := 0
+
+    for _, i := range result.Items {
+        item := Item{}
+
+        err = dynamodbattribute.UnmarshalMap(i, &item)
+
+        if err != nil {
+            fmt.Println("Got error unmarshalling:")
+            fmt.Println(err.Error())
+            os.Exit(1)
+        }
+
+        // Which ones had a higher rating than minimum?
+        if item.Rating > minRating {
+            // Or it we had filtered by rating previously:
+            //   if item.Year == year {
+            numItems++
+
+            fmt.Println("Title: ", item.Title)
+            fmt.Println("Rating:", item.Rating)
+            fmt.Println()
+        }
+    }
+
+    fmt.Println("Found", numItems, "movie(s) with a rating above", minRating, "in", year)
+    // snippet-end:[dynamodb.go.scan_items.process]
+}
+// snippet-end:[dynamodb.go.scan_items]

--- a/go/example_code/dynamodb/DynamoDBUpdateItem.go
+++ b/go/example_code/dynamodb/DynamoDBUpdateItem.go
@@ -1,0 +1,85 @@
+// snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
+// snippet-sourceauthor:[Doug-AWS]
+// snippet-sourcedescription:[DynamoDBUpdateItem.go updates an item in an Amazon DynamoDB table.]
+// snippet-keyword:[Amazon DynamoDB]
+// snippet-keyword:[UpdateItem function]
+// snippet-keyword:[Go]
+// snippet-service:[dynamodb]
+// snippet-keyword:[Code Sample]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-03-19]
+/*
+   Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+// snippet-start:[dynamodb.go.update_item]
+package main
+
+// snippet-start:[dynamodb.go.update_item.imports]
+import (
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/dynamodb"
+
+    "fmt"
+)
+// snippet-end:[dynamodb.go.update_item.imports]
+
+func main() {
+    // snippet-start:[dynamodb.go.update_item.session]
+    // Initialize a session that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and region from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
+
+    // Create DynamoDB client
+    svc := dynamodb.New(sess)
+    // snippet-end:[dynamodb.go.update_item.session]
+
+    // snippet-start:[dynamodb.go.update_item.call]
+    // Create item in table Movies
+    tableName := "Movies"
+    movieName := "The Big New Movie"
+    movieYear := "2015"
+    movieRating := "0.5"
+
+    input := &dynamodb.UpdateItemInput{
+        ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+            ":r": {
+                N: aws.String(movieRating),
+            },
+        },
+        TableName: aws.String(tableName),
+        Key: map[string]*dynamodb.AttributeValue{
+            "Year": {
+                N: aws.String(movieYear),
+            },
+            "Title": {
+                S: aws.String(movieName),
+            },
+        },
+        ReturnValues:     aws.String("UPDATED_NEW"),
+        UpdateExpression: aws.String("set Rating = :r"),
+    }
+
+    _, err := svc.UpdateItem(input)
+    if err != nil {
+        fmt.Println(err.Error())
+        return
+    }
+
+    fmt.Println("Successfully updated '" + movieName + "' (" + movieYear + ") rating to " + movieRating)
+    // snippet-end:[dynamodb.go.update_item.call]
+}
+// snippet-end:[dynamodb.go.update_item]

--- a/go/example_code/dynamodb/movie_data.json
+++ b/go/example_code/dynamodb/movie_data.json
@@ -1,35 +1,14 @@
 [
     {
-        "year" : 2013,
-        "title" : "Turn It Down, Or Else!",
-        "info" : {
-            "directors" : [
-                "Alice Smith",
-                "Bob Jones"
-            ],
-            "release_date" : "2013-01-18T00:00:00Z",
-            "rating" : 6.2,
-            "genres" : [
-                "Comedy",
-                "Drama"
-            ],
-            "image_url" : "http://ia.media-imdb.com/images/N/O9ERWAU7FS797AJ7LU8HN09AMUP908RLlo5JF90EWR7LJKQ7@@._V1_SX400_.jpg",
-            "plot" : "A rock band plays their music at high volumes, annoying the neighbors.",
-            "rank" : 11,
-            "running_time_secs" : 5215,
-            "actors" : [
-                "David Matthewman",
-                "Ann Thomas",
-                "Jonathan G. Neff"
-            ]
-        }
+        "Year" : 2013,
+        "Title" : "Turn It Down, Or Else!",
+        "Plot" : "A rock band plays their music at high volumes, annoying the neighbors.",
+        "Rating" : 4.5
     },
     {
-        "year": 2015,
-        "title": "The Big New Movie",
-        "info": {
-            "plot": "Nothing happens at all.",
-            "rating": 0
-        }
+        "Year": 2015,
+        "Title": "The Big New Movie",
+        "Plot": "Nothing happens at all.",
+        "Rating": 0.1
     }
 ]

--- a/go/example_code/ec2/describing_instances.go
+++ b/go/example_code/ec2/describing_instances.go
@@ -25,11 +25,10 @@
 package main
 
 import (
-    "fmt"
-
-    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/ec2"
+
+    "fmt"
 )
 
 func main() {

--- a/go/example_code/extending_sdk/addTags.go
+++ b/go/example_code/extending_sdk/addTags.go
@@ -8,7 +8,7 @@
 // snippet-service:[s3]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2018-03-16]
+// snippet-sourcedate:[2019-03-14]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -26,11 +26,11 @@
 package main
 
 import (
-    "github.com/aws/aws-sdk-go/aws"
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 
-    "fmt"
+	"fmt"
 )
 
 // Tag S3 bucket MyBucket with cost center tag "123456" and stack tag "MyTestStack".
@@ -38,73 +38,73 @@ import (
 // See:
 //    http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html
 func main() {
-    // Pre-defined values
-    bucket := "MyBucket"
-    tagName1 := "Cost Center"
-    tagValue1 := "123456"
-    tagName2 := "Stack"
-    tagValue2 := "MyTestStack"
-    
-    // Initialize a session in us-west-2 that the SDK will use to load credentials
-    // from the shared credentials file. (~/.aws/credentials).
-    sess, err := session.NewSession(&aws.Config{
-        Region: aws.String("us-west-2")},
-    )
-    if err != nil {
-        fmt.Println(err.Error())
-        return
-    }
+	// Pre-defined values
+	bucket := "MyBucket"
+	tagName1 := "Cost Center"
+	tagValue1 := "123456"
+	tagName2 := "Stack"
+	tagValue2 := "MyTestStack"
 
-    // Create S3 service client
-    svc := s3.New(sess)
+	// Initialize a session in us-west-2 that the SDK will use to load credentials
+	// from the shared credentials file. (~/.aws/credentials).
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-west-2")},
+	)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
 
-    // Create input for PutBucket method
-    input := &s3.PutBucketTaggingInput{
-        Bucket: aws.String(bucket),
-        Tagging: &s3.Tagging{
-            TagSet: []*s3.Tag{
-                {
-                    Key:   aws.String(tagName1),
-                    Value: aws.String(tagValue1),
-                },
-                {
-                    Key:   aws.String(tagName2),
-                    Value: aws.String(tagValue2),
-              },
-            },
-        },
-    }
+	// Create S3 service client
+	svc := s3.New(sess)
 
-    _, err = svc.PutBucketTagging(input)
-    if err != nil {
-        fmt.Println(err.Error())
-        return
-    }
+	// Create input for PutBucket method
+	putInput := &s3.PutBucketTaggingInput{
+		Bucket: aws.String(bucket),
+		Tagging: &s3.Tagging{
+			TagSet: []*s3.Tag{
+				{
+					Key:   aws.String(tagName1),
+					Value: aws.String(tagValue1),
+				},
+				{
+					Key:   aws.String(tagName2),
+					Value: aws.String(tagValue2),
+				},
+			},
+		},
+	}
 
-    // Now show the tags
-    // Create input for GetBucket method
-    input := &s3.GetBucketTaggingInput{
-        Bucket: aws.String(bucket),
-    }
+	_, err = svc.PutBucketTagging(putInput)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
 
-    result, err := svc.GetBucketTagging(input)
-    if err != nil {
-        fmt.Println(err.Error())
-        return
-    }
+	// Now show the tags
+	// Create input for GetBucket method
+	getInput := &s3.GetBucketTaggingInput{
+		Bucket: aws.String(bucket),
+	}
 
-    numTags := len(result.TagSet)
+	result, err := svc.GetBucketTagging(getInput)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
 
-    if numTags > 0 {
-        fmt.Println("Found", numTags, "Tag(s):")
-        fmt.Println("")
+	numTags := len(result.TagSet)
 
-        for _, t := range result.TagSet {
-            fmt.Println("  Key:  ", *t.Key)
-            fmt.Println("  Value:", *t.Value)
-            fmt.Println("")
-        }
-    } else {
-        fmt.Println("Did not find any tags")
-    }
+	if numTags > 0 {
+		fmt.Println("Found", numTags, "Tag(s):")
+		fmt.Println("")
+
+		for _, t := range result.TagSet {
+			fmt.Println("  Key:  ", *t.Key)
+			fmt.Println("  Value:", *t.Value)
+			fmt.Println("")
+		}
+	} else {
+		fmt.Println("Did not find any tags")
+	}
 }

--- a/go/example_code/extending_sdk/ecs/update_deployment_with_setters.go
+++ b/go/example_code/extending_sdk/ecs/update_deployment_with_setters.go
@@ -6,7 +6,7 @@
 // snippet-keyword:[Go]
 // snippet-service:[aws-go-sdk]
 // snippet-sourcetype:[snippet]
-// snippet-sourcedate:[2018-03-16]
+// snippet-sourcedate:[2019-03-14]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -20,10 +20,34 @@
    CONDITIONS OF ANY KIND, either express or implied. See the License for the
    specific language governing permissions and limitations under the License.
 */
+package main
 
-resp, err := svc.UpdateService((&ecs.UpdateServiceInput{}).
-    SetService("myService").
-    SetDeploymentConfiguration((&ecs.DeploymentConfiguration{}).
-        SetMinimumHealthyPercent(80),
-    ),
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecs"
 )
+
+func main() {
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+
+	svc := ecs.New(sess)
+
+	// start snippet
+	resp, err := svc.UpdateService((&ecs.UpdateServiceInput{}).
+		SetService("myService").
+		SetDeploymentConfiguration((&ecs.DeploymentConfiguration{}).
+			SetMinimumHealthyPercent(80),
+		),
+	)
+	// end snippet
+	if err != nil {
+		fmt.Println("Error calling UpdateService:")
+		fmt.Println(err.Error())
+	} else {
+		fmt.Println(resp)
+	}
+}

--- a/go/example_code/extending_sdk/request_context.go
+++ b/go/example_code/extending_sdk/request_context.go
@@ -5,7 +5,7 @@
 // snippet-keyword:[Go]
 // snippet-service:[aws-go-sdk]
 // snippet-sourcetype:[snippet]
-// snippet-sourcedate:[2018-03-16]
+// snippet-sourcedate:[2019-03-14]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -19,12 +19,57 @@
    CONDITIONS OF ANY KIND, either express or implied. See the License for the
    specific language governing permissions and limitations under the License.
 */
+package main
 
-    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-    defer cancel()
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 
-    // SQS ReceiveMessage
-    params := &sqs.ReceiveMessageInput{ ... }
-    req, resp := s.ReceiveMessageRequest(params)
-    req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
-    err := req.Send()
+	// ??? context
+	"github.com/aws/aws-sdk-go/service/sqs"
+
+	"context"
+	"fmt"
+	"time"
+)
+
+func main() {
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+
+	svc := sqs.New(sess)
+
+	// URL to our queue
+	qURL := "QueueURL"
+
+	// start snippet
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// SQS ReceiveMessage
+	params := &sqs.ReceiveMessageInput{
+		AttributeNames: []*string{
+			aws.String(sqs.MessageSystemAttributeNameSentTimestamp),
+		},
+		MessageAttributeNames: []*string{
+			aws.String(sqs.QueueAttributeNameAll),
+		},
+		QueueUrl:            &qURL,
+		MaxNumberOfMessages: aws.Int64(1),
+		VisibilityTimeout:   aws.Int64(20), // 20 seconds
+		WaitTimeSeconds:     aws.Int64(0),
+	}
+
+	req, resp := svc.ReceiveMessageRequest(params)
+	req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
+	err := req.Send()
+	// end snippet
+
+	if err != nil {
+		fmt.Println("Got error receiving message:")
+		fmt.Println(err.Error())
+	} else {
+		fmt.Println(resp)
+	}
+}

--- a/go/example_code/glacier/create_vault.go
+++ b/go/example_code/glacier/create_vault.go
@@ -7,7 +7,7 @@
 // snippet-service:[glacier]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2018-03-16]
+// snippet-sourcedate:[2019-03-14]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -21,13 +21,36 @@
    CONDITIONS OF ANY KIND, either express or implied. See the License for the
    specific language governing permissions and limitations under the License.
 */
+package main
 
-    svc := glacier.New(session.New(&aws.Config{Region: aws.String("us-west-2")}))
-    _, err := svc.CreateVault(&glacier.CreateVaultInput{
-        VaultName: aws.String("YOUR_VAULT_NAME"),
-    })
-    if err != nil {
-        log.Println(err)
-        return
-    }
-    log.Println("Created vault!")
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/glacier"
+)
+
+func main() {
+	// Initialize a session that the SDK uses to load
+	// credentials from the shared credentials file ~/.aws/credentials
+	// and configuration from the shared configuration file ~/.aws/config.
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+
+	// Create Glacier client in default region
+	svc := glacier.New(sess)
+
+	// start snippet
+	_, err := svc.CreateVault(&glacier.CreateVaultInput{
+		VaultName: aws.String("YOUR_VAULT_NAME"),
+	})
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	log.Println("Created vault!")
+	// end snippet
+}

--- a/go/example_code/glacier/upload_archive.go
+++ b/go/example_code/glacier/upload_archive.go
@@ -7,7 +7,7 @@
 // snippet-service:[glacier]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2018-03-16]
+// snippet-sourcedate:[2019-03-14]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -21,19 +21,39 @@
    CONDITIONS OF ANY KIND, either express or implied. See the License for the
    specific language governing permissions and limitations under the License.
 */
+package main
 
-    vaultName := "YOUR_VAULT_NAME"
+import (
+	"bytes"
+	"log"
 
-    svc := glacier.New(session.New(&aws.Config{Region: aws.String("us-west-2")}))
-    result, err := svc.UploadArchive(&glacier.UploadArchiveInput{
-        AccountId: aws.String("-"),
-        VaultName: &vaultName,
-        Body:      bytes.NewReader(make([]byte, 2*1024*1024)), // 2 MB buffer
-    })
-    if err != nil {
-        log.Println("Error uploading archive.", err)
-        return
-    }
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/glacier"
+)
 
-    log.Println("Uploaded to archive", *result.ArchiveId)
-    
+func main() {
+	// Initialize a session that the SDK uses to load
+	// credentials from the shared credentials file ~/.aws/credentials
+	// and configuration from the shared configuration file ~/.aws/config.
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+
+	// Create Glacier client in default region
+	svc := glacier.New(sess)
+
+	// start snippet
+	vaultName := "YOUR_VAULT_NAME"
+
+	result, err := svc.UploadArchive(&glacier.UploadArchiveInput{
+		VaultName: &vaultName,
+		Body:      bytes.NewReader(make([]byte, 2*1024*1024)), // 2 MB buffer
+	})
+	if err != nil {
+		log.Println("Error uploading archive.", err)
+		return
+	}
+
+	log.Println("Uploaded to archive", *result.ArchiveId)
+	// end snippet
+}

--- a/go/example_code/kms/kms_decrypt_data.go
+++ b/go/example_code/kms/kms_decrypt_data.go
@@ -7,7 +7,7 @@
 // snippet-service:[kms]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2018-03-16]
+// snippet-sourcedate:[2019-03-14]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -25,35 +25,36 @@
 package main
 
 import (
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kms"
 
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 )
 
 func main() {
-    // Initialize a session in us-west-2 that the SDK will use to load
-    // credentials from the shared credentials file ~/.aws/credentials.
-    sess, err := session.NewSession(&aws.Config{
-        Region: aws.String("us-west-2")},
-    )
+	// Initialize a session that the SDK uses to load
+	// credentials from the shared credentials file ~/.aws/credentials
+	// and configuration from the shared configuration file ~/.aws/config.
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 
-    // Create KMS service client
-    svc := kms.New(sess)
+	// Create KMS service client
+	svc := kms.New(sess)
 
-    // Encrypted data
-    blob := []byte{...}
+	// Encrypted data
+	blob := []byte("1234567890")
 
-    // Decrypt the data
-    result, err := svc.Decrypt(&kms.DecryptInput{CiphertextBlob: blob})
+	// Decrypt the data
+	result, err := svc.Decrypt(&kms.DecryptInput{CiphertextBlob: blob})
 
-    if err != nil {
-        fmt.Println("Got error decrypting data: ", err)
-        os.Exit(1)
-    }
+	if err != nil {
+		fmt.Println("Got error decrypting data: ", err)
+		os.Exit(1)
+	}
 
-    blob_string := string(result.Plaintext)
+	blob_string := string(result.Plaintext)
 
-    fmt.Println(blob_string)
+	fmt.Println(blob_string)
 }

--- a/go/example_code/kms/kms_re_encrypt_data.go
+++ b/go/example_code/kms/kms_re_encrypt_data.go
@@ -7,7 +7,7 @@
 // snippet-service:[kms]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2018-03-16]
+// snippet-sourcedate:[2018-03-14]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -25,40 +25,41 @@
 package main
 
 import (
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kms"
 
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 )
 
 func main() {
-    // Initialize a session in us-west-2 that the SDK will use to load
-    // credentials from the shared credentials file ~/.aws/credentials.
-    sess, err := session.NewSession(&aws.Config{
-        Region: aws.String("us-west-2")},
-    )
+	// Initialize a session that the SDK uses to load
+	// credentials from the shared credentials file ~/.aws/credentials
+	// and configuration from the shared configuration file ~/.aws/config.
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 
-    // Create KMS service client
-    svc := kms.New(sess)
+	// Create KMS service client
+	svc := kms.New(sess)
 
-    // Encrypt data key
-    //
-    // Replace the fictitious key ARN with a valid key ID
+	// Encrypt data key
+	//
+	// Replace the fictitious key ARN with a valid key ID
 
-    keyId := "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+	keyId := "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
 
-    // Encrypted data
-    blob := []byte{...}
+	// Encrypted data
+	blob := []byte("1234567890")
 
-    // Re-encrypt the data key
-    result, err := svc.ReEncrypt(&kms.ReEncryptInput{CiphertextBlob: blob, DestinationKeyId: &keyId})
+	// Re-encrypt the data key
+	result, err := svc.ReEncrypt(&kms.ReEncryptInput{CiphertextBlob: blob, DestinationKeyId: &keyId})
 
-    if err != nil {
-        fmt.Println("Got error re-encrypting data: ", err)
-        os.Exit(1)
-    }
+	if err != nil {
+		fmt.Println("Got error re-encrypting data: ", err)
+		os.Exit(1)
+	}
 
-    fmt.Println("Blob (base-64 byte array):")
-    fmt.Println(result.CiphertextBlob)
+	fmt.Println("Blob (base-64 byte array):")
+	fmt.Println(result.CiphertextBlob)
 }

--- a/go/example_code/s3/s3_encrypt_on_server_with_kms.go
+++ b/go/example_code/s3/s3_encrypt_on_server_with_kms.go
@@ -69,5 +69,5 @@ func main() {
         os.Exit(1)
     }
 
-    fmt.Println("Added object " + obj + " to bucket " + bucket + " with AWS KMS encryption")
+    fmt.Println("Added object " + object + " to bucket " + bucket + " with AWS KMS encryption")
 }

--- a/go/example_code/s3/s3_get_bucket_acl.go
+++ b/go/example_code/s3/s3_get_bucket_acl.go
@@ -26,9 +26,9 @@
 package main
 
 import (
-    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/s3"
+    
     "fmt"
     "os"
 )

--- a/go/example_code/s3/s3_get_bucket_object_acl.go
+++ b/go/example_code/s3/s3_get_bucket_object_acl.go
@@ -26,9 +26,9 @@
 package main
 
 import (
-    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/s3"
+    
     "fmt"
     "os"
 )

--- a/go/example_code/s3/s3_put_bucket_acl.go
+++ b/go/example_code/s3/s3_put_bucket_acl.go
@@ -27,9 +27,9 @@
 package main
 
 import (
-    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/s3"
+    
     "fmt"
     "os"
 )

--- a/go/example_code/s3/s3_put_bucket_object_acl.go
+++ b/go/example_code/s3/s3_put_bucket_object_acl.go
@@ -27,9 +27,9 @@
 package main
 
 import (
-    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/s3"
+    
     "fmt"
     "os"
 )

--- a/go/example_code/s3/s3_require_server_encryption.go
+++ b/go/example_code/s3/s3_require_server_encryption.go
@@ -30,7 +30,6 @@ import (
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/s3"
 
-    "flag"
     "fmt"
     "os"
     "encoding/json"
@@ -87,7 +86,7 @@ func main() {
     }
 
     input := &s3.PutBucketPolicyInput{
-        Bucket: bucketPtr,
+        Bucket: aws.String(bucket),
         Policy: aws.String(string(policy)),
     }
 

--- a/go/example_code/ses/ses_get_statistics.go
+++ b/go/example_code/ses/ses_get_statistics.go
@@ -30,7 +30,6 @@ import (
     "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/ses"
-    "github.com/aws/aws-sdk-go/aws/awserr"
 
     "fmt"
 )

--- a/go/example_code/workdocs/wd_list_user_docs.go
+++ b/go/example_code/workdocs/wd_list_user_docs.go
@@ -26,11 +26,12 @@
 package main
 
 import (
-    "flag"
-    "fmt"
-
+    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/workdocs"
+
+    "flag"
+    "fmt"
 )
 
 /*

--- a/go/example_code/workdocs/wd_list_users.go
+++ b/go/example_code/workdocs/wd_list_users.go
@@ -25,11 +25,12 @@
 package main
 
 import (
-    "flag"
-    "fmt"
-
+    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/workdocs"
+
+    "flag"
+    "fmt"
 )
 
 /*


### PR DESCRIPTION
I ran "go build" on my Go examples and found errors in many files, so I fixed them.
I rewrote the DynamoDB examples for Go to resolve an issue with a previous commit.

Note that there is a duplication in the DynamoDB examples in Go. This is intentional.
As soon as the new code is available, I'll check in the Go dev guide example topics for Go,
and delete all of the lower-case examples.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
