### PR TITLE
Changed CDK ECS tutorial to use ECR for Docker image

### DIFF
--- a/typescript/example_code/cdk/my_ecs_construct-stack.ts
+++ b/typescript/example_code/cdk/my_ecs_construct-stack.ts
@@ -47,7 +47,7 @@ export class MyEcsConstructStack extends cdk.Stack {
       cluster: cluster,  // Required
       cpu: '512', // Default is 256
       desiredCount: 6,  // Default is 1
-      image: ecs.ContainerImage.fromDockerHub('amazon/amazon-ecs-sample'), // Required
+      image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample"), // Required
       memoryMiB: '2048',  // Default is 512
       publicLoadBalancer: true  // Default is false
     });


### PR DESCRIPTION
Docker thinks the tutorial might be causing their site to get hammered, so I changed the code to hit ECR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
