### PR TITLE
Fix typo

### DIFF
--- a/javascript/example_code/sns/sns_listsubscriptions.js
+++ b/javascript/example_code/sns/sns_listsubscriptions.js
@@ -31,8 +31,12 @@ var AWS = require('aws-sdk');
 // Set region
 AWS.config.update({region: 'REGION'});
 
+const params = {
+  TopicArn : 'TOPIC_ARN'
+}
+
 // Create promise and SNS service object
-var subslistPromise = new AWS.SNS({apiVersion: '2010-03-31'}).listSubscriptionsByTopic({TopicArn : TOPIC_ARN}).promise();
+var subslistPromise = new AWS.SNS({apiVersion: '2010-03-31'}).listSubscriptionsByTopic(params).promise();
 
 // Handle promise's fulfilled/rejected states
   subslistPromise.then(


### PR DESCRIPTION
Stringify `TOPIC_ARN` variable to fix typo in example-- matched style used in example **[here](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/javascript/example_code/sns/sns_publishtotopic.js#L41)**

*Description of changes:*

From (broken):
```js
var subslistPromise = new AWS.SNS({apiVersion: '2010-03-31'}).listSubscriptionsByTopic({TopicArn : TOPIC_ARN}).promise();	
```

To:
```js
const params = {
  TopicArn : 'TOPIC_ARN'
}

var subslistPromise = new AWS.SNS({apiVersion: '2010-03-31'}).listSubscriptionsByTopic(params).promise();
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
