### PR TITLE
Updated Directory Service snippet tag in example

### DIFF
--- a/dotnet/example_code/DirectoryService/DirectoryServicePortTest.cs
+++ b/dotnet/example_code/DirectoryService/DirectoryServicePortTest.cs
@@ -8,7 +8,7 @@
 //snippet-sourcetype:[full-example]
 //snippet-sourcedate:[]
 //snippet-sourceauthor:[AWS]
-//snippet-start:[directoryservice.java.directory_service_port_test.complete]
+//snippet-start:[directoryservice.dotNET.directory_service_port_test.complete]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -285,5 +285,5 @@ namespace DirectoryServicePortTest
         }
     }
 }
-//snippet-end:[directoryservice.java.directory_service_port_test.complete]
+//snippet-end:[directoryservice.dotNET.directory_service_port_test.complete]
 


### PR DESCRIPTION
#696 

Changed 'java' to 'dotNET' in snippet tag for Directory Service example in C#/.NET.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
