### PR TITLE
Update Incorrect S3 CSE-KMS StrictAuthenticatedEncryption Example

### DIFF
--- a/java/example_code/s3/src/main/java/aws/example/s3/S3Encrypt.java
+++ b/java/example_code/s3/src/main/java/aws/example/s3/S3Encrypt.java
@@ -327,7 +327,7 @@ public class S3Encrypt {
         AmazonS3Encryption s3Encryption = AmazonS3EncryptionClientBuilder
                 .standard()
                 .withRegion(Regions.US_WEST_2)
-                .withCryptoConfiguration(new CryptoConfiguration(CryptoMode.AuthenticatedEncryption).withAwsKmsRegion(Region.getRegion(Regions.US_WEST_2)))
+                .withCryptoConfiguration(new CryptoConfiguration(CryptoMode.StrictAuthenticatedEncryption).withAwsKmsRegion(Region.getRegion(Regions.US_WEST_2)))
                 // Can either be Key ID or alias (prefixed with 'alias/')
                 .withEncryptionMaterials(new KMSEncryptionMaterialsProvider("alias/s3-kms-key"))
                 .build();


### PR DESCRIPTION
The first code block under Strict Authenticated Encryption is incorrect as `CryptoMode.AuthenticatedEncryption` should be `CryptoMode.StrictAuthenticatedEncryption`
See this snippet for an example of a correct line: https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/java/example_code/s3/src/main/java/aws/example/s3/S3Encrypt.java#L156


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
