### PR TITLE
dotnet: adding metadata.yaml file for dotnet examples

### DIFF
--- a/dotnet/metadata.yaml
+++ b/dotnet/metadata.yaml
@@ -1,0 +1,19 @@
+# High-value example
+# files:
+#  - path: <file path relative to this metadata.yaml>
+#    services:
+#      - s3
+#      - sqs
+#  - path: <file 2>
+#    services:
+#      - dynamodb
+#
+#
+# Code cleanup example
+# files:
+#  - path: <file path 1 relative to this metadata.yaml>
+#    services:
+#      - s3
+#  - path: <file path 2 relative to this metadata.yaml>
+#    services:
+#      - s3

--- a/dotnet/metadata.yaml
+++ b/dotnet/metadata.yaml
@@ -1,4 +1,9 @@
-# High-value example
+# Be sure to list any .cs supporting files that don't contain service calls
+#   (such as test files) with just the path and no services block.
+# Otherwise, they'll be picked up as not yet cleaned.
+#
+# ---
+# High-value example 1
 # files:
 #  - path: <file path relative to this metadata.yaml>
 #    services:
@@ -8,7 +13,20 @@
 #    services:
 #      - dynamodb
 #
+# ...
+# ---
+# High-value example 2
+# files:
+#  - path: <file path relative to this metadata.yaml>
+#    services:
+#      - s3
+#      - sqs
+#  - path: <file 2>
+#    services:
+#      - dynamodb
 #
+# ...
+# ---
 # Code cleanup example
 # files:
 #  - path: <file path 1 relative to this metadata.yaml>
@@ -17,3 +35,4 @@
 #  - path: <file path 2 relative to this metadata.yaml>
 #    services:
 #      - s3
+# ...


### PR DESCRIPTION
Description of changes: I've added the metadata.yaml file for tracking .NET code example work.  No other code or file changes.

Laren, since you are the keeper of the metadata, can you review the metadata file that I added?  Currently it's all commented out as a place holder for the future.  If it looks good to you, please merge as on call.  Thank you!

Checklist:  All items are n/a.
- [n/a] The submitter has added unit tests for all code paths, run all of them, and they all pass.
- [n/a] The submitter has run a linter on the code, and all of the submitter's team's minimum rules pass.
- [n/a] The submitter has added the team's minimum usage documentation to the code.
- [n/a] The submitter has had the code reviewed, and the submitter has incorporated any and all resulting review comments.
- [n/a] The submitter has had their Editor edit all comments and strings, and the submitter has incorporated any and all resulting edits.
- [n/a] The submitter has added all of the submitter's team's related API reporting metadata.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
