### PR TITLE
Add example code for AwsException containing modeled exception data

### DIFF
--- a/php/example_code/s3/ErrorHandling.php
+++ b/php/example_code/s3/ErrorHandling.php
@@ -54,6 +54,10 @@ try {
     echo $e->getAwsRequestId() . "\n";
     echo $e->getAwsErrorType() . "\n";
     echo $e->getAwsErrorCode() . "\n";
+
+    // This dumps any modeled response data, if supported by the service
+    // Specific members can be accessed directly (e.g. $e['MemberName'])
+    var_dump($e->toArray());
 }
 
 // snippet-end:[s3.php.error_handling.client]


### PR DESCRIPTION
* Add example code for AwsException containing modeled exception data. Related to [this PR](https://github.com/awsdocs/aws-php-developers-guide/pull/62) for the developer guide, and should be merged in together. Note that this example will not be valid until the [modeled exceptions PR](https://github.com/aws/aws-sdk-php/pull/1792) is merged in the PHP SDK.