### PR TITLE
Updated copyright notice in README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,12 +1,12 @@
 <!--Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0
-International License (the "License"). You may not use this file except in compliance with the
-License. A copy of the License is located at http://creativecommons.org/licenses/by-nc-sa/4.0/.
+This file is licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License. 
+The full license text is provided in the LICENSE file accompanying this repository.
 
-This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-either express or implied. See the License for the specific language governing permissions and
-limitations under the License.
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+specific language governing permissions and limitations under the License.
 -->
 # Scripts
 


### PR DESCRIPTION
The copyright notice in the README of the Scripts folder was not the correct one. This PR updates it to the reference the Apache 2.0 license.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
