### PR TITLE
Fixed DynamoDB CreateTable example in Go

### DIFF
--- a/go/example_code/dynamodb/DynamoDBCreateTable.go
+++ b/go/example_code/dynamodb/DynamoDBCreateTable.go
@@ -70,7 +70,7 @@ func main() {
                 KeyType:       aws.String("HASH"),
             },
             {
-                AttributeName: aws.String("Title"),
+                AttributeName: aws.String("Namee"),
                 KeyType:       aws.String("RANGE"),
             },
         },


### PR DESCRIPTION
*Issue #, if available:*
DynamoDB CreateTable example had title, but it should be name.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
