### PR TITLE
Change promise switch to catch

### DIFF
--- a/javascript/example_code/ses/ses_updatetemplate.js
+++ b/javascript/example_code/ses/ses_updatetemplate.js
@@ -49,7 +49,7 @@ var templatePromise = new AWS.SES({apiVersion: '2010-12-01'}).updateTemplate(par
 templatePromise.then(
   function(data) {
     console.log("Template Updated");
-  }).switch(
+  }).catch(
     function(err) {
     console.error(err, err.stack);
   });


### PR DESCRIPTION
*Description of changes:*
Running the SES update template example for Node/Javascript (javascript/example_code/ses/ses_updatetemplate.js) I get the error:

```
TypeError: templatePromise.then(...).switch is not a function
```

It would appear there is and error in the promise using `switch` instead of `catch`:

```
templatePromise.then(
  function(data) {
    console.log("Template Updated");
  }).switch(
    function(err) {
    console.error(err, err.stack);
  });
```

This PR replaces `switch` with `catch` allowing template to be updated without errors.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
