### PR TITLE
Fix incorrect variable names.

### DIFF
--- a/javascript/example_code/cloudwatch/cw_enablealarmactions.js
+++ b/javascript/example_code/cloudwatch/cw_enablealarmactions.js
@@ -61,7 +61,7 @@ cw.putMetricAlarm(params, function(err, data) {
   } else {
     console.log("Alarm action added", data);
     var paramsEnableAlarmAction = {
-      AlarmNames: [paramsUpdateAlarm.AlarmName]
+      AlarmNames: [params.AlarmName]
     };
     cw.enableAlarmActions(paramsEnableAlarmAction, function(err, data) {
       if (err) {


### PR DESCRIPTION
*Issue #, if available:*
None.

*Description of changes:*
- Fix because there was an error in the variable name of the sample code.
- The line feed code was mixed with LF and CRLF, and there were more CRLF lines, so they were unified with CRLF.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
