### PR TITLE
AWS.config.mediaconvert is a property, not a function

### DIFF
--- a/javascript/example_code/mediaconvert/emc_create_jobtemplate.js
+++ b/javascript/example_code/mediaconvert/emc_create_jobtemplate.js
@@ -30,7 +30,7 @@ var AWS = require('aws-sdk');
 // Set the region 
 AWS.config.update({region: 'us-west-2'});
 // Set the custom endpoint for your acccount
-AWS.config.mediaconvert({endpoint: 'ACCOUNT_ENDPOINT'});
+AWS.config.mediaconvert = {endpoint : 'ACCOUNT_ENDPOINT'};
 
 var params = {
   Category: 'YouTube Jobs',

--- a/javascript/example_code/mediaconvert/emc_createjob.js
+++ b/javascript/example_code/mediaconvert/emc_createjob.js
@@ -32,7 +32,7 @@ var AWS = require('aws-sdk');
 // Set the region 
 AWS.config.update({region: 'us-west-2'});
 // Set the custom endpoint for your acccount
-AWS.config.mediaconvert({endpoint: 'ACCOUNT_ENDPOINT'});
+AWS.config.mediaconvert = {endpoint : 'ACCOUNT_ENDPOINT'};
 // snippet-end:[mediaconvert.JavaScript.jobs.createJob_config]
 
 // snippet-start:[mediaconvert.JavaScript.jobs.createJob_define]

--- a/javascript/example_code/mediaconvert/emc_template_createjob.js
+++ b/javascript/example_code/mediaconvert/emc_template_createjob.js
@@ -30,7 +30,7 @@ var AWS = require('aws-sdk');
 // Set the region 
 AWS.config.update({region: 'us-west-2'});
 // Set the custom endpoint for your acccount
-AWS.config.mediaconvert({endpoint: 'ACCOUNT_ENDPOINT'});
+AWS.config.mediaconvert = {endpoint : 'ACCOUNT_ENDPOINT'};
 
 var params = {
   "Queue": "QUEUE_ARN",


### PR DESCRIPTION
Some MediaConvert examples were treating AWS.config.mediaconvert as a function.

Changed usage to a property.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
