### PR TITLE
Fix CloudWatchGetLogEvents example

### DIFF
--- a/go/example_code/cloudwatch/CloudWatchGetLogEvents.go
+++ b/go/example_code/cloudwatch/CloudWatchGetLogEvents.go
@@ -60,7 +60,7 @@ func main() {
 
     for _, event := range resp.Events {
         gotToken = nextToken
-        nextToken := *resp.NextForwardToken
+        nextToken = *resp.NextForwardToken
 
         if gotToken == nextToken {
             break


### PR DESCRIPTION
Overwrite `nextToken` var in order to use it in next loop iteration.

*Issue #, if available:*

*Description of changes:*
Correct me if I'm wrong but I think the example should rewrite `nextToken` var in order to reuse it on next loop iteration. Otherwise `nextToken` inside the loop is a new variable every time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
