### PR TITLE
Replaced t1.micro with t2.micro in EC2 example

### DIFF
--- a/dotnet/example_code/ec2/AwsEC2Sample1/Program.cs
+++ b/dotnet/example_code/ec2/AwsEC2Sample1/Program.cs
@@ -78,7 +78,7 @@ namespace AwsEC2Sample1
                 ImageId = imageId,
                 MinCount = 1,
                 MaxCount = 1,
-                InstanceType = new InstanceType("t1.micro")
+                InstanceType = new InstanceType("t2.micro")
 
             };
             var instanceId = ec2Client.RunInstances(runRequest).Reservation.Instances[0].InstanceId;


### PR DESCRIPTION
*Issue #, if available:*

t.micro is deprecated

*Description of changes:*

Replaced with t2.micro


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
