### PR TITLE
Removed Units from CloudWatch alarm example

### DIFF
--- a/dotnet/example_code/CloudWatch/AwsCloudWatchSample1/Program.cs
+++ b/dotnet/example_code/CloudWatch/AwsCloudWatchSample1/Program.cs
@@ -126,8 +126,7 @@ namespace AWSSDKDocSamples.CloudWatch
                     Dimensions = new List<Dimension>
                     {
                         new Dimension { Name = "InstanceId", Value = instanceId }
-                    },
-                    Unit = StandardUnit.Seconds
+                    }
                 });
 
                 client.EnableAlarmActions(new EnableAlarmActionsRequest
@@ -175,8 +174,7 @@ namespace AWSSDKDocSamples.CloudWatch
                 Dimensions = new List<Dimension>
                     {
                         new Dimension { Name = "InstanceId", Value = "INSTANCE_ID" }
-                    },
-                Unit = StandardUnit.Seconds
+                    }
             });
 
         }


### PR DESCRIPTION
*Issue #, if available:* PutMetricAlarmRequest class recommends omitting Unit

*Description of changes:* Removed units from example code


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
