### PR TITLE
Added check for duplicate snippet tags.

### DIFF
--- a/scripts/checkin_tests.py
+++ b/scripts/checkin_tests.py
@@ -181,15 +181,19 @@ def verify_snippet_start_end(file_contents, file_location):
     snippet_tags = set()
     for word in file_contents.split():
         if snippet_start in word:
-            word = word.split('[')[1]
-            snippet_tags.add(word)
-        elif snippet_end in word:
-            word = word.split('[')[1]
-            if word in snippet_tags:
-                snippet_tags.remove(word)
+            tag = word.split('[')[1]
+            if tag in snippet_tags:
+                logger.error(f"Duplicate tag {tag[:-1]} found in {file_location}.")
+                error_count += 1
             else:
-                logger.error(f"End tag {word[:-1]} with no matching start tag found "
-                             f"in {file_location}.")
+                snippet_tags.add(tag)
+        elif snippet_end in word:
+            tag = word.split('[')[1]
+            if tag in snippet_tags:
+                snippet_tags.remove(tag)
+            else:
+                logger.error(f"End tag {tag[:-1]} with no matching start tag "
+                             f"found in {file_location}.")
                 error_count += 1
 
     for tag in snippet_tags:

--- a/scripts/tests/test_checkin_tests.py
+++ b/scripts/tests/test_checkin_tests.py
@@ -66,6 +66,14 @@ def test_verify_no_secret_keys(file_contents, expected_error_count):
     ("snippet" + "-start:[this.is.a.snippet.tag]\n"
      "This is not code.\n"
      "snippet" + "-end:[this.is.a.snippet.tag.with.extra.stuff]\n", 2),
+    ("snippet" + "-start:[this.is.a.snippet.tag]\n"
+     "snippet" + "-start:[this.is.a.snippet.tag]\n"
+     "This is not code.\n"
+     "snippet" + "-end:[this.is.a.snippet.tag]\n", 1),
+    ("snippet" + "-start:[this.is.a.snippet.tag]\n"
+      "This is not code.\n"
+      "snippet" + "-end:[this.is.a.snippet.tag]\n"
+      "snippet" + "-end:[this.is.a.snippet.tag]\n", 1),
 ])
 def test_verify_snippet_start_end(file_contents, expected_error_count):
     """Test that various kinds of mismatched snippet-start and -end tags are


### PR DESCRIPTION
Added a check to checkin_tests.py to find and report duplicate snippet-start and snippet-end tags.

Also added unit tests to verify these two cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
