### PR TITLE
Removed 'main' from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,4 @@ __pycache__
 venv
 composer.*
 vendor/
-main
 main.zip


### PR DESCRIPTION
At some point, a 'main' entry was added to .gitignore, which caused certain changes in folders named 'main' to be ignored, specifically in new java projects. I've removed it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
