### PR TITLE
Rekognition dotnet example cleanup

### DIFF
--- a/dotnet/example_code/Rekognition/AwsRekognitionSample1/Program.cs
+++ b/dotnet/example_code/Rekognition/AwsRekognitionSample1/Program.cs
@@ -53,7 +53,7 @@ namespace NETRekognitionConsole
             if (outcome.FaceDetails.Count > 0)
             {
                 // Load a bitmap to modify with face bounding box rectangles
-                System.Drawing.Bitmap facesHighlighted = new System.Drawing.Bitmap(filename);
+                Bitmap facesHighlighted = new Bitmap(filename);
                 Pen pen = new Pen(Color.Black, 3);
 
                 // Create a graphics context
@@ -63,23 +63,28 @@ namespace NETRekognitionConsole
                     {
                         // Get the bounding box
                         BoundingBox bb = fd.BoundingBox;
-                        Console.WriteLine("Bounding box = (" + bb.Left + ", " + bb.Top + ", " +
-                            bb.Height + ", " + bb.Width + ")");
+                        Console.WriteLine($"Bounding box = ({bb.Left}, {bb.Top}, {bb.Height}, {bb.Width})");
+
                         // Draw the rectangle using the bounding box values
                         // They are percentages so scale them to picture
-                        graphics.DrawRectangle(pen, x: facesHighlighted.Width * bb.Left,
+                        graphics.DrawRectangle(pen,
+                            x: facesHighlighted.Width * bb.Left,
                             y: facesHighlighted.Height * bb.Top,
                             width: facesHighlighted.Width * bb.Width,
                             height: facesHighlighted.Height * bb.Height);
                     }
                 }
+
                 // Save the image with highlights as PNG
                 string fileout = filename.Replace(Path.GetExtension(filename), "_faces.png");
                 facesHighlighted.Save(fileout, System.Drawing.Imaging.ImageFormat.Png);
+
                 Console.WriteLine(">>> " + outcome.FaceDetails.Count + " face(s) highlighted in file " + fileout);
             }
             else
+            {
                 Console.WriteLine(">>> No faces found");
+            }
         }
 
         static void IdentifyCelebrityFaces(string filename)
@@ -102,9 +107,8 @@ namespace NETRekognitionConsole
 
             if (outcome.CelebrityFaces.Count > 0)
             {
-
                 // Load a bitmap to modify with face bounding box rectangles
-                System.Drawing.Bitmap facesHighlighted = new System.Drawing.Bitmap(filename);
+                Bitmap facesHighlighted = new Bitmap(filename);
                 Pen pen = new Pen(Color.Black, 3);
                 Font drawFont = new Font("Arial", 12);
 
@@ -115,25 +119,33 @@ namespace NETRekognitionConsole
                     {
                         // Get the bounding box
                         BoundingBox bb = fd.Face.BoundingBox;
-                        Console.WriteLine("Bounding box = (" + bb.Left + ", " + bb.Top + ", " +
-                            bb.Height + ", " + bb.Width + ")");
+                        Console.WriteLine($"Bounding box = ({bb.Left}, {bb.Top}, {bb.Height}, {bb.Width})");
+
                         // Draw the rectangle using the bounding box values
                         // They are percentages so scale them to picture
-                        graphics.DrawRectangle(pen, x: facesHighlighted.Width * bb.Left,
+                        graphics.DrawRectangle(pen,
+                            x: facesHighlighted.Width * bb.Left,
                             y: facesHighlighted.Height * bb.Top,
                             width: facesHighlighted.Width * bb.Width,
                             height: facesHighlighted.Height * bb.Height);
-                        graphics.DrawString(fd.Name, drawFont, Brushes.White, facesHighlighted.Width * bb.Left,
-                            facesHighlighted.Height * bb.Top + facesHighlighted.Height * bb.Height);
+                        graphics.DrawString(fd.Name,
+                            font: drawFont,
+                            brush: Brushes.White,
+                            x: facesHighlighted.Width * bb.Left,
+                            y: facesHighlighted.Height * bb.Top + facesHighlighted.Height * bb.Height);
                     }
                 }
+
                 // Save the image with highlights as PNG
                 string fileout = filename.Replace(Path.GetExtension(filename), "_celebrityfaces.png");
                 facesHighlighted.Save(fileout, System.Drawing.Imaging.ImageFormat.Png);
+
                 Console.WriteLine(">>> " + outcome.CelebrityFaces.Count + " celebrity face(s) highlighted in file " + fileout);
             }
             else
+            {
                 Console.WriteLine(">>> No celebrity faces found");
+            }
         }
 
         static void Main(string[] args)

--- a/dotnet/example_code/Rekognition/AwsRekognitionSample1/Program.cs
+++ b/dotnet/example_code/Rekognition/AwsRekognitionSample1/Program.cs
@@ -37,19 +37,18 @@ namespace NETRekognitionConsole
             // Using USWest2, not the default region
             AmazonRekognitionClient rekoClient = new AmazonRekognitionClient(Amazon.RegionEndpoint.USWest2);
 
-            DetectFacesRequest dfr = new DetectFacesRequest();
+            // Request needs image bytes, so read and add to request
+            byte[] data = File.ReadAllBytes(filename);
 
-            // Request needs image butes, so read and add to request
-            Amazon.Rekognition.Model.Image img = new Amazon.Rekognition.Model.Image();
-            byte[] data = null;
-            using (FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read))
+            DetectFacesRequest dfr = new DetectFacesRequest
             {
-                data = new byte[fs.Length];
-                fs.Read(data, 0, (int)fs.Length);
-            }
-            img.Bytes = new MemoryStream(data);
-            dfr.Image = img;
-            var outcome = rekoClient.DetectFaces(dfr);
+                Image = new Amazon.Rekognition.Model.Image
+                {
+                    Bytes = new MemoryStream(data)
+                }
+            };
+
+            DetectFacesResponse outcome = rekoClient.DetectFaces(dfr);
 
             if (outcome.FaceDetails.Count > 0)
             {
@@ -87,20 +86,19 @@ namespace NETRekognitionConsole
         {
             // Using USWest2, not the default region
             AmazonRekognitionClient rekoClient = new AmazonRekognitionClient(Amazon.RegionEndpoint.USWest2);
+            
+            // Request needs image bytes, so read and add to request
+            byte[] data = File.ReadAllBytes(filename);
 
-            RecognizeCelebritiesRequest dfr = new RecognizeCelebritiesRequest();
-
-            // Request needs image butes, so read and add to request
-            Amazon.Rekognition.Model.Image img = new Amazon.Rekognition.Model.Image();
-            byte[] data = null;
-            using (FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read))
+            RecognizeCelebritiesRequest rcr = new RecognizeCelebritiesRequest
             {
-                data = new byte[fs.Length];
-                fs.Read(data, 0, (int)fs.Length);
-            }
-            img.Bytes = new MemoryStream(data);
-            dfr.Image = img;
-            var outcome = rekoClient.RecognizeCelebrities(dfr);
+                Image = new Amazon.Rekognition.Model.Image
+                {
+                    Bytes = new MemoryStream(data)
+                }
+            };
+
+            RecognizeCelebritiesResponse outcome = rekoClient.RecognizeCelebrities(rcr);
 
             if (outcome.CelebrityFaces.Count > 0)
             {


### PR DESCRIPTION
*Description of changes:*

Cleaning up AWS Rekognition example for dotnet, simplifying file reading, using object initializators, string interpolation where applicable and spacing for readability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
