### PR TITLE
Fix: client creation errors in PHP samples.

### DIFF
--- a/php/example_code/s3/CreateClient.php
+++ b/php/example_code/s3/CreateClient.php
@@ -34,7 +34,6 @@ use Aws\Exception\AwsException;
 // snippet-start:[s3.php.create_client.client]
 //Create a S3Client
 $s3 = new Aws\S3\S3Client([
-    'profile' => 'default',
     'version' => 'latest',
     'region' => 'us-east-2'
 ]);

--- a/php/example_code/s3/ErrorHandling.php
+++ b/php/example_code/s3/ErrorHandling.php
@@ -33,11 +33,10 @@ use Aws\S3\Exception\S3Exception;
  */
 // snippet-start:[s3.php.error_handling.main]
 // snippet-start:[s3.php.error_handling.client]
-//Create a S3Client
-$s3Client = new S3Client([
-    'profile' => 'default',
-    'region' => 'us-east-2',
-    'version' => 'latest'
+// Create an SDK class used to share configuration across clients.
+$sdk = new Aws\Sdk([
+    'region'   => 'us-west-2',
+    'version'  => 'latest'
 ]);
 
 // Use an Aws\Sdk class to create the S3Client object.

--- a/php/example_code/s3/ListBucketsAsync.php
+++ b/php/example_code/s3/ListBucketsAsync.php
@@ -31,13 +31,11 @@ use Aws\Exception\AwsException;
 // snippet-start:[s3.php.list_buckets_async.main]
 // snippet-start:[s3.php.list_buckets_async.client]
 // snippet-start:[s3.php.list_buckets_async.async]
-//Create a S3Client
-$s3Client = new S3Client([
-    'profile' => 'default',
-    'region' => 'us-east-2',
-    'version' => 'latest'
+// Create an SDK class used to share configuration across clients.
+$sdk = new Aws\Sdk([
+    'region'   => 'us-west-2',
+    'version'  => 'latest'
 ]);
-
 // Use an Aws\Sdk class to create the S3Client object.
 $s3Client = $sdk->createS3();
 // snippet-end:[s3.php.list_buckets_async.client]


### PR DESCRIPTION
Noticed a few problems while working on https://github.com/aws-samples/aws-dataexchange-api-samples/pull/34.

*Description of changes:*

- in the create client example we don't want to specify a profile, or it won't pickup ENV variables, and we say on the page somewhere that that's what happens
- in a couple of places we do `$s3Client = $sdk->createS3();`, but don't create `$sdk`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
