### PR TITLE
Correcting error in Java code example for sending email through Amazon Pinpoint

### DIFF
--- a/java/example_code/pinpoint/pinpoint_send_email_message_api.java
+++ b/java/example_code/pinpoint/pinpoint_send_email_message_api.java
@@ -85,7 +85,7 @@ public class SendMessages {
             Map<String,AddressConfiguration> addressMap = 
                 new HashMap<String,AddressConfiguration>();
                
-            addressMap.put(senderAddress, new AddressConfiguration()
+            addressMap.put(toAddress, new AddressConfiguration()
                 .withChannelType(ChannelType.EMAIL));
                
             AmazonPinpoint client = AmazonPinpointClientBuilder.standard()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The code example originally sent email to the sender's address, rather than the recipient's address. Updated the code example to refer to the correct variable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
