### PR TITLE
Rename TableName 'TABLE' to 'CUSTOMER_LIST'

### DIFF
--- a/javascript/example_code/dynamodb/ddb_getitem.js
+++ b/javascript/example_code/dynamodb/ddb_getitem.js
@@ -34,7 +34,7 @@ AWS.config.update({region: 'REGION'});
 var ddb = new AWS.DynamoDB({apiVersion: '2012-08-10'});
 
 var params = {
-  TableName: 'TABLE',
+  TableName: 'CUSTOMER_LIST',
   Key: {
     'KEY_NAME': {N: '001'}
   },


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
PutItem uses TableName 'CUSTOMER_LIST' while GetItem uses 'TABLE' ([documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/dynamodb-example-table-read-write.html)), this PR fixes it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
