### PR TITLE
Revised checking in if statement

### DIFF
--- a/php/example_code/sqs/ReceiveMessage.php
+++ b/php/example_code/sqs/ReceiveMessage.php
@@ -48,7 +48,7 @@ try {
         'QueueUrl' => $queueUrl, // REQUIRED
         'WaitTimeSeconds' => 0,
     ));
-    if (count($result->get('Messages')) > 0) {
+    if (!empty($result->get('Messages'))) {
         var_dump($result->get('Messages')[0]);
         $result = $client->deleteMessage([
             'QueueUrl' => $queueUrl, // REQUIRED


### PR DESCRIPTION
`$result->get('Messages')` returns null if there are no messages in the queue, calling `count()` on the result of this call when the queue is empty and returning null will result in an exception being thrown in modern versions of PHP: 

> PHP Warning:  count(): Parameter must be an array or an object that implements Countable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
