### PR TITLE
Added __pycache__ to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ php/example_code/Find_replace_confirm changes.py
 cpp/.vs/
 *.iml
 .vscode
+__pycache__


### PR DESCRIPTION
The __pycache__ folder is created by the Python interpreter to store bytecode-compiled versions of the code files. These files are essentially build artifacts and should never be checked in to the repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
