### PR TITLE
Fixed unit mistakes

### DIFF
--- a/javascript/example_code/cloudwatch/cw_enablealarmactions.js
+++ b/javascript/example_code/cloudwatch/cw_enablealarmactions.js
@@ -52,7 +52,7 @@ var params = {
       Value: 'INSTANCE_ID'
     },
   ],
-  Unit: 'Seconds'
+  Unit: 'Percent'
 };
 
 cw.putMetricAlarm(params, function(err, data) {


### PR DESCRIPTION
*Issue #, if available:*
None.

*Description of changes:*
There was an error in the unit of eample code, and the alarm did not work properly.

Perhaps Unit is correct for Percent.

![image](https://user-images.githubusercontent.com/1306365/64681447-b0feb980-d4ba-11e9-96bc-b296df6f15b4.png)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
