### PR TITLE
update ECS CDK example to use new property for specifying the container image

### DIFF
--- a/typescript/example_code/cdk/my_ecs_construct-stack.ts
+++ b/typescript/example_code/cdk/my_ecs_construct-stack.ts
@@ -50,7 +50,7 @@ export class MyEcsConstructStack extends core.Stack {
       cluster: cluster, // Required
       cpu: 512, // Default is 256
       desiredCount: 6, // Default is 1
-      image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample"), // Required
+      taskImageOptions: { image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample") },
       memoryLimitMiB: 2048, // Default is 512
       publicLoadBalancer: true // Default is false
     });


### PR DESCRIPTION
*Description of changes:*
The `ApplicationLoadBalancedFargateService` now has a `taskImageOptions` property rather than an `image` property for specifying the container image to be used. Update this example to use the new property since the old one won't work any more.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
