### PR TITLE
Update Go S3 ListObjects example

### DIFF
--- a/go/example_code/s3/s3_list_objects.go
+++ b/go/example_code/s3/s3_list_objects.go
@@ -3,12 +3,12 @@
 // snippet-sourcedescription:[Lists the items in an S3 bucket.]
 // snippet-keyword:[Amazon Simple Storage Service]
 // snippet-keyword:[Amazon S3]
-// snippet-keyword:[ListObjects function]
+// snippet-keyword:[ListObjectsV2 function]
 // snippet-keyword:[Go]
 // snippet-service:[s3]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2018-03-16]
+// snippet-sourcedate:[2019-04-06]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -55,7 +55,7 @@ func main() {
     svc := s3.New(sess)
 
     // Get the list of items
-    resp, err := svc.ListObjects(&s3.ListObjectsInput{Bucket: aws.String(bucket)})
+    resp, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{Bucket: aws.String(bucket)})
     if err != nil {
         exitErrorf("Unable to list items in bucket %q, %v", bucket, err)
     }


### PR DESCRIPTION
Go example of S3 list objects was using old function.

Changed:

```resp, err := svc.ListObjects(&s3.ListObjectsInput{Bucket: aws.String(bucket)})```

to:

```resp, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{Bucket: aws.String(bucket)})```

I ran the code on my Windows laptop and confirmed it works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
