### PR TITLE
Fixed comment chars after moving snippet tags

### DIFF
--- a/javascript/example_code/browserstart/polly.html
+++ b/javascript/example_code/browserstart/polly.html
@@ -43,7 +43,7 @@
       <source id="audioSource" type="audio/mp3" src="">
     </audio>
     <script src="https://sdk.amazonaws.com/js/aws-sdk-2.410.0.min.js"></script>
-    // snippet-start:[Polly.HTML.BrowserExample.config]
+    <!-- snippet-start:[Polly.HTML.BrowserExample.config] -->
     <script type="text/javascript">
 
         // Initialize the Amazon Cognito credentials provider
@@ -80,7 +80,7 @@
           });
         }
     </script>
-    // snippet-end:[Polly.HTML.BrowserExample.synthesize]
+    <!-- snippet-end:[Polly.HTML.BrowserExample.synthesize] -->
   </body>
 </html>
 <!-- snippet-end:[Polly.HTML.BrowserExample.complete] -->


### PR DESCRIPTION
Comment chars for snippet tags were incorrect.

// ... -> <!-- ... -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
