### PR TITLE
Update maximum ReceiveMessageWaitTimeSeconds

### DIFF
--- a/java/example_code/sqs/src/main/java/aws/example/sqs/LongPolling.java
+++ b/java/example_code/sqs/src/main/java/aws/example/sqs/LongPolling.java
@@ -70,7 +70,7 @@ public class LongPolling
         // Enable long polling on a message receipt
         ReceiveMessageRequest receive_request = new ReceiveMessageRequest()
                 .withQueueUrl(queue_url)
-                .withWaitTimeSeconds(40);
+                .withWaitTimeSeconds(20);
         sqs.receiveMessage(receive_request);
     }
 }


### PR DESCRIPTION
*Description of changes:*

It appears that a WaitTimeSeconds has an enforced maximum of 20s.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
