### PR TITLE
Update to use modern import style

### DIFF
--- a/typescript/example_code/cdk/HelloCdk.ts
+++ b/typescript/example_code/cdk/HelloCdk.ts
@@ -21,10 +21,9 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.HelloCdk]
-import core = require('@aws-cdk/core');
-
+import * as cdk from '@aws-cdk/core';
 import { HelloCdkStack } from '../lib/HelloCdk-stack';
 
-const app = new core.App();
+const app = new cdk.App();
 new HelloCdkStack(app, 'HelloCdkStack');
 // snippet-end:[cdk.typescript.HelloCdk]


### PR DESCRIPTION
The require() syntax for imports is the old way. Update to the new way because:

* It's what TypeScript developers will expect
* Babel won't convert the old syntax and I'm going to use Babel to convert all these to JavaScript soon