### PR TITLE
Updated Fargate construct for CDK release 0.33.0

### DIFF
--- a/typescript/example_code/cdk/MyRdsDbStack-stack.ts
+++ b/typescript/example_code/cdk/MyRdsDbStack-stack.ts
@@ -2,14 +2,15 @@
 // snippet-comment:[This is a full sample when you include MyRdsDbStack.ts, which goes in the bin dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Instantiates the stack in MyRdsDbStack.ts.]
-// snippet-keyword:[CDK V0.24.1]
-// snippet-keyword:[ec2.VpcNetwork function]
-// snippet-keyword:[rds.DatabaseCluster function]
+// snippet-keyword:[CDK V0.32.0]
+// snippet-keyword:[AWS CDK]
+// snippet-keyword:[aws-ec2.Vpc function]
+// snippet-keyword:[aws-rds.DatabaseCluster function]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-2-8]
+// snippet-sourcedate:[2019-6-4]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").
@@ -30,7 +31,7 @@ export class MyRdsDbStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    const vpc = new ec2.VpcNetwork(this, "VPC");
+    const vpc = new ec2.Vpc(this, "VPC");
 
     new rds.DatabaseCluster(this, "MyRdsDb", {
       defaultDatabaseName: "MyAuroraDatabase",

--- a/typescript/example_code/cdk/MyRdsDbStack.ts
+++ b/typescript/example_code/cdk/MyRdsDbStack.ts
@@ -2,14 +2,13 @@
 // snippet-comment:[This is a full sample when you include MyRdsDbStack-stack.ts, which goes in the lib dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Creates an RDS database.]
-// snippet-keyword:[CDK V0.29.0]
-// snippet-keyword:[ec2.VpcNetwork function]
-// snippet-keyword:[rds.DatabaseCluster function]
+// snippet-keyword:[CDK V0.32.0]
+// snippet-keyword:[AWS CDK]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-29]
+// snippet-sourcedate:[2019-6-4]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/SecretsManager-stack.ts
+++ b/typescript/example_code/cdk/SecretsManager-stack.ts
@@ -1,13 +1,15 @@
 // snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 // snippet-comment:[This is a full sample when you include SecretsManager.ts, which goes in the bin dir.]
 // snippet-sourceauthor:[Doug-AWS]
-// snippet-sourcedescription:[SecretsManager-stack.ts ???]
-// snippet-keyword:[CDK V0.28.0]
+// snippet-sourcedescription:[SecretsManager-stack.ts creates a stack with an S3 bucket using a secret value.]
+// snippet-keyword:[CDK V0.32.0]
+// snippet-keyword:[AWS CDK]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
+// snippet-keyword:[aws-secretsmanager.Secret.fromSecretAttributes function]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-5]
+// snippet-sourcedate:[2019-6-4]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").
@@ -33,7 +35,7 @@ export class SecretsManagerStack extends cdk.Stack {
       secretArn:
         "arn:aws:secretsmanager:<region>:<account-id-number>:secret:<secret-name>-<random-6-characters>"
       // If the secret is encrypted using a KMS-hosted CMK, either import or reference that key:
-      // encryptionKey,
+      // Key,
     });
 // snippet-end:[cdk.typescript.secrets_manager_stack_code]
 

--- a/typescript/example_code/cdk/my_ecs_construct-stack.ts
+++ b/typescript/example_code/cdk/my_ecs_construct-stack.ts
@@ -4,12 +4,13 @@
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Creates a Fargate service with versioning enabled.]
 // snippet-keyword:[CDK V0.24.1]
-// snippet-keyword:[ function]
+// snippet-keyword:[AWS CDK]
+// snippet-keyword:[aws-ec2.Vpc function]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-2-8]
+// snippet-sourcedate:[2019-6-4]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").
@@ -34,7 +35,7 @@ export class MyEcsConstructStack extends cdk.Stack {
     super(scope, id, props);
 
     // snippet-start:[cdk.typescript.my_ecs_construct.create_fargate_service]
-    const vpc = new ec2.VpcNetwork(this, 'MyVpc', {
+    const vpc = new ec2.Vpc(this, 'MyVpc', {
       maxAZs: 3 // Default is all AZs in region
     });
 

--- a/typescript/example_code/cdk/my_ecs_construct-stack.ts
+++ b/typescript/example_code/cdk/my_ecs_construct-stack.ts
@@ -3,7 +3,7 @@
 // snippet-comment:[This this should go in the lib directory.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Creates a Fargate service with versioning enabled.]
-// snippet-keyword:[CDK V0.24.1]
+// snippet-keyword:[CDK V0.33.0]
 // snippet-keyword:[AWS CDK]
 // snippet-keyword:[aws-ec2.Vpc function]
 // snippet-keyword:[TypeScript]
@@ -27,6 +27,7 @@ import cdk = require('@aws-cdk/cdk');
 // snippet-start:[cdk.typescript.my_ecs_construct-stack.imports]
 import ec2 = require('@aws-cdk/aws-ec2');
 import ecs = require('@aws-cdk/aws-ecs');
+import ecs_patterns = require('@aws-cdk/aws-ecs-patterns');
 // snippet-end:[cdk.typescript.my_ecs_construct-stack.imports]
 
 // snippet-start:[cdk.typescript.my_ecs_construct-stack.class]
@@ -44,7 +45,7 @@ export class MyEcsConstructStack extends cdk.Stack {
     });
 
     // Create a load-balanced Fargate service and make it public
-    new ecs.LoadBalancedFargateService(this, 'MyFargateService', {
+    new ecs_patterns.LoadBalancedFargateService(this, 'MyFargateService', {
       cluster: cluster,  // Required
       cpu: '512', // Default is 256
       desiredCount: 6,  // Default is 1


### PR DESCRIPTION
Updated reference to Fargate for CDK release 0.33.0.

@aws-cdk/aws-ecs.LoadBalancedFargateService -> @aws-cdk/aws-ecs-patterns.LoadBalancedFargateService

I tested the new code on my Window laptop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
