### PR TITLE
API Report module with accompanying unit tests and readme.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,55 @@
+<!--Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0
+International License (the "License"). You may not use this file except in compliance with the
+License. A copy of the License is located at http://creativecommons.org/licenses/by-nc-sa/4.0/.
+
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Scripts
+
+The scripts contained in this module are primarily for internal use by the AWS
+Code Examples team.
+
+## API Report
+
+#### Purpose
+
+Reads API metadata and writes a report of API coverage. The script can be run to 
+scan a folder and its subfolders for metadata descriptions of code examples and 
+the APIs they demonstrate. It can also be run on an individual metadata file to
+verify that it is formatted correctly and reports as expected.
+
+#### Prerequisites
+
+To run this script, you must have the following installed globally or in a virtual
+environment:
+ 
+* Python 3.6 or later
+* PyYaml
+* PyTest (to run unit tests)
+
+#### Running the script
+
+The typical usage of this script is to determine the API coverage contained in this
+GitHub repository. To generate a CSV-formatted report of API coverage, in a command
+window at the root folder of the repository, run the following:
+
+```
+python -m scripts.api_report --root . --report report.csv
+``` 
+
+This script can also be used to verify an individual metadata file. To verify a
+single file and write a report to the command window output, in a command window at
+the root folder of the repository, run the following:
+
+```
+python -m scripts.api_report --verify aws-cli\bash-linux\s3\metadata.yaml
+``` 
+
+#### Running the tests
+
+To run the unit tests associated with this script, in a command window at the 
+`scripts\tests` folder of the repository, run `pytest`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,8 +28,8 @@ To run this script, you must have the following installed globally or in a virtu
 environment:
  
 * Python 3.6 or later
-* PyYaml
-* PyTest (to run unit tests)
+* PyYaml 5.3 or later
+* PyTest 5.3.5 or later (to run unit tests)
 
 #### Running the script
 

--- a/scripts/api_report.py
+++ b/scripts/api_report.py
@@ -1,0 +1,195 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""
+Reads API metadata and writes a report of API coverage.
+
+This module can be run in two modes: report or verify.
+
+Report mode
+
+Specify a root folder and an output file path. The module scans the root folder
+and all of its subfolders for 'metadata.yaml' files and writes their data in CSV
+format to the specified output file path. The module also reports a count of unique
+APIs along with the total number of APIs and examples. A 'unique API' is defined
+by its language, service, and operation name, such as Python, S3, create_bucket.
+
+Verify mode
+
+Specify a metadata file by name. The module reads only that file and writes a report
+to the command window. This can be used when updating a metadata file to verify that
+the count and coverage output is what you expect.
+"""
+
+import argparse
+import os
+import pathlib
+import sys
+from urllib.parse import urljoin
+import urllib.request as request
+import yaml
+from yaml.scanner import ScannerError
+
+METADATA_FILENAME = 'metadata.yaml'
+GITHUB_URL = 'https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/'
+
+EXT_LOOKUP = {
+    'c': 'C',
+    'cpp': 'C++',
+    'cs': 'C#',
+    'go': 'Go',
+    'java': 'Java',
+    'js': 'JavaScript',
+    'php': 'PHP',
+    'py': 'Python',
+    'rb': 'Ruby',
+    'ts': 'TypeScript',
+    'sh': 'AWS-CLI',
+    'cmd': 'AWS-CLI'
+}
+
+
+def gather_data(examples_folder):
+    """
+    Scan a folder and its subfolders for metadata files and read them into a
+    list of example dictionaries.
+
+    :type examples_folder: string
+    :param examples_folder: The root folder where the scan is started.
+    """
+    if not os.path.isdir(examples_folder):
+        raise FileNotFoundError(f"{examples_folder} is not a directory.")
+
+    examples = []
+    for folder_name, _, file_list in os.walk(examples_folder):
+        for file_name in [f for f in file_list if f.lower() == METADATA_FILENAME]:
+            file_path = os.path.join(folder_name, file_name)
+            print(f"Found metadata: {file_path}.")
+            read_metadata(file_path, examples)
+    return examples
+
+
+def read_metadata(file_path, examples):
+    """
+    Read the specified file and append its contents into the specified list
+    of dictionaries.
+
+    :type file_path: string
+    :param file_path: A metadata file that contains example metadata in yaml format.
+    :type examples: list
+    :param examples: A list of example dictionaries. Examples read from the metadata
+                     are appended to this list.
+    """
+    with open(file_path, 'r') as meta_stream:
+        try:
+            meta_docs = yaml.safe_load_all(meta_stream)
+            for example_meta in meta_docs:
+                example_meta['metadata_path'] = file_path
+                examples.append(example_meta)
+        except ScannerError as err:
+            print(f"Yaml parser error in {file_path}, skipping.")
+            print(err)
+
+
+def write_report(examples, report_path=None):
+    """
+    Writes a report of APIs covered by the list of examples. The report includes
+    the count of unique APIs, total API and example counts, and the full list of
+    examples in CS format.
+
+    :type examples: list
+    :param examples: A list of example dictionaries.
+    :type report_path: string
+    :param report_path: The output file to write the report. If this file exists,
+                        it is overwritten. If no file is specified, the report
+                        is written to sys.stdout.
+    :rtype: int
+    :return: The count of unique APIs covered by the examples list.
+    """
+    lines = ["Created,File,Language,Service,Operation"]
+    unique_apis = set()
+
+    for example in examples:
+        try:
+            created = example['created']
+            for file in example['files']:
+                metadata_folder = os.path.split(example['metadata_path'])[0]
+                metadata_url = request.pathname2url(metadata_folder)
+                base_url = urljoin(GITHUB_URL, metadata_url) + '/'
+                file_url = request.pathname2url(file['path'])
+                file_url = urljoin(base_url, file_url)
+                ext = os.path.splitext(file_url)[1].lstrip('.')
+                language = EXT_LOOKUP[ext]
+                for api in file['apis']:
+                    service = api['service']
+                    for operation in api['operations']:
+                        unique_apis.add((language, service, operation))
+                        lines.append(
+                            ','.join([str(created), file_url, language,
+                                      service, operation]))
+        except KeyError as error:
+            print(f"ERROR: example missing a required key: {example}.")
+
+    report = open(report_path, 'w') if report_path else sys.stdout
+    try:
+        report.write(f"Number of unique APIs: {len(unique_apis)}.\n")
+        report.write(f"Total number of APIs: {len(lines) - 1}.\n")
+        report.write(f"Total number of examples: {len(examples)}.\n")
+        if len(lines) > 1:
+            report.write("\n")
+            report.write('\n'.join(lines))
+    finally:
+        if report is not sys.stdout:
+            report.close()
+            print(f"Report written to {report_path}.")
+
+    return len(unique_apis)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Reads API metadata and writes a report of API coverage. To"
+                    "scan a folder tree and write to a file, specify root and report. "
+                    "To verify a single file and write to the console, specify verify.")
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="The folder to start the search for metadata files. Defaults to the"
+             "current folder."
+    )
+    parser.add_argument(
+        "--report",
+        default="report.csv",
+        help="The file path to write the report. Defaults to 'report.csv'."
+    )
+    parser.add_argument(
+        "--verify",
+        help="A single metadata file to verify. If specified, root and report "
+             "arguments are ignored and the output is written to the console."
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.verify:
+            examples = []
+            read_metadata(args.verify, examples)
+            write_report(examples)
+        else:
+            examples = gather_data(args.root)
+            write_report(examples, args.report)
+    except KeyError as error:
+        print(error)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/api_report.py
+++ b/scripts/api_report.py
@@ -138,7 +138,7 @@ def write_report(examples, report_path=None):
                             ','.join([str(created), file_url, language,
                                       service, operation]))
         except KeyError as error:
-            print(f"ERROR: example missing a required key: {example}.")
+            print(f"ERROR: example missing a required {error} key: {example}.")
 
     report = open(report_path, 'w') if report_path else sys.stdout
     try:

--- a/scripts/tests/test_api_report.py
+++ b/scripts/tests/test_api_report.py
@@ -1,0 +1,326 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""
+Tests the api_report module.
+
+Test metadata Yaml files are stored in the test_api_report_yamls subfolder.
+"""
+
+from datetime import date
+import os
+from unittest.mock import patch, mock_open
+
+# pylint: disable=redefined-outer-name
+import pytest
+
+import api_report
+
+
+def mock_walk(examples_folder):
+    """Mock the os.walk function to return a single file."""
+    folder_list = []
+    file_list = ["metadata.yaml"]
+    return [("", folder_list, file_list)]
+
+
+def verify_example_data(example):
+    """Verifies basic correctness of example data."""
+    if 'description' in example:
+        assert isinstance(example['description'], str)
+    assert isinstance(example['created'], date)
+    assert len(example['files']) >= 1
+    file = example['files'][0]
+    assert isinstance(file['path'], str)
+    name, ext = os.path.splitext(file['path'])
+    assert name
+    assert ext.lstrip('.') in api_report.EXT_LOOKUP
+    assert len(file['apis']) >= 1
+    api = file['apis'][0]
+    assert isinstance(api['service'], str)
+    assert len(api['operations']) >= 1
+    assert isinstance(api['operations'][0], str)
+
+
+def test_gather_data_complex(monkeypatch):
+    """Reads complex metadata and verifies the output."""
+    def mock_join(folder_name, file_name):
+        return "test_api_report_yamls/complex_metadata.yaml"
+
+    monkeypatch.setattr(os, "walk", mock_walk)
+    monkeypatch.setattr(os.path, "join", mock_join)
+
+    examples = api_report.gather_data("test_api_report_yamls")
+    assert len(examples) == 1
+    verify_example_data(examples[0])
+
+
+def test_gather_data_multi_file(monkeypatch):
+    """Reads metadata that contains multiple documents in one Yaml file."""
+    def mock_join(folder_name, file_name):
+        return "test_api_report_yamls/multi_file_metadata.yaml"
+
+    monkeypatch.setattr(os, "walk", mock_walk)
+    monkeypatch.setattr(os.path, "join", mock_join)
+
+    examples = api_report.gather_data("test_api_report_yamls")
+    assert len(examples) == 3
+    for example in examples:
+        verify_example_data(example)
+
+
+def test_gather_data_bad_yaml(monkeypatch):
+    """Reads a file that contains incorrect Yaml and verifies that it rejects the
+    file but does not raise an exception."""
+    def mock_join(folder_name, file_name):
+        return "test_api_report_yamls/bad_metadata.yaml"
+
+    monkeypatch.setattr(os, "walk", mock_walk)
+    monkeypatch.setattr(os.path, "join", mock_join)
+
+    examples = api_report.gather_data("test_api_report_yamls")
+    assert len(examples) == 0
+
+
+def test_gather_data_capitalization(monkeypatch):
+    """Tests that capitalization does not break reading a metadata.yaml file."""
+    def mock_walk_caps(examples_folder):
+        folder_list = []
+        file_list = ["METAdata.yaml"]
+        return [("", folder_list, file_list)]
+
+    def mock_join(folder_name, file_name):
+        return "test_api_report_yamls/complex_metadata.yaml"
+
+    monkeypatch.setattr(os, "walk", mock_walk_caps)
+    monkeypatch.setattr(os.path, "join", mock_join)
+
+    examples = api_report.gather_data("test_api_report_yamls")
+    assert len(examples) == 1
+
+
+def test_gather_data_no_metadata(monkeypatch):
+    """Tests that a file list with no metadata.yaml in it does not fail."""
+    def mock_walk_no_meta(examples_folder):
+        folder_list = []
+        file_list = ["something_else.yaml", "actual_file.py"]
+        return [("", folder_list, file_list)]
+
+    monkeypatch.setattr(os, "walk", mock_walk_no_meta)
+
+    examples = api_report.gather_data("test_api_report_yamls")
+    assert len(examples) == 0
+
+
+@pytest.fixture
+def mock_opened_file():
+    """Mocks opening a file in a context manager."""
+    with patch('builtins.open', mock_open()) as mock_file:
+        yield mock_file
+
+
+def test_write_empty_report(mock_opened_file):
+    """Tests that writing an empty report does not cause failure."""
+    api_report.write_report([], 'test.csv')
+    mock_opened_file.assert_called_with('test.csv', 'w')
+    handle = mock_opened_file()
+    handle.write.assert_called()
+
+
+def test_write_single_report(mock_opened_file):
+    """Tests writing a single report."""
+    created = date(2020, 2, 1)
+    path = 'test_path.py'
+    service = 'testsvc'
+    operation = 'test_operation'
+    api_report.write_report([{
+        'metadata_path': 'metadata.yaml',
+        'created': created,
+        'files': [{
+            'path': path,
+            'apis': [{
+                'service': service,
+                'operations': [operation]
+            }]
+        }]
+    }], 'test.csv')
+    handle = mock_opened_file()
+    handle.write.assert_called_with(
+        "Created,File,Language,Service,Operation\n" +
+        ",".join([str(created), api_report.GITHUB_URL + path,
+                  'Python', service, operation]))
+
+
+def test_write_multi_report(mock_opened_file):
+    """Tests writing a list of reports."""
+    examples = []
+    lines = []
+    for count in range(1, 5):
+        created = date(2020, 2, count)
+        path = f'test_path_{count}.cpp'
+        service = f'testsvc{count}'
+        operation = f'test_operation_{count}'
+        examples.append({
+            'metadata_path': 'metadata.yaml',
+            'created': created,
+            'files': [{
+                'path': path,
+                'apis': [{
+                    'service': service,
+                    'operations': [operation]
+                }]
+            }]
+        })
+        lines.append(','.join([str(created), api_report.GITHUB_URL + path,
+                               'C++', service, operation]))
+
+    api_count = api_report.write_report(examples, 'test.csv')
+    assert api_count == count
+    handle = mock_opened_file()
+    handle.write.assert_called_with(
+        "Created,File,Language,Service,Operation\n" +
+        "\n".join(lines)
+    )
+
+
+def test_write_report_missing_key(mock_opened_file):
+    """Tests that writing a report for an example with a missing key skips the
+    example but does not otherwise fail."""
+    created = date(2020, 2, 1)
+    path = 'test_path.py'
+    service = 'testsvc'
+    operation = 'test_operation'
+
+    api_count = api_report.write_report([{
+        'metadata_path': 'metadata.yaml',
+        'created': created,
+        'wrong_key': [{
+            'path': path,
+            'apis': [{
+                'service': service,
+                'operations': [operation]
+            }]
+        }]
+    }, {
+        'metadata_path': 'metadata.yaml',
+        'created': created,
+        'files': [{
+            'path': path,
+            'apis': [{
+                'service': service,
+                'operations': [operation]
+            }]
+        }]
+
+    }], 'test.csv')
+    assert api_count == 1
+
+
+@pytest.mark.parametrize(
+    "examples,expected_api_count", [
+        ([{
+            'metadata_path': 'metadata.yaml',
+            'created': '2020-02-01',
+            'files': [{
+                'path': 'test_path.py',
+                'apis': [{
+                    'service': 'testsvc',
+                    'operations': ['test_op']
+                }]
+            }]
+        }], 1),
+        ([{
+            'metadata_path': 'metadata.yaml',
+            'created': '2020-02-01',
+            'files': [{
+                'path': 'test_path.py',
+                'apis': [{
+                    'service': 'testsvc',
+                    'operations': ['test_op1', 'test_op2', 'test_op3']
+                }]
+            }]
+        }], 3),
+        ([{
+            'metadata_path': 'metadata.yaml',
+            'created': '2020-02-01',
+            'files': [{
+                'path': 'test_path.py',
+                'apis': [{
+                    'service': 'testsvc1',
+                    'operations': ['test_op1', 'test_op2', 'test_op3']
+                }, {
+                    'service': 'testsvc2',
+                    'operations': ['test_op1', 'test_op2']
+                }]
+            }]
+        }], 5),
+        ([{
+            'metadata_path': 'metadata.yaml',
+            'created': '2020-02-01',
+            'files': [{
+                'path': 'test_path.py',
+                'apis': [{
+                    'service': 'testsvc1',
+                    'operations': ['test_op1', 'test_op2', 'test_op3']
+                }, {
+                    'service': 'testsvc2',
+                    'operations': ['test_op1', 'test_op2']
+                }]
+            }],
+        }, {
+            'metadata_path': 'metadata.yaml',
+            'created': '2020-02-01',
+            'files': [{
+                'path': 'test_path.cpp',
+                'apis': [{
+                    'service': 'testsvc1',
+                    'operations': ['test_op1', 'test_op2', 'test_op3']
+                }, {
+                    'service': 'testsvc2',
+                    'operations': ['test_op1', 'test_op2']
+                }]
+            }]
+        }], 10),
+        ([{
+            'metadata_path': 'metadata.yaml',
+            'created': '2020-02-01',
+            'files': [{
+                'path': 'test_path.py',
+                'apis': [{
+                    'service': 'testsvc1',
+                    'operations': ['test_op1', 'test_op2', 'test_op3']
+                }, {
+                    'service': 'testsvc2',
+                    'operations': ['test_op1', 'test_op2']
+                }]
+            }],
+        }, {
+            'metadata_path': 'metadata.yaml',
+            'created': '2020-02-01',
+            'files': [{
+                'path': 'test_path.py',
+                'apis': [{
+                    'service': 'testsvc1',
+                    'operations': ['test_op1', 'test_op5', 'test_op6']
+                }, {
+                    'service': 'testsvc2',
+                    'operations': ['test_op1', 'test_op3']
+                }]
+            }]
+        }], 8),
+    ]
+)
+def test_count_apis(mock_opened_file, examples, expected_api_count):
+    """Tests several scenarios to verify that unique APIs are counted correctly."""
+    api_count = api_report.write_report(examples, 'test.csv')
+    assert api_count == expected_api_count

--- a/scripts/tests/test_api_report.py
+++ b/scripts/tests/test_api_report.py
@@ -19,7 +19,7 @@ Test metadata Yaml files are stored in the test_api_report_yamls subfolder.
 
 from datetime import date
 import os
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, Mock
 
 # pylint: disable=redefined-outer-name
 import pytest

--- a/scripts/tests/test_api_report_yamls/bad_metadata.yaml
+++ b/scripts/tests/test_api_report_yamls/bad_metadata.yaml
@@ -1,0 +1,50 @@
+---
+# Metadata for multiple examples separated as yaml documents.
+name: Simple S3 example
+description: Creates an S3 bucket.
+created: 2020-01-31
+author: Laren-AWS
+tier: 1
+files:weird garbage, does this break?
+          - DeleteBucket
+...
+---
+name: Some other S3 example
+description: Does some other S3 stuff.
+created: 2020-01-31
+author: Laren-AWS
+tier: 1
+files:
+  - path: fix_the_bucket.py
+    apis:
+      - service: s3
+        operations:
+          - CreateBucket
+          - CreateObject
+          - DeleteObject
+  - path: kick_the_bucket.py
+    apis:
+      - service: s3
+        operations:
+          - DeleteBucket
+...
+---
+name: Some other S3 example
+description: Does some other S3 stuff.
+created: 2020-01-31
+author: Laren-AWS
+tier: 1
+files:
+  - path: fix_the_bucket.py
+    apis:
+      - service: s3
+        operations:
+          - CreateBucket
+          - CreateObject
+          - DeleteObject
+  - path: kick_the_bucket.py
+    apis:
+      - service: s3
+        operations:
+          - DeleteBucket
+...

--- a/scripts/tests/test_api_report_yamls/complex_metadata.yaml
+++ b/scripts/tests/test_api_report_yamls/complex_metadata.yaml
@@ -1,0 +1,67 @@
+---
+# Metadata for a complex example that uses several services and files.
+created: 2020-01-31
+files:
+  - path: start_the_things.py
+    apis:
+      - service: s3
+        operations:
+          - CreateBucket
+          - CreateObject
+      - service: sqs
+        operations:
+          - CreateQueue
+          - SetQueueAttributes
+      - service: rds
+        operations:
+          - CreateDBCluster
+          - CreateDBInstance
+  - path: middle_the_things.py
+    apis:
+      - service: sqs
+        operations:
+          - GetQueueUrl
+          - ListQueues
+      - service: lambda
+        operations:
+          - GetPolicy
+          - GetFunction
+  - path: cleanup_the_things.py
+    apis:
+      - service: s3
+        operations:
+          - DeleteObject
+          - DeleteBucket
+      - service: sqs
+        operations:
+          - DeleteMessageBatch
+          - DeleteQueue
+      - service: rds
+        operations:
+          - DeleteDBInstance
+          - DeleteDBCluster
+  - path: data/send_the_things.py
+    apis:
+      - service: s3
+        operations:
+          - PutObject
+      - service: sqs
+        operations:
+          - SendMessage
+      - service: rds
+        operations:
+          - ExecuteStatement
+  - path: data/receive_the_things.py
+    apis:
+      - service: s3
+        operations:
+          - PutObject
+      - service: sqs
+        operations:
+          - ReceiveMessage
+          - DeleteMessage
+      - service: rds
+        operations:
+          - BeginTransaction
+          - ExecuteStatement
+          - CommitTransaction

--- a/scripts/tests/test_api_report_yamls/missing_key_metadata.yaml
+++ b/scripts/tests/test_api_report_yamls/missing_key_metadata.yaml
@@ -1,0 +1,9 @@
+---
+description: Creates an S3 bucket.
+created: 2020-01-31
+bad_key:
+  - path: create_bucket.py
+    apis:
+      - service: s3
+        operations:
+          - CreateBucket

--- a/scripts/tests/test_api_report_yamls/multi_file_metadata.yaml
+++ b/scripts/tests/test_api_report_yamls/multi_file_metadata.yaml
@@ -1,0 +1,55 @@
+---
+# Metadata for multiple examples separated as yaml documents.
+name: Simple S3 example
+description: Creates an S3 bucket.
+created: 2020-01-31
+author: Laren-AWS
+tier: 1
+files:
+  - path: create_bucket.py
+    apis:
+      - service: s3
+        operations:
+          - CreateBucket
+          - DeleteBucket
+...
+---
+name: Some other S3 example
+description: Does some other S3 stuff.
+created: 2020-01-31
+author: Laren-AWS
+tier: 1
+files:
+  - path: fix_the_bucket.py
+    apis:
+      - service: s3
+        operations:
+          - CreateBucket
+          - CreateObject
+          - DeleteObject
+  - path: kick_the_bucket.py
+    apis:
+      - service: s3
+        operations:
+          - DeleteBucket
+...
+---
+name: Some other S3 example
+description: Does some other S3 stuff.
+created: 2020-01-31
+author: Laren-AWS
+tier: 1
+files:
+  - path: fix_the_bucket.py
+    apis:
+      - service: s3
+        operations:
+          - CreateBucket
+          - CreateObject
+          - DeleteObject
+  - path: kick_the_bucket.py
+    apis:
+      - service: s3
+        operations:
+          - DeleteBucket
+...

--- a/scripts/tests/test_api_report_yamls/simpler_metadata.yaml
+++ b/scripts/tests/test_api_report_yamls/simpler_metadata.yaml
@@ -1,0 +1,45 @@
+---
+# Complex example with simplified format that does not allow
+# for file -> api linking
+name: Complex SQS + RDS example
+description: Does lots of neat things.
+created: 2020-01-31
+author: Laren-AWS
+tier: 4,
+files:
+  - start_the_things.py
+  - middle_the_things.py
+  - cleanup_the_things.py
+  - data/send_the_things.py
+  - data/receive_the_things.py
+apis:
+  - service: lambda
+    operations: [GetPolicy, GetFunction]
+  - service: s3
+    operations:
+      - CreateBucket
+      - CreateObject
+      - DeleteObject
+      - DeleteBucket
+      - PutObject
+      - PutObject
+  - service: sqs
+    operations:
+      - CreateQueue
+      - SetQueueAttributes
+      - GetQueueUrl
+      - ListQueues
+      - DeleteMessageBatch
+      - DeleteQueue
+      - SendMessage
+      - ReceiveMessage
+      - DeleteMessage
+  - service: rds
+    operations:
+      - CreateDBCluster
+      - CreateDBInstance
+      - DeleteDBInstance
+      - DeleteDBCluster
+      - ExecuteStatement
+      - BeginTransaction
+      - CommitTransaction


### PR DESCRIPTION
The API Report module scans a folder hierarchy for 'metadata.yaml' files and generates a CSV-formatted report from them. This is used both to count coverage of unique APIs as well as to gather general code example API coverage across the repo.

- [x] The submitter has added unit tests for all code paths, run all of them, and they all pass.

- [x] The submitter has run a linter on the code, and all of the submitter's team's minimum rules pass.

- [x] The submitter has added the team's minimum usage documentation to the code.

- [x] The submitter has had the code reviewed, and the submitter has incorporated any and all resulting review comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
