### PR TITLE
Remove potential timing issue in Python aws_service.py example

### DIFF
--- a/python/example_code/apigateway/aws_service/aws_service.py
+++ b/python/example_code/apigateway/aws_service/aws_service.py
@@ -626,11 +626,7 @@ def main():
     if api_url is None:
         exit(1)
     logging.info(f'Translate service TranslateText URL: {api_url}')
-
-    # Invoke the Translate.TranslateText REST API
-    translated_text = translate_text('Hello, my friend')
-    if translated_text is not None:
-        logging.info(f'Translated Text: {translated_text}')
+    logging.info('To translate text with the API, run the program with the option -t "Text to translate"')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
*Issue #, if available:*
Removed a potential timing issue when calling an API Gateway API immediately after creating it, but before it has a chance to "get settled."

*Description of changes:*
Removed call to translate_text() immediately after creating the underlying API Gateway interface.

My access to the GitHub repo was prematurely removed, so I had to fork the repo and submit this pull request. Please merge this minor change asap. Cheers.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
