### PR TITLE
Updated CDK samples to 0.39.0

### DIFF
--- a/typescript/example_code/cdk/BucketResource-stack.ts
+++ b/typescript/example_code/cdk/BucketResource-stack.ts
@@ -3,12 +3,12 @@
 // snippet-comment:[This is a full sample when you include BucketResource.ts, which goes in the bin dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[HelloCdk-stack.ts creates a stack with an S3 bucket that has replication.]
-// snippet-keyword:[CDK V0.27.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-3]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/BucketResource-stack.ts
+++ b/typescript/example_code/cdk/BucketResource-stack.ts
@@ -21,12 +21,12 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.BucketResource-stack]
-import cdk = require("@aws-cdk/cdk");
+import core = require("@aws-cdk/core");
 import iam = require("@aws-cdk/aws-iam");
 import s3 = require("@aws-cdk/aws-s3");
 
-export class BucketResourceStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+export class BucketResourceStack extends core.Stack {
+  constructor(scope: core.App, id: string, props?: core.StackProps) {
     super(scope, id, props);
 
     // Since our S3.Bucket class does not expose ReplicationConfiguration,

--- a/typescript/example_code/cdk/BucketResource.ts
+++ b/typescript/example_code/cdk/BucketResource.ts
@@ -2,12 +2,12 @@
 // snippet-comment:[This is a full sample when you include BucketResource-stack.ts, which goes in the lib dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[BucketResource.ts creates a stack with an S3 bucket that has replication using BucketResource-stack.]
-// snippet-keyword:[CDK V0.27.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-3]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/BucketResource.ts
+++ b/typescript/example_code/cdk/BucketResource.ts
@@ -20,10 +20,10 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.BucketResource]
-import cdk = require("@aws-cdk/cdk");
+import core = require("@aws-cdk/core");
 
 import { BucketResourceStack } from "../lib/BucketResource-stack";
 
-const app = new cdk.App();
+const app = new core.App();
 new BucketResourceStack(app, "BucketResourceStack");
 // snippet-end:[cdk.typescript.BucketResource]

--- a/typescript/example_code/cdk/HelloCdk-stack.ts
+++ b/typescript/example_code/cdk/HelloCdk-stack.ts
@@ -3,7 +3,7 @@
 // snippet-comment:[This is a full sample when you include HelloCdk.ts, which goes in the bin dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[HelloCdk-stack.ts creates a stack with an SQS queue, SNS topic, subscribes the queue to the topic, and sets a CloudWatch metric and alarm on the SQS queue.]
-// snippet-keyword:[CDK V0.24.1]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[sqs.Queue function]
 // snippet-keyword:[sns.Topic function]
 // snippet-keyword:[Topic.subscribeQueue function]
@@ -13,7 +13,7 @@
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-2-13]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/HelloCdk-stack.ts
+++ b/typescript/example_code/cdk/HelloCdk-stack.ts
@@ -26,24 +26,24 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.HelloCdk-stack]
-import cdk = require("@aws-cdk/cdk");
+import core = require("@aws-cdk/core");
 import cloudwatch = require("@aws-cdk/aws-cloudwatch");
 import sns = require("@aws-cdk/aws-sns");
 import sqs = require("@aws-cdk/aws-sqs");
 import subscriptions = require("@aws-cdk/aws-sns-subscriptions");
 
-export class HelloCdkStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+export class HelloCdkStack extends core.Stack {
+  constructor(scope: core.App, id: string, props?: core.StackProps) {
     super(scope, id, props);
 
     const queue = new sqs.Queue(this, "HelloCdkQueue", {
-      visibilityTimeoutSec: 300
+      visibilityTimeout: core.Duration.seconds(300)
     });
 
     const topic = new sns.Topic(this, "HelloCdkTopic");
 
     const sub = new subscriptions.SqsSubscription(queue, {});
-    sub.bind(this, topic);
+    sub.bind(topic);
 
     // Raise an alarm if we have more than 100 messages available for retrieval
     // in two of the last three seconds

--- a/typescript/example_code/cdk/HelloCdk.ts
+++ b/typescript/example_code/cdk/HelloCdk.ts
@@ -2,12 +2,12 @@
 // snippet-comment:[This is a full sample when you include HelloCdk-stack.ts, which goes in the lib dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Instantiates a stack using HelloCdk-stack]
-// snippet-keyword:[CDK V0.29.0
+// snippet-keyword:[CDK V1.0.0
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-29]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/HelloCdk.ts
+++ b/typescript/example_code/cdk/HelloCdk.ts
@@ -20,10 +20,10 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.HelloCdk]
-import cdk = require('@aws-cdk/cdk');
+import core = require('@aws-cdk/core');
 
 import { HelloCdkStack } from '../lib/HelloCdk-stack';
 
-const app = new cdk.App();
+const app = new core.App();
 new HelloCdkStack(app, 'HelloCdkStack');
 // snippet-end:[cdk.typescript.HelloCdk]

--- a/typescript/example_code/cdk/MyApp-stack.ts
+++ b/typescript/example_code/cdk/MyApp-stack.ts
@@ -22,20 +22,20 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.MyApp-stack]
-import cdk = require("@aws-cdk/cdk");
+import core = require("@aws-cdk/core");
 import s3 = require("@aws-cdk/aws-s3");
 
-interface MyStackProps extends cdk.StackProps {
+interface MyStackProps extends core.StackProps {
   enc: boolean;
 }
 
-export class MyStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props: MyStackProps) {
+export class MyStack extends core.Stack {
+  constructor(scope: core.App, id: string, props: MyStackProps) {
     super(scope, id, props);
 
     if (props.enc) {
       new s3.Bucket(this, "MyGroovyBucket", {
-        encryption: s3.BucketEncryption.KmsManaged
+        encryption: s3.BucketEncryption.KMS_MANAGED
       });
     } else {
       new s3.Bucket(this, "MyGroovyBucket");

--- a/typescript/example_code/cdk/MyApp-stack.ts
+++ b/typescript/example_code/cdk/MyApp-stack.ts
@@ -3,13 +3,13 @@
 // snippet-comment:[This is a full sample when you include MyApp.ts, which goes in the bin dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[MyApp-stack.ts creates a stack in a specific region with an S3 bucket with optional encrypted storage.]
-// snippet-keyword:[CDK V0.27.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[S3.Alarm function]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-2]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/MyApp.ts
+++ b/typescript/example_code/cdk/MyApp.ts
@@ -20,10 +20,10 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.MyApp]
-import cdk = require("@aws-cdk/cdk");
+import core = require("@aws-cdk/core");
 import { MyStack } from "../lib/MyApp-stack";
 
-const app = new cdk.App();
+const app = new core.App();
 
 new MyStack(app, "MyWestCdkStack", {
   env: {

--- a/typescript/example_code/cdk/MyApp.ts
+++ b/typescript/example_code/cdk/MyApp.ts
@@ -2,12 +2,12 @@
 // snippet-comment:[This is a full sample when you include MyApp-stack.ts, which goes in the lib dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[MyApp.ts instantiates two stacks using MyApp-stack]
-// snippet-keyword:[CDK V0.27.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-2]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/MyRdsDbStack-stack.ts
+++ b/typescript/example_code/cdk/MyRdsDbStack-stack.ts
@@ -2,7 +2,7 @@
 // snippet-comment:[This is a full sample when you include MyRdsDbStack.ts, which goes in the bin dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Instantiates the stack in MyRdsDbStack.ts.]
-// snippet-keyword:[CDK V0.32.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[AWS CDK]
 // snippet-keyword:[aws-ec2.Vpc function]
 // snippet-keyword:[aws-rds.DatabaseCluster function]
@@ -10,7 +10,7 @@
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-6-4]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/MyRdsDbStack-stack.ts
+++ b/typescript/example_code/cdk/MyRdsDbStack-stack.ts
@@ -23,12 +23,12 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.MyRdsDbStack-stack]
-import cdk = require("@aws-cdk/cdk");
+import core = require("@aws-cdk/core");
 import ec2 = require("@aws-cdk/aws-ec2");
 import rds = require("@aws-cdk/aws-rds");
 
-export class MyRdsDbStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+export class MyRdsDbStack extends core.Stack {
+  constructor(scope: core.App, id: string, props?: core.StackProps) {
     super(scope, id, props);
 
     const vpc = new ec2.Vpc(this, "VPC");
@@ -38,15 +38,14 @@ export class MyRdsDbStack extends cdk.Stack {
       masterUser: {
         username: "admin"
       },
-      engine: rds.DatabaseClusterEngine.Aurora,
+      engine: rds.DatabaseClusterEngine.AURORA,
       instanceProps: {
-        instanceType: new ec2.InstanceTypePair(
-          ec2.InstanceClass.Burstable2,
-          ec2.InstanceSize.Small
+        instanceType: new ec2.InstanceType(
+          ec2.InstanceClass.BURSTABLE2
         ),
         vpc: vpc,
         vpcSubnets: {
-          subnetType: ec2.SubnetType.Public
+          subnetType: ec2.SubnetType.PUBLIC
         }
       }
     });

--- a/typescript/example_code/cdk/MyRdsDbStack.ts
+++ b/typescript/example_code/cdk/MyRdsDbStack.ts
@@ -2,13 +2,13 @@
 // snippet-comment:[This is a full sample when you include MyRdsDbStack-stack.ts, which goes in the lib dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Creates an RDS database.]
-// snippet-keyword:[CDK V0.32.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[AWS CDK]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-6-4]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/MyRdsDbStack.ts
+++ b/typescript/example_code/cdk/MyRdsDbStack.ts
@@ -21,9 +21,9 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.MyRdsDbStack]
-import cdk = require('@aws-cdk/cdk');
+import core = require('@aws-cdk/core');
 import { MyRdsDbStack } from '../lib/MyRdsDbStack-stack';
 
-const app = new cdk.App();
+const app = new core.App();
 new MyRdsDbStack(app, 'MyRdsDbStack');
 // snippet-end:[cdk.typescript.MyRdsDbStack]

--- a/typescript/example_code/cdk/SecretsManager-stack.ts
+++ b/typescript/example_code/cdk/SecretsManager-stack.ts
@@ -22,13 +22,13 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.secrets_manager_stack]
-import cdk = require("@aws-cdk/cdk");
+import core = require("@aws-cdk/core");
 import s3 = require("@aws-cdk/aws-s3");
 // snippet-start:[cdk.typescript.secrets_manager_stack_code]
 import sm = require("@aws-cdk/aws-secretsmanager");
 
-export class SecretsManagerStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+export class SecretsManagerStack extends core.Stack {
+  constructor(scope: core.App, id: string, props?: core.StackProps) {
     super(scope, id, props);
 
     const secret = sm.Secret.fromSecretAttributes(this, "ImportedSecret", {

--- a/typescript/example_code/cdk/SecretsManager-stack.ts
+++ b/typescript/example_code/cdk/SecretsManager-stack.ts
@@ -2,14 +2,14 @@
 // snippet-comment:[This is a full sample when you include SecretsManager.ts, which goes in the bin dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[SecretsManager-stack.ts creates a stack with an S3 bucket using a secret value.]
-// snippet-keyword:[CDK V0.32.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[AWS CDK]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-keyword:[aws-secretsmanager.Secret.fromSecretAttributes function]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-6-4]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/SecretsManager.ts
+++ b/typescript/example_code/cdk/SecretsManager.ts
@@ -2,12 +2,12 @@
 // snippet-comment:[This is a full sample when you include SecretsManager-stack.ts, which goes in the lib dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[SecretsManager.ts creates a stack using SecrectsManager-stack.ts.]
-// snippet-keyword:[CDK V0.28.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-5]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/SecretsManager.ts
+++ b/typescript/example_code/cdk/SecretsManager.ts
@@ -20,9 +20,9 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.secrets_manager]
-import cdk = require("@aws-cdk/cdk");
+import core = require("@aws-cdk/core");
 import { SecretsManagerStack } from "../lib/SecretsManager-stack";
 
-const app = new cdk.App();
+const app = new core.App();
 new SecretsManagerStack(app, "SecretsManagerStack");
 // snippet-end:[cdk.typescript.secrets_manager]

--- a/typescript/example_code/cdk/hello-cdk-stack.ts
+++ b/typescript/example_code/cdk/hello-cdk-stack.ts
@@ -2,13 +2,13 @@
 // snippet-comment:[This is a full sample when you include HelloCdk.ts, which goes in the bin dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Creates an S3 bucket with versioning enabled.]
-// snippet-keyword:[CDK V0.24.1]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[s3.Bucket function]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-2-8]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/hello-cdk-stack.ts
+++ b/typescript/example_code/cdk/hello-cdk-stack.ts
@@ -21,11 +21,11 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.hello-cdk-stack]
-import cdk = require('@aws-cdk/cdk');
+import core = require('@aws-cdk/core');
 import s3 = require('@aws-cdk/aws-s3');
 
-export class HelloCdkStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+export class HelloCdkStack extends core.Stack {
+  constructor(scope: core.App, id: string, props?: core.StackProps) {
     super(scope, id, props);
 
     new s3.Bucket(this, 'MyFirstBucket', {

--- a/typescript/example_code/cdk/hello-cdk-stack2.ts
+++ b/typescript/example_code/cdk/hello-cdk-stack2.ts
@@ -21,11 +21,11 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.hello-cdk-stack.version2]
-import cdk = require('@aws-cdk/cdk');
+import core = require('@aws-cdk/core');
 import s3 = require('@aws-cdk/aws-s3');
 
-export class HelloCdkStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+export class HelloCdkStack extends core.Stack {
+  constructor(scope: core.App, id: string, props?: core.StackProps) {
     super(scope, id, props);
 
     // Don't change the formatting of this section

--- a/typescript/example_code/cdk/hello-cdk-stack2.ts
+++ b/typescript/example_code/cdk/hello-cdk-stack2.ts
@@ -2,13 +2,13 @@
 // snippet-comment:[This is a full sample when you include HelloCdk.ts, which goes in the bin dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Creates an S3 bucket with encryption and versioning enabled.]
-// snippet-keyword:[CDK V0.24.1]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[s3.Bucket function]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-2-8]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/hello-cdk.ts
+++ b/typescript/example_code/cdk/hello-cdk.ts
@@ -20,10 +20,10 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.hello-cdk]
-import cdk = require('@aws-cdk/cdk');
+import core = require('@aws-cdk/core');
 
 import { HelloCdkStack } from '../lib/hello-cdk-stack';
 
-const app = new cdk.App();
+const app = new core.App();
 new HelloCdkStack(app, 'HelloCdkStack');
 // snippet-end:[cdk.typescript.hello-cdk]

--- a/typescript/example_code/cdk/hello-cdk.ts
+++ b/typescript/example_code/cdk/hello-cdk.ts
@@ -2,12 +2,12 @@
 // snippet-comment:[This is a full sample when you include hello-cdk-stack.ts, which goes in the lib dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Instantiates the stack in hello-cdk-stack.ts.]
-// snippet-keyword:[CDK V0.29.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-29]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/hello-cdk2.ts
+++ b/typescript/example_code/cdk/hello-cdk2.ts
@@ -20,10 +20,10 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.hello-cdk.version2]
-import cdk = require('@aws-cdk/cdk');
+import core = require('@aws-cdk/core');
 
 import { HelloCdkStack } from '../lib/hello-cdk-stack2';
 
-const app = new cdk.App();
+const app = new core.App();
 new HelloCdkStack(app, 'HelloCdkStack');
 // snippet-end:[cdk.typescript.hello-cdk.version2]

--- a/typescript/example_code/cdk/hello-cdk2.ts
+++ b/typescript/example_code/cdk/hello-cdk2.ts
@@ -2,12 +2,12 @@
 // snippet-comment:[This is a full sample when you include hello-cdk-stack.ts, which goes in the lib dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Instantiates the stack in hello-cdk-stack.ts.]
-// snippet-keyword:[CDK V0.29.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-29]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/integ.event-task.lit.ts
+++ b/typescript/example_code/cdk/integ.event-task.lit.ts
@@ -1,12 +1,12 @@
 // snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[integ.event-task.lit.ts starts an ECS task on an EC2-backed cluster.]
-// snippet-keyword:[CDK V0.24.1]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[snippet]
-// snippet-sourcedate:[2019-2-11]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/my_ecs_construct-stack.ts
+++ b/typescript/example_code/cdk/my_ecs_construct-stack.ts
@@ -3,14 +3,14 @@
 // snippet-comment:[This this should go in the lib directory.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Creates a Fargate service with versioning enabled.]
-// snippet-keyword:[CDK V0.33.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[AWS CDK]
 // snippet-keyword:[aws-ec2.Vpc function]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-6-4]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").
@@ -23,7 +23,7 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.my_ecs_construct-stack]
-import cdk = require("@aws-cdk/cdk");
+import core = require("@aws-cdk/core");
 // snippet-start:[cdk.typescript.my_ecs_construct-stack.imports]
 import ec2 = require("@aws-cdk/aws-ec2");
 import ecs = require("@aws-cdk/aws-ecs");
@@ -31,13 +31,13 @@ import ecs_patterns = require("@aws-cdk/aws-ecs-patterns");
 // snippet-end:[cdk.typescript.my_ecs_construct-stack.imports]
 
 // snippet-start:[cdk.typescript.my_ecs_construct-stack.class]
-export class MyEcsConstructStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+export class MyEcsConstructStack extends core.Stack {
+  constructor(scope: core.App, id: string, props?: core.StackProps) {
     super(scope, id, props);
 
     // snippet-start:[cdk.typescript.my_ecs_construct.create_fargate_service]
     const vpc = new ec2.Vpc(this, "MyVpc", {
-      maxAZs: 3 // Default is all AZs in region
+      maxAzs: 3 // Default is all AZs in region
     });
 
     const cluster = new ecs.Cluster(this, "MyCluster", {

--- a/typescript/example_code/cdk/my_ecs_construct.ts
+++ b/typescript/example_code/cdk/my_ecs_construct.ts
@@ -3,12 +3,12 @@
 // snippet-comment:[This is a full sample when you include my_ecs_construct-stack.ts, which goes in the lib dir.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Instantiates the stack in my_ecs_construct-stack.ts.]
-// snippet-keyword:[CDK V0.29.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-29]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/my_ecs_construct.ts
+++ b/typescript/example_code/cdk/my_ecs_construct.ts
@@ -21,10 +21,10 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.my_ecs_construct]
-import cdk = require('@aws-cdk/cdk');
+import core = require('@aws-cdk/core');
 
 import { MyEcsConstructStack } from '../lib/my_ecs_construct-stack';
 
-const app = new cdk.App();
+const app = new core.App();
 new MyEcsConstructStack(app, 'MyEcsConstruct');
 // snippet-end:[cdk.typescript.my_ecs_construct]

--- a/typescript/example_code/cdk/my_widget_service-stack.ts
+++ b/typescript/example_code/cdk/my_widget_service-stack.ts
@@ -4,12 +4,12 @@
 // snippet-comment:[and widgets.js in the resources/ directory.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Creates a stack for the WidgetService.]
-// snippet-keyword:[CDK V0.24.1]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-2-8]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/my_widget_service-stack.ts
+++ b/typescript/example_code/cdk/my_widget_service-stack.ts
@@ -22,13 +22,13 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.my_widget_service-stack]
-import cdk = require('@aws-cdk/cdk');
+import core = require('@aws-cdk/core');
 // snippet-start:[cdk.typescript.my_widget_service-stack.import]
 import widget_service = require('../lib/widget_service');
 // snippet-end:[cdk.typescript.my_widget_service-stack.import]
 
-export class MyWidgetServiceStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+export class MyWidgetServiceStack extends core.Stack {
+  constructor(scope: core.App, id: string, props?: core.StackProps) {
     super(scope, id, props);
 
     // snippet-start:[cdk.typescript.my_widget_service-stack.new_widget_service]

--- a/typescript/example_code/cdk/my_widget_service.ts
+++ b/typescript/example_code/cdk/my_widget_service.ts
@@ -4,12 +4,12 @@
 // snippet-comment:[and widgets.js in the resources/ directory.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Instantiates the stack in my_widget_service-stack.ts.]
-// snippet-keyword:[CDK V0.29.0]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[TypeScript]
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-4-29]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").

--- a/typescript/example_code/cdk/my_widget_service.ts
+++ b/typescript/example_code/cdk/my_widget_service.ts
@@ -22,9 +22,9 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.my_widget_service]
-import cdk = require('@aws-cdk/cdk');
+import core = require('@aws-cdk/core');
 import { MyWidgetServiceStack } from '../lib/my_widget_service-stack';
 
-const app = new cdk.App();
+const app = new core.App();
 new MyWidgetServiceStack(app, 'MyWidgetServiceStack');
 // snippet-end:[cdk.typescript.my_widget_service]

--- a/typescript/example_code/cdk/widget_service.ts
+++ b/typescript/example_code/cdk/widget_service.ts
@@ -27,13 +27,13 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.widget_service]
-import cdk = require("@aws-cdk/cdk");
+import core = require("@aws-cdk/core");
 import apigateway = require("@aws-cdk/aws-apigateway");
 import lambda = require("@aws-cdk/aws-lambda");
 import s3 = require("@aws-cdk/aws-s3");
 
-export class WidgetService extends cdk.Construct {
-  constructor(scope: cdk.Construct, id: string) {
+export class WidgetService extends core.Construct {
+  constructor(scope: core.Construct, id: string) {
     super(scope, id);
 
     const bucket = new s3.Bucket(this, "WidgetStore");

--- a/typescript/example_code/cdk/widget_service.ts
+++ b/typescript/example_code/cdk/widget_service.ts
@@ -4,7 +4,7 @@
 // snippet-comment:[and widgets.js in the resources/ directory.]
 // snippet-sourceauthor:[Doug-AWS]
 // snippet-sourcedescription:[Creates an S3 bucket, handler for HTTP requests, and API Gateway to Lambda functions.]
-// snippet-keyword:[CDK V0.24.1]
+// snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[ApiGateway.LambdaIntegration function]
 // snippet-keyword:[ApiGateway.RestApi function]
 // snippet-keyword:[Bucket.grantReadWrite function]
@@ -14,7 +14,7 @@
 // snippet-service:[cdk]
 // snippet-keyword:[Code Sample]
 // snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2019-2-8]
+// snippet-sourcedate:[2019-7-11]
 // Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // This file is licensed under the Apache License, Version 2.0 (the "License").
@@ -39,7 +39,7 @@ export class WidgetService extends core.Construct {
     const bucket = new s3.Bucket(this, "WidgetStore");
 
     const handler = new lambda.Function(this, "WidgetHandler", {
-      runtime: lambda.Runtime.Nodejs810, // So we can use async in widget.js
+      runtime: lambda.Runtime.NODEJS_8_10, // So we can use async in widget.js
       code: lambda.Code.asset("resources"),
       handler: "widgets.main",
       environment: {


### PR DESCRIPTION
Confirmed CDK code examples work in CDK release 0.39.0.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
