### PR TITLE
t1.micro -> t2.micro

### DIFF
--- a/javascript/example_code/ec2/ec2_createinstances.js
+++ b/javascript/example_code/ec2/ec2_createinstances.js
@@ -37,7 +37,7 @@ var ec2 = new AWS.EC2({apiVersion: '2016-11-15'});
 // AMI is amzn-ami-2011.09.1.x86_64-ebs
 var instanceParams = {
    ImageId: 'AMI_ID', 
-   InstanceType: 't1.micro',
+   InstanceType: 't2.micro',
    KeyName: 'KEY_PAIR_NAME',
    MinCount: 1,
    MaxCount: 1


### PR DESCRIPTION
*Issue #, if available:*

EC2 (not ECS, sorry about the branch name) had deprecated t1.micro.

*Description of changes:*

Replaced it with t2.micro

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
