### PR TITLE
Updated CDK example spacing

### DIFF
--- a/typescript/example_code/cdk/hello-cdk-stack2.ts
+++ b/typescript/example_code/cdk/hello-cdk-stack2.ts
@@ -28,11 +28,12 @@ export class HelloCdkStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
+    // Don't change the formatting of this section
     // snippet-start:[cdk.typescript.hello-cdk-stack.version2_bucket]
-    new s3.Bucket(this, 'MyFirstBucket', {
-      versioned: true,
-      encryption: s3.BucketEncryption.KmsManaged
-    });
+new s3.Bucket(this, 'MyFirstBucket', {
+  versioned: true,
+  encryption: s3.BucketEncryption.KmsManaged
+});
     // snippet-end:[cdk.typescript.hello-cdk-stack.version2_bucket]    
   }
 }


### PR DESCRIPTION
Since Zonbook has no feature to eat spaces before a line, I had to do it manually.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
