### PR TITLE
Updated EC2 examples for JavaScript to use AWS.config.update

### DIFF
--- a/javascript/example_code/ec2/ec2_createinstances.js
+++ b/javascript/example_code/ec2/ec2_createinstances.js
@@ -29,7 +29,7 @@
 // Load the AWS SDK for Node.js
 var AWS = require('aws-sdk');
 // Load credentials and set region from JSON file
-AWS.config.loadFromPath('./config.json');
+AWS.config.update({region: 'REGION'});
 
 // Create EC2 service object
 var ec2 = new AWS.EC2({apiVersion: '2016-11-15'});

--- a/javascript/example_code/ec2/ec2_createsecuritygroup.js
+++ b/javascript/example_code/ec2/ec2_createsecuritygroup.js
@@ -29,7 +29,7 @@
 // Load the AWS SDK for Node.js
 var AWS = require('aws-sdk');
 // Load credentials and set region from JSON file
-AWS.config.loadFromPath('./config.json');
+AWS.config.update({region: 'REGION'});
 
 // Create EC2 service object
 var ec2 = new AWS.EC2({apiVersion: '2016-11-15'});


### PR DESCRIPTION
*Issue #, if available:* A couple EC2 JS examples were using a local version of config.json instead of the default region from ~/.aws/config.

*Description of changes:* I changed them to match the other JS EC2 examples.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
