### PR TITLE
Added cleanup report script

### DIFF
--- a/aws-cli/bash-linux/ec2/metadata.yaml
+++ b/aws-cli/bash-linux/ec2/metadata.yaml
@@ -1,25 +1,6 @@
-# Example: change-ec2-instance-type
-
-description: Converts the instance type of a running instance
-created: 2020-02-21
+# Converts the instance type of a running instance
 files:
-  - path: change-ec2-instance-type/change-ec2-instance-type.sh
-    apis:
-      - service: ec2
-        operations:
-          - describe-instances
-          - stop-instances
-          - modify-instance-attribute
-          - start-instances
-          - wait:instance-stopped
-          - wait:instance-running
-  - path: change-ec2-instance-type/test-change-ec2-instance-type.sh
-    apis:
-      - service: ec2
-        operations:
-          - describe-images
-          - run-instances
-          - terminate-instances
-          - wait:instance-exists
-          - wait:instance-running
-          - wait:instance-terminated
+  - path: change-ec2-instance-type/change_ec2_instance_type.sh
+    services:
+      - ec2
+  - path: change-ec2-instance-type/test_change_ec2_instance_type.sh

--- a/aws-cli/bash-linux/s3/metadata.yaml
+++ b/aws-cli/bash-linux/s3/metadata.yaml
@@ -1,15 +1,7 @@
-# Example: bucket-lifecycle-operations
-description: Demonstrates basic CRUD operations on S3 buckets and their contents.
-created: 2020-02-06
+# Demonstrates basic CRUD operations on S3 buckets and their contents.
 files:
-  - path: bucket-lifecycle-operations/bucket-operations.sh
-    apis:
-      - service: s3
-        operations:
-          - head-bucket
-          - create-bucket
-          - put-object
-          - copy-object
-          - list-objects
-          - delete-object
-          - delete-bucket
+  - path: bucket-lifecycle-operations/bucket_operations.sh
+    service:
+      - s3
+  - path: bucket-lifecycle-operations/awsdocs_general.sh
+  - path: bucket-lifecycle-operations/test_bucket_operations.sh

--- a/go/cloudtrail/metadata.yaml
+++ b/go/cloudtrail/metadata.yaml
@@ -1,17 +1,8 @@
 ---
-created: 2020-02-20
 files:
   - path: cloudtrailOps.go
-    apis:
-      - service: cloudtrail
-        operations:
-          - CreateTrail
-          - DeleteTrail
-          - DescribeTrails
-          - LookupEvents
-      - service: s3
-        operations:
-          - PutBucketPolicy
-      - service: sts
-        operations:
-          - GetCallerIdentity
+    services:
+      - cloudtrail
+      - s3
+      - sts
+  - path: cloudtrailOps_test.go

--- a/go/example_code/cloudformation/metadata.yaml
+++ b/go/example_code/cloudformation/metadata.yaml
@@ -1,17 +1,6 @@
 ---
-created: 2020-01-31
 files:
-
   - path: CfnCrudOps.go
-
-    apis:
-
-      - service: cloudformation
-
-        operations:
-
-          - CreateStack
-          - WaitUntilStackCreateComplete
-          - ListStacks
-          - DeleteStack
-          - WaitUntilStackDeleteComplete
+    services:
+      - cloudformation
+  - path: CfnCrudOps_test.go

--- a/go/example_code/s3/delete-buckets-by-prefix/metadata.yaml
+++ b/go/example_code/s3/delete-buckets-by-prefix/metadata.yaml
@@ -1,10 +1,6 @@
 ---
-created: 2020-02-14
 files:
   - path: s3_delete_buckets.go
-    apis:
-      - service: s3
-        operations:
-          - ListBuckets
-          - DeleteBucket
-          - WaitUntilBucketNotExists
+    service:
+      - s3
+  - path: s3_delete_buckets_test.go

--- a/go/s3/metadata.yaml
+++ b/go/s3/metadata.yaml
@@ -1,13 +1,9 @@
-created: 2020-02-21
 files:
   - path: CustomClient/CustomHTTPClient.go
-    apis:
-      - service: s3
-        operations:
-          - GetObject
-          - GetObjectWithContext
+    services:
+      - s3
+  - path: CustomClient/CustomHTTPClient_test.go
   - path: TLS/s3SetTls12.go
-    apis:
-      - service: s3
-        operations:
-          - HeadObject
+    services:
+      - s3
+  - path: TLS/s3SetTls12_test.go

--- a/go/sqs/metadata.yaml
+++ b/go/sqs/metadata.yaml
@@ -1,68 +1,54 @@
 ---
-created: Mar 6 2020
 files:
   - path: ChangeMsgVisibility/ChangeMsgVisibility.go
-    apis:
-      - service: sqs
-        operations:
-          - ChangeMessageVisibility
+    services:
+      - sqs
+  - path: ChangeMsgVisibility/ChangeMsgVisibility_test.go
   - path: ConfigureLPQueue/ConfigureLPQueue.go
-    apis:
-      - service: sqs
-        operations:
-          - SetQueueAttributes
+    services:
+      - sqs
+  - path: ConfigureLPQueue/ConfigureLPQueue_test.go
   - path: CreateLPQueue/CreateLPQueue.go
-    apis:
-      - service: sqs
-        operations:          
-          - CreateQueue
+    services:
+      - sqs
+  - path: CreateLPQueue/CreateLPQueue_test.go
   - path: CreateQueue/CreateQueue.go
-    apis:
-      - service: sqs
-        operations:
-          - CreateQueue
+    services:
+      - sqs
+  - path: CreateQueue/CreateQueue_test.go
   - path: DeadLetterQueue/DeadLetterQueue.go
-    apis:
-      - service: sqs
-        operations:
-          - SetQueueAttributes
+    services:
+      - sqs
+  - path: DeadLetterQueue/DeadLetterQueue_test.go
   - path: DeleteMessage/DeleteMessage.go
-    apis:
-      - service: sqs
-        operations:
-          - DeleteMessage
+    services:
+      - sqs
+  - path: DeleteMessage/DeleteMessage_test.go
   - path: DeleteQueue/DeleteQueue.go
-    apis:
-      - service: sqs
-        operations:
-          - DeleteQueue
+    services:
+      - sqs
+  - path: DeleteQueue/DeleteQueue_test.go
   - path: GetQueueURL/GetQueueURL.go
-    apis:
-      - service: sqs
-        operations:
-          - GetQueueUrl
+    services:
+      - sqs
+  - path: GetQueueURL/GetQueueURL_test.go
   - path: ListQueues/ListQueues.go
-    apis:
-      - service: sqs
-        operations:
-          - ListQueues
+    services:
+      - sqs
+  - path: ListQueues/ListQueues_test.go
   - path: ReceiveLPMessage/ReceiveLPMessage.go
-    apis:
-      - service: sqs
-        operations:
-          - ReceiveMessage
+    services:
+      - sqs
+  - path: ReceiveLPMessage/ReceiveLPMessage_test.go
   - path: ReceiveMessage/ReceiveMessage.go
-    apis:
-      - service: sqs
-        operations:
-          - ReceiveMessage
+    services:
+      - sqs
+  - path: ReceiveMessage/ReceiveMessage_test.go
   - path: SendMessage/SendMessage.go
-    apis:
-      - service: sqs
-        operations:
-          - SendMessage
+    services:
+      - sqs
+  - path: SendMessage/SendMessage_test.go
   - path: SendReceiveLongPolling/SendReceiveLongPolling.go
-    apis:
-      - service: sqs
-        operations:
-          - SendMessage
+    services:
+      - sqs
+  - path: SendReceiveLongPolling/SendReceiveLongPolling_test.go

--- a/javav2/example_code/cloudwatch/metadata.yaml
+++ b/javav2/example_code/cloudwatch/metadata.yaml
@@ -1,78 +1,48 @@
 --- 
-created: 2020-02-25
-files: 
- - path: /src/main/java/com/example/cloudwatch/DeleteAlarm.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - DeleteAlarms
- - path: /src/main/java/com/example/cloudwatch/DeleteSubscriptionFilter.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - DeleteSubscriptionFilter        
- - path: /src/main/java/com/example/cloudwatch/DescribeAlarms.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - DescribeAlarms
- - path: /src/main/java/com/example/cloudwatch/DescribeSubscriptionFilters.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - DescribeSubscriptionFilters
- - path: /src/main/java/com/example/cloudwatch/DisableAlarmActions.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - DisableAlarmActions
- - path: /src/main/java/com/example/cloudwatch/EnableAlarmActions.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - EnableAlarmActions    
- - path: /src/main/java/com/example/cloudwatch/GetLogEvents.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - GetLogEvents   
- - path: /src/main/java/com/example/cloudwatch/ListMetrics.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - ListMetrics
- - path: /src/main/java/com/example/cloudwatch/PutEvents.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - PutEvents
- - path: /src/main/java/com/example/cloudwatch/PutLogEvents.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - PutLogEvents              
- - path: /src/main/java/com/example/cloudwatch/PutMetricAlarm.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - PutMetricAlarm   
- - path: /src/main/java/com/example/cloudwatch/PutMetricData.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - PutMetricData  
- - path: /src/main/java/com/example/cloudwatch/PutRule.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - PutRule 
- - path: /src/main/java/com/example/cloudwatch/PutSubscriptionFilter.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - PutSubscriptionFilter           
- - path: /src/main/java/com/example/cloudwatch/PutTargets.java
-   apis: 
-      - service: cloudwatch
-        operations: 
-        - PutTargets
+files:
+ - path: src/main/java/com/example/cloudwatch/DeleteAlarm.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/DeleteSubscriptionFilter.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/DescribeAlarms.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/DescribeSubscriptionFilters.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/DisableAlarmActions.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/EnableAlarmActions.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/GetLogEvents.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/ListMetrics.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/PutEvents.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/PutLogEvents.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/PutMetricAlarm.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/PutMetricData.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/PutRule.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/PutSubscriptionFilter.java
+   services:
+     - cloudwatch
+ - path: src/main/java/com/example/cloudwatch/PutTargets.java
+   services:
+     - cloudwatch
+ - path: src/test/java/CloudWatchServiceIntegrationTest.java

--- a/javav2/example_code/dynamodb/metadata.yaml
+++ b/javav2/example_code/dynamodb/metadata.yaml
@@ -1,67 +1,39 @@
 --- 
-created: 2020-02-25
-files: 
- - path: /src/main/java/com/example/dynamodb/CreateTable.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - CreateTable
-        
- - path: /src/main/java/com/example/dynamodb/CreateTableCompositeKey.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - CreateTable
- - path: /src/main/java/com/example/dynamodb/DeleteItem.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - DeleteItem
- - path: /src/main/java/com/example/dynamodb/DeleteTable.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - DeleteTable 
- - path: /src/main/java/com/example/dynamodb/DynamoDBScanItems.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - Scan
-        
- - path: /src/main/java/com/example/dynamodb/GetItem.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - GetItem
- - path: /src/main/java/com/example/dynamodb/ListTables.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - ListTables
-      
- - path: /src/main/java/com/example/dynamodb/PutItem.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - PutItem
- - path: /src/main/java/com/example/dynamodb/Query.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - Query
-       
- - path: /src/main/java/com/example/dynamodb/SyncPagination.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - ListTables
- - path: /src/main/java/com/example/dynamodb/UpdateItem.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - UpdateItem   
- - path: /src/main/java/com/example/dynamodb/UpdateTable.java
-   apis: 
-      - service: dynamodb
-        operations: 
-        - UpdateTable  
+files:
+  - path: src/main/java/com/example/dynamodb/CreateTable.java
+    services:
+      - dynamodb
+  - path: src/main/java/com/example/dynamodb/CreateTableCompositeKey.java
+    services:
+      - dynamodb
+  - path: src/main/java/com/example/dynamodb/DeleteItem.java
+    services:
+      - dynamodb
+  - path: src/main/java/com/example/dynamodb/DeleteTable.java
+    services:
+      - dynamodb
+  - path: src/main/java/com/example/dynamodb/DynamoDBScanItems.java
+    services:
+      - dynamodb
+  - path: src/main/java/com/example/dynamodb/GetItem.java
+    services:
+      - dynamodb
+  - path: src/main/java/com/example/dynamodb/ListTables.java
+    services:
+      - dynamodb
+  - path: src/main/java/com/example/dynamodb/PutItem.java
+    services:
+      - dynamodb
+  - path: src/main/java/com/example/dynamodb/Query.java
+    services:
+      - dynamodb
+  - path: src/main/java/com/example/dynamodb/SyncPagination.java
+    services:
+      - dynamodb
+  - path: src/main/java/com/example/dynamodb/UpdateItem.java
+    services:
+      - dynamodb
+  - path: src/main/java/com/example/dynamodb/UpdateTable.java
+    services:
+      - dynamodb
+  - path: src/test/java/AWSDynamoServiceIntegrationTest.java

--- a/javav2/example_code/ec2/metadata.yaml
+++ b/javav2/example_code/ec2/metadata.yaml
@@ -1,102 +1,60 @@
 --- 
-created: 2020-02-25
-files: 
- - path: /src/main/java/com/example/ec2/AllocateAddress.java
-   apis: 
-      - service: ec2
-        operations: 
-        - AllocateAddress
-        - AssociateAddress
- - path: /src/main/java/com/example/ec2/CreateInstance.java
-   apis: 
-      - service: ec2
-        operations: 
-        - RunInstances
-        - CreateTags
- - path: /src/main/java/com/example/ec2/CreateKeyPair.java
-   apis: 
-      - service: ec2
-        operations: 
-        - CreateKeyPair
- - path: /src/main/java/com/example/ec2/CreateSecurityGroup.java
-   apis: 
-      - service: ec2
-        operations: 
-        - CreateSecurityGroup
- - path: /src/main/java/com/example/ec2/DeleteKeyPair.java
-   apis: 
-      - service: ec2
-        operations: 
-        - DeleteKeyPair
- - path: /src/main/java/com/example/ec2/DeleteSecurityGroup.java
-   apis: 
-      - service: ec2
-        operations: 
-        - DeleteSecurityGroup        
- - path: /src/main/java/com/example/ec2/DescribeAccount.java
-   apis: 
-      - service: ec2
-        operations: 
-        - DescribeAccountAttributes
- - path: /src/main/java/com/example/ec2/DescribeAddresses.java
-   apis: 
-      - service: ec2
-        operations: 
-        - DescribeAddresses
- - path: /src/main/java/com/example/ec2/DescribeInstances.java
-   apis: 
-      - service: ec2
-        operations: 
-        - DescribeInstances
- - path: /src/main/java/com/example/ec2/DescribeKeyPairs.java
-   apis: 
-      - service: ec2
-        operations: 
-        - DescribeKeyPairs
- - path: /src/main/java/com/example/ec2/DescribeRegionsAndZones.java
-   apis: 
-      - service: ec2
-        operations: 
-        - DescribeRegions
- - path: /src/main/java/com/example/ec2/DescribeReservedInstances.java
-   apis: 
-      - service: ec2
-        operations: 
-        - DescribeReservedInstances
- - path: /src/main/java/com/example/ec2/DescribeSecurityGroups.java
-   apis: 
-      - service: ec2
-        operations: 
-        - DescribeSecurityGroups
- - path: /src/main/java/com/example/ec2/DescribeVPCs.java
-   apis: 
-      - service: ec2
-        operations: 
-        - DescribeVpcs
- - path: /src/main/java/com/example/ec2/FindRunningInstances.java
-   apis: 
-      - service: ec2
-        operations: 
-        - FindRunningInstances
- - path: /src/main/java/com/example/ec2/MonitorInstance.java
-   apis: 
-      - service: ec2
-        operations: 
-        - MonitorInstances
-        - UnmonitorInstances
- - path: RebootInstance.java
-   apis: 
-      - service: ec2
-        operations: 
-        - RebootInstances
- - path: /src/main/java/com/example/ec2/ReleaseAddress.java
-   apis: 
-      - service: ec2
-        operations: 
-        - ReleaseAddress
- - path: /src/main/java/com/example/ec2/StartStopInstance.java
-   apis: 
-      - service: ec2
-        operations: 
-        - StartInstances
-        - StopInstances
+files:
+  - path: src/main/java/com/example/ec2/AllocateAddress.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/CreateInstance.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/CreateKeyPair.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/CreateSecurityGroup.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/DeleteKeyPair.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/DeleteSecurityGroup.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/DescribeAccount.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/DescribeAddresses.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/DescribeInstances.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/DescribeKeyPairs.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/DescribeRegionsAndZones.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/DescribeReservedInstances.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/DescribeSecurityGroups.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/DescribeVPCs.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/FindRunningInstances.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/MonitorInstance.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/RebootInstance.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/ReleaseAddress.java
+    services:
+      - ec2
+  - path: src/main/java/com/example/ec2/StartStopInstance.java
+    services:
+      - ec2
+  - path: src/test/java/AWSEC2ServiceIntegrationTest.java

--- a/javav2/example_code/iam/metadata.yaml
+++ b/javav2/example_code/iam/metadata.yaml
@@ -1,108 +1,63 @@
 --- 
-created: 2020-02-25
-files: 
- - path: /src/main/java/com/example/iam/AccessKeyLastUsed.java
-   apis: 
-      - service: iam
-        operations: 
-        - GetAccessKeyLastUsed
- - path: /src/main/java/com/example/iam/AttachRolePolicy.java
-   apis: 
-      - service: iam
-        operations: 
-        - ListAttachedRolePolicies 
- - path: /src/main/java/com/example/iam/CreateAccessKey.java
-   apis: 
-      - service: iam
-        operations: 
-        - CreateAccessKey        
- - path: /src/main/java/com/example/iam/CreateAccountAlias.java
-   apis: 
-      - service: iam
-        operations: 
-        - CreateAccountAlias 
- - path: /src/main/java/com/example/iam/CreatePolicy.java
-   apis: 
-      - service: iam
-        operations: 
-        - CreatePolicy    
- - path: /src/main/java/com/example/iam/CreateUser.java
-   apis: 
-      - service: iam
-        operations: 
-        - CreateUser         
- - path: /src/main/java/com/example/iam/DeleteAccessKey.java
-   apis: 
-      - service: iam
-        operations: 
-        - DeleteAccessKey 
- - path: /src/main/java/com/example/iam/DeleteAccountAlias.java
-   apis: 
-      - service: iam
-        operations: 
-        - DeleteAccountAlias    
- - path: /src/main/java/com/example/iam/DeletePolicy.java
-   apis: 
-      - service: iam
-        operations: 
-        - DeletePolicy   
- - path: /src/main/java/com/example/iam/DeleteServerCertificate.java
-   apis: 
-      - service: iam
-        operations: 
-        - DeleteServerCertificate     
- - path: /src/main/java/com/example/iam/DeleteServerCertificate.java
-   apis: 
-      - service: iam
-        operations: 
-        - DeleteServerCertificate   
- - path: /src/main/java/com/example/iam/DeleteUser.java
-   apis: 
-      - service: iam
-        operations: 
-        - DeleteUser   
- - path: /src/main/java/com/example/iam/DetachRolePolicy.java
-   apis: 
-      - service: iam
-        operations: 
-        - DetachRolePolicy  
- - path: /src/main/java/com/example/iam/GetPolicy.java
-   apis: 
-      - service: iam
-        operations: 
-        - GetPolicy    
- - path: /src/main/java/com/example/iam/ListAccessKeys.java
-   apis: 
-      - service: iam
-        operations: 
-        - ListAccessKeys   
- - path: /src/main/java/com/example/iam/ListAccountAliases.java
-   apis: 
-      - service: iam
-        operations: 
-        - ListAccountAliases        
- - path: /src/main/java/com/example/iam/ListServerCertificates.java
-   apis: 
-      - service: iam
-        operations: 
-        - ListServerCertificates   
- - path: /src/main/java/com/example/iam/ListUsers.java
-   apis: 
-      - service: iam
-        operations: 
-        - ListUsers      
- - path: /src/main/java/com/example/iam/UpdateAccessKey.java
-   apis: 
-      - service: iam
-        operations: 
-        - UpdateAccessKey  
- - path: /src/main/java/com/example/iam/UpdateServerCertificate.java
-   apis: 
-      - service: iam
-        operations: 
-        - UpdateServerCertificate     
- - path: /src/main/java/com/example/iam/UpdateUser.java
-   apis: 
-      - service: iam
-        operations: 
-        - UpdateUser 
+files:
+  - path: src/main/java/com/example/iam/AccessKeyLastUsed.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/AttachRolePolicy.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/CreateAccessKey.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/CreateAccountAlias.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/CreatePolicy.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/CreateUser.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/DeleteAccessKey.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/DeleteAccountAlias.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/DeletePolicy.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/DeleteServerCertificate.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/DeleteUser.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/DetachRolePolicy.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/GetPolicy.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/ListAccessKeys.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/ListAccountAliases.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/ListServerCertificates.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/ListUsers.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/UpdateAccessKey.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/UpdateServerCertificate.java
+    services:
+      - iam
+  - path: src/main/java/com/example/iam/UpdateUser.java
+    services:
+      - iam
+  - path: src/test/java/IAMServiceIntegrationTest.java

--- a/javav2/example_code/s3/metadata.yaml
+++ b/javav2/example_code/s3/metadata.yaml
@@ -1,95 +1,57 @@
 --- 
-created: 2020-02-26
-files: 
- - path: /src/main/java/com/example/s3/CopyObject.java
-   apis: 
-      - service: s3
-        operations: 
-        - CopyObject
- - path: /src/main/java/com/example/s3/DeleteBucketPolicy.java
-   apis: 
-      - service: s3
-        operations: 
-        - DeleteBucketPolicy
- - path: /src/main/java/com/example/s3/DeleteObjects.java
-   apis: 
-      - service: s3
-        operations: 
-        - DeleteObjects   
- - path: /src/main/java/com/example/s3/DeleteWebsiteConfiguration.java
-   apis: 
-      - service: s3
-        operations: 
-        - DeleteBucketWebsite 
- - path: /src/main/java/com/example/s3/GeneratePresignedUrlAndUploadObject.java
-   apis: 
-      - service: s3
-        operations: 
-        - PresignPutObject
- - path: /src/main/java/com/example/s3/GetAcl.java
-   apis: 
-      - service: s3
-        operations: 
-        - GetObjectAcl
- - path: /src/main/java/com/example/s3/GetBucketPolicy.java
-   apis: 
-      - service: s3
-        operations: 
-        - GetBucketPolicy
- - path: /src/main/java/com/example/s3/GetObjectPresignedUrl.java
-   apis: 
-      - service: s3
-        operations: 
-        - PresignGetObject
- - path: /src/main/java/com/example/s3/GetObjectTags.java
-   apis: 
-      - service: s3
-        operations: 
-        - GetObjectTagging
- - path: /src/main/java/com/example/s3/ListObjects.java
-   apis: 
-      - service: s3
-        operations: 
-        - ListObjects
- - path: /src/main/java/com/example/s3/S3AsyncOps.java
-   apis: 
-      - service: s3
-        operations: 
-        - PutObject
- - path: /src/main/java/com/example/s3/S3BucketDeletion.java
-   apis: 
-      - service: s3
-        operations: 
-        - DeleteBucket
- - path: /src/main/java/com/example/s3/S3AsyncStreamOps.java
-   apis: 
-      - service: s3
-        operations: 
-        - GetObject        
- - path: /src/main/java/com/example/s3/S3BucketOps.java
-   apis: 
-      - service: s3
-        operations: 
-        - CreateBucket
- - path: /src/main/java/com/example/s3/S3ObjectOperations.java
-   apis: 
-      - service: s3
-        operations: 
-        - DeleteObject
-        - CompleteMultipartUpload
-        - UploadPart
- - path: /src/main/java/com/example/s3/SetAcl.java
-   apis: 
-      - service: s3
-        operations: 
-        - PutBucketAcl
- - path: /src/main/java/com/example/s3/SetBucketPolicy.java
-   apis: 
-      - service: s3
-        operations: 
-        - PutBucketPolicy
- - path: /src/main/java/com/example/s3/SetWebsiteConfiguration.java
-   apis: 
-      - service: s3
-        operations: 
-        - PutBucketWebsite
+files:
+  - path: src/main/java/com/example/s3/CopyObject.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/DeleteBucketPolicy.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/DeleteObjects.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/DeleteWebsiteConfiguration.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/GeneratePresignedUrlAndUploadObject.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/GetAcl.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/GetBucketPolicy.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/GetObjectPresignedUrl.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/GetObjectTags.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/ListObjects.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/S3AsyncOps.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/S3BucketDeletion.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/S3AsyncStreamOps.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/S3BucketOps.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/S3ObjectOperations.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/SetAcl.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/SetBucketPolicy.java
+    services:
+      - s3
+  - path: src/main/java/com/example/s3/SetWebsiteConfiguration.java
+    services:
+      - s3
+  - path: src/test/AmazonS3ServiceIntegrationTest.java

--- a/javav2/example_code/sns/metadata.yaml
+++ b/javav2/example_code/sns/metadata.yaml
@@ -1,103 +1,57 @@
 --- 
-created: 2020-02-25
-files: 
- - path: /src/main/java/com/example/sns/CheckOptOut.java
-   apis: 
-      - service: sns
-        operations: 
-        - CheckIfPhoneNumberIsOptedOut
-       
- - path: /src/main/java/com/example/sns/ConfirmSubscription.java
-   apis: 
-      - service: sns
-        operations: 
-        - ConfirmSubscription
- - path: /src/main/java/com/example/sns/CreateTopic.java
-   apis: 
-      - service: sns
-        operations: 
-        - CreateTopic
-       
- - path: /src/main/java/com/example/sns/DeleteTopic.java
-   apis: 
-      - service: sns
-        operations: 
-        - DeleteTopic
- - path: /src/main/java/com/example/sns/GetSMSAtrributes.java
-   apis: 
-      - service: sns
-        operations: 
-        - GetSubscriptionAttributes
-        
- - path: /src/main/java/com/example/sns/GetTopicAttributes.java
-   apis: 
-      - service: sns
-        operations: 
-        - GetTopicAttributes
- - path: /src/main/java/com/example/sns/ListOptOut.java
-   apis: 
-      - service: sns
-        operations: 
-        - ListPhoneNumbersOptedOut
-        
- - path: /src/main/java/com/example/sns/ListSubscriptions.java
-   apis: 
-      - service: sns
-        operations: 
-        - ListSubscriptions
-            
- - path: /src/main/java/com/example/sns/ListTopics.java
-   apis: 
-      - service: sns
-        operations: 
-        - ListTopics
-            
- - path: /src/main/java/com/example/sns/PublishTextSMS.java
-   apis: 
-      - service: sns
-        operations: 
-        - Publish
-            
- - path: /src/main/java/com/example/sns/PublishTopic.java
-   apis: 
-      - service: sns
-        operations: 
-        - Publish
-      
- - path: /src/main/java/com/example/sns/SetSMSAttributes.java
-   apis: 
-      - service: sns
-        operations: 
-        - SetSMSAttributes
-        
- - path: /src/main/java/com/example/sns/SetTopicAttributes.java
-   apis: 
-      - service: sns
-        operations: 
-        - SetTopicAttributes
- - path: /src/main/java/com/example/sns/SubscribeEmail.java
-   apis: 
-      - service: sns
-        operations: 
-        - Subscribe
-       
- - path: /src/main/java/com/example/sns/SubscribeHTTPS.java
-   apis: 
-      - service: sns
-        operations: 
-        - Subscribe
- - path: /src/main/java/com/example/sns/SubscribeLambda.java
-   apis: 
-      - service: sns
-        operations: 
-        - Subscribe      
- - path: /src/main/java/com/example/sns/SubscribeTextSMS.java
-   apis: 
-      - service: sns
-        operations: 
-        - Subscribe  
- - path: /src/main/java/com/example/sns/Unsubscribe.java
-   apis: 
-      - service: sns
-        operations: 
-        - Unsubscribe  
+files:
+  - path: src/main/java/com/example/sns/CheckOptOut.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/ConfirmSubscription.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/CreateTopic.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/DeleteTopic.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/GetSMSAtrributes.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/GetTopicAttributes.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/ListOptOut.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/ListSubscriptions.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/ListTopics.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/PublishTextSMS.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/PublishTopic.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/SetSMSAttributes.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/SetTopicAttributes.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/SubscribeEmail.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/SubscribeHTTPS.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/SubscribeLambda.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/SubscribeTextSMS.java
+    services:
+      - sns
+  - path: src/main/java/com/example/sns/Unsubscribe.java
+    services:
+      - sns
+  - path: src/main/test/java/AWSSNSServiceIntegrationTest.java

--- a/javav2/example_code/sqs/metadata.yaml
+++ b/javav2/example_code/sqs/metadata.yaml
@@ -1,30 +1,18 @@
 --- 
-created: 2020-02-25
-files: 
- - path: /src/main/java/com/example/sqs/DeadLetterQueues.java
-   apis: 
-      - service: sqs
-        operations: 
-        - SetQueueAttributes
- - path: /src/main/java/com/example/sqs/LongPolling.java
-   apis: 
-      - service: sqs
-        operations: 
-        - CreateQueue
-        - GetQueueUrl
- - path: /src/main/java/com/example/sqs/SQSExample.java
-   apis: 
-      - service: sqs
-        operations: 
-        - ListQueues
-        - SendMessage
- - path: /src/main/java/com/example/sqs/SendReceiveMessages.java
-   apis: 
-      - service: sqs
-        operations: 
-        - ReceiveMessage
- - path: /src/main/java/com/example/sqs/VisibilityTimeout.java
-   apis: 
-      - service: sqs
-        operations: 
-        - ChangeMessageVisibility
+files:
+  - path: src/main/java/com/example/sqs/DeadLetterQueues.java
+    services:
+      - sqs
+  - path: src/main/java/com/example/sqs/LongPolling.java
+    services:
+      - sqs
+  - path: src/main/java/com/example/sqs/SQSExample.java
+    services:
+      - sqs
+  - path: src/main/java/com/example/sqs/SendReceiveMessages.java
+    services:
+      - sqs
+  - path: src/main/java/com/example/sqs/VisibilityTimeout.java
+    services:
+      - sqs
+  - path: src/test/java/SQSServiceIntegrationTest.java

--- a/python/example_code/sqs/metadata.yaml
+++ b/python/example_code/sqs/metadata.yaml
@@ -1,28 +1,13 @@
 ---
-description: Learn how to create, get, and delete queues.
-created: 2020-03-13
+# Learn how to create, get, and delete queues and send, receive, and delete messages.
 files:
   - path: queue_wrapper.py
-    apis:
-      - service: sqs
-        operations:
-          - create_queue
-          - get_queue_by_name
-          - queues.all
-          - queues.filter
-          - queue.delete
-...
----
-description: Learn how to send, receive, and delete messages from a queue.
-created: 2020-03-13
-files:
+    services:
+      - sqs
   - path: message_wrapper.py
-    apis:
-      - service: sqs
-        operations:
-          - queue.send_message
-          - queue.send_messages
-          - queue.receive_messages
-          - queue.delete_messages
-          - message.delete
+    services:
+      - sqs
+  - path: test/conftest.py
+  - path: test/test_message_wrapper.py
+  - path: test/test_queue_wrapper.py
 ...

--- a/ruby/example_code/cloudtrail/metadata.yaml
+++ b/ruby/example_code/cloudtrail/metadata.yaml
@@ -1,46 +1,30 @@
 ---
-description: Creates a trail in AWS CloudTrail.
-created: 2020-02-24
+# Creates a trail in AWS CloudTrail.
 files:
   - path: aws-ruby-sdk-cloudtrail-example-create-trail.rb
-    apis:
-      - service: cloudtrail
-        operations:
-          - CreateTrail
-      - service: s3api
-        operations: 
-          - PutBucketPolicy
-      - service: sts
-        operations: 
-          - GetCallerIdentity
+    services:
+    - cloudtrail
+    - s3api
+    - sts
 ...
 ---
-description: Deletes a trail in AWS CloudTrail.
-created: 2020-02-24
+# Deletes a trail in AWS CloudTrail.
 files:
   - path: aws-ruby-sdk-cloudtrail-example-delete-trail.rb
-    apis:
-      - service: cloudtrail
-        operations:
-          - DeleteTrail
+    services:
+      - cloudtrail
 ...
 ---
-description: Lists trails in AWS CloudTrail.
-created: 2020-02-24
+# Lists trails in AWS CloudTrail.
 files:
   - path: aws-ruby-sdk-cloudtrail-example-describe-trails.rb
-    apis:
-      - service: cloudtrail
-        operations:
-          - DescribeTrails
+    services:
+      - cloudtrail
 ...
 ---
-description: Lists events in AWS CloudTrail.
-created: 2020-02-24
+# Lists events in AWS CloudTrail.
 files:
   - path: aws-ruby-sdk-cloudtrail-example-lookup-events.rb
-    apis:
-      - service: cloudtrail
-        operations:
-          - LookupEvents
+    services:
+      - cloudtrail
 ...

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,45 @@ specific language governing permissions and limitations under the License.
 The scripts contained in this module are primarily for internal use by the AWS
 Code Examples team.
 
+## Cleanup report
+
+#### Purpose
+
+Reads cleanup metadata and writes a report of files cleaned up vs. files still
+needing cleanup. A cleaned file contains code that has been brought up to coding
+standard, has been tested, and has at least minimal comments. To include a file
+in the cleaned report, list it in a metadata.yaml file somewhere in the repo.
+
+#### Prerequisites
+
+To run this script, you must have the following installed globally or in a virtual
+environment:
+ 
+* Python 3.6 or later
+* PyYaml 5.3 or later
+* PyTest 5.3.5 or later (to run unit tests)
+
+#### Running the script
+
+The typical usage of this script is to determine the cleanup coverage in this
+GitHub repository. To generate a CSV-formatted report of cleanup coverage, in a command
+window at the root folder of the repository, run the following.
+
+```
+python -m scripts.cleanup_report
+``` 
+
+You can also run the script against a subfolder and output the report to a custom
+location, which can be useful for testing new metadata files.
+
+    python -m scripts.cleanup_report --root python/example_code/sqs --report ~/temp/sqs_rep.csv
+
+#### Running the tests
+
+To run the unit tests associated with this script, in a command window at the 
+`scripts\tests` folder of the repository, run `python -m pytest test_cleanup_report.py`.
+
+
 ## API Report
 
 #### Purpose
@@ -35,15 +74,15 @@ environment:
 
 The typical usage of this script is to determine the API coverage contained in this
 GitHub repository. To generate a CSV-formatted report of API coverage, in a command
-window at the root folder of the repository, run the following:
+window at the root folder of the repository, run the following.
 
 ```
-python -m scripts.api_report --root . --report report.csv
+python -m scripts.api_report
 ``` 
 
 This script can also be used to verify an individual metadata file. To verify a
 single file and write a report to the command window output, in a command window at
-the root folder of the repository, run the following:
+the root folder of the repository, run the following.
 
 ```
 python -m scripts.api_report --verify aws-cli\bash-linux\s3\metadata.yaml
@@ -52,4 +91,4 @@ python -m scripts.api_report --verify aws-cli\bash-linux\s3\metadata.yaml
 #### Running the tests
 
 To run the unit tests associated with this script, in a command window at the 
-`scripts\tests` folder of the repository, run `pytest`.
+`scripts\tests` folder of the repository, run `python -m pytest test_api_report.py`.

--- a/scripts/cleanup_report.py
+++ b/scripts/cleanup_report.py
@@ -1,0 +1,229 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""
+Reads cleanup metadata and writes a report of files cleaned up vs. files still
+needing cleanup. A cleaned file contains code that has been brought up to coding
+standard, has been tested, and has at least minimal comments. To include a file
+in the cleaned report, list it in a metadata.yaml file somewhere in the repo.
+
+How to run a report
+    To run a full report over the entire repo, in the base folder of your repo,
+    run the following command.
+
+        python -m scripts.cleanup_report
+
+    This scans the full repository for files named 'metadata.yaml', digests them
+    into a list of cleaned files that are compared against existing code files,
+    and write a report to a file named 'report.csv' in the same folder.
+
+    You can also run the script against a subfolder and output the report to a custom
+    location, which can be useful for testing new metadata files.
+
+        python -m scripts.cleanup_report --root python/example_code/sqs --report ~/temp/sqs_rep.csv
+"""
+
+import argparse
+import os
+import sys
+from urllib.parse import urljoin
+import urllib.request as request
+import yaml
+from yaml.scanner import ScannerError
+
+METADATA_FILENAME = 'metadata.yaml'
+GITHUB_URL = 'https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/'
+
+# A file must have one of these extensions to be counted in file total.
+EXT_LOOKUP = {
+    'c': 'C',
+    'cpp': 'C++',
+    'cs': 'C#',
+    'go': 'Go',
+    'html': 'JavaScript',
+    'java': 'Java',
+    'js': 'JavaScript',
+    'php': 'PHP',
+    'py': 'Python',
+    'rb': 'Ruby',
+    'ts': 'TypeScript',
+    'sh': 'AWS-CLI',
+    'cmd': 'AWS-CLI'
+}
+
+IGNORE_FOLDERS = {
+    'venv',
+    'scripts',
+    '__pycache__',
+    '.pytest_cache'
+}
+
+
+def make_github_url(folder_name, file_name):
+    """
+    Concatenate the GitHub base URL, a relative path to a folder, and a file name
+    to form a full URL to the file.
+
+    :param folder_name: The relative path to the folder that contains the file.
+    :param file_name: The name of the file.
+    :return: The full URL to the file on GitHub.
+    """
+    folder_url = request.pathname2url(folder_name)
+    base_url = urljoin(GITHUB_URL, folder_url) + '/'
+    file_url = request.pathname2url(file_name)
+    file_url = urljoin(base_url, file_url)
+    return file_url
+
+
+def gather_data(examples_folder):
+    """
+    Scan a folder and its subfolders for metadata files and read them into a
+    list of example dictionaries. Also collect all files that have one of the
+    specified code extensions.
+
+    :param examples_folder: The root folder where the scan is started.
+    :return: A tuple of examples and file names.
+    """
+    if not os.path.isdir(examples_folder):
+        raise FileNotFoundError(f"{examples_folder} is not a directory.")
+
+    examples = []
+    files = []
+    for folder_name, dirs, file_list in os.walk(examples_folder, topdown=True):
+        dirs[:] = [d for d in dirs if d not in IGNORE_FOLDERS]
+
+        for file_name in file_list:
+            ext = os.path.splitext(file_name)[1].lstrip('.')
+            if ext.lower() in EXT_LOOKUP:
+                file_url = make_github_url(folder_name, file_name)
+                files.append(file_url)
+            elif file_name.lower() == METADATA_FILENAME:
+                file_path = os.path.join(folder_name, file_name)
+                print(f"Found metadata: {file_path}.")
+                read_metadata(file_path, examples)
+    return examples, files
+
+
+def read_metadata(file_path, examples):
+    """
+    Read the specified metadata file and append its contents into the specified list
+    of dictionaries.
+
+    :param file_path: That path to a metadata file that contains example metadata
+                      in yaml format.
+    :param examples: A list of example dictionaries. Examples read from the metadata
+                     are appended to this list.
+    """
+    with open(file_path, 'r') as meta_stream:
+        try:
+            meta_docs = yaml.safe_load_all(meta_stream)
+            for example_meta in meta_docs:
+                example_meta['metadata_path'] = file_path
+                examples.append(example_meta)
+        except ScannerError as err:
+            print(f"Yaml parser error in {file_path}, skipping.")
+            print(err)
+
+
+def write_report(examples, repo_files, report_path=None):
+    """
+    Writes a report of files cleaned versus files awaiting cleanup.
+    Files that are listed in metadata but do not exist in the repo are output
+    as missing files.
+    Files that are listed more than once in any metadata are output as duplicates.
+    The report includes the full list of example metadata in CSV format.
+
+    :param examples: A list of example dictionaries.
+    :param repo_files:
+    :param report_path: The output file to write the report. If this file exists,
+                        it is overwritten. If no file is specified, the report
+                        is written to sys.stdout.
+    """
+    lines = ["File,Language,Service"]
+    clean_files = []
+    missing_files = []
+    bad_examples = []
+    repo_files_lookup = {rf.lower() for rf in repo_files}
+
+    for example in examples:
+        try:
+            for file in example['files']:
+                metadata_folder = os.path.split(example['metadata_path'])[0]
+                file_url = make_github_url(metadata_folder, file['path'])
+                if file_url.lower() in repo_files_lookup:
+                    if file_url not in clean_files:
+                        clean_files.append(file_url)
+                        ext = os.path.splitext(file_url)[1].lstrip('.')
+                        language = EXT_LOOKUP[ext]
+                        for service in file.get('services', ['']):
+                            lines.append(
+                                ','.join([file_url, language, service]))
+                    else:
+                        print(f"File '{file_url}' reported a second time in "
+                              f"{example['metadata_path']}.")
+                else:
+                    missing_files.append(file_url)
+                    print(
+                        f"File '{file_url}' reported in metadata "
+                        f"does not exist in the repo.")
+        except KeyError as error:
+            print(f"ERROR: example missing a required {error} key: {example}.")
+            bad_examples.append(example)
+
+    report = open(report_path, 'w') if report_path else sys.stdout
+    try:
+        clean_count = len(clean_files)
+        total_count = len(repo_files)
+        report.write(f"Total number of examples: "
+                     f"{len(examples) - len(bad_examples)}.\n")
+        report.write(f"Total number of cleaned files: {clean_count}.\n")
+        report.write(f"Total number of files: {total_count}.\n")
+        if total_count > 0:
+            report.write(f"Percent clean: "
+                         f"{clean_count/total_count:.0%}.")
+        if len(lines) > 1:
+            report.write("\n")
+            report.write('\n'.join(lines))
+    finally:
+        if report is not sys.stdout:
+            report.close()
+            print(f"Report written to {report_path}.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Reads API metadata and writes a report of API coverage. To"
+                    "scan a folder tree and write to a file, specify root and report. "
+                    "To verify a single file and write to the console, specify verify.")
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="The folder to start the search for metadata files. Defaults to the"
+             "current folder."
+    )
+    parser.add_argument(
+        "--report",
+        default="report.csv",
+        help="The file path to write the report. Defaults to 'report.csv'."
+    )
+    args = parser.parse_args()
+
+    try:
+        examples, files = gather_data(args.root)
+        write_report(examples, files, args.report)
+    except KeyError as error:
+        print(error)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tests/test_cleanup_report.py
+++ b/scripts/tests/test_cleanup_report.py
@@ -1,0 +1,387 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""
+Tests the cleanup_report module.
+
+Test metadata Yaml files are stored in the test_cleanup_report_yamls subfolder.
+"""
+
+import os
+from unittest.mock import patch, mock_open, call
+
+# pylint: disable=redefined-outer-name
+import pytest
+
+import cleanup_report
+
+
+def mock_walk(file_list):
+    def _mock_walk(examples_folder, topdown=True):
+        """Mock the os.walk function to return the specified files."""
+        folder_list = []
+        return [("", folder_list, file_list)]
+    return _mock_walk
+
+
+def verify_example_data(example):
+    """Verifies basic correctness of example data."""
+    assert len(example['files']) >= 1
+    file = example['files'][0]
+    assert isinstance(file['path'], str)
+    name, ext = os.path.splitext(file['path'])
+    assert name
+    assert ext.lstrip('.') in cleanup_report.EXT_LOOKUP
+    assert 'services' not in file or len(file['services']) >= 1
+    service = file['services'][0]
+    assert isinstance(service, str)
+
+
+@pytest.mark.parametrize("file_list", [
+    ["metadata.yaml"],
+    ["metadata.yaml", "start_the_things.py", "something_random.py"],
+    ["metadata.yaml", "start_the_things.py", "data/send_the_things.py",
+     "test/test_the_things.py"],
+    ["metadata.yaml", "something.py", "something.cs", "something.js", "something.java"],
+    ["metadata.yaml", "something.ts", "something.xml", "something.sln", "something.txt"]
+])
+def test_gather_data_complex(monkeypatch, file_list):
+    """Reads complex metadata and verifies the output."""
+    def mock_join(folder_name, file_name):
+        return "test_cleanup_report_yamls/complex_metadata.yaml"
+
+    monkeypatch.setattr(os, "walk", mock_walk(file_list))
+    monkeypatch.setattr(os.path, "join", mock_join)
+
+    examples, files = cleanup_report.gather_data("test_cleanup_report_yamls")
+    assert len(examples) == 1
+    verify_example_data(examples[0])
+    assert len(files) == len([
+        f for f in file_list
+        if os.path.splitext(f)[1].lstrip('.') in cleanup_report.EXT_LOOKUP
+    ])
+
+
+def test_gather_data_multi_file(monkeypatch):
+    """Reads metadata that contains multiple documents in one Yaml file."""
+    def mock_join(folder_name, file_name):
+        return "test_cleanup_report_yamls/multi_file_metadata.yaml"
+
+    monkeypatch.setattr(os, "walk", mock_walk(["metadata.yaml"]))
+    monkeypatch.setattr(os.path, "join", mock_join)
+
+    examples = cleanup_report.gather_data("test_cleanup_report_yamls")[0]
+    assert len(examples) == 3
+    for example in examples:
+        verify_example_data(example)
+
+
+def test_gather_data_bad_yaml(monkeypatch):
+    """Reads a file that contains incorrect Yaml and verifies that it rejects the
+    file but does not raise an exception."""
+    def mock_join(folder_name, file_name):
+        return "test_cleanup_report_yamls/bad_metadata.yaml"
+
+    monkeypatch.setattr(os, "walk", mock_walk(["metadata.yaml"]))
+    monkeypatch.setattr(os.path, "join", mock_join)
+
+    examples = cleanup_report.gather_data("test_cleanup_report_yamls")[0]
+    assert len(examples) == 0
+
+
+def test_gather_data_capitalization(monkeypatch):
+    """Tests that capitalization does not break reading a metadata.yaml file."""
+    def mock_walk_caps(examples_folder, topdown):
+        folder_list = []
+        file_list = ["METAdata.yaml"]
+        return [("", folder_list, file_list)]
+
+    def mock_join(folder_name, file_name):
+        return "test_cleanup_report_yamls/complex_metadata.yaml"
+
+    monkeypatch.setattr(os, "walk", mock_walk_caps)
+    monkeypatch.setattr(os.path, "join", mock_join)
+
+    examples = cleanup_report.gather_data("test_cleanup_report_yamls")[0]
+    assert len(examples) == 1
+
+
+def test_gather_data_no_metadata(monkeypatch):
+    """Tests that a file list with no metadata.yaml in it does not fail."""
+    def mock_walk_no_meta(examples_folder, topdown):
+        folder_list = []
+        file_list = ["something_else.yaml", "actual_file.py"]
+        return [("", folder_list, file_list)]
+
+    monkeypatch.setattr(os, "walk", mock_walk_no_meta)
+
+    examples, files = cleanup_report.gather_data("test_cleanup_report_yamls")
+    assert len(examples) == 0
+    assert len(files) == 1
+
+
+@pytest.fixture
+def mock_opened_file():
+    """Mocks opening a file in a context manager."""
+    with patch('builtins.open', mock_open()) as mock_file:
+        yield mock_file
+
+
+def make_expected_calls(example_count, clean_file_count, total_file_count, lines):
+    """Make a list of calls expected to be made by the report function."""
+    return [
+        call(f"Total number of examples: {example_count}.\n"),
+        call(f"Total number of cleaned files: {clean_file_count}.\n"),
+        call(f"Total number of files: {total_file_count}.\n"),
+        call(f"Percent clean: {clean_file_count/total_file_count:.0%}."),
+        call("\n"),
+        call(
+            "File,Language,Service\n" + "\n".join(lines))
+    ]
+
+
+def test_write_empty_report(mock_opened_file):
+    """Tests that writing an empty report does not cause failure."""
+    cleanup_report.write_report([], [], 'test.csv')
+    mock_opened_file.assert_called_with('test.csv', 'w')
+    handle = mock_opened_file()
+    handle.write.assert_called()
+
+
+def test_write_single_report(mock_opened_file):
+    """Tests writing a report of a single file."""
+    path = 'test_path.py'
+    service = 'testsvc'
+    cleanup_report.write_report([{
+        'metadata_path': 'metadata.yaml',
+        'files': [{
+            'path': path,
+            'services': [service]
+        }]
+    }], [cleanup_report.make_github_url('', path)], 'test.csv')
+    handle = mock_opened_file()
+    calls = make_expected_calls(
+        1, 1, 1,
+        [','.join([cleanup_report.GITHUB_URL + path, 'Python', service])]
+    )
+    handle.write.assert_has_calls(calls)
+
+
+def test_write_report_missing_file(mock_opened_file):
+    """Tests writing a report where a file is listed in the metadata but does
+    not exist in the repo."""
+    handle = mock_opened_file()
+    cleanup_report.write_report([{
+        'metadata_path': 'metadata.yaml',
+        'files': [
+            {'path': 'example_path1.py', 'services': ['example_svc']},
+            {'path': 'example_path2.py', 'services': ['example_svc']},
+            {'path': 'example_path3.py', 'services': ['example_svc']}
+        ]
+    }], [
+        cleanup_report.make_github_url('', 'example_path1.py'),
+        cleanup_report.make_github_url('', 'example_path3.py')
+    ], 'test.csv')
+    calls = make_expected_calls(
+        1, 2, 2, [
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path1.py'), 'Python', 'example_svc']),
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path3.py'), 'Python', 'example_svc'])
+        ]
+    )
+    handle.write.assert_has_calls(calls)
+
+
+def test_write_report_unclean_files(mock_opened_file):
+    """Tests writing a report when files exist in the repo that have not been
+    cleaned."""
+    handle = mock_opened_file()
+    cleanup_report.write_report([{
+        'metadata_path': 'metadata.yaml',
+        'files': [
+            {'path': 'example_path1.py', 'services': ['example_svc']},
+        ]
+    }], [
+        cleanup_report.make_github_url('', 'example_path1.py'),
+        cleanup_report.make_github_url('', 'example_path2.py'),
+        cleanup_report.make_github_url('', 'example_path3.py')
+    ], 'test.csv')
+    calls = make_expected_calls(
+        1, 1, 3, [
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path1.py'), 'Python', 'example_svc'])
+        ]
+    )
+    handle.write.assert_has_calls(calls)
+
+
+def test_write_report_dup_files(mock_opened_file):
+    """Tests writing a report when a file is listed twice in the metadata."""
+    handle = mock_opened_file()
+    cleanup_report.write_report([{
+        'metadata_path': 'metadata.yaml',
+        'files': [
+            {'path': 'example_path1.py', 'services': ['example_svc']},
+            {'path': 'example_path1.py', 'services': ['example_svc']},
+        ]
+    }], [
+        cleanup_report.make_github_url('', 'example_path1.py'),
+    ], 'test.csv')
+    calls = make_expected_calls(
+        1, 1, 1, [
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path1.py'), 'Python', 'example_svc'])
+        ]
+    )
+    handle.write.assert_has_calls(calls)
+
+
+def test_write_multi_report(mock_opened_file):
+    """Tests writing a report for a list of examples."""
+    examples = []
+    files = []
+    lines = []
+    for count in range(1, 5):
+        path = f'test_path_{count}.cpp'
+        service = f'testsvc{count}'
+        examples.append({
+            'metadata_path': 'metadata.yaml',
+            'files': [{
+                'path': path,
+                'services': [service]
+            }]
+        })
+        lines.append(','.join([cleanup_report.GITHUB_URL + path,
+                               'C++', service]))
+        files.append(cleanup_report.make_github_url('', path))
+
+    cleanup_report.write_report(examples, files, 'test.csv')
+    handle = mock_opened_file()
+    calls = make_expected_calls(len(lines), len(lines), len(lines), lines)
+    handle.write.assert_has_calls(calls)
+
+
+def test_write_report_missing_key(mock_opened_file):
+    """Tests that writing a report for an example with a missing key skips the
+    example but does not otherwise fail."""
+    path = 'test_path.py'
+    service = 'testsvc'
+
+    cleanup_report.write_report([{
+        'metadata_path': 'metadata.yaml',
+        'wrong_key': [{
+            'path': path,
+            'services': [service]
+        }]
+    }, {
+        'metadata_path': 'metadata.yaml',
+        'files': [{
+            'path': path,
+            'services': [service]
+        }]
+
+    }], [cleanup_report.make_github_url('', path)], 'test.csv')
+    calls = make_expected_calls(
+        1, 1, 1,
+        [','.join([cleanup_report.make_github_url('', path), 'Python', service])]
+    )
+    handle = mock_opened_file()
+    handle.write.assert_has_calls(calls)
+
+
+@pytest.mark.parametrize(
+    "examples,repo_files,lines", [
+        ([{
+            'metadata_path': 'metadata.yaml',
+            'files': [{
+                'path': 'example_path.py',
+                'services': ['test_svc']
+            }]
+        }], [
+            cleanup_report.make_github_url('', 'example_path.py')
+        ], [
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path.py'), 'Python', 'test_svc'])
+        ]), ([{
+            'metadata_path': 'metadata.yaml',
+            'files': [{
+                'path': 'example_path.py',
+                'services': ['test_svc1', 'test_svc2', 'test_svc3']
+            }]
+        }], [
+            cleanup_report.make_github_url('', 'example_path.py')
+        ], [
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path.py'), 'Python', 'test_svc1']),
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path.py'), 'Python', 'test_svc2']),
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path.py'), 'Python', 'test_svc3'])
+        ]), ([{
+            'metadata_path': 'metadata.yaml',
+            'files': [{
+                'path': 'example_path.py',
+                'services': ['test_svc']
+            }],
+        }, {
+            'metadata_path': 'metadata.yaml',
+            'files': [{
+                'path': 'example_path.cpp',
+                'services': ['test_svc']
+            }]
+        }], [
+            cleanup_report.make_github_url('', 'example_path.py'),
+            cleanup_report.make_github_url('', 'example_path.cpp'),
+        ], [
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path.py'), 'Python', 'test_svc']),
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path.cpp'), 'C++', 'test_svc'])
+        ]), ([{
+            'metadata_path': 'metadata.yaml',
+            'files': [{
+                'path': 'example_path_1.py',
+                'services': ['test_svc']
+            }, {
+                'path': 'example_path_2.py',
+                'services': ['test_svc']
+            }, {
+                'path': 'supporting_path_1.py'
+            }, {
+                'path': 'test_path_1.py'
+            }],
+        }], [
+             cleanup_report.make_github_url('', 'example_path_1.py'),
+             cleanup_report.make_github_url('', 'example_path_2.py'),
+             cleanup_report.make_github_url('', 'supporting_path_1.py'),
+             cleanup_report.make_github_url('', 'test_path_1.py')
+        ], [
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path_1.py'), 'Python', 'test_svc']),
+            ','.join([cleanup_report.make_github_url(
+                '', 'example_path_2.py'), 'Python', 'test_svc']),
+            ','.join([cleanup_report.make_github_url(
+                '', 'supporting_path_1.py'), 'Python', '']),
+            ','.join([cleanup_report.make_github_url(
+                '', 'test_path_1.py'), 'Python', ''])
+        ]),
+    ]
+)
+def test_count_files(mock_opened_file, examples, repo_files, lines):
+    """Tests several scenarios to verify that files are counted correctly and
+    reports are written as expected."""
+    cleanup_report.write_report(examples, repo_files, 'test.csv')
+    calls = make_expected_calls(len(examples), len(repo_files), len(repo_files), lines)
+    handle = mock_opened_file()
+    handle.write.assert_has_calls(calls)

--- a/scripts/tests/test_cleanup_report_yamls/bad_metadata.yaml
+++ b/scripts/tests/test_cleanup_report_yamls/bad_metadata.yaml
@@ -1,0 +1,16 @@
+---
+# Metadata for multiple examples separated as yaml documents.
+files:
+  - path: something.py
+this is wrong yaml, should raise
+          - what's this?
+...
+---
+files:
+  - path: fix_the_bucket.py
+    services:
+      - s3
+  - path: kick_the_bucket.py
+    services:
+      - s3
+...

--- a/scripts/tests/test_cleanup_report_yamls/complex_metadata.yaml
+++ b/scripts/tests/test_cleanup_report_yamls/complex_metadata.yaml
@@ -1,0 +1,30 @@
+---
+# Metadata for a complex example that uses several services and files.
+files:
+  - path: start_the_things.py
+    services:
+      - s3
+      - sqs
+  - service: rds
+  - path: middle_the_things.py
+    services:
+      - sqs
+      - lambda
+  - path: cleanup_the_things.py
+    services:
+      - s3
+      - sqs
+      - rds
+  - path: data/send_the_things.py
+    services:
+      - s3
+      - sqs
+      - rds
+  - path: data/receive_the_things.py
+    services:
+      - s3
+      - sqs
+      - rds
+  - path: test/test_the_things.py
+  - path: test/test_some_other_things.py
+...

--- a/scripts/tests/test_cleanup_report_yamls/missing_key_metadata.yaml
+++ b/scripts/tests/test_cleanup_report_yamls/missing_key_metadata.yaml
@@ -1,0 +1,6 @@
+---
+bad_key:
+  - path: create_bucket.py
+    services:
+      - s3
+...

--- a/scripts/tests/test_cleanup_report_yamls/multi_file_metadata.yaml
+++ b/scripts/tests/test_cleanup_report_yamls/multi_file_metadata.yaml
@@ -1,0 +1,27 @@
+---
+# Metadata for multiple examples separated as yaml documents.
+files:
+  - path: create_bucket.py
+    services:
+      - s3
+...
+---
+files:
+  - path: fix_the_bucket.py
+    services:
+      - s3
+  - path: kick_the_bucket.py
+    services:
+      - s3
+  - path: support_the_bucket.py
+...
+---
+files:
+  - path: fix_the_bucket.py
+    services:
+      - s3
+  - path: kick_the_bucket.py
+    services:
+      - s3
+  - path: test_the_bucket.py
+...


### PR DESCRIPTION
The cleanup report script counts files listed in metadata files as cleaned and compares
the count of cleaned files with the total existing code files in the repo. From this data,
the script generates a report of percentage clean and writes the metadata file in CSV format
so it can be further analyzed.

This commit also includes updated versions of all existing metadata.yaml files to the new format.

- [x] The submitter has added unit tests for all code paths, run all of them, and they all pass.

- [x] The submitter has run a linter on the code, and all of the submitter's team's minimum rules pass.

- [x] The submitter has added the team's minimum usage documentation to the code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
