### PR TITLE
Fixed rubocop errors

### DIFF
--- a/ruby/example_code/cloudtrail/aws-ruby-sdk-cloudtrail-example-create-trail.rb
+++ b/ruby/example_code/cloudtrail/aws-ruby-sdk-cloudtrail-example-create-trail.rb
@@ -114,7 +114,7 @@ end
 client = Aws::CloudTrail::Client.new(region: 'us-west-2')
 
 begin
-  resp = client.create_trail({
+  client.create_trail({
     name: name, # required
     s3_bucket_name: bucket, # required
   })

--- a/ruby/example_code/cloudtrail/aws-ruby-sdk-cloudtrail-example-delete-trail.rb
+++ b/ruby/example_code/cloudtrail/aws-ruby-sdk-cloudtrail-example-delete-trail.rb
@@ -33,7 +33,7 @@ name = ARGV[0]
 client = Aws::CloudTrail::Client.new(region: 'us-west-2')
 
 begin
-  resp = client.delete_trail({
+  client.delete_trail({
     name: name, # required
   })
 

--- a/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-build-project.rb
+++ b/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-build-project.rb
@@ -34,7 +34,7 @@ end
 client = Aws::CodeBuild::Client.new(region: 'us-west-2')
 
 begin
-  resp = client.start_build({project_name: project_name, })
+  client.start_build(project_name: project_name)
   puts 'Building project ' + project_name
 rescue StandardError => ex
   puts 'Error building project: ' + ex.message

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesDeleteTable.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesDeleteTable.rb
@@ -36,7 +36,7 @@ params = {
 }
 
 begin
-    result = dynamodb.delete_table(params)
+    dynamodb.delete_table(params)
     puts "Deleted table."
 
 rescue  Aws::DynamoDB::Errors::ServiceError => error

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps01.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps01.rb
@@ -51,7 +51,7 @@ params = {
 }
 
 begin
-    result = dynamodb.put_item(params)
+    dynamodb.put_item(params)
     puts "Added item: #{year}  - #{title}"
 
 rescue  Aws::DynamoDB::Errors::ServiceError => error

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps02.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps02.rb
@@ -36,11 +36,6 @@ table_name = 'Movies'
 year = 2015
 title = "The Big New Movie"
 
-key = {
-    year: year,
-    title: title
-}
-
 params = {
     table_name: table_name,
     key: {

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps03.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps03.rb
@@ -52,7 +52,7 @@ params = {
 }
 
 begin
-    result = dynamodb.update_item(params)
+    dynamodb.update_item(params)
     puts "Added item: #{year}  - #{title}"
 
 rescue  Aws::DynamoDB::Errors::ServiceError => error

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps06.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps06.rb
@@ -49,7 +49,7 @@ params = {
 }
 
 begin
-    result = dynamodb.delete_item(params)
+    dynamodb.delete_item(params)
     puts "Deleted item."
 
 rescue  Aws::DynamoDB::Errors::ServiceError => error

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesLoadData.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesLoadData.rb
@@ -44,7 +44,7 @@ movies.each{|movie|
     }
 
     begin
-        result = dynamodb.put_item(params)
+        dynamodb.put_item(params)
         puts "Added movie: #{movie["year"]} #{movie["title"]}"
 
     rescue  Aws::DynamoDB::Errors::ServiceError => error

--- a/ruby/example_code/dynamodb/dynamodb_ruby_example_create_movies_item.rb
+++ b/ruby/example_code/dynamodb/dynamodb_ruby_example_create_movies_item.rb
@@ -39,7 +39,7 @@ params = {
 }
 
 begin
-  result = dynamodb.put_item(params)
+  dynamodb.put_item(params)
   puts 'Added movie: ' + year.to_i.to_s + ' - ' + title
 rescue  Aws::DynamoDB::Errors::ServiceError => error
   puts 'Unable to add movie:'

--- a/ruby/example_code/dynamodb/dynamodb_ruby_example_delete_movies_item.rb
+++ b/ruby/example_code/dynamodb/dynamodb_ruby_example_delete_movies_item.rb
@@ -34,7 +34,7 @@ params = {
 }
 
 begin
-  result = dynamodb.delete_item(params)
+  dynamodb.delete_item(params)
   puts 'Deleted movie'
 rescue  Aws::DynamoDB::Errors::ServiceError => error
   puts 'Unable to delete movie:'

--- a/ruby/example_code/dynamodb/dynamodb_ruby_example_load_movies.rb
+++ b/ruby/example_code/dynamodb/dynamodb_ruby_example_load_movies.rb
@@ -36,8 +36,8 @@ movies.each{|movie|
   }
 
   begin
-    result = dynamodb.put_item(params)
-    puts 'Added movie: ' + {movie['year']}.to_i.to_s  + ' - ' + {movie['title']}
+    dynamodb.put_item(params)
+    puts 'Added movie: ' + movie['year'].to_i.to_s  + ' - ' + movie['title']
 
   rescue  Aws::DynamoDB::Errors::ServiceError => error
     puts 'Unable to add movie:'

--- a/ruby/example_code/dynamodb/dynamodb_ruby_example_update_movies_item.rb
+++ b/ruby/example_code/dynamodb/dynamodb_ruby_example_update_movies_item.rb
@@ -37,7 +37,7 @@ params = {
 }
 
 begin
-  result = dynamodb.update_item(params)
+  dynamodb.update_item(params)
   puts 'Rating successfully set'
 rescue  Aws::DynamoDB::Errors::ServiceError => error
   puts 'Unable to set rating:'

--- a/ruby/example_code/ec2/ec2-ruby-example-elastic-ips.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-elastic-ips.rb
@@ -62,7 +62,7 @@ puts "Before allocating the address for the instance...."
 display_addresses(ec2, instance_id)
 
 puts "\nAllocating the address for the instance..."
-allocate_address_result = ec2.allocate_address({
+ec2.allocate_address({
   domain: "vpc" 
 })
 
@@ -70,7 +70,7 @@ puts "\nAfter allocating the address for instance, but before associating the ad
 display_addresses(ec2, instance_id)
 
 puts "\nAssociating the address with the instance..."
-associate_address_result = ec2.associate_address({
+ec2.associate_address({
   allocation_id: allocate_address_result.allocation_id, 
   instance_id: instance_id, 
 })

--- a/ruby/example_code/ec2/ec2-ruby-example-key-pairs.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-key-pairs.rb
@@ -52,8 +52,8 @@ key_pairs_result = ec2.describe_key_pairs()
 
 if key_pairs_result.key_pairs.count > 0
   puts "\nKey pair names:"
-  key_pairs_result.key_pairs.each do |key_pair|
-    puts key_pair.key_name
+  key_pairs_result.key_pairs.each do |kp|
+    puts kp.key_name
   end
 end
 

--- a/ruby/example_code/ec2/ec2-ruby-example-regions-availability-zones.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-regions-availability-zones.rb
@@ -42,7 +42,7 @@ describe_availability_zones_result.availability_zones.each do |zone|
   puts "#{zone.zone_name} is #{zone.state}"
   if zone.messages.count > 0
     zone.messages.each do |message|
-      "  #{message.message}"
+      puts "  #{message.message}"
     end
   end
 end

--- a/ruby/example_code/ec2/ec2-ruby-example-security-group.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-security-group.rb
@@ -86,8 +86,8 @@ end
 def describe_ip_permission(ip_permission)
   puts "-" * 22
   puts "IP Protocol: #{ip_permission.ip_protocol}"
-  puts "From Port: #{ip_permission.from_port.to_s}"
-  puts "To Port: #{ip_permission.to_port.to_s}"
+  puts "From Port: #{ip_permission.from_port}"
+  puts "To Port: #{ip_permission.to_port}"
   if ip_permission.ip_ranges.count > 0
     puts "IP Ranges:"
     ip_permission.ip_ranges.each do |ip_range|

--- a/ruby/example_code/elasticbeanstalk/elb-ruby-example-update-myrailsapp.rb
+++ b/ruby/example_code/elasticbeanstalk/elb-ruby-example-update-myrailsapp.rb
@@ -49,7 +49,7 @@ resp = eb.create_storage_location()
 
 puts "Created storage location in bucket #{resp.s3_bucket}"
 
-resp = s3.list_objects({
+s3.list_objects({
   prefix: s3_key,
   bucket: bucket
 })
@@ -67,7 +67,7 @@ zip_contents = File.read(zip_file_name)
 
 key = app_name + "\\" + zip_file_name
 
-resp = s3.put_object({
+s3.put_object({
   body: zip_contents,
   bucket: bucket,
   key: key

--- a/ruby/example_code/iam/iam-ruby-example-construct-url-federated-users.rb
+++ b/ruby/example_code/iam/iam-ruby-example-construct-url-federated-users.rb
@@ -87,5 +87,6 @@ issuer_param = "&Issuer=" + CGI.escape(issuer_url)
 destination_param = "&Destination=" + CGI.escape(console_url)
 login_url = signin_url + "?Action=login" + signin_token_param + 
 issuer_param + destination_param
+puts 'Login URL: ' + login_url
 # snippet-end:[iam.ruby.construct-url-federated-users.complete]
 

--- a/ruby/example_code/iam/iam-ruby-example-create-user-access-keys.rb
+++ b/ruby/example_code/iam/iam-ruby-example-create-user-access-keys.rb
@@ -31,6 +31,6 @@ begin
 
   puts "Access key: #{key_pair.access_key_id}"
   puts "Secret key: #{key_pair.secret}"
-rescue Aws::IAM::Errors::NoSuchEntity => ex
+rescue Aws::IAM::Errors::NoSuchEntity
   puts 'User does not exist'
 end

--- a/ruby/example_code/iam/iam-ruby-example-get-ssh-public-keys.rb
+++ b/ruby/example_code/iam/iam-ruby-example-get-ssh-public-keys.rb
@@ -40,6 +40,6 @@ begin
     puts ssh_public_key_response.ssh_public_key.ssh_public_key_body
   end
 
-rescue Aws::IAM::Errors::NoSuchEntity => ex
+rescue Aws::IAM::Errors::NoSuchEntity
   puts 'User does not exist'
 end

--- a/ruby/example_code/lambda/aws-ruby-sdk-lambda-example-configure-function-for-notification.rb
+++ b/ruby/example_code/lambda/aws-ruby-sdk-lambda-example-configure-function-for-notification.rb
@@ -31,4 +31,4 @@ args[:action] = 'lambda:InvokeFunction'
 args[:principal] = 's3.amazonaws.com'
 args[:source_arn] = 'my-resource-arn'
 
-client.add_permission{args]
+client.add_permission(args)

--- a/ruby/example_code/s3/auth_federation_token_request_test.rb
+++ b/ruby/example_code/s3/auth_federation_token_request_test.rb
@@ -71,7 +71,6 @@ end
 region = 'us-west-2'
 user_name = ''
 bucket_name = ''
-debug = false
 
 i = 0
 
@@ -88,12 +87,7 @@ while i < ARGV.length
 
     when '-r'
       i += 1
-
       region = ARGV[i]
-
-    when '-d'
-      puts 'Debugging enabled'
-      debug = true
 
     when '-h'
       puts USAGE
@@ -121,9 +115,6 @@ if user_name == ''
   exit 1
 end
 
-# Identify the IAM user we allow to list Amazon S3 bucket items for an hour.
-user = get_user(region, user_name, debug)
-
 # Create a new STS client and get temporary credentials.
 sts = Aws::STS::Client.new(region: region)
 
@@ -143,8 +134,8 @@ begin
   s3.bucket(bucket_name).objects.limit(50).each do |obj|
     puts "  #{obj.key} => #{obj.etag}"
   end
-rescue Exception => ex
-  puts 'Caught exception accessing bucket ' +  bucket_name + ':'
+rescue StandardError => ex
+  puts 'Caught exception accessing bucket ' + bucket_name + ':'
   puts ex.message
 end
 # snippet-end:[s3.ruby.auth_federation_token_request_test.rb]

--- a/ruby/example_code/s3/auth_session_token_request_test.rb
+++ b/ruby/example_code/s3/auth_session_token_request_test.rb
@@ -79,7 +79,6 @@ end
 region = 'us-west-2'
 user_name = ''
 bucket_name = ''
-debug = false
 
 i = 0
 
@@ -98,10 +97,6 @@ while i &lt; ARGV.length
       i += 1
 
       region = ARGV[i]
-
-    when '-d'
-      puts 'Debugging enabled'
-      debug = true
 
     when '-h'
       puts USAGE
@@ -129,9 +124,6 @@ if user_name == ''
   exit 1
 end
 
-#Identify the IAM user that is allowed to list Amazon S3 bucket items for an hour.
-user = get_user(region, user_name, debug)
-
 # Create a new Amazon STS client and get temporary credentials. This uses a role that was already created.
 begin
   creds = Aws::AssumeRoleCredentials.new(
@@ -149,8 +141,8 @@ begin
   s3.bucket(bucket_name).objects.limit(50).each do |obj|
     puts "  #{obj.key} => #{obj.etag}"
   end
- rescue Exception => ex
-  puts 'Caught exception accessing bucket ' +  bucket_name + ':'
+rescue StandardError => ex
+  puts 'Caught exception accessing bucket ' + bucket_name + ':'
   puts ex.message
 end
 # snippet-end:[s3.ruby.auth_session_token_request_test.rb]

--- a/ruby/example_code/s3/copy_object_between_buckets.rb
+++ b/ruby/example_code/s3/copy_object_between_buckets.rb
@@ -30,9 +30,9 @@ target_key = '*** Provide target key ***'
 
 begin
   s3 = Aws::S3::Client.new(region: 'us-west-2')
-  s3.copy_object({bucket: target_bucket_name, copy_source: source_bucket_name + '/' + source_key, key: target_key})
-rescue Exception => ex
-  puts 'Caught exception copying object ' +  source_key + ' from bucket ' + source_bucket_name + ' to bucket ' + target_bucket_name + ' as ' + target_key + ':'
+  s3.copy_object(bucket: target_bucket_name, copy_source: source_bucket_name + '/' + source_key, key: target_key)
+rescue StandardError => ex
+  puts 'Caught exception copying object ' + source_key + ' from bucket ' + source_bucket_name + ' to bucket ' + target_bucket_name + ' as ' + target_key + ':'
   puts ex.message
 end
 

--- a/ruby/example_code/s3/determine_object_encryption_state.rb
+++ b/ruby/example_code/s3/determine_object_encryption_state.rb
@@ -26,7 +26,7 @@ require 'aws-sdk-s3'
 
 regionName = 'us-west-2' 
 bucketName='bucket-name'
-key = 'key' '
+key = 'key'
 
 s3 = Aws::S3::Resource.new(region:regionName)
 enc = s3.bucket(bucketName).object(key).server_side_encryption

--- a/ruby/example_code/s3/s3-ruby-example-add-cspk-item.rb
+++ b/ruby/example_code/s3/s3-ruby-example-add-cspk-item.rb
@@ -45,7 +45,7 @@ begin
   )
 
   puts 'Added ' + item_name + ' to bucket ' + bucket + ' using key from ' + key_file
-rescue StandardError => err
+rescue StandardError
   puts 'Could not add item'
   puts 'Error:'
   puts ex.message

--- a/ruby/example_code/s3/s3-ruby-example-bucket-accessable.rb
+++ b/ruby/example_code/s3/s3-ruby-example-bucket-accessable.rb
@@ -28,7 +28,15 @@ s3 = Aws::S3::Resource.new(region: 'us-west-2')
 # Does such a bucket exist?
 found_bucket = s3.buckets.any? { |b| b.name == 'my-bucket' }
 
-# If so, is it in this region?
-if found_bucket
+if !found_bucket
+  puts 'Bucket does not exist'
+else
+  # Is it in this region?
   found_bucket = s3.client.get_bucket_location(bucket: 'my-bucket').location_constraint == 'us-east-1'
+
+  if found_bucket
+    puts 'Bucket exists in this region'
+  else
+    puts 'Bucket does not exist in this region'
+  end
 end

--- a/ruby/example_code/s3/s3-ruby-example-bucket-exists.rb
+++ b/ruby/example_code/s3/s3-ruby-example-bucket-exists.rb
@@ -25,3 +25,9 @@ require 'aws-sdk-s3'  # v2: require 'aws-sdk'
       
 s3 = Aws::S3::Resource.new(region: 'us-west-2')
 bucket_exists = s3.bucket('my-bucket').exists?
+
+if bucket_exists
+    puts 'Bucket exists'
+else
+    puts 'Bucket does not exist'
+end

--- a/ruby/example_code/s3/s3-ruby-example-find-open-buckets.rb
+++ b/ruby/example_code/s3/s3-ruby-example-find-open-buckets.rb
@@ -54,7 +54,8 @@ s3.buckets.each do |b|
         break
       end
     end
-  rescue
+  rescue StandardError
+    puts 'Got error'
   end
 end
 

--- a/ruby/example_code/s3/s3-ruby-example-get-cspk-item.rb
+++ b/ruby/example_code/s3/s3-ruby-example-get-cspk-item.rb
@@ -36,7 +36,7 @@ key_file = 'private_key.pem'
 
 begin
   private_key = File.binread(key_file)
-  key = OpenSSL::PKey::RSA.new(private_key, passphrase)
+  key = OpenSSL::PKey::RSA.new(private_key, pass_phrase)
 
   # encryption client
   enc_client = Aws::S3::Encryption::Client.new(encryption_key: key)

--- a/ruby/example_code/s3/s3-ruby-example-head-bucket.rb
+++ b/ruby/example_code/s3/s3-ruby-example-head-bucket.rb
@@ -22,11 +22,11 @@
 
 require 'aws-sdk-s3'  # v2: require 'aws-sdk'
 
-bucket_exists = false
 client = Aws::S3::Client.new(region: 'us-west-2')
 
 begin
-  resp = client.head_bucket({bucket: bucket_name, use_accelerate_endpoint: false})
-  bucket_exists = true
-rescue
+  client.head_bucket({bucket: 'bucket_name', use_accelerate_endpoint: false})
+  # We know bucket exists
+rescue StandardError
+  puts 'Bucket does not exist'
 end

--- a/ruby/example_code/s3/s3_add_bucket_ssekms_encryption_policy.rb
+++ b/ruby/example_code/s3/s3_add_bucket_ssekms_encryption_policy.rb
@@ -31,6 +31,8 @@ iam = Aws::IAM::Resource.new(region: region)
 user = iam.current_user
 arn = user.arn
 
+puts 'User ARN: ' + arn
+
 s3 = Aws::S3::Client.new(region: region)
 
 policy = {

--- a/ruby/example_code/s3/s3_add_csaes_encrypt_item.rb
+++ b/ruby/example_code/s3/s3_add_csaes_encrypt_item.rb
@@ -31,7 +31,6 @@ end
 
 encoded_string = ARGV[0]
 key = encoded_string.unpack("m*")[0]
-md5 = Digest::MD5.digest(key)
 
 bucket = 'my_bucket'
 item = 'my_item'

--- a/ruby/example_code/s3/s3_ruby_create_bucket.rb
+++ b/ruby/example_code/s3/s3_ruby_create_bucket.rb
@@ -40,8 +40,8 @@ s3 = Aws::S3::Client.new(profile: profile_name, region: region)
 
 # Display a List of Amazon S3 Buckets
 resp = s3.list_buckets
-resp.buckets.each do |bucket|
-  puts bucket.name
+resp.buckets.each do |b|
+  puts b.name
 end
 
 # Create a S3 bucket from S3::client

--- a/ruby/example_code/ses/ses_send_verification.rb
+++ b/ruby/example_code/ses/ses_send_verification.rb
@@ -22,10 +22,6 @@
 
 require 'aws-sdk-ses'  # v2: require 'aws-sdk'
 
-# Replace sender@example.com with your "From" address.
-# This address must be verified with Amazon SES.
-sender = "sender@example.com"
-
 # Replace recipient@example.com with a "To" address.
 recipient = "recipient@example.com"
 
@@ -36,7 +32,7 @@ ses = Aws::SES::Client.new(region: 'us-west-2')
 # Try to verify email address.
 begin
   ses.verify_email_identity({
-    email_address: recipient,
+    email_address: recipient
   })
 
   puts 'Email sent to ' + email_address

--- a/ruby/example_code/sqs/sqs-ruby-example-send-message-batch.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-send-message-batch.rb
@@ -24,7 +24,7 @@ require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
 
 sqs = Aws::SQS::Client.new(region: 'us-west-2')
 
-resp = sqs.send_message_batch({
+sqs.send_message_batch({
   queue_url: URL,
   entries: [
     {

--- a/ruby/example_code/sqs/sqs-ruby-example-visibility-timeout2.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-visibility-timeout2.rb
@@ -23,7 +23,7 @@
 require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
 
 # Process the message
-def do_something(msg)
+def do_something(_)
   true
 end
 


### PR DESCRIPTION
I ran:

rubocop -l

against the Ruby examples and found lint errors in 38 files, so I fixed them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
