### PR TITLE
Fixed Java V2 S3 CopyObject example

### DIFF
--- a/javav2/example_code/s3/src/main/java/com/example/s3/CopyObject.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/CopyObject.java
@@ -3,8 +3,8 @@
 //snippet-keyword:[Code Sample]
 //snippet-service:[s3]
 //snippet-sourcetype:[full-example]
-//snippet-sourcedate:[]
-//snippet-sourceauthor:[soo-aws]
+//snippet-sourcedate:[2019-11-13]
+//snippet-sourceauthor:[scmacdon]
 /*
    Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -84,8 +84,7 @@ public class CopyObject
             System.exit(1);
         }
         System.out.println("Done!");
+        // snippet-end:[s3.java2.copy_object.main]
     }
 }
- 
-// snippet-end:[s3.java2.copy_object.main]
 // snippet-end:[s3.java2.copy_object.complete]


### PR DESCRIPTION
*Issue #, if available:*

Java S3 copy object code had spaces

*Description of changes:*

Removed prefix spaces

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
