### PR TITLE
Updated JavaScript SQS example to trap empty message list

### DIFF
--- a/javascript/example_code/sqs/sqs_changingvisibility.js
+++ b/javascript/example_code/sqs/sqs_changingvisibility.js
@@ -10,59 +10,60 @@
  * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
-*/
+ */
 
-//snippet-sourcedescription:[sqs_changingvisibility.js demonstrates how to change the visibility timeout of a message in an Amazon SQS queue.]
-//snippet-service:[sqs]
-//snippet-keyword:[JavaScript]
-//snippet-sourcesyntax:[javascript]
-//snippet-keyword:[Code Sample]
-//snippet-keyword:[Amazon Simple Queue Service]
-//snippet-sourcetype:[full-example]
-//snippet-sourcedate:[2018-06-02]
-//snippet-sourceauthor:[AWS-JSDG]
+// snippet-sourcedescription:[sqs_changingvisibility.js demonstrates how to change the visibility timeout of a message in an Amazon SQS queue.]
+// snippet-service:[sqs]
+// snippet-keyword:[JavaScript]
+// snippet-sourcesyntax:[javascript]
+// snippet-keyword:[Code Sample]
+// snippet-keyword:[Amazon Simple Queue Service]
+// snippet-sourcetype:[full-example]
+// snippet-sourcedate:[2019-10-10]
+// snippet-sourceauthor:[Doug-AWS]
 
 // ABOUT THIS NODE.JS SAMPLE: This sample is part of the SDK for JavaScript Developer Guide topic at
 // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/sqs-examples-managing-visibility-timeout.html
 
 // snippet-start:[sqs.JavaScript.visibility.receiveMessage]
 // Load the AWS SDK for Node.js
-var AWS = require('aws-sdk');
-// Set the region 
-AWS.config.update({region: 'REGION'});
+var AWS = require('aws-sdk')
+// Set the region to us-west-2
+AWS.config.update({ region: 'us-west-2' })
 
 // Create the SQS service object
-var sqs = new AWS.SQS({apiVersion: '2012-11-05'});
+var sqs = new AWS.SQS({ apiVersion: '2012-11-05' })
 
-var queueURL = "SQS_QUEUE_URL";
+var queueURL = 'https://sqs.REGION.amazonaws.com/ACCOUNT-ID/QUEUE-NAME'
 
 var params = {
-  AttributeNames: [
-    "SentTimestamp"
-  ],
+  AttributeNames: ['SentTimestamp'],
   MaxNumberOfMessages: 1,
-  MessageAttributeNames: [
-    "All"
-  ],
+  MessageAttributeNames: ['All'],
   QueueUrl: queueURL
-};
+}
 
-sqs.receiveMessage(params, function(err, data) {
+sqs.receiveMessage(params, function (err, data) {
   if (err) {
-    console.log("Receive Error", err);
+    console.log('Receive Error', err)
   } else {
-    var visibilityParams = {
-      QueueUrl: queueURL,
-      ReceiptHandle: data.Messages[0].ReceiptHandle,
-      VisibilityTimeout: 20 // 20 second timeout
-    };
-    sqs.changeMessageVisibility(visibilityParams, function(err, data) {
-      if (err) {
-        console.log("Delete Error", err);
-      } else {
-        console.log("Timeout Changed", data);
+    // Make sure we have a message
+    if (data.Messages != null) {
+      var visibilityParams = {
+        QueueUrl: queueURL,
+        ReceiptHandle: data.Messages[0].ReceiptHandle,
+        VisibilityTimeout: 20 // 20 second timeout
       }
-    });
+      sqs.changeMessageVisibility(visibilityParams, function (err, data) {
+        if (err) {
+          console.log('Delete Error', err)
+        } else {
+          console.log('Timeout Changed', data)
+        }
+      })
+    } else {
+      console.log('No messages to change')
+    }
   }
-});
+})
 // snippet-end:[sqs.JavaScript.visibility.receiveMessage]


### PR DESCRIPTION
*Issue #, if available:*

JavaScript sample would throw an error if the SQS queue was empty.

*Description of changes:*

It now tests whether data.messages is null.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
