### PR TITLE
Removed duplicate snippet-start tag

### DIFF
--- a/javav2/example_code/lambda/src/main/java/com/example/lambda/LambdaInvoke.java
+++ b/javav2/example_code/lambda/src/main/java/com/example/lambda/LambdaInvoke.java
@@ -52,7 +52,6 @@ public class LambdaInvoke {
         */
         String functionName = args[0];
 
-        // snippet-start:[lambda.java2.invoke.main]
         InvokeResponse res = null ;
         try
         {


### PR DESCRIPTION
*Issue #, if available:*

LambdaInvoke.java had duplicate snippet-start tag for lambda.java2.invoke.main

*Description of changes:*

Deleted redundant snippet-start

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
