### PR TITLE
fix php ses classname

### DIFF
--- a/php/example_code/ses/Add_Domain.php
+++ b/php/example_code/ses/Add_Domain.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.add_domain.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.add_domain.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Add_Email.php
+++ b/php/example_code/ses/Add_Email.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.add_email.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.add_email.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Authorize_Sender.php
+++ b/php/example_code/ses/Authorize_Sender.php
@@ -21,7 +21,7 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.authorize_sender.import]
 

--- a/php/example_code/ses/Create_Filter.php
+++ b/php/example_code/ses/Create_Filter.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.create_filter.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.create_filter.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Create_Rule.php
+++ b/php/example_code/ses/Create_Rule.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.create_rule.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.create_rule.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Create_Rule_Set.php
+++ b/php/example_code/ses/Create_Rule_Set.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.create_rule_set.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.create_rule_set.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Create_Template.php
+++ b/php/example_code/ses/Create_Template.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.create_template.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.create_template.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Delete_Authorized_Sender.php
+++ b/php/example_code/ses/Delete_Authorized_Sender.php
@@ -21,7 +21,7 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.delete_authorized_senders.import]
 

--- a/php/example_code/ses/Delete_Domain.php
+++ b/php/example_code/ses/Delete_Domain.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.delete_domain.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.delete_domain.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Delete_Email.php
+++ b/php/example_code/ses/Delete_Email.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.delete_email.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.delete_email.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Delete_Filter.php
+++ b/php/example_code/ses/Delete_Filter.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.delete_filter.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.delete_filter.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Delete_Rule.php
+++ b/php/example_code/ses/Delete_Rule.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.delete_rule.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.delete_rule.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Delete_Rule_Set.php
+++ b/php/example_code/ses/Delete_Rule_Set.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.delete_rule_set.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.delete_rule_set.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Delete_Template.php
+++ b/php/example_code/ses/Delete_Template.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.delete_template.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.delete_template.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Describe_Rule.php
+++ b/php/example_code/ses/Describe_Rule.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.describe_rule.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.describe_rule.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Describe_Rule_Set.php
+++ b/php/example_code/ses/Describe_Rule_Set.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.describe_rule_set.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.describe_rule_set.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Get_Authorized_Policies.php
+++ b/php/example_code/ses/Get_Authorized_Policies.php
@@ -21,7 +21,7 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.get_authorized_policies.import]
 

--- a/php/example_code/ses/Get_Authorized_Sender.php
+++ b/php/example_code/ses/Get_Authorized_Sender.php
@@ -21,7 +21,7 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.get_authorized_senders.import]
 

--- a/php/example_code/ses/Get_Template.php
+++ b/php/example_code/ses/Get_Template.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.get_template.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.get_template.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/List_Authorized_Senders.php
+++ b/php/example_code/ses/List_Authorized_Senders.php
@@ -21,7 +21,7 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.list_authorized_senders.import]
 

--- a/php/example_code/ses/List_Domain.php
+++ b/php/example_code/ses/List_Domain.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.list_domain.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.list_domain.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/List_Email.php
+++ b/php/example_code/ses/List_Email.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.list_email.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.list_email.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/List_Filters.php
+++ b/php/example_code/ses/List_Filters.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.list_filters.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.list_filters.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/List_Rules_Sets.php
+++ b/php/example_code/ses/List_Rules_Sets.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.list_rules_sets.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.list_rules_sets.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/List_Templates.php
+++ b/php/example_code/ses/List_Templates.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.list_template.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.list_template.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Send_Email.php
+++ b/php/example_code/ses/Send_Email.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.send_email.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.send_email.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Send_Quota.php
+++ b/php/example_code/ses/Send_Quota.php
@@ -21,7 +21,7 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.send_quota.import]
 

--- a/php/example_code/ses/Send_Statistics.php
+++ b/php/example_code/ses/Send_Statistics.php
@@ -21,7 +21,7 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.send_statistics.import]
 

--- a/php/example_code/ses/Send_Templated_Email.php
+++ b/php/example_code/ses/Send_Templated_Email.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.send_templated_email.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.send_templated_email.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Update_Rule.php
+++ b/php/example_code/ses/Update_Rule.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.update_rule.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.update_rule.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'

--- a/php/example_code/ses/Update_Template.php
+++ b/php/example_code/ses/Update_Template.php
@@ -21,13 +21,13 @@
 
 require 'vendor/autoload.php';
 
-use Aws\SES\SESClient; 
+use Aws\Ses\SesClient; 
 use Aws\Exception\AwsException;
 // snippet-end:[ses.php.update_template.import]
 
 //Create a SESClient 
 // snippet-start:[ses.php.update_template.main]
-$SesClient = new Aws\SES\SESClient([
+$SesClient = new Aws\Ses\SesClient([
     'profile' => 'default',
     'version' => '2010-12-01',
     'region' => 'us-east-2'


### PR DESCRIPTION
*Description of changes:*
fix php SES classname "Aws\SES\SESClient" to "Aws\Ses\SesClient".
https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.Ses.SesClient.html

"Aws\SES\SESClient" work on mac, but not work on Ubuntu 18.04.2 on PHP 7.3.5.
"Aws\Ses\SesClient" work perfectly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.