### PR TITLE
Cut off "wire up" code from initial widget_service snippet

### DIFF
--- a/typescript/example_code/cdk/widget_service.ts
+++ b/typescript/example_code/cdk/widget_service.ts
@@ -59,6 +59,7 @@ export class WidgetService extends core.Construct {
     });
 
     api.root.addMethod("GET", getWidgetsIntegration); // GET /
+    // snippet-end:[cdk.typescript.widget_service]
 
     // snippet-start:[cdk.typescript.widget_service.wire_up_functions]
     const widget = api.root.addResource("{id}");
@@ -78,4 +79,3 @@ export class WidgetService extends core.Construct {
     // snippet-end:[cdk.typescript.widget_service.wire_up_functions]
   }
 }
-// snippet-end:[cdk.typescript.widget_service]


### PR DESCRIPTION
This snippet is used in the Serverless example in the CDK Dev Guide. With this marker at the end of the file, we tell them to add the wire-up code twice since it's already in there the first time.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
