### PR TITLE
Fixed typos in Go and Ruby

### DIFF
--- a/go/example_code/s3/s3_get_bucket_acl.go
+++ b/go/example_code/s3/s3_get_bucket_acl.go
@@ -45,7 +45,7 @@ func main() {
     bucket := os.Args[1]
 
     // Initialize a session that loads credentials from the shared credentials file ~/.aws/credentials
-    // and the region from the shared configuratin file ~/.aws/config.
+    // and the region from the shared configuration file ~/.aws/config.
     sess := session.Must(session.NewSessionWithOptions(session.Options{
         SharedConfigState: session.SharedConfigEnable,
     }))

--- a/go/example_code/s3/s3_get_bucket_object_acl.go
+++ b/go/example_code/s3/s3_get_bucket_object_acl.go
@@ -46,7 +46,7 @@ func main() {
     key := os.Args[2]
 
     // Initialize a session that loads credentials from the shared credentials file ~/.aws/credentials
-    // and the region from the shared configuratin file ~/.aws/config.
+    // and the region from the shared configuration file ~/.aws/config.
     sess := session.Must(session.NewSessionWithOptions(session.Options{
         SharedConfigState: session.SharedConfigEnable,
     }))

--- a/go/example_code/s3/s3_put_bucket_acl.go
+++ b/go/example_code/s3/s3_put_bucket_acl.go
@@ -63,7 +63,7 @@ func main() {
     userType := "AmazonCustomerByEmail"
 
     // Initialize a session that loads credentials from the shared credentials file ~/.aws/credentials
-    // and the region from the shared configuratin file ~/.aws/config.
+    // and the region from the shared configuration file ~/.aws/config.
     sess := session.Must(session.NewSessionWithOptions(session.Options{
         SharedConfigState: session.SharedConfigEnable,
     }))

--- a/go/example_code/s3/s3_put_bucket_object_acl.go
+++ b/go/example_code/s3/s3_put_bucket_object_acl.go
@@ -61,7 +61,7 @@ func main() {
     }
 
     // Initialize a session that loads credentials from the shared credentials file ~/.aws/credentials
-    // and the region from the shared configuratin file ~/.aws/config.
+    // and the region from the shared configuration file ~/.aws/config.
     sess := session.Must(session.NewSessionWithOptions(session.Options{
         SharedConfigState: session.SharedConfigEnable,
     }))

--- a/go/example_code/sns/SnsSubscribe.go
+++ b/go/example_code/sns/SnsSubscribe.go
@@ -36,7 +36,7 @@ import (
 )
 
 func main() {
-    emailPtr := flag.String("e", "", "The email address of the user subcribing to the topic")
+    emailPtr := flag.String("e", "", "The email address of the user subscribing to the topic")
     topicPtr := flag.String("t", "", "The ARN of the topic to which the user subscribes")
     flag.Parse()
     email := *emailPtr

--- a/ruby/example_code/cloudwatch/cw-ruby-example-send-events-ec2.rb
+++ b/ruby/example_code/cloudwatch/cw-ruby-example-send-events-ec2.rb
@@ -29,7 +29,7 @@
 
 # To test this code, you must have:
 # 1. An AWS Lambda function that uses the hello-world blueprint to serve as the target for events. To learn how,
-#    see "Step 1: Create a Lambda Function" of the "Tutorial: Log the State of an EC2 Intance Using CloudWatch Events"
+#    see "Step 1: Create a Lambda Function" of the "Tutorial: Log the State of an EC2 Instance Using CloudWatch Events"
 #    topic in the Amazon CloudWatch Events User Guide.
 #    Make a note of the AWS Lambda function Amazon Resource Name (ARN), as you will need it later in the code.
 # 2. An AWS IAM service role containing a policy granting permission to Amazon CloudWatch Events.

--- a/ruby/example_code/ec2/ec2-ruby-example-manage-instances.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-manage-instances.rb
@@ -87,7 +87,7 @@ describe_instances_result.reservations.each do |reservation|
       puts "State: #{instance.state.name}"
       puts "Image ID: #{instance.image_id}"
       puts "Instance Type: #{instance.instance_type}"
-      puts "Architecure: #{instance.architecture}"
+      puts "Architecture: #{instance.architecture}"
       puts "IAM Instance Profile: #{instance.iam_instance_profile}"
       puts "Key Name: #{instance.key_name}"
       puts "Launch Time: #{instance.launch_time}"

--- a/ruby/example_code/s3/auth_session_token_request_test.rb
+++ b/ruby/example_code/s3/auth_session_token_request_test.rb
@@ -11,7 +11,7 @@
  #* CONDITIONS OF ANY KIND, either express or implied. See the License for the
  #* specific language governing permissions and limitations under the License.
 #**
-# snippet-sourcedescription:[auth_session_token_request_test.rb creates a temporary user to list the items in a specified bucket for one hour. To use this example, you must have AWS credentials that have the necessary permissions to create new AWS Security Token Service (AWS STS) clients, and list Amaazon S3 buckets using temporary security credentials] 
+# snippet-sourcedescription:[auth_session_token_request_test.rb creates a temporary user to list the items in a specified bucket for one hour. To use this example, you must have AWS credentials that have the necessary permissions to create new AWS Security Token Service (AWS STS) clients, and list Amazon S3 buckets using temporary security credentials] 
 # snippet-service:[s3]
 # snippet-keyword:[Ruby]
 # snippet-keyword:[Amazon S3]
@@ -24,7 +24,7 @@
 # This snippet example does the following:
 # The following Ruby example creates a temporary user to list the items in a specified bucket
 # for one hour. To use this example, you must have AWS credentials that have the necessary
-# permissions to create new AWS Security Token Service (AWS STS) clients, and list Amaazon S3 buckets using temporary security credentials 
+# permissions to create new AWS Security Token Service (AWS STS) clients, and list Amazon S3 buckets using temporary security credentials 
 # using your AWS account security credentials, the temporary security credentials are valid for only one hour. You can
 # specify session duration only if you use &IAM; user credentials to request a session.
 

--- a/ruby/example_code/s3/s3-ruby-example-bucket-accessible.rb
+++ b/ruby/example_code/s3/s3-ruby-example-bucket-accessible.rb
@@ -1,6 +1,6 @@
 # snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 # snippet-sourceauthor:[Doug-AWS]
-# snippet-sourcedescription:[???.]
+# snippet-sourcedescription:[s3-ruby-example-bucket-accessible.rb determines whether you can access an S3 bucket.]
 # snippet-keyword:[Amazon Simple Storage Service]
 # snippet-keyword:[get_bucket_location method]
 # snippet-keyword:[Resource.buckets.any method]

--- a/ruby/example_code/s3/s3_add_bucket_sses3_encryption_policy.rb
+++ b/ruby/example_code/s3/s3_add_bucket_sses3_encryption_policy.rb
@@ -1,6 +1,6 @@
 # snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 # snippet-sourceauthor:[Doug-AWS]
-# snippet-sourcedescription:[Adds a policy to and S3 bucket that requires server-side KMS encrytion on items uploaded.]
+# snippet-sourcedescription:[Adds a policy to and S3 bucket that requires server-side KMS encryption on items uploaded.]
 # snippet-keyword:[Amazon Simple Storage Service]
 # snippet-keyword:[put_bucket_policy method]
 # snippet-keyword:[Ruby]

--- a/ruby/example_code/s3/s3_create_AES_key.rb
+++ b/ruby/example_code/s3/s3_create_AES_key.rb
@@ -31,4 +31,4 @@ encoded_string = Base64.encode64(key)
 puts encoded_string
 
 # To decode the encoded string:
-#   key = encodd_string.unpack("m*")[0]
+#   key = encoded_string.unpack("m*")[0]

--- a/ruby/example_code/s3/s3_ruby_bucket_website.rb
+++ b/ruby/example_code/s3/s3_ruby_bucket_website.rb
@@ -1,3 +1,4 @@
+
 # snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 # snippet-sourceauthor:[Doug-AWS]
 # snippet-sourcedescription:[Creates, populates, and deletes a static website from an S3 bucket.]
@@ -69,7 +70,7 @@ s3.put_bucket_website(
 
 # Accessing as a Website
 index_path = "http://#{bucket}.s3-website-us-west-2.amazonaws.com/"
-error_path = "http://#{bucket}.s3-website-us-west-2.amazonaws.com/nonexistant.html"
+error_path = "http://#{bucket}.s3-website-us-west-2.amazonaws.com/nonexistent.html"
 
 puts "Index Page Contents:\n#{Net::HTTP.get(URI(index_path))}\n\n"
 puts "Error Page Contents:\n#{Net::HTTP.get(URI(error_path))}\n\n"

--- a/ruby/example_code/sqs/sqs-ruby-example-visibility-timeout.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-visibility-timeout.rb
@@ -1,6 +1,6 @@
 # snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 # snippet-sourceauthor:[Doug-AWS]
-# snippet-sourcedescription:[Polls for messages on an SQS quueue.]
+# snippet-sourcedescription:[Polls for messages on an SQS queue.]
 # snippet-keyword:[Amazon Simple Queue Service]
 # snippet-keyword:[QueuePoller.poll method]
 # snippet-keyword:[Ruby]


### PR DESCRIPTION
Typos in Go and Ruby code examples.

Fixed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
