### PR TITLE
updating ddb list_tables example to add pagination to tablenames

### DIFF
--- a/go/example_code/dynamodb/DynamoDBListTables.go
+++ b/go/example_code/dynamodb/DynamoDBListTables.go
@@ -7,7 +7,7 @@
 // snippet-service:[dynamodb]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-03-18]
+// snippet-sourcedate:[2019-04-24]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/go/example_code/dynamodb/DynamoDBListTables.go
+++ b/go/example_code/dynamodb/DynamoDBListTables.go
@@ -26,43 +26,67 @@ package main
 
 // snippet-start:[dynamodb.go.list_tables.imports]
 import (
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 
-    "fmt"
-    "os"
+	"fmt"
 )
+
 // snippet-end:[dynamodb.go.list_tables.imports]
 
 func main() {
-    // snippet-start:[dynamodb.go.list_tables.session]
-    // Initialize a session that the SDK will use to load
-    // credentials from the shared credentials file ~/.aws/credentials
-    // and region from the shared configuration file ~/.aws/config.
-    sess := session.Must(session.NewSessionWithOptions(session.Options{
-        SharedConfigState: session.SharedConfigEnable,
-    }))
+	// snippet-start:[dynamodb.go.list_tables.session]
+	// Initialize a session that the SDK will use to load
+	// credentials from the shared credentials file ~/.aws/credentials
+	// and region from the shared configuration file ~/.aws/config.
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 
-    // Create DynamoDB client
-    svc := dynamodb.New(sess)
-    // snippet-end:[dynamodb.go.list_tables.session]
+	// Create DynamoDB client
+	svc := dynamodb.New(sess)
+	// snippet-end:[dynamodb.go.list_tables.session]
 
-    // snippet-start:[dynamodb.go.list_tables.call]
-    // Get the list of tables
-    result, err := svc.ListTables(&dynamodb.ListTablesInput{})
-    if err != nil {
-        fmt.Println(err)
-        os.Exit(1)
-    }
+	// snippet-start:[dynamodb.go.list_tables.call]
+	// create the input configuration instance
+	input := &dynamodb.ListTablesInput{}
 
-    fmt.Println("Tables:")
-    fmt.Println("")
+	fmt.Printf("Tables:\n")
 
-    for _, n := range result.TableNames {
-        fmt.Println(*n)
-    }
+	for {
+		// Get the list of tables
+		result, err := svc.ListTables(input)
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				switch aerr.Code() {
+				case dynamodb.ErrCodeInternalServerError:
+					fmt.Println(dynamodb.ErrCodeInternalServerError, aerr.Error())
+				default:
+					fmt.Println(aerr.Error())
+				}
+			} else {
+				// Print the error, cast err to awserr.Error to get the Code and
+				// Message from an error.
+				fmt.Println(err.Error())
+			}
+			return
+		}
 
-    fmt.Println("")
-    // snippet-end:[dynamodb.go.list_tables.call]
+		for _, n := range result.TableNames {
+			fmt.Println(*n)
+		}
+
+		// assign the last read tablename as the start for our next call to the ListTables function
+		// the maximum number of table names returned in a call is 100 (default), which requires us to make
+		// multiple calls to the ListTables function to retrieve all table names
+		input.ExclusiveStartTableName = result.LastEvaluatedTableName
+
+		if result.LastEvaluatedTableName == nil {
+			break
+		}
+	}
+	// snippet-end:[dynamodb.go.list_tables.call]
 }
+
 // snippet-end:[dynamodb.go.list_tables]

--- a/go/example_code/dynamodb/list_tables.go
+++ b/go/example_code/dynamodb/list_tables.go
@@ -25,38 +25,59 @@
 package main
 
 import (
-    "fmt"
-    "os"
+	"fmt"
 
-    "github.com/aws/aws-sdk-go/aws"
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 func main() {
-    // Initialize a session in us-west-2 that the SDK will use to load
-    // credentials from the shared credentials file ~/.aws/credentials.
-    sess, err := session.NewSession(&aws.Config{
-        Region: aws.String("us-west-2")},
-    )
+	// Initialize a session in us-west-2 that the SDK will use to load
+	// credentials from the shared credentials file ~/.aws/credentials.
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-west-2")},
+	)
 
-    // Create DynamoDB client
-    svc := dynamodb.New(sess)
+	// Create DynamoDB client
+	svc := dynamodb.New(sess)
 
-    // Get the list of tables
-    result, err := svc.ListTables(&dynamodb.ListTablesInput{})
+	// create the input configuration instance
+	input := &dynamodb.ListTablesInput{}
 
-    if err != nil {
-        fmt.Println(err)
-        os.Exit(1)
-    }
+	fmt.Printf("Tables:\n")
 
-    fmt.Println("Tables:")
-    fmt.Println("")
+	for {
+		// Get the list of tables
+		result, err := svc.ListTables(input)
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				switch aerr.Code() {
+				case dynamodb.ErrCodeInternalServerError:
+					fmt.Println(dynamodb.ErrCodeInternalServerError, aerr.Error())
+				default:
+					fmt.Println(aerr.Error())
+				}
+			} else {
+				// Print the error, cast err to awserr.Error to get the Code and
+				// Message from an error.
+				fmt.Println(err.Error())
+			}
+			return
+		}
 
-    for _, n := range result.TableNames {
-        fmt.Println(*n)
-    }
+		for _, n := range result.TableNames {
+			fmt.Println(*n)
+		}
 
-    fmt.Println("")
+		// assign the last read tablename as the start for our next call to the ListTables function
+		// the maximum number of table names returned in a call is 100 (default), which requires us to make
+		// multiple calls to the ListTables function to retrieve all table names
+		input.ExclusiveStartTableName = result.LastEvaluatedTableName
+
+		if result.LastEvaluatedTableName == nil {
+			break
+		}
+	}
 }

--- a/go/example_code/dynamodb/list_tables.go
+++ b/go/example_code/dynamodb/list_tables.go
@@ -7,7 +7,7 @@
 // snippet-service:[dynamodb]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2018-03-16]
+// snippet-sourcedate:[2019-04-24]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -36,7 +36,7 @@ import (
 func main() {
 	// Initialize a session in us-west-2 that the SDK will use to load
 	// credentials from the shared credentials file ~/.aws/credentials.
-	sess, err := session.NewSession(&aws.Config{
+	sess, _ := session.NewSession(&aws.Config{
 		Region: aws.String("us-west-2")},
 	)
 


### PR DESCRIPTION
*Description of changes:*
When requesting to list **all** `dynamodb` tables in an environment with >100 tables, the calls to `ListTables` must be paginated accordingly. Setting the `ListTablesInput` value to anything >100 on its own yields a `ValidationException`.

```
ValidationException: 1 validation error detected: Value '1000' at 'limit' failed to satisfy constraint: Member must have value less than or equal to 100
```

This PR will output a list of tables as follows...

```
Tables:
table1
table2
table3
...
table100
table101
table102
...
tableN
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
