### PR TITLE
Add connect realtime and historical metric api example

### DIFF
--- a/javascript/example_code/connect/getHistoricalMetrics.js
+++ b/javascript/example_code/connect/getHistoricalMetrics.js
@@ -2,23 +2,162 @@ const aws = require('aws-sdk');
 const connect = new aws.Connect();
 
 let params = {
-        InstanceId: "<provide your connect instance id>",
-        EndTime: 1570845600,  //change the end time
-        StartTime:1570780800, //change the start time
+        InstanceId: "1e8f045a-d7f1-4405-96c1-66701c25fd32",
+        EndTime: 1571184000,
+        StartTime:1571153400,
         Filters:{
-            Queues:["<provide your connect instances queue id>"],
+            Queues:["943031b0-62ce-49a7-8688-9e84accd94fc"],
             Channels:["VOICE"]
         },
-        HistoricalMetrics:[{
-            Name: "CONTACTS_ABANDONED", //add more metrics in this section. View https://docs.aws.amazon.com/connect/latest/APIReference/API_GetMetricData.html
-            Unit: "COUNT",
-            Statistic:"SUM"
-        },
-        {
-        Name: "CONTACTS_HOLD_ABANDONS",
-        Unit: "COUNT",
-        Statistic: "SUM"
-        }]
+        HistoricalMetrics : [
+      {
+         "Name" : "AFTER_CONTACT_WORK_TIME",
+         "Unit" : "SECONDS",
+         "Statistic" : "AVG"
+      },
+      {
+         "Name" : "CONTACTS_QUEUED",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "CONTACTS_HANDLED",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "HANDLE_TIME",
+         "Unit" : "SECONDS",
+         "Statistic" : "AVG"
+      },
+      {
+         "Name" : "CONTACTS_TRANSFERRED_OUT",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "CONTACTS_MISSED",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "OCCUPANCY",
+         "Unit" : "PERCENT",
+         "Statistic" : "AVG"
+      },
+      {
+         "Name" : "QUEUED_TIME",
+         "Unit" : "SECONDS",
+         "Statistic" : "MAX"
+      },
+      {
+         "Name" : "HOLD_TIME",
+         "Unit" : "SECONDS",
+         "Statistic" : "AVG"
+      },
+      {
+         "Name" : "SERVICE_LEVEL",
+         "Threshold" : {
+            "Comparison" : "LT",
+            "ThresholdValue" : 60.0
+         },
+         "Unit" : "PERCENT",
+         "Statistic" : "AVG"
+      },
+      {
+         "Name" : "SERVICE_LEVEL",
+         "Threshold" : {
+            "Comparison" : "LT",
+            "ThresholdValue" : 120.0
+         },
+         "Unit" : "PERCENT",
+         "Statistic" : "AVG"
+      },
+      {
+         "Name" : "SERVICE_LEVEL",
+         "Threshold" : {
+            "Comparison" : "LT",
+            "ThresholdValue" : 30.0
+         },
+         "Unit" : "PERCENT",
+         "Statistic" : "AVG"
+      },
+      {
+         "Name" : "CONTACTS_ABANDONED",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "CONTACTS_CONSULTED",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "CONTACTS_AGENT_HUNG_UP_FIRST",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "CONTACTS_HANDLED_INCOMING",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "CONTACTS_HANDLED_OUTBOUND",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "CONTACTS_HOLD_ABANDONS",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "CONTACTS_TRANSFERRED_IN",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "CONTACTS_TRANSFERRED_IN_FROM_QUEUE",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "CONTACTS_TRANSFERRED_OUT_FROM_QUEUE",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "CALLBACK_CONTACTS_HANDLED",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "API_CONTACTS_HANDLED",
+         "Unit" : "COUNT",
+         "Statistic" : "SUM"
+      },
+      {
+         "Name" : "ABANDON_TIME",
+         "Unit" : "SECONDS",
+         "Statistic" : "AVG"
+      },
+      {
+         "Name" : "QUEUE_ANSWER_TIME",
+         "Unit" : "SECONDS",
+         "Statistic" : "AVG"
+      },
+      {
+         "Name" : "INTERACTION_TIME",
+         "Unit" : "SECONDS",
+         "Statistic" : "AVG"
+      },
+      {
+         "Name" : "INTERACTION_AND_HOLD_TIME",
+         "Unit" : "SECONDS",
+         "Statistic" : "AVG"
+      }
+   ]
     };
 
 
@@ -35,6 +174,4 @@ exports.handler = async (event) => {
     
     var metrics = result["MetricResults"]
         console.log(metrics[0].Collections);
-    
-    
 };

--- a/javascript/example_code/connect/getHistoricalMetrics.js
+++ b/javascript/example_code/connect/getHistoricalMetrics.js
@@ -2,11 +2,11 @@ const aws = require('aws-sdk');
 const connect = new aws.Connect();
 
 let params = {
-        InstanceId: "1e8f045a-d7f1-4405-96c1-66701c25fd32",
-        EndTime: 1571184000,
-        StartTime:1571153400,
+        InstanceId: "Provide your connect instance id",
+        EndTime: 1571184000,	//enter a new end time
+        StartTime:1571153400,	//enter a new start time
         Filters:{
-            Queues:["943031b0-62ce-49a7-8688-9e84accd94fc"],
+            Queues:["Provide your connect instance queue id"],
             Channels:["VOICE"]
         },
         HistoricalMetrics : [

--- a/javascript/example_code/connect/getHistoricalMetrics.js
+++ b/javascript/example_code/connect/getHistoricalMetrics.js
@@ -1,0 +1,40 @@
+const aws = require('aws-sdk');
+const connect = new aws.Connect();
+
+let params = {
+        InstanceId: "<provide your connect instance id>",
+        EndTime: 1570845600,  //change the end time
+        StartTime:1570780800, //change the start time
+        Filters:{
+            Queues:["<provide your connect instances queue id>"],
+            Channels:["VOICE"]
+        },
+        HistoricalMetrics:[{
+            Name: "CONTACTS_ABANDONED", //add more metrics in this section. View https://docs.aws.amazon.com/connect/latest/APIReference/API_GetMetricData.html
+            Unit: "COUNT",
+            Statistic:"SUM"
+        },
+        {
+        Name: "CONTACTS_HOLD_ABANDONS",
+        Unit: "COUNT",
+        Statistic: "SUM"
+        }]
+    };
+
+
+exports.handler = async (event) => {
+
+    let result = await connect.getMetricData(params, function(err, data) {
+        if (err){
+                 console.log(err, err.stack);
+        }
+        else{   
+             console.log(data);        
+        }
+    }).promise();
+    
+    var metrics = result["MetricResults"]
+        console.log(metrics[0].Collections);
+    
+    
+};

--- a/javascript/example_code/connect/getRealtimeMetrics.js
+++ b/javascript/example_code/connect/getRealtimeMetrics.js
@@ -1,0 +1,21 @@
+const aws = require('aws-sdk');
+const connect = new aws.Connect({apiVersion: '2017-08-08'});
+ 
+let params = {
+        CurrentMetrics: [{
+            Name: "AGENTS_AVAILABLE",
+            Unit: "COUNT"
+        }],
+        Filters: {
+            Channels: ["VOICE"],
+            Queues: ["yourQueueID"] //replace 'yourQueueID' with your Queue ID
+        },
+        InstanceId: "yourInstanceID" //replace 'yourInstanceID' with your Instance ID
+    };
+ 
+exports.handler = async (event) => {
+        let data = await connect.getCurrentMetricData(params).promise();
+        console.log(data);
+        var str = JSON.stringify(data, null, 2);
+        console.log(str);
+}


### PR DESCRIPTION
*Issue #, if available:*
No Connect Service API examples. These will work with AWS Lambda.

Users only need to supply connect instance ID/queue id, and start and end times.

Users are able to include more metrics if they wish, but these are good jumping off points and easy to understand.

*Description of changes:*
Add new connect api examples for getting realtime and historical metrics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
