### PR TITLE
Fix: correct the minimal CMakeLists for recent AWS SDK changes.

### DIFF
--- a/cpp/example_code/general/CMakeLists-minimal.txt
+++ b/cpp/example_code/general/CMakeLists-minimal.txt
@@ -1,10 +1,6 @@
 # Minimal CMakeLists.txt for the AWS SDK for C++.
 cmake_minimum_required(VERSION 3.2)
 
-# Build using the C++ standard version 11.
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Use shared libraries, which is the default for the AWS C++ SDK build.
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
@@ -21,6 +17,9 @@ find_package(AWSSDK REQUIRED COMPONENTS s3 cloudtrail ...)
 
 # The executable name and its sourcefiles.
 add_executable(my-example my-example.cpp)
+
+# Build using the C++ standard version 11.
+target_compile_features(my-example PUBLIC cxx_std_11)
 
 # The libraries used by your executable.
 target_link_libraries(my-example ${AWSSDK_LINK_LIBRARIES})

--- a/cpp/example_code/general/CMakeLists-minimal.txt
+++ b/cpp/example_code/general/CMakeLists-minimal.txt
@@ -7,10 +7,6 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 # "my-example" is just an example value.
 project(my-example)
 
-# By default the AWS SDK for C++ is installed into /usr/local.
-# You may need to adjust the default include path on some platforms.
-# include_directories(/usr/local/include)
-
 # Locate the AWS SDK for C++ package.
 # "s3" and "cloudtrail" are just example values.
 find_package(AWSSDK REQUIRED COMPONENTS s3 cloudtrail ...)

--- a/cpp/example_code/general/CMakeLists-minimal.txt
+++ b/cpp/example_code/general/CMakeLists-minimal.txt
@@ -9,7 +9,7 @@ project(my-example)
 
 # Locate the AWS SDK for C++ package.
 # "s3" and "cloudtrail" are just example values.
-find_package(AWSSDK REQUIRED COMPONENTS s3 cloudtrail ...)
+find_package(AWSSDK REQUIRED COMPONENTS s3 cloudtrail)
 
 # The executable name and its sourcefiles.
 add_executable(my-example my-example.cpp)

--- a/cpp/example_code/general/CMakeLists-minimal.txt
+++ b/cpp/example_code/general/CMakeLists-minimal.txt
@@ -1,18 +1,26 @@
-# minimal CMakeLists.txt for the AWS SDK for C++
+# Minimal CMakeLists.txt for the AWS SDK for C++.
 cmake_minimum_required(VERSION 3.2)
+
+# Build using the C++ standard version 11.
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Use shared libraries, which is the default for the AWS C++ SDK build.
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 # "my-example" is just an example value.
 project(my-example)
 
-# Locate the AWS SDK for C++ package.
-# Requires that you build with:
-#   -DCMAKE_PREFIX_PATH=/path/to/sdk_install
-find_package(AWSSDK REQUIRED COMPONENTS service1 service2 ...)
+# By default the AWS SDK for C++ is installed into /usr/local.
+# You may need to adjust the default include path on some platforms.
+# include_directories(/usr/local/include)
 
-# The executable name and its sourcefiles
+# Locate the AWS SDK for C++ package.
+# "s3" and "cloudtrail" are just example values.
+find_package(AWSSDK REQUIRED COMPONENTS s3 cloudtrail ...)
+
+# The executable name and its sourcefiles.
 add_executable(my-example my-example.cpp)
 
 # The libraries used by your executable.
-# "aws-cpp-sdk-s3" is just an example.
 target_link_libraries(my-example ${AWSSDK_LINK_LIBRARIES})
-


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-cpp/issues/1334

*Description of changes:*

- correct minimal CMakeLists, tested with AWS SDK for C++ 1.7.278 
- make capitalization/periods consistent

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
