### PR TITLE
Change name of cdk module to core in Python CDK examples

### DIFF
--- a/python/example_code/cdk/app.py
+++ b/python/example_code/cdk/app.py
@@ -23,19 +23,19 @@
 # snippet-start:[cdk.python.bucket]
 from aws_cdk import (
     aws_s3 as s3,
-    core as cdk,
+    core,
 )
 
 
-class S3Stack(cdk.Stack):
-    def __init__(self, app: cdk.App, id: str) -> None:
+class S3Stack(core.Stack):
+    def __init__(self, app: core.App, id: str) -> None:
         super().__init__(app, id)
 
         bucket = aws_s3.Bucket(
             self, "MyBucket",
             versioned=True)
 
-app = cdk.App()
+app = core.App()
 S3Stack(app, "MyStack")
 app.run()
 # snippet-end:[cdk.python.bucket]

--- a/python/example_code/cdk/app.py
+++ b/python/example_code/cdk/app.py
@@ -23,7 +23,7 @@
 # snippet-start:[cdk.python.bucket]
 from aws_cdk import (
     aws_s3 as s3,
-    cdk,
+    core as cdk,
 )
 
 

--- a/python/example_code/cdk/app2.py
+++ b/python/example_code/cdk/app2.py
@@ -23,12 +23,12 @@
 # snippet-start:[cdk.python.bucket2]
 from aws_cdk import (
     aws_s3 as s3,
-    core as cdk,
+    core,
 )
 
 
-class S3Stack(cdk.Stack):
-    def __init__(self, app: cdk.App, id: str) -> None:
+class S3Stack(core.Stack):
+    def __init__(self, app: core.App, id: str) -> None:
         super().__init__(app, id)
 
         bucket = aws_s3.Bucket(
@@ -36,7 +36,7 @@ class S3Stack(cdk.Stack):
             versioned=True,
             encryption=aws_s3.BucketEncryption.KmsManaged)
 
-app = cdk.App()
+app = core.App()
 S3Stack(app, "MyStack")
 app.run()
 # snippet-end:[cdk.python.bucket2]

--- a/python/example_code/cdk/app2.py
+++ b/python/example_code/cdk/app2.py
@@ -23,7 +23,7 @@
 # snippet-start:[cdk.python.bucket2]
 from aws_cdk import (
     aws_s3 as s3,
-    cdk,
+    core as cdk,
 )
 
 


### PR DESCRIPTION
CDK changed name of its main `cdk` module to `core` some time ago. Update these two code examples to work with the new name.