### PR TITLE
Correcting metadata title

### DIFF
--- a/java/example_code/s3/src/main/java/UploadObject.java
+++ b/java/example_code/s3/src/main/java/UploadObject.java
@@ -58,7 +58,7 @@ public class UploadObject {
             PutObjectRequest request = new PutObjectRequest(bucketName, fileObjKeyName, new File(fileName));
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentType("plain/text");
-            metadata.addUserMetadata("x-amz-meta-title", "someTitle");
+            metadata.addUserMetadata("title", "someTitle");
             request.setMetadata(metadata);
             s3Client.putObject(request);
         } catch (AmazonServiceException e) {


### PR DESCRIPTION
Removing "x-amz-meta-" prefix from the metadata key, per the guidance here: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/ObjectMetadata.html#addUserMetadata-java.lang.String-java.lang.String-

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
