### PR TITLE
Give correct name for encryption key property

### DIFF
--- a/typescript/example_code/cdk/SecretsManager-stack.ts
+++ b/typescript/example_code/cdk/SecretsManager-stack.ts
@@ -36,7 +36,7 @@ export class SecretsManagerStack extends core.Stack {
       secretArn:
         "arn:aws:secretsmanager:<region>:<account-id-number>:secret:<secret-name>-<random-6-characters>"
       // If the secret is encrypted using a KMS-hosted CMK, either import or reference that key:
-      // Key,
+      // encryptionKey: ...
     });
     // snippet-end:[cdk.typescript.secrets_manager_stack_code]
 


### PR DESCRIPTION
in Secret.fromSecretAttributes() call

It appears that the comment suggesting the property used to specify the key when a secret is encrypted was truncated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
