### PR TITLE
Updated CDK example to v0.31.0

### DIFF
--- a/typescript/example_code/cdk/SecretsManager-stack.ts
+++ b/typescript/example_code/cdk/SecretsManager-stack.ts
@@ -29,7 +29,7 @@ export class SecretsManagerStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    const secret = sm.Secret.import(this, "ImportedSecret", {
+    const secret = sm.Secret.fromSecretAttributes(this, "ImportedSecret", {
       secretArn:
         "arn:aws:secretsmanager:<region>:<account-id-number>:secret:<secret-name>-<random-6-characters>"
       // If the secret is encrypted using a KMS-hosted CMK, either import or reference that key:


### PR DESCRIPTION
CDK released 0.31.0 last week.

Secret.import -> Secret.fromSecretAttributes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
