### PR TITLE
Expanded tabs in Go example to 4 spaces

### DIFF
--- a/go/example_code/cognito/CognitoCreateUser.go
+++ b/go/example_code/cognito/CognitoCreateUser.go
@@ -25,63 +25,63 @@
 package main
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 
-	"flag"
-	"fmt"
-	"os"
+    "flag"
+    "fmt"
+    "os"
 )
 
 func main() {
-	emailIDptr := flag.String("e", "", "The email address of the user")
-	userPoolIdptr := flag.String("p", "", "The ID of the user pool")
-	userNameptr := flag.String("n", "", "The name of the user")
+    emailIDptr := flag.String("e", "", "The email address of the user")
+    userPoolIdptr := flag.String("p", "", "The ID of the user pool")
+    userNameptr := flag.String("n", "", "The name of the user")
 
-	flag.Parse()
+    flag.Parse()
 
-	emailID := *emailIDptr
-	userPoolID := *userPoolIdptr
-	userName := *userNameptr
+    emailID := *emailIDptr
+    userPoolID := *userPoolIdptr
+    userName := *userNameptr
 
-	if emailID == "" || userPoolID == "" || userName == "" {
-		fmt.Println("You must supply an email address, user pool ID, and user name")
-		fmt.Println("Usage: go run CreateUser.go -e EMAIL-ADDRESS -p USER-POOL-ID -n USER-NAME")
-		os.Exit(1)
-	}
+    if emailID == "" || userPoolID == "" || userName == "" {
+        fmt.Println("You must supply an email address, user pool ID, and user name")
+        fmt.Println("Usage: go run CreateUser.go -e EMAIL-ADDRESS -p USER-POOL-ID -n USER-NAME")
+        os.Exit(1)
+    }
 
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
-	if err != nil {
-		fmt.Println("Got error creating session:", err)
-		os.Exit(1)
-	}
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+    )
+    if err != nil {
+        fmt.Println("Got error creating session:", err)
+        os.Exit(1)
+    }
 
-	// Create Cognito service client
-	cognitoClient := cognitoidentityprovider.New(sess)
+    // Create Cognito service client
+    cognitoClient := cognitoidentityprovider.New(sess)
 
-	newUserData := &cognitoidentityprovider.AdminCreateUserInput{
-		DesiredDeliveryMediums: []*string{
-			aws.String("EMAIL"),
-		},
-		UserAttributes: []*cognitoidentityprovider.AttributeType{
-			{
-				Name:  aws.String("email"),
-				Value: aws.String(emailID),
-			},
-		},
-	}
+    newUserData := &cognitoidentityprovider.AdminCreateUserInput{
+        DesiredDeliveryMediums: []*string{
+            aws.String("EMAIL"),
+        },
+        UserAttributes: []*cognitoidentityprovider.AttributeType{
+            {
+                Name:  aws.String("email"),
+                Value: aws.String(emailID),
+            },
+        },
+    }
 
-	newUserData.SetUserPoolId(userPoolID)
-	newUserData.SetUsername(userName)
+    newUserData.SetUserPoolId(userPoolID)
+    newUserData.SetUsername(userName)
 
-	_, err = cognitoClient.AdminCreateUser(newUserData)
-	if err != nil {
-		fmt.Println("Got error creating user:", err)
-	}
+    _, err = cognitoClient.AdminCreateUser(newUserData)
+    if err != nil {
+        fmt.Println("Got error creating user:", err)
+    }
 }
 // snippet-end:[cognito.go.create_user]

--- a/go/example_code/cognito/CognitoCreateUserPool.go
+++ b/go/example_code/cognito/CognitoCreateUserPool.go
@@ -25,19 +25,19 @@
 package main
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
-	"github.com/aws/aws-sdk-go/service/iam"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+    "github.com/aws/aws-sdk-go/service/iam"
 
-	"fmt"
-	"os"
-	"strings"
+    "fmt"
+    "os"
+    "strings"
 )
 
 func getRoleName(poolName string) string {
-	name := strings.Replace(poolName, "-", "", -1)
-	return name + "-SMS-Role"
+    name := strings.Replace(poolName, "-", "", -1)
+    return name + "-SMS-Role"
 }
 
 // Creates Cognito user pool POOL_NAME
@@ -45,114 +45,114 @@ func getRoleName(poolName string) string {
 // Usage:
 //    go run CognitoCreateUserPool.go POOL_NAME
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Println("Pool name is required")
-		fmt.Println("Usage: go run", os.Args[0], "POOL_NAME")
-	}
+    if len(os.Args) < 2 {
+        fmt.Println("Pool name is required")
+        fmt.Println("Usage: go run", os.Args[0], "POOL_NAME")
+    }
 
-	poolName := os.Args[2]
+    poolName := os.Args[2]
 
-	emailMsg := "{username} {####}" // Must match regex: [\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{####\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*
-	emailSubject := "AWS TW Chat"
-	smsMsg := "{username} {####}" // Must match regex: .*\{####\}.*
+    emailMsg := "{username} {####}" // Must match regex: [\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{####\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*
+    emailSubject := "AWS TW Chat"
+    smsMsg := "{username} {####}" // Must match regex: .*\{####\}.*
 
-	waitDays := int64(1)
+    waitDays := int64(1)
 
-	emailVerifyMsg := "{####}" // Must match regex: [\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{####\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*
-	emailVerifySub := "AWS TW Chat"
-	smsAuthMsg := "{####}"   // Must match regex: .*\{####\}.*
-	smsVerifyMsg := "{####}" // Must match regex: .*\{####\}.*
+    emailVerifyMsg := "{####}" // Must match regex: [\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{####\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*
+    emailVerifySub := "AWS TW Chat"
+    smsAuthMsg := "{####}"   // Must match regex: .*\{####\}.*
+    smsVerifyMsg := "{####}" // Must match regex: .*\{####\}.*
 
-	// Initialize a session that the SDK will use to load configuration,
-	// credentials, and region from the shared config file. (~/.aws/config).
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+    // Initialize a session that the SDK will use to load configuration,
+    // credentials, and region from the shared config file. (~/.aws/config).
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
 
-	// 	// Create SMS role so pool can msg new users on your behalf
-	iamSvc := iam.New(sess)
+    //     // Create SMS role so pool can msg new users on your behalf
+    iamSvc := iam.New(sess)
 
-	doc := "{ \"Version\": \"2012-10-17\", \"Statement\": [ { \"Sid\": \"\", \"Effect\": \"Allow\", \"Principal\": { \"Service\": \"cognito-idp.amazonaws.com\" }, \"Action\": \"sts:AssumeRole\" } ] }"
+    doc := "{ \"Version\": \"2012-10-17\", \"Statement\": [ { \"Sid\": \"\", \"Effect\": \"Allow\", \"Principal\": { \"Service\": \"cognito-idp.amazonaws.com\" }, \"Action\": \"sts:AssumeRole\" } ] }"
 
-	// Create SMS role with pool name, less any hyphens
-	roleName := getRoleName(poolName) // Required
+    // Create SMS role with pool name, less any hyphens
+    roleName := getRoleName(poolName) // Required
 
-	path := "/service-role/"
+    path := "/service-role/"
 
-	iamResp, iamErr := iamSvc.CreateRole(
-		&iam.CreateRoleInput{
-			AssumeRolePolicyDocument: &doc,
-			RoleName:                 &roleName,
-			Path:                     &path})
+    iamResp, iamErr := iamSvc.CreateRole(
+        &iam.CreateRoleInput{
+            AssumeRolePolicyDocument: &doc,
+            RoleName:                 &roleName,
+            Path:                     &path})
 
-	if iamErr != nil {
-		fmt.Println("Could not create role")
-		os.Exit(1)
-	}
+    if iamErr != nil {
+        fmt.Println("Could not create role")
+        os.Exit(1)
+    }
 
-	roleArn := iamResp.Role.Arn
-	roleID := iamResp.Role.RoleId
+    roleArn := iamResp.Role.Arn
+    roleID := iamResp.Role.RoleId
 
-	// Create Cognito client
-	cgSvc := cognitoidentityprovider.New(sess)
+    // Create Cognito client
+    cgSvc := cognitoidentityprovider.New(sess)
 
-	params := &cognitoidentityprovider.CreateUserPoolInput{
-		PoolName: &poolName, // Required
-		AdminCreateUserConfig: &cognitoidentityprovider.AdminCreateUserConfigType{
-			AllowAdminCreateUserOnly: aws.Bool(false), // false == users can sign themselves up
-			InviteMessageTemplate: &cognitoidentityprovider.MessageTemplateType{
-				EmailMessage: &emailMsg,     // Welcome message to new users
-				EmailSubject: &emailSubject, // Welcome subject to new users
-				SMSMessage:   &smsMsg,
-			},
-			UnusedAccountValidityDays: &waitDays, // How many days to wait before rescinding offer
-		},
-		AutoVerifiedAttributes: []*string{ // Auto-verified means the user confirmed the SNS message
-			aws.String("email"), // Required; either email or phone_number
-			aws.String("phone_number"),
-		},
-		EmailVerificationMessage: &emailVerifyMsg,
-		EmailVerificationSubject: &emailVerifySub,
-		Policies: &cognitoidentityprovider.UserPoolPolicyType{
-			PasswordPolicy: &cognitoidentityprovider.PasswordPolicyType{
-				MinimumLength:    aws.Int64(6), // Require a password of at least 6 chars
-				RequireLowercase: aws.Bool(false),
-				RequireNumbers:   aws.Bool(false),
-				RequireSymbols:   aws.Bool(false),
-				RequireUppercase: aws.Bool(false),
-			},
-		},
-		Schema: []*cognitoidentityprovider.SchemaAttributeType{
-			{ // Required
-				AttributeDataType:      aws.String("String"),
-				DeveloperOnlyAttribute: aws.Bool(false),
-				Mutable:                aws.Bool(false),
-				Name:                   aws.String("user_name"),
-				Required:               aws.Bool(false),
-				StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
-					MaxLength: aws.String("64"), // user name can be up to 64 chars
-					MinLength: aws.String("3"),  // or as few as 3 chars
-				},
-			},
-		},
-		SmsAuthenticationMessage: &smsAuthMsg,
-		SmsConfiguration: &cognitoidentityprovider.SmsConfigurationType{
-			SnsCallerArn: roleArn, // Required
-			ExternalId:   roleID,
-		},
-		SmsVerificationMessage: &smsVerifyMsg,
-	}
+    params := &cognitoidentityprovider.CreateUserPoolInput{
+        PoolName: &poolName, // Required
+        AdminCreateUserConfig: &cognitoidentityprovider.AdminCreateUserConfigType{
+            AllowAdminCreateUserOnly: aws.Bool(false), // false == users can sign themselves up
+            InviteMessageTemplate: &cognitoidentityprovider.MessageTemplateType{
+                EmailMessage: &emailMsg,     // Welcome message to new users
+                EmailSubject: &emailSubject, // Welcome subject to new users
+                SMSMessage:   &smsMsg,
+            },
+            UnusedAccountValidityDays: &waitDays, // How many days to wait before rescinding offer
+        },
+        AutoVerifiedAttributes: []*string{ // Auto-verified means the user confirmed the SNS message
+            aws.String("email"), // Required; either email or phone_number
+            aws.String("phone_number"),
+        },
+        EmailVerificationMessage: &emailVerifyMsg,
+        EmailVerificationSubject: &emailVerifySub,
+        Policies: &cognitoidentityprovider.UserPoolPolicyType{
+            PasswordPolicy: &cognitoidentityprovider.PasswordPolicyType{
+                MinimumLength:    aws.Int64(6), // Require a password of at least 6 chars
+                RequireLowercase: aws.Bool(false),
+                RequireNumbers:   aws.Bool(false),
+                RequireSymbols:   aws.Bool(false),
+                RequireUppercase: aws.Bool(false),
+            },
+        },
+        Schema: []*cognitoidentityprovider.SchemaAttributeType{
+            { // Required
+                AttributeDataType:      aws.String("String"),
+                DeveloperOnlyAttribute: aws.Bool(false),
+                Mutable:                aws.Bool(false),
+                Name:                   aws.String("user_name"),
+                Required:               aws.Bool(false),
+                StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+                    MaxLength: aws.String("64"), // user name can be up to 64 chars
+                    MinLength: aws.String("3"),  // or as few as 3 chars
+                },
+            },
+        },
+        SmsAuthenticationMessage: &smsAuthMsg,
+        SmsConfiguration: &cognitoidentityprovider.SmsConfigurationType{
+            SnsCallerArn: roleArn, // Required
+            ExternalId:   roleID,
+        },
+        SmsVerificationMessage: &smsVerifyMsg,
+    }
 
-	fmt.Println("")
+    fmt.Println("")
 
-	cgResp, cgErr := cgSvc.CreateUserPool(params)
+    cgResp, cgErr := cgSvc.CreateUserPool(params)
 
-	if cgErr != nil {
-		fmt.Println("Could not create user pool")
-		os.Exit(1)
-	}
+    if cgErr != nil {
+        fmt.Println("Could not create user pool")
+        os.Exit(1)
+    }
 
-	fmt.Println("")
-	fmt.Println(cgResp)
+    fmt.Println("")
+    fmt.Println(cgResp)
 }
 // snippet-end:[cognito.go.create_user_pool]

--- a/go/example_code/cognito/CognitoListUsers.go
+++ b/go/example_code/cognito/CognitoListUsers.go
@@ -25,62 +25,62 @@
 package main
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 
-	"flag"
-	"fmt"
-	"os"
+    "flag"
+    "fmt"
+    "os"
 )
 
 func main() {
-	userPoolIdptr := flag.String("p", "", "The ID of the user pool")
+    userPoolIdptr := flag.String("p", "", "The ID of the user pool")
 
-	flag.Parse()
+    flag.Parse()
 
-	userPoolID := *userPoolIdptr
+    userPoolID := *userPoolIdptr
 
-	if userPoolID == "" {
-		fmt.Println("You must supply a user pool ID")
-		fmt.Println("Usage: go run CreateUser.go -p USER-POOL-ID")
-		os.Exit(1)
-	}
+    if userPoolID == "" {
+        fmt.Println("You must supply a user pool ID")
+        fmt.Println("Usage: go run CreateUser.go -p USER-POOL-ID")
+        os.Exit(1)
+    }
 
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
-	if err != nil {
-		fmt.Println("Got error creating session:", err)
-		os.Exit(1)
-	}
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+    )
+    if err != nil {
+        fmt.Println("Got error creating session:", err)
+        os.Exit(1)
+    }
 
-	// Create Cognito service client
-	cognitoClient := cognitoidentityprovider.New(sess)
+    // Create Cognito service client
+    cognitoClient := cognitoidentityprovider.New(sess)
 
-	results, err := cognitoClient.ListUsers(
-		&cognitoidentityprovider.ListUsersInput{
-			UserPoolId: userPoolIdptr})
-	if err != nil {
-		fmt.Println("Got error listing users")
-		os.Exit(1)
-	}
+    results, err := cognitoClient.ListUsers(
+        &cognitoidentityprovider.ListUsersInput{
+            UserPoolId: userPoolIdptr})
+    if err != nil {
+        fmt.Println("Got error listing users")
+        os.Exit(1)
+    }
 
-	// Show their names an email addresses
-	for _, user := range results.Users {
-		attributes := user.Attributes
+    // Show their names an email addresses
+    for _, user := range results.Users {
+        attributes := user.Attributes
 
-		for _, a := range attributes {
-			if *a.Name == "name" {
-				fmt.Println("Name:  " + *a.Value)
-			} else if *a.Name == "email" {
-				fmt.Println("Email: " + *a.Value)
-			}
-		}
+        for _, a := range attributes {
+            if *a.Name == "name" {
+                fmt.Println("Name:  " + *a.Value)
+            } else if *a.Name == "email" {
+                fmt.Println("Email: " + *a.Value)
+            }
+        }
 
-		fmt.Println("")
-	}
+        fmt.Println("")
+    }
 }
 // snippet-end:[cognito.go.list_users]

--- a/go/example_code/dynamodb/DynamoDBCreateTable.go
+++ b/go/example_code/dynamodb/DynamoDBCreateTable.go
@@ -26,68 +26,68 @@ package main
 
 // snippet-start:[dynamodb.go.create_table.imports]
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/dynamodb"
 
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 )
 // snippet-end:[dynamodb.go.create_table.imports]
 
 func main() {
-	// snippet-start:[dynamodb.go.create_table.session]
-	// Initialize a session that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials
-	// and region from the shared configuration file ~/.aws/config.
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+    // snippet-start:[dynamodb.go.create_table.session]
+    // Initialize a session that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and region from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
 
-	// Create DynamoDB client
-	svc := dynamodb.New(sess)
-	// snippet-end:[dynamodb.go.create_table.session]
+    // Create DynamoDB client
+    svc := dynamodb.New(sess)
+    // snippet-end:[dynamodb.go.create_table.session]
 
-	// snippet-start:[dynamodb.go.create_table.call]
-	// Create table Movies
-	tableName := "Movies"
+    // snippet-start:[dynamodb.go.create_table.call]
+    // Create table Movies
+    tableName := "Movies"
 
-	input := &dynamodb.CreateTableInput{
-		AttributeDefinitions: []*dynamodb.AttributeDefinition{
-			{
-				AttributeName: aws.String("Year"),
-				AttributeType: aws.String("N"),
-			},
-			{
-				AttributeName: aws.String("Title"),
-				AttributeType: aws.String("S"),
-			},
-		},
-		KeySchema: []*dynamodb.KeySchemaElement{
-			{
-				AttributeName: aws.String("Year"),
-				KeyType:       aws.String("HASH"),
-			},
-			{
-				AttributeName: aws.String("Title"),
-				KeyType:       aws.String("RANGE"),
-			},
-		},
-		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
-			ReadCapacityUnits:  aws.Int64(10),
-			WriteCapacityUnits: aws.Int64(10),
-		},
-		TableName: aws.String(tableName),
-	}
+    input := &dynamodb.CreateTableInput{
+        AttributeDefinitions: []*dynamodb.AttributeDefinition{
+            {
+                AttributeName: aws.String("Year"),
+                AttributeType: aws.String("N"),
+            },
+            {
+                AttributeName: aws.String("Title"),
+                AttributeType: aws.String("S"),
+            },
+        },
+        KeySchema: []*dynamodb.KeySchemaElement{
+            {
+                AttributeName: aws.String("Year"),
+                KeyType:       aws.String("HASH"),
+            },
+            {
+                AttributeName: aws.String("Title"),
+                KeyType:       aws.String("RANGE"),
+            },
+        },
+        ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+            ReadCapacityUnits:  aws.Int64(10),
+            WriteCapacityUnits: aws.Int64(10),
+        },
+        TableName: aws.String(tableName),
+    }
 
-	_, err := svc.CreateTable(input)
-	if err != nil {
-		fmt.Println("Got error calling CreateTable:")
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
+    _, err := svc.CreateTable(input)
+    if err != nil {
+        fmt.Println("Got error calling CreateTable:")
+        fmt.Println(err.Error())
+        os.Exit(1)
+    }
 
-	fmt.Println("Created the table", tableName)
-	// snippet-end:[dynamodb.go.create_table.call]
+    fmt.Println("Created the table", tableName)
+    // snippet-end:[dynamodb.go.create_table.call]
 }
 // snippet-end:[dynamodb.go.create_table]

--- a/go/example_code/dynamodb/create_item.go
+++ b/go/example_code/dynamodb/create_item.go
@@ -25,13 +25,13 @@
 package main
 
 import (
-    "fmt"
-    "os"
-
     "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/dynamodb"
     "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+
+    "fmt"
+    "os"
 )
 
 // Create structs to hold info about new item

--- a/go/example_code/dynamodb/delete_item.go
+++ b/go/example_code/dynamodb/delete_item.go
@@ -28,8 +28,10 @@ import (
     "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/dynamodb"
-
+    "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+    
     "fmt"
+    "os"
 )
 
 // Item has the values for a movie

--- a/go/example_code/dynamodb/update_item.go
+++ b/go/example_code/dynamodb/update_item.go
@@ -28,8 +28,10 @@ import (
     "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/dynamodb"
-
+    "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+    
     "fmt"
+    "os"
 )
 
 // ItemInfo holds info to update
@@ -59,7 +61,7 @@ func main() {
 
     item := Item{
         Year:  2015,
-        Title: "The Big New Movie,
+        Title: "The Big New Movie",
     }
 
     expr, err := dynamodbattribute.MarshalMap(info)

--- a/go/example_code/ec2/get_console_output.go
+++ b/go/example_code/ec2/get_console_output.go
@@ -15,47 +15,47 @@
 package main
 
 import (
-	"encoding/base64"
-	"fmt"
-	"os"
+    "encoding/base64"
+    "fmt"
+    "os"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/endpoints"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/ec2"
 )
 
 func decodeOutputb64(encoded string) string {
-	decoded, err := base64.StdEncoding.DecodeString(encoded)
-	if err != nil {
-		fmt.Println("Error", err)
-		return ""
-	}
+    decoded, err := base64.StdEncoding.DecodeString(encoded)
+    if err != nil {
+        fmt.Println("Error", err)
+        return ""
+    }
 
-	return string(decoded)
+    return string(decoded)
 }
 
 func main() {
-	// Create new EC2 service
-	ec2Svc := ec2.New(session.Must(session.NewSession(&aws.Config{
-		Region: aws.String(endpoints.UsWest2RegionID),
-	})))
+    // Create new EC2 service
+    ec2Svc := ec2.New(session.Must(session.NewSession(&aws.Config{
+        Region: aws.String(endpoints.UsWest2RegionID),
+    })))
 
-	if len(os.Args) == 1 {
-		fmt.Printf("Usage %s <instance-id>\n", os.Args[0])
-		os.Exit(1)
-	}
+    if len(os.Args) == 1 {
+        fmt.Printf("Usage %s <instance-id>\n", os.Args[0])
+        os.Exit(1)
+    }
 
-	instanceId := os.Args[1]
+    instanceId := os.Args[1]
 
-	// Call EC2 GetConsoleOutput API on the given instance according
-	//   https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.GetConsoleOutput
+    // Call EC2 GetConsoleOutput API on the given instance according
+    //   https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.GetConsoleOutput
 
-	input := ec2.GetConsoleOutputInput{InstanceId: aws.String(instanceId)}
-	json, err := ec2Svc.GetConsoleOutput(&input)
-	if err != nil {
-		fmt.Println("Error", err)
-	} else {
-		fmt.Println(decodeOutputb64(*json.Output))
-	}
+    input := ec2.GetConsoleOutputInput{InstanceId: aws.String(instanceId)}
+    json, err := ec2Svc.GetConsoleOutput(&input)
+    if err != nil {
+        fmt.Println("Error", err)
+    } else {
+        fmt.Println(decodeOutputb64(*json.Output))
+    }
 }

--- a/go/example_code/extending_sdk/addTags.go
+++ b/go/example_code/extending_sdk/addTags.go
@@ -1,6 +1,6 @@
 // snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 // snippet-sourceauthor:[Doug-AWS]
-// snippet-sourcedescription:[Adds tags to an S3 bucket and displays its tags.]
+// snippet-sourcedescription:[addTags.go adds tags to an S3 bucket and displays its tags.]
 // snippet-keyword:[Amazon S3]
 // snippet-keyword:[GetBucketTagging function]
 // snippet-keyword:[PutBucketTagging function]
@@ -8,7 +8,7 @@
 // snippet-service:[s3]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-03-14]
+// snippet-sourcedate:[2019-03-22]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -22,15 +22,15 @@
    CONDITIONS OF ANY KIND, either express or implied. See the License for the
    specific language governing permissions and limitations under the License.
 */
-
+//snippet-start:[extending.go.add_tags]
 package main
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/s3"
 
-	"fmt"
+    "fmt"
 )
 
 // Tag S3 bucket MyBucket with cost center tag "123456" and stack tag "MyTestStack".
@@ -38,73 +38,74 @@ import (
 // See:
 //    http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html
 func main() {
-	// Pre-defined values
-	bucket := "MyBucket"
-	tagName1 := "Cost Center"
-	tagValue1 := "123456"
-	tagName2 := "Stack"
-	tagValue2 := "MyTestStack"
+    // Pre-defined values
+    bucket := "MyBucket"
+    tagName1 := "Cost Center"
+    tagValue1 := "123456"
+    tagName2 := "Stack"
+    tagValue2 := "MyTestStack"
 
-	// Initialize a session in us-west-2 that the SDK will use to load credentials
-	// from the shared credentials file. (~/.aws/credentials).
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
-	if err != nil {
-		fmt.Println(err.Error())
-		return
-	}
+    // Initialize a session in us-west-2 that the SDK will use to load credentials
+    // from the shared credentials file. (~/.aws/credentials).
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+    )
+    if err != nil {
+        fmt.Println(err.Error())
+        return
+    }
 
-	// Create S3 service client
-	svc := s3.New(sess)
+    // Create S3 service client
+    svc := s3.New(sess)
 
-	// Create input for PutBucket method
-	putInput := &s3.PutBucketTaggingInput{
-		Bucket: aws.String(bucket),
-		Tagging: &s3.Tagging{
-			TagSet: []*s3.Tag{
-				{
-					Key:   aws.String(tagName1),
-					Value: aws.String(tagValue1),
-				},
-				{
-					Key:   aws.String(tagName2),
-					Value: aws.String(tagValue2),
-				},
-			},
-		},
-	}
+    // Create input for PutBucket method
+    putInput := &s3.PutBucketTaggingInput{
+        Bucket: aws.String(bucket),
+        Tagging: &s3.Tagging{
+            TagSet: []*s3.Tag{
+                {
+                    Key:   aws.String(tagName1),
+                    Value: aws.String(tagValue1),
+                },
+                {
+                    Key:   aws.String(tagName2),
+                    Value: aws.String(tagValue2),
+                },
+            },
+        },
+    }
 
-	_, err = svc.PutBucketTagging(putInput)
-	if err != nil {
-		fmt.Println(err.Error())
-		return
-	}
+    _, err = svc.PutBucketTagging(putInput)
+    if err != nil {
+        fmt.Println(err.Error())
+        return
+    }
 
-	// Now show the tags
-	// Create input for GetBucket method
-	getInput := &s3.GetBucketTaggingInput{
-		Bucket: aws.String(bucket),
-	}
+    // Now show the tags
+    // Create input for GetBucket method
+    getInput := &s3.GetBucketTaggingInput{
+        Bucket: aws.String(bucket),
+    }
 
-	result, err := svc.GetBucketTagging(getInput)
-	if err != nil {
-		fmt.Println(err.Error())
-		return
-	}
+    result, err := svc.GetBucketTagging(getInput)
+    if err != nil {
+        fmt.Println(err.Error())
+        return
+    }
 
-	numTags := len(result.TagSet)
+    numTags := len(result.TagSet)
 
-	if numTags > 0 {
-		fmt.Println("Found", numTags, "Tag(s):")
-		fmt.Println("")
+    if numTags > 0 {
+        fmt.Println("Found", numTags, "Tag(s):")
+        fmt.Println("")
 
-		for _, t := range result.TagSet {
-			fmt.Println("  Key:  ", *t.Key)
-			fmt.Println("  Value:", *t.Value)
-			fmt.Println("")
-		}
-	} else {
-		fmt.Println("Did not find any tags")
-	}
+        for _, t := range result.TagSet {
+            fmt.Println("  Key:  ", *t.Key)
+            fmt.Println("  Value:", *t.Value)
+            fmt.Println("")
+        }
+    } else {
+        fmt.Println("Did not find any tags")
+    }
 }
+//snippet-end:[extending.go.add_tags]

--- a/go/example_code/extending_sdk/ecs/update_deployment_with_setters.go
+++ b/go/example_code/extending_sdk/ecs/update_deployment_with_setters.go
@@ -1,12 +1,12 @@
 // snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 // snippet-sourceauthor:[Doug-AWS]
-// snippet-sourcedescription:[Uses chainable setters on nested fields in an API operation request.]
+// snippet-sourcedescription:[update_deployment_with_setters.go uses chainable setters on nested fields in an API operation request.]
 // snippet-keyword:[Extending the SDK]
 // snippet-keyword:[UpdateService function]
 // snippet-keyword:[Go]
 // snippet-service:[aws-go-sdk]
 // snippet-sourcetype:[snippet]
-// snippet-sourcedate:[2019-03-14]
+// snippet-sourcedate:[2019-03-22]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -20,34 +20,36 @@
    CONDITIONS OF ANY KIND, either express or implied. See the License for the
    specific language governing permissions and limitations under the License.
 */
+//snippet-start:[s3.go.update_deployment]
 package main
 
 import (
-	"fmt"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/ecs"
 
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ecs"
+    "fmt"
 )
 
 func main() {
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
 
-	svc := ecs.New(sess)
+    svc := ecs.New(sess)
 
-	// start snippet
-	resp, err := svc.UpdateService((&ecs.UpdateServiceInput{}).
-		SetService("myService").
-		SetDeploymentConfiguration((&ecs.DeploymentConfiguration{}).
-			SetMinimumHealthyPercent(80),
-		),
-	)
-	// end snippet
-	if err != nil {
-		fmt.Println("Error calling UpdateService:")
-		fmt.Println(err.Error())
-	} else {
-		fmt.Println(resp)
-	}
+    //snippet-start:[s3.go.update_deployment.call]
+    resp, err := svc.UpdateService((&ecs.UpdateServiceInput{}).
+        SetService("myService").
+        SetDeploymentConfiguration((&ecs.DeploymentConfiguration{}).
+            SetMinimumHealthyPercent(80),
+        ),
+    )
+    //snippet-end:[s3.go.update_deployment.call]
+    if err != nil {
+        fmt.Println("Error calling UpdateService:")
+        fmt.Println(err.Error())
+    } else {
+        fmt.Println(resp)
+    }
 }
+//snippet-end:[s3.go.update_deployment]

--- a/go/example_code/extending_sdk/request_context.go
+++ b/go/example_code/extending_sdk/request_context.go
@@ -1,6 +1,6 @@
 // snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 // snippet-sourceauthor:[Doug-AWS]
-// snippet-sourcedescription:[request_context.go shows how to usie context.Context with SDK requests.]
+// snippet-sourcedescription:[request_context.go shows how to use context.Context with SDK requests.]
 // snippet-keyword:[Extending the SDK]
 // snippet-keyword:[Go]
 // snippet-service:[aws-go-sdk]

--- a/go/example_code/extending_sdk/request_context.go
+++ b/go/example_code/extending_sdk/request_context.go
@@ -1,6 +1,6 @@
 // snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 // snippet-sourceauthor:[Doug-AWS]
-// snippet-sourcedescription:[Using context.Context with SDK requests.]
+// snippet-sourcedescription:[request_context.go shows how to usie context.Context with SDK requests.]
 // snippet-keyword:[Extending the SDK]
 // snippet-keyword:[Go]
 // snippet-service:[aws-go-sdk]
@@ -22,54 +22,52 @@
 package main
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/sqs"
 
-	// ??? context
-	"github.com/aws/aws-sdk-go/service/sqs"
-
-	"context"
-	"fmt"
-	"time"
+    "context"
+    "fmt"
+    "time"
 )
 
 func main() {
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
 
-	svc := sqs.New(sess)
+    svc := sqs.New(sess)
 
-	// URL to our queue
-	qURL := "QueueURL"
+    // URL to our queue
+    qURL := "QueueURL"
 
-	// start snippet
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    defer cancel()
 
-	// SQS ReceiveMessage
-	params := &sqs.ReceiveMessageInput{
-		AttributeNames: []*string{
-			aws.String(sqs.MessageSystemAttributeNameSentTimestamp),
-		},
-		MessageAttributeNames: []*string{
-			aws.String(sqs.QueueAttributeNameAll),
-		},
-		QueueUrl:            &qURL,
-		MaxNumberOfMessages: aws.Int64(1),
-		VisibilityTimeout:   aws.Int64(20), // 20 seconds
-		WaitTimeSeconds:     aws.Int64(0),
-	}
+    // SQS ReceiveMessage
+    params := &sqs.ReceiveMessageInput{
+        AttributeNames: []*string{
+            aws.String(sqs.MessageSystemAttributeNameSentTimestamp),
+        },
+        MessageAttributeNames: []*string{
+            aws.String(sqs.QueueAttributeNameAll),
+        },
+        QueueUrl:            &qURL,
+        MaxNumberOfMessages: aws.Int64(1),
+        VisibilityTimeout:   aws.Int64(20), // 20 seconds
+        WaitTimeSeconds:     aws.Int64(0),
+    }
 
-	req, resp := svc.ReceiveMessageRequest(params)
-	req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
-	err := req.Send()
-	// end snippet
-
-	if err != nil {
-		fmt.Println("Got error receiving message:")
-		fmt.Println(err.Error())
-	} else {
-		fmt.Println(resp)
-	}
+    //snippet-start:[extending.go.receive_message_request]
+    req, resp := svc.ReceiveMessageRequest(params)
+    req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
+    
+    err := req.Send()
+    if err != nil {
+        fmt.Println("Got error receiving message:")
+        fmt.Println(err.Error())
+    } else {
+        fmt.Println(resp)
+    }
+    //snippet-end:[extending.go.receive_message_request]
 }

--- a/go/example_code/glacier/create_vault.go
+++ b/go/example_code/glacier/create_vault.go
@@ -24,33 +24,33 @@
 package main
 
 import (
-	"log"
+    "log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/glacier"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/glacier"
 )
 
 func main() {
-	// Initialize a session that the SDK uses to load
-	// credentials from the shared credentials file ~/.aws/credentials
-	// and configuration from the shared configuration file ~/.aws/config.
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+    // Initialize a session that the SDK uses to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and configuration from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
 
-	// Create Glacier client in default region
-	svc := glacier.New(sess)
+    // Create Glacier client in default region
+    svc := glacier.New(sess)
 
-	// start snippet
-	_, err := svc.CreateVault(&glacier.CreateVaultInput{
-		VaultName: aws.String("YOUR_VAULT_NAME"),
-	})
-	if err != nil {
-		log.Println(err)
-		return
-	}
+    // start snippet
+    _, err := svc.CreateVault(&glacier.CreateVaultInput{
+        VaultName: aws.String("YOUR_VAULT_NAME"),
+    })
+    if err != nil {
+        log.Println(err)
+        return
+    }
 
-	log.Println("Created vault!")
-	// end snippet
+    log.Println("Created vault!")
+    // end snippet
 }

--- a/go/example_code/glacier/upload_archive.go
+++ b/go/example_code/glacier/upload_archive.go
@@ -24,36 +24,36 @@
 package main
 
 import (
-	"bytes"
-	"log"
+    "bytes"
+    "log"
 
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/glacier"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/glacier"
 )
 
 func main() {
-	// Initialize a session that the SDK uses to load
-	// credentials from the shared credentials file ~/.aws/credentials
-	// and configuration from the shared configuration file ~/.aws/config.
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+    // Initialize a session that the SDK uses to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and configuration from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
 
-	// Create Glacier client in default region
-	svc := glacier.New(sess)
+    // Create Glacier client in default region
+    svc := glacier.New(sess)
 
-	// start snippet
-	vaultName := "YOUR_VAULT_NAME"
+    // start snippet
+    vaultName := "YOUR_VAULT_NAME"
 
-	result, err := svc.UploadArchive(&glacier.UploadArchiveInput{
-		VaultName: &vaultName,
-		Body:      bytes.NewReader(make([]byte, 2*1024*1024)), // 2 MB buffer
-	})
-	if err != nil {
-		log.Println("Error uploading archive.", err)
-		return
-	}
+    result, err := svc.UploadArchive(&glacier.UploadArchiveInput{
+        VaultName: &vaultName,
+        Body:      bytes.NewReader(make([]byte, 2*1024*1024)), // 2 MB buffer
+    })
+    if err != nil {
+        log.Println("Error uploading archive.", err)
+        return
+    }
 
-	log.Println("Uploaded to archive", *result.ArchiveId)
-	// end snippet
+    log.Println("Uploaded to archive", *result.ArchiveId)
+    // end snippet
 }

--- a/go/example_code/iam/iam_getpublickeys.go
+++ b/go/example_code/iam/iam_getpublickeys.go
@@ -26,52 +26,52 @@
 package main
 
 import (
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/iam"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/iam"
 )
 
 // Usage:
 // go run iam_getpublickeys.go <username>
 func main() {
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+    )
 
-	// Create a IAM service client.
-	svc := iam.New(sess)
+    // Create a IAM service client.
+    svc := iam.New(sess)
 
-	// List SSH public keys.
-	keysResult, err := svc.ListSSHPublicKeys(&iam.ListSSHPublicKeysInput{
-		UserName: &os.Args[1],
-	})
+    // List SSH public keys.
+    keysResult, err := svc.ListSSHPublicKeys(&iam.ListSSHPublicKeysInput{
+        UserName: &os.Args[1],
+    })
 
-	if err != nil {
-		fmt.Println("Error", err)
-		return
-	}
+    if err != nil {
+        fmt.Println("Error", err)
+        return
+    }
 
-	for _, key := range keysResult.SSHPublicKeys {
-		if key == nil {
-			continue
-		}
+    for _, key := range keysResult.SSHPublicKeys {
+        if key == nil {
+            continue
+        }
 
-		// Get a SSH public key.
-		keyResult, err := svc.GetSSHPublicKey(&iam.GetSSHPublicKeyInput{
-			UserName:       &os.Args[1],
-			SSHPublicKeyId: key.SSHPublicKeyId,
-			Encoding:       aws.String("SSH"),
-		})
+        // Get a SSH public key.
+        keyResult, err := svc.GetSSHPublicKey(&iam.GetSSHPublicKeyInput{
+            UserName:       &os.Args[1],
+            SSHPublicKeyId: key.SSHPublicKeyId,
+            Encoding:       aws.String("SSH"),
+        })
 
-		if err != nil {
-			continue
-		}
+        if err != nil {
+            continue
+        }
 
-		fmt.Printf("%s\n", *keyResult.SSHPublicKey.SSHPublicKeyBody)
-	}
+        fmt.Printf("%s\n", *keyResult.SSHPublicKey.SSHPublicKeyBody)
+    }
 }

--- a/go/example_code/kms/kms_decrypt_data.go
+++ b/go/example_code/kms/kms_decrypt_data.go
@@ -25,36 +25,36 @@
 package main
 
 import (
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/kms"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/kms"
 
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 )
 
 func main() {
-	// Initialize a session that the SDK uses to load
-	// credentials from the shared credentials file ~/.aws/credentials
-	// and configuration from the shared configuration file ~/.aws/config.
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+    // Initialize a session that the SDK uses to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and configuration from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
 
-	// Create KMS service client
-	svc := kms.New(sess)
+    // Create KMS service client
+    svc := kms.New(sess)
 
-	// Encrypted data
-	blob := []byte("1234567890")
+    // Encrypted data
+    blob := []byte("1234567890")
 
-	// Decrypt the data
-	result, err := svc.Decrypt(&kms.DecryptInput{CiphertextBlob: blob})
+    // Decrypt the data
+    result, err := svc.Decrypt(&kms.DecryptInput{CiphertextBlob: blob})
 
-	if err != nil {
-		fmt.Println("Got error decrypting data: ", err)
-		os.Exit(1)
-	}
+    if err != nil {
+        fmt.Println("Got error decrypting data: ", err)
+        os.Exit(1)
+    }
 
-	blob_string := string(result.Plaintext)
+    blob_string := string(result.Plaintext)
 
-	fmt.Println(blob_string)
+    fmt.Println(blob_string)
 }

--- a/go/example_code/kms/kms_re_encrypt_data.go
+++ b/go/example_code/kms/kms_re_encrypt_data.go
@@ -25,41 +25,41 @@
 package main
 
 import (
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/kms"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/kms"
 
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 )
 
 func main() {
-	// Initialize a session that the SDK uses to load
-	// credentials from the shared credentials file ~/.aws/credentials
-	// and configuration from the shared configuration file ~/.aws/config.
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+    // Initialize a session that the SDK uses to load
+    // credentials from the shared credentials file ~/.aws/credentials
+    // and configuration from the shared configuration file ~/.aws/config.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
 
-	// Create KMS service client
-	svc := kms.New(sess)
+    // Create KMS service client
+    svc := kms.New(sess)
 
-	// Encrypt data key
-	//
-	// Replace the fictitious key ARN with a valid key ID
+    // Encrypt data key
+    //
+    // Replace the fictitious key ARN with a valid key ID
 
-	keyId := "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+    keyId := "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
 
-	// Encrypted data
-	blob := []byte("1234567890")
+    // Encrypted data
+    blob := []byte("1234567890")
 
-	// Re-encrypt the data key
-	result, err := svc.ReEncrypt(&kms.ReEncryptInput{CiphertextBlob: blob, DestinationKeyId: &keyId})
+    // Re-encrypt the data key
+    result, err := svc.ReEncrypt(&kms.ReEncryptInput{CiphertextBlob: blob, DestinationKeyId: &keyId})
 
-	if err != nil {
-		fmt.Println("Got error re-encrypting data: ", err)
-		os.Exit(1)
-	}
+    if err != nil {
+        fmt.Println("Got error re-encrypting data: ", err)
+        os.Exit(1)
+    }
 
-	fmt.Println("Blob (base-64 byte array):")
-	fmt.Println(result.CiphertextBlob)
+    fmt.Println("Blob (base-64 byte array):")
+    fmt.Println(result.CiphertextBlob)
 }

--- a/go/example_code/lambda/aws-go-sdk-lambda-example-configure-function-for-notification.go
+++ b/go/example_code/lambda/aws-go-sdk-lambda-example-configure-function-for-notification.go
@@ -62,8 +62,8 @@ func addNotification(functionName *string, sourceArn *string) {
 }
 
 func main() {
-    flag.String(&functionName, "f", "", "The name of the Lambda function")
-    flag.String(&sourceArn, "a", "", "The ARN of the entity invoking the function")
+    functionName := flag.String("f", "", "The name of the Lambda function")
+    sourceArn := flag.String("a", "", "The ARN of the entity invoking the function")
     flag.Parse()
 
     addNotification(functionName, sourceArn)

--- a/go/example_code/lambda/aws-go-sdk-lambda-example-create-function.go
+++ b/go/example_code/lambda/aws-go-sdk-lambda-example-create-function.go
@@ -26,77 +26,77 @@
 package main
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/lambda"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/lambda"
 
-	"flag"
-	"fmt"
-	"io/ioutil"
-	"os"
+    "flag"
+    "fmt"
+    "io/ioutil"
+    "os"
 )
 
 func createFunction(zipFileName string, bucketName string, functionName string, handler string, resourceArn string, runtime string) {
-	// Initialize a session
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+    // Initialize a session
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
 
-	// Create Lambda service client
-	svc := lambda.New(sess, &aws.Config{Region: aws.String("us-west-2")})
+    // Create Lambda service client
+    svc := lambda.New(sess, &aws.Config{Region: aws.String("us-west-2")})
 
-	contents, err := ioutil.ReadFile(zipFileName + ".zip")
+    contents, err := ioutil.ReadFile(zipFileName + ".zip")
 
-	if err != nil {
-		fmt.Println("Could not read " + zipFileName + ".zip")
-		os.Exit(0)
-	}
+    if err != nil {
+        fmt.Println("Could not read " + zipFileName + ".zip")
+        os.Exit(0)
+    }
 
-	createCode := &lambda.FunctionCode{
-		S3Bucket:        aws.String(bucketName),
-		S3Key:           aws.String(zipFileName),
-		S3ObjectVersion: aws.String(""),
-		ZipFile:         contents,
-	}
+    createCode := &lambda.FunctionCode{
+        S3Bucket:        aws.String(bucketName),
+        S3Key:           aws.String(zipFileName),
+        S3ObjectVersion: aws.String(""),
+        ZipFile:         contents,
+    }
 
-	createArgs := &lambda.CreateFunctionInput{
-		Code:         createCode,
-		FunctionName: aws.String(functionName),
-		Handler:      aws.String(handler),
-		Role:         aws.String(resourceArn),
-		Runtime:      aws.String(runtime),
-	}
+    createArgs := &lambda.CreateFunctionInput{
+        Code:         createCode,
+        FunctionName: aws.String(functionName),
+        Handler:      aws.String(handler),
+        Role:         aws.String(resourceArn),
+        Runtime:      aws.String(runtime),
+    }
 
-	result, err := svc.CreateFunction(createArgs)
-	if err != nil {
-		fmt.Println("Cannot create function: " + err.Error())
-	} else {
-		fmt.Println(result)
-	}
+    result, err := svc.CreateFunction(createArgs)
+    if err != nil {
+        fmt.Println("Cannot create function: " + err.Error())
+    } else {
+        fmt.Println(result)
+    }
 }
 
 func main() {
-	zipFilePtr := flag.String("z", "", "The name of the ZIP file (without the .zip extension)")
-	bucketPtr := flag.String("b", "", "the name of bucket to which the ZIP file is uploaded")
-	functionPtr := flag.String("f", "", "The name of the Lambda function")
-	handlerPtr := flag.String("h", "", "The name of the package.class handling the call")
-	resourcePtr := flag.String("a", "", "The ARN of the role that calls the function")
-	runtimePtr := flag.String("r", "", "The runtime for the function.")
+    zipFilePtr := flag.String("z", "", "The name of the ZIP file (without the .zip extension)")
+    bucketPtr := flag.String("b", "", "the name of bucket to which the ZIP file is uploaded")
+    functionPtr := flag.String("f", "", "The name of the Lambda function")
+    handlerPtr := flag.String("h", "", "The name of the package.class handling the call")
+    resourcePtr := flag.String("a", "", "The ARN of the role that calls the function")
+    runtimePtr := flag.String("r", "", "The runtime for the function.")
 
-	flag.Parse()
+    flag.Parse()
 
-	zipFile := *zipFilePtr
-	bucketName := *bucketPtr
-	functionName := *functionPtr
-	handler := *handlerPtr
-	resourceArn := *resourcePtr
-	runtime := *runtimePtr
+    zipFile := *zipFilePtr
+    bucketName := *bucketPtr
+    functionName := *functionPtr
+    handler := *handlerPtr
+    resourceArn := *resourcePtr
+    runtime := *runtimePtr
 
-	if zipFile == "" || bucketName == "" || functionName == "" || handler == "" || resourceArn == "" || runtime == "" {
-		fmt.Println("You must supply a zip file name, bucket name, function name, handler, ARN, and runtime.")
-		os.Exit(0)
-	}
+    if zipFile == "" || bucketName == "" || functionName == "" || handler == "" || resourceArn == "" || runtime == "" {
+        fmt.Println("You must supply a zip file name, bucket name, function name, handler, ARN, and runtime.")
+        os.Exit(0)
+    }
 
-	createFunction(zipFile, bucketName, functionName, handler, resourceArn, runtime)
+    createFunction(zipFile, bucketName, functionName, handler, resourceArn, runtime)
 }
 // snippet-end:[lambda.go.create_function.complete]

--- a/go/example_code/rds/rds_create_cluster_snapshot.go
+++ b/go/example_code/rds/rds_create_cluster_snapshot.go
@@ -26,14 +26,14 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"strings"
-	"time"
+    "fmt"
+    "os"
+    "strings"
+    "time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/rds"
 )
 
 // Creates a RDS Cluster snapshot in the region configured in the shared config
@@ -42,51 +42,51 @@ import (
 // Usage:
 //    go run rds_create_cluster_snapshot CLUSTER_NAME
 func main() {
-	if len(os.Args) != 2 {
-		exitErrorf("Cluster name missing!\nUsage: %s cluster_name", os.Args[0])
-	}
+    if len(os.Args) != 2 {
+        exitErrorf("Cluster name missing!\nUsage: %s cluster_name", os.Args[0])
+    }
 
-	cluster := os.Args[1]
+    cluster := os.Args[1]
 
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+    )
 
-	// Create RDS service client
-	svc := rds.New(sess)
+    // Create RDS service client
+    svc := rds.New(sess)
 
-	// Get the current date and time to uniquely identify snapshot
-	currentTime := time.Now()
-	t := currentTime.Format("2006-01-02 15:04:05")
-	// Replace space with underscore
-	t = strings.Replace(t, " ", "_", -1)
+    // Get the current date and time to uniquely identify snapshot
+    currentTime := time.Now()
+    t := currentTime.Format("2006-01-02 15:04:05")
+    // Replace space with underscore
+    t = strings.Replace(t, " ", "_", -1)
 
-	// Create the RDS Cluster snapshot
-	_, err = svc.CreateDBClusterSnapshot(&rds.CreateDBClusterSnapshotInput{
-		DBClusterIdentifier:         aws.String(cluster),
-		DBClusterSnapshotIdentifier: aws.String(cluster + t),
-	})
-	if err != nil {
-		exitErrorf("Unable to create snapshot in cluster %q, %v", cluster, err)
-	}
+    // Create the RDS Cluster snapshot
+    _, err = svc.CreateDBClusterSnapshot(&rds.CreateDBClusterSnapshotInput{
+        DBClusterIdentifier:         aws.String(cluster),
+        DBClusterSnapshotIdentifier: aws.String(cluster + t),
+    })
+    if err != nil {
+        exitErrorf("Unable to create snapshot in cluster %q, %v", cluster, err)
+    }
 
-	// Wait until snapshot is created before finishing
-	fmt.Printf("Waiting for snapshot in cluster %q to be created...\n", cluster)
+    // Wait until snapshot is created before finishing
+    fmt.Printf("Waiting for snapshot in cluster %q to be created...\n", cluster)
 
-	err = svc.WaitUntilDBSnapshotAvailable(&rds.DescribeDBSnapshotsInput{
-		DBInstanceIdentifier: aws.String(cluster),
-	})
-	if err != nil {
-		exitErrorf("Error occurred while waiting for snapshot to be created in cluster, %v", cluster)
-	}
+    err = svc.WaitUntilDBSnapshotAvailable(&rds.DescribeDBSnapshotsInput{
+        DBInstanceIdentifier: aws.String(cluster),
+    })
+    if err != nil {
+        exitErrorf("Error occurred while waiting for snapshot to be created in cluster, %v", cluster)
+    }
 
-	fmt.Printf("Snapshot %q successfully created in cluster\n", cluster)
+    fmt.Printf("Snapshot %q successfully created in cluster\n", cluster)
 }
 
 func exitErrorf(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg+"\n", args...)
-	os.Exit(1)
+    fmt.Fprintf(os.Stderr, msg+"\n", args...)
+    os.Exit(1)
 }
 // snippet-end:[rds.go.create_cluster_snapshot]

--- a/go/example_code/rds/rds_create_snapshot.go
+++ b/go/example_code/rds/rds_create_snapshot.go
@@ -1,9 +1,3 @@
-/*
-   Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-   This file is licensed under the Apache License, Version 2.0 (the "License").
-   You may not use this file except in compliance with the License. A copy of
-   the License is located at
 // snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 // snippet-sourceauthor:[AWS]
 // snippet-sourcedescription:[rds_create_snapshot creates a snapshot of an RDS instance.]
@@ -32,87 +26,14 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"strings"
-	"time"
+    "fmt"
+    "os"
+    "strings"
+    "time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
-)
-
-// Creates a RDS snapshot in the region configured in the shared config
-// or AWS_REGION environment variable.
-//
-// Usage:
-//    go run s3_create_snapshot INSTANCE_NAME
-func main() {
-	if len(os.Args) != 2 {
-		exitErrorf("Instance name missing!\nUsage: %s instance_name", os.Args[0])
-	}
-
-	instance := os.Args[1]
-
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
-
-	// Create RDS service client
-	svc := rds.New(sess)
-
-	// Get the current date and time to uniquely identify snapshot
-	currentTime := time.Now()
-	t := currentTime.Format("2006-01-02 15:04:05")
-	// Replace space with underscore
-	t = strings.Replace(t, " ", "_", -1)
-
-	// Create the RDS snapshot
-	_, err = svc.CreateDBSnapshot(&rds.CreateDBSnapshotInput{
-		DBInstanceIdentifier: aws.String(instance),
-		DBSnapshotIdentifier: aws.String(instance + t),
-	})
-	if err != nil {
-		exitErrorf("Unable to create snapshot in instance %q, %v", instance, err)
-	}
-
-	// Wait until snapshot is created before finishing
-	fmt.Printf("Waiting for snapshot in instance %q to be created...\n", instance)
-
-	err = svc.WaitUntilDBSnapshotAvailable(&rds.DescribeDBSnapshotsInput{
-		DBInstanceIdentifier: aws.String(instance),
-	})
-	if err != nil {
-		exitErrorf("Error occurred while waiting for snapshot to be created in instance, %v", instance)
-	}
-
-	fmt.Printf("Snapshot %q successfully created in instance\n", instance)
-}
-
-func exitErrorf(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg+"\n", args...)
-	os.Exit(1)
-}
-
-// snippet-end:[rds.go.create_db_snapshot]
-
-    http://aws.amazon.com/apache2.0/
-
-   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-   CONDITIONS OF ANY KIND, either express or implied. See the License for the
-   specific language governing permissions and limitations under the License.
-*/
-
-package main
-
-import (
     "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/rds"
-    "fmt"
-    "os"
 )
 
 // Creates a RDS snapshot in the region configured in the shared config
@@ -136,12 +57,19 @@ func main() {
     // Create RDS service client
     svc := rds.New(sess)
 
+    // Get the current date and time to uniquely identify snapshot
+    currentTime := time.Now()
+    t := currentTime.Format("2006-01-02 15:04:05")
+    // Replace space with underscore
+    t = strings.Replace(t, " ", "_", -1)
+
     // Create the RDS snapshot
     _, err = svc.CreateDBSnapshot(&rds.CreateDBSnapshotInput{
         DBInstanceIdentifier: aws.String(instance),
+        DBSnapshotIdentifier: aws.String(instance + t),
     })
     if err != nil {
-        exitErrorf("Unable to create snapshot in instance %q, %v", cluster, err)
+        exitErrorf("Unable to create snapshot in instance %q, %v", instance, err)
     }
 
     // Wait until snapshot is created before finishing
@@ -161,3 +89,4 @@ func exitErrorf(msg string, args ...interface{}) {
     fmt.Fprintf(os.Stderr, msg+"\n", args...)
     os.Exit(1)
 }
+// snippet-end:[rds.go.create_db_snapshot]

--- a/go/example_code/rds/rds_list_all_instances.go
+++ b/go/example_code/rds/rds_list_all_instances.go
@@ -26,39 +26,39 @@
 package main
 
 import (
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/rds"
 )
 
 func main() {
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+    )
 
-	// Create RDS service client
-	svc := rds.New(sess)
+    // Create RDS service client
+    svc := rds.New(sess)
 
-	result, err := svc.DescribeDBInstances(nil)
-	if err != nil {
-		exitErrorf("Unable to list instances, %v", err)
-	}
+    result, err := svc.DescribeDBInstances(nil)
+    if err != nil {
+        exitErrorf("Unable to list instances, %v", err)
+    }
 
-	fmt.Println("Instances:")
+    fmt.Println("Instances:")
 
-	for _, d := range result.DBInstances {
-		fmt.Printf("* %s created on %s\n",
-			aws.StringValue(d.DBInstanceIdentifier), aws.TimeValue(d.InstanceCreateTime))
-	}
+    for _, d := range result.DBInstances {
+        fmt.Printf("* %s created on %s\n",
+            aws.StringValue(d.DBInstanceIdentifier), aws.TimeValue(d.InstanceCreateTime))
+    }
 }
 
 func exitErrorf(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg+"\n", args...)
-	os.Exit(1)
+    fmt.Fprintf(os.Stderr, msg+"\n", args...)
+    os.Exit(1)
 }
 // snippet-end:[rds.go.describe_db_instances]

--- a/go/example_code/rds/rds_list_cluster_snapshots.go
+++ b/go/example_code/rds/rds_list_cluster_snapshots.go
@@ -26,37 +26,37 @@
 package main
 
 import (
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/rds"
 )
 
 func main() {
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+    )
 
-	// Create RDS service client
-	svc := rds.New(sess)
+    // Create RDS service client
+    svc := rds.New(sess)
 
-	result, err := svc.DescribeDBClusterSnapshots(nil)
-	if err != nil {
-		exitErrorf("Unable to list snapshots, %v", err)
-	}
+    result, err := svc.DescribeDBClusterSnapshots(nil)
+    if err != nil {
+        exitErrorf("Unable to list snapshots, %v", err)
+    }
 
-	for _, s := range result.DBClusterSnapshots {
-		fmt.Printf("* %s with status %s\n",
-			aws.StringValue(s.DBClusterSnapshotIdentifier), aws.StringValue(s.Status))
-	}
+    for _, s := range result.DBClusterSnapshots {
+        fmt.Printf("* %s with status %s\n",
+            aws.StringValue(s.DBClusterSnapshotIdentifier), aws.StringValue(s.Status))
+    }
 }
 
 func exitErrorf(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg+"\n", args...)
-	os.Exit(1)
+    fmt.Fprintf(os.Stderr, msg+"\n", args...)
+    os.Exit(1)
 }
 // snippet-end:[rds.go.describe_db_cluster_snapshots]

--- a/go/example_code/rds/rds_list_instance_snapshots.go
+++ b/go/example_code/rds/rds_list_instance_snapshots.go
@@ -26,37 +26,37 @@
 package main
 
 import (
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/rds"
 )
 
 func main() {
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+    )
 
-	// Create RDS service client
-	svc := rds.New(sess)
+    // Create RDS service client
+    svc := rds.New(sess)
 
-	result, err := svc.DescribeDBSnapshots(nil)
-	if err != nil {
-		exitErrorf("Unable to list snapshots, %v", err)
-	}
+    result, err := svc.DescribeDBSnapshots(nil)
+    if err != nil {
+        exitErrorf("Unable to list snapshots, %v", err)
+    }
 
-	for _, s := range result.DBSnapshots {
-		fmt.Printf("* %s with status %s\n",
-			aws.StringValue(s.DBSnapshotIdentifier), aws.StringValue(s.Status))
-	}
+    for _, s := range result.DBSnapshots {
+        fmt.Printf("* %s with status %s\n",
+            aws.StringValue(s.DBSnapshotIdentifier), aws.StringValue(s.Status))
+    }
 }
 
 func exitErrorf(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg+"\n", args...)
-	os.Exit(1)
+    fmt.Fprintf(os.Stderr, msg+"\n", args...)
+    os.Exit(1)
 }
 // snippet-end:[rds.go.describe_db_snapshots]

--- a/go/example_code/rds/rds_list_parameter_groups.go
+++ b/go/example_code/rds/rds_list_parameter_groups.go
@@ -26,37 +26,37 @@
 package main
 
 import (
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/rds"
 )
 
 func main() {
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+    )
 
-	// Create RDS service client
-	svc := rds.New(sess)
+    // Create RDS service client
+    svc := rds.New(sess)
 
-	result, err := svc.DescribeDBParameterGroups(nil)
-	if err != nil {
-		exitErrorf("Unable to list parameter groups, %v", err)
-	}
+    result, err := svc.DescribeDBParameterGroups(nil)
+    if err != nil {
+        exitErrorf("Unable to list parameter groups, %v", err)
+    }
 
-	for _, p := range result.DBParameterGroups {
-		fmt.Printf("* %s with description: %s\n",
-			aws.StringValue(p.DBParameterGroupName), aws.StringValue(p.Description))
-	}
+    for _, p := range result.DBParameterGroups {
+        fmt.Printf("* %s with description: %s\n",
+            aws.StringValue(p.DBParameterGroupName), aws.StringValue(p.Description))
+    }
 }
 
 func exitErrorf(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg+"\n", args...)
-	os.Exit(1)
+    fmt.Fprintf(os.Stderr, msg+"\n", args...)
+    os.Exit(1)
 }
 // snippet-end:[rds.go.describe_db_parameter_groups]

--- a/go/example_code/rds/rds_list_security_group.go
+++ b/go/example_code/rds/rds_list_security_group.go
@@ -26,37 +26,37 @@
 package main
 
 import (
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/rds"
 )
 
 func main() {
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+    )
 
-	// Create RDS service client
-	svc := rds.New(sess)
+    // Create RDS service client
+    svc := rds.New(sess)
 
-	result, err := svc.DescribeDBSecurityGroups(nil)
-	if err != nil {
-		exitErrorf("Unable to list security groups, %v", err)
-	}
+    result, err := svc.DescribeDBSecurityGroups(nil)
+    if err != nil {
+        exitErrorf("Unable to list security groups, %v", err)
+    }
 
-	for _, s := range result.DBSecurityGroups {
-		fmt.Printf("* %s in VpcId: %s\n",
-			aws.StringValue(s.DBSecurityGroupName), aws.StringValue(s.VpcId))
-	}
+    for _, s := range result.DBSecurityGroups {
+        fmt.Printf("* %s in VpcId: %s\n",
+            aws.StringValue(s.DBSecurityGroupName), aws.StringValue(s.VpcId))
+    }
 }
 
 func exitErrorf(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg+"\n", args...)
-	os.Exit(1)
+    fmt.Fprintf(os.Stderr, msg+"\n", args...)
+    os.Exit(1)
 }
 // snippet-end:[rds.go.describe_db_security_groups]

--- a/go/example_code/rds/rds_list_subnet_groups.go
+++ b/go/example_code/rds/rds_list_subnet_groups.go
@@ -26,37 +26,37 @@
 package main
 
 import (
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/rds"
 )
 
 func main() {
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+    )
 
-	// Create RDS service client
-	svc := rds.New(sess)
+    // Create RDS service client
+    svc := rds.New(sess)
 
-	result, err := svc.DescribeDBSubnetGroups(nil)
-	if err != nil {
-		exitErrorf("Unable to list subnets groups, %v", err)
-	}
+    result, err := svc.DescribeDBSubnetGroups(nil)
+    if err != nil {
+        exitErrorf("Unable to list subnets groups, %v", err)
+    }
 
-	for _, s := range result.DBSubnetGroups {
-		fmt.Printf("* %s in VpcId: %s\n",
-			aws.StringValue(s.DBSubnetGroupName), aws.StringValue(s.VpcId))
-	}
+    for _, s := range result.DBSubnetGroups {
+        fmt.Printf("* %s in VpcId: %s\n",
+            aws.StringValue(s.DBSubnetGroupName), aws.StringValue(s.VpcId))
+    }
 }
 
 func exitErrorf(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg+"\n", args...)
-	os.Exit(1)
+    fmt.Fprintf(os.Stderr, msg+"\n", args...)
+    os.Exit(1)
 }
 // snippet-end:[rds.go.describe_db_subnet_groups]

--- a/go/example_code/s3/put_object_with_setters.go
+++ b/go/example_code/s3/put_object_with_setters.go
@@ -1,13 +1,13 @@
 // snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 // snippet-sourceauthor:[Doug-AWS]
-// snippet-sourcedescription:[Using API field setters with SDK requests.]
+// snippet-sourcedescription:[put_object_with_setters.go shows how to use API field setters with SDK requests.]
 // snippet-keyword:[Extending the SDK]
 // snippet-keyword:[PutObject function]
 // snippet-keyword:[Go]
 // snippet-service:[s3]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2018-03-16]
+// snippet-sourcedate:[2019-03-22]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -21,29 +21,33 @@
    CONDITIONS OF ANY KIND, either express or implied. See the License for the
    specific language governing permissions and limitations under the License.
 */
+//snippet-start:[s3.go.put_object]
 package main
 
 import (
-    "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/s3"
+    
     "strings"
 )
 
 func main() {
-    // Initialize a session in us-west-2 that the SDK will use to load
+    // Initialize a session that loads
     // credentials from the shared credentials file ~/.aws/credentials.
-    sess, _ := session.NewSession(&aws.Config{
-        Region: aws.String("us-west-2")},
-    )
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
 
     // Create S3 service client
     svc := s3.New(sess)
 
+    //snippet-start:[s3.go.put_object.call]
     svc.PutObject((&s3.PutObjectInput{}).
         SetBucket("myBucket").
         SetKey("myKey").
         SetBody(strings.NewReader("object body")).
         SetWebsiteRedirectLocation("https://example.com/something"),
     )
+    //snippet-end:[s3.go.put_object.call]
+    //snippet-end:[s3.go.put_object]
 }

--- a/go/example_code/s3/s3_upload_directory.go
+++ b/go/example_code/s3/s3_upload_directory.go
@@ -1,107 +1,107 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
+    "fmt"
+    "os"
+    "path/filepath"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
 const exitError = 1
 
 func main() {
-	if len(os.Args) != 4 {
-		exitErrorf("region, bucket and directory path required\nUsage: %s region bucket_name path",
-			os.Args[0])
-	}
+    if len(os.Args) != 4 {
+        exitErrorf("region, bucket and directory path required\nUsage: %s region bucket_name path",
+            os.Args[0])
+    }
 
-	region := os.Args[1]
-	bucket := os.Args[2]
-	path := os.Args[3]
-	di := NewDirectoryIterator(bucket, path)
+    region := os.Args[1]
+    bucket := os.Args[2]
+    path := os.Args[3]
+    di := NewDirectoryIterator(bucket, path)
 
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(region)},
-	)
-	if err != nil {
-		exitErrorf("failed to create a session %q, %v", err)
-	}
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String(region)},
+    )
+    if err != nil {
+        exitErrorf("failed to create a session %q, %v", err)
+    }
 
-	uploader := s3manager.NewUploader(sess)
+    uploader := s3manager.NewUploader(sess)
 
-	if err := uploader.UploadWithIterator(aws.BackgroundContext(), di); err != nil {
-		exitErrorf("failed to upload %q, %v", err)
-	}
-	fmt.Printf("successfully uploaded %q to %q", path, bucket)
+    if err := uploader.UploadWithIterator(aws.BackgroundContext(), di); err != nil {
+        exitErrorf("failed to upload %q, %v", err)
+    }
+    fmt.Printf("successfully uploaded %q to %q", path, bucket)
 }
 
 // DirectoryIterator represents an iterator of a specified directory
 type DirectoryIterator struct {
-	filePaths []string
-	bucket    string
-	next      struct {
-		path string
-		f    *os.File
-	}
-	err error
+    filePaths []string
+    bucket    string
+    next      struct {
+        path string
+        f    *os.File
+    }
+    err error
 }
 
 // NewDirectoryIterator builds a new DirectoryIterator
 func NewDirectoryIterator(bucket, dir string) s3manager.BatchUploadIterator {
-	var paths []string
-	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() {
-			paths = append(paths, path)
-		}
-		return nil
-	})
+    var paths []string
+    filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+        if !info.IsDir() {
+            paths = append(paths, path)
+        }
+        return nil
+    })
 
-	return &DirectoryIterator{
-		filePaths: paths,
-		bucket:    bucket,
-	}
+    return &DirectoryIterator{
+        filePaths: paths,
+        bucket:    bucket,
+    }
 }
 
 // Next returns whether next file exists or not
 func (di *DirectoryIterator) Next() bool {
-	if len(di.filePaths) == 0 {
-		di.next.f = nil
-		return false
-	}
+    if len(di.filePaths) == 0 {
+        di.next.f = nil
+        return false
+    }
 
-	f, err := os.Open(di.filePaths[0])
-	di.err = err
-	di.next.f = f
-	di.next.path = di.filePaths[0]
-	di.filePaths = di.filePaths[1:]
+    f, err := os.Open(di.filePaths[0])
+    di.err = err
+    di.next.f = f
+    di.next.path = di.filePaths[0]
+    di.filePaths = di.filePaths[1:]
 
-	return true && di.Err() == nil
+    return true && di.Err() == nil
 }
 
 // Err returns error of DirectoryIterator
 func (di *DirectoryIterator) Err() error {
-	return di.err
+    return di.err
 }
 
 // UploadObject uploads a file
 func (di *DirectoryIterator) UploadObject() s3manager.BatchUploadObject {
-	f := di.next.f
-	return s3manager.BatchUploadObject{
-		Object: &s3manager.UploadInput{
-			Bucket: &di.bucket,
-			Key:    &di.next.path,
-			Body:   f,
-		},
-		After: func() error {
-			return f.Close()
-		},
-	}
+    f := di.next.f
+    return s3manager.BatchUploadObject{
+        Object: &s3manager.UploadInput{
+            Bucket: &di.bucket,
+            Key:    &di.next.path,
+            Body:   f,
+        },
+        After: func() error {
+            return f.Close()
+        },
+    }
 }
 
 func exitErrorf(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg+"\n", args...)
-	os.Exit(exitError)
+    fmt.Fprintf(os.Stderr, msg+"\n", args...)
+    os.Exit(exitError)
 }

--- a/go/example_code/sns/sns_publish_to_topic.go
+++ b/go/example_code/sns/sns_publish_to_topic.go
@@ -25,40 +25,40 @@
 package main
 
 import (
-	"fmt"
+    "fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sns"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/sns"
 )
 
 // usage:
 // go run sns_publish_to_topic.go
 func main() {
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2"),
-	})
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2"),
+    })
 
-	if err != nil {
-		fmt.Println("NewSession error:", err)
-		return
-	}
+    if err != nil {
+        fmt.Println("NewSession error:", err)
+        return
+    }
 
-	client := sns.New(sess)
-	input := &sns.PublishInput{
-		Message:  aws.String("Hello world!"),
-		TopicArn: aws.String("arn:aws:sns:us-west-2:123456789012:YourTopic"),
-	}
+    client := sns.New(sess)
+    input := &sns.PublishInput{
+        Message:  aws.String("Hello world!"),
+        TopicArn: aws.String("arn:aws:sns:us-west-2:123456789012:YourTopic"),
+    }
 
-	result, err := client.Publish(input)
-	if err != nil {
-		fmt.Println("Publish error:", err)
-		return
-	}
+    result, err := client.Publish(input)
+    if err != nil {
+        fmt.Println("Publish error:", err)
+        return
+    }
 
-	fmt.Println(result)
+    fmt.Println(result)
 }
 
 // snippet-end:[sns.go.publish]

--- a/go/example_code/sqs/sqs_receive_message.go
+++ b/go/example_code/sqs/sqs_receive_message.go
@@ -26,46 +26,46 @@
 package main
 
 import (
-	"fmt"
+    "fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sqs"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/sqs"
 )
 
 // Usage:
 // go run sqs_receive_message.go
 func main() {
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+    }))
 
-	svc := sqs.New(sess)
+    svc := sqs.New(sess)
 
-	// URL to our queue
-	qURL := "QueueURL"
+    // URL to our queue
+    qURL := "QueueURL"
 
-	result, err := svc.ReceiveMessage(&sqs.ReceiveMessageInput{
-		AttributeNames: []*string{
-			aws.String(sqs.MessageSystemAttributeNameSentTimestamp),
-		},
-		MessageAttributeNames: []*string{
-			aws.String(sqs.QueueAttributeNameAll),
-		},
-		QueueUrl:            &qURL,
-		MaxNumberOfMessages: aws.Int64(10),
-		VisibilityTimeout:   aws.Int64(60), // 60 seconds
-		WaitTimeSeconds:     aws.Int64(0),
-	})
-	if err != nil {
-		fmt.Println("Error", err)
-		return
-	}
-	if len(result.Messages) == 0 {
-		fmt.Println("Received no messages")
-		return
-	}
+    result, err := svc.ReceiveMessage(&sqs.ReceiveMessageInput{
+        AttributeNames: []*string{
+            aws.String(sqs.MessageSystemAttributeNameSentTimestamp),
+        },
+        MessageAttributeNames: []*string{
+            aws.String(sqs.QueueAttributeNameAll),
+        },
+        QueueUrl:            &qURL,
+        MaxNumberOfMessages: aws.Int64(10),
+        VisibilityTimeout:   aws.Int64(60), // 60 seconds
+        WaitTimeSeconds:     aws.Int64(0),
+    })
+    if err != nil {
+        fmt.Println("Error", err)
+        return
+    }
+    if len(result.Messages) == 0 {
+        fmt.Println("Received no messages")
+        return
+    }
 
-	fmt.Printf("Success: %+v\n", result.Messages)
+    fmt.Printf("Success: %+v\n", result.Messages)
 }
 // snippet-end:[sqs.go.receive_message]

--- a/go/example_code/sts/sts_assume_role.go
+++ b/go/example_code/sts/sts_assume_role.go
@@ -23,42 +23,42 @@
 package main
 
 import (
-	"fmt"
+    "fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sts"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/sts"
 )
 
 // Usage:
 // go run sts_assume_role.go
 func main() {
-	// Initialize a session in us-west-2 that the SDK will use to load
-	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2"),
-	})
+    // Initialize a session in us-west-2 that the SDK will use to load
+    // credentials from the shared credentials file ~/.aws/credentials.
+    sess, err := session.NewSession(&aws.Config{
+        Region: aws.String("us-west-2"),
+    })
 
-	if err != nil {
-		fmt.Println("NewSession Error", err)
-		return
-	}
+    if err != nil {
+        fmt.Println("NewSession Error", err)
+        return
+    }
 
-	// Create a STS client
-	svc := sts.New(sess)
+    // Create a STS client
+    svc := sts.New(sess)
 
-	roleToAssumeArn := "arn:aws:iam::123456789012:role/roleName"
-	sessionName := "test_session"
-	result, err := svc.AssumeRole(&sts.AssumeRoleInput{
-		RoleArn:         &roleToAssumeArn,
-		RoleSessionName: &sessionName,
-	})
+    roleToAssumeArn := "arn:aws:iam::123456789012:role/roleName"
+    sessionName := "test_session"
+    result, err := svc.AssumeRole(&sts.AssumeRoleInput{
+        RoleArn:         &roleToAssumeArn,
+        RoleSessionName: &sessionName,
+    })
 
-	if err != nil {
-		fmt.Println("AssumeRole Error", err)
-		return
-	}
+    if err != nil {
+        fmt.Println("AssumeRole Error", err)
+        return
+    }
 
-	fmt.Println(result.AssumedRoleUser)
+    fmt.Println(result.AssumedRoleUser)
 }
 // snippet-end:[sts.go.assume_role]


### PR DESCRIPTION
Go examples had tabs, which wreak havoc in the docs when calling dendent.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
