### PR TITLE
Updated S3 Python example to differentiate source file from bucket key

### DIFF
--- a/python/example_code/s3/s3-python-example-upload-file.py
+++ b/python/example_code/s3/s3-python-example-upload-file.py
@@ -22,7 +22,7 @@ bucket_name = 'my-bucket'
 
 # Uploads the given file using a managed uploader, which will split up large
 # files automatically and upload parts in parallel.
-s3.upload_file(filename, bucket_name, filename)
+s3.upload_file(source_filename, bucket_name, key_name)
  
 
 # snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]


### PR DESCRIPTION
*Issue #, if available:*

Python example did not make it clear which filename was the source file and which filename was the bucket key.

*Description of changes:*

The first filename is the source file; the second is the bucket key; I renamed both.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
