### PR TITLE
fixed typo

### DIFF
--- a/javav2/example_code/cognito/src/main/java/com/example/cognito/CreateAdminUser.java
+++ b/javav2/example_code/cognito/src/main/java/com/example/cognito/CreateAdminUser.java
@@ -69,7 +69,7 @@ public class CreateAdminUser {
                                 .name("email")
                                 .value(email)
                                 .build())
-                        .messageAction("SURPRESS")
+                        .messageAction("SUPPRESS")
                         .build()
         );
 


### PR DESCRIPTION
*Issue #, if available:*
Typo caused the following exception:
Exception in thread "main" software.amazon.awssdk.services.cognitoidentityprovider.model.InvalidParameterException: 1 validation error detected: Value 'SURPRESS' at 'messageAction' failed to satisfy constraint: Member must satisfy enum value set: [SUPPRESS, RESEND] (Service: CognitoIdentityProvider, Status Code: 400, Request ID: XXXX)

*Description of changes:*
just changed the string value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
