### PR TITLE
Revert "Update Test"

### DIFF
--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/AllocateAddress.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/AllocateAddress.java
@@ -80,8 +80,7 @@ public class AllocateAddress {
             return associateResponse.associationId();
 
          } catch (Ec2Exception e) {
-            System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+           e.getStackTrace();
         }
        return "";
         // snippet-end:[ec2.java2.allocate_address.main]

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/CreateInstance.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/CreateInstance.java
@@ -92,8 +92,7 @@ public class CreateInstance {
           return instanceId;
 
         } catch (Ec2Exception e) {
-            System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+            System.err.println(e.getMessage());
         }
         // snippet-end:[ec2.java2.create_instance.main]
         return "";

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/CreateKeyPair.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/CreateKeyPair.java
@@ -68,8 +68,7 @@ public class CreateKeyPair {
                 keyName);
 
         } catch (Ec2Exception e) {
-             System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+        e.getStackTrace();
         }
         // snippet-end:[ec2.java2.create_key_pair.main]
       }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/CreateSecurityGroup.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/CreateSecurityGroup.java
@@ -30,18 +30,17 @@ import software.amazon.awssdk.services.ec2.model.AuthorizeSecurityGroupIngressRe
 import software.amazon.awssdk.services.ec2.model.AuthorizeSecurityGroupIngressResponse;
 import software.amazon.awssdk.services.ec2.model.Ec2Exception;
 import software.amazon.awssdk.services.ec2.model.IpPermission;
-import software.amazon.awssdk.services.ec2.model.CreateSecurityGroupResponse;
 import software.amazon.awssdk.services.ec2.model.IpRange;
 // snippet-end:[ec2.java2.create_security_group.import]
 
 /**
- * Creates an EC2 security group.
+ * Creates an Amazon EC2 security group
  */
 public class CreateSecurityGroup {
 
     public static void main(String[] args) {
         final String USAGE =
-                "To run this example, supply a group name, group description and vpc id\n" +
+                "To run this example, supply a group name, group description, and VPC ID.\n" +
                         "Ex: CreateSecurityGroup <group-name> <group-description> <vpc-id>\n";
 
         if (args.length != 3) {
@@ -53,20 +52,17 @@ public class CreateSecurityGroup {
         String groupDesc = args[1];
         String vpcId = args[2];
 
-        //Create an Ec2Client object
+        // Create an Ec2Client object
         Region region = Region.US_WEST_2;
         Ec2Client ec2 = Ec2Client.builder()
                 .region(region)
                 .build();
 
-        String id = createEC2SecurityGroup(ec2, groupName, groupDesc, vpcId);
-        System.out.printf(
-                "Successfully created security group with this ID %s",
-                id);
+        createEC2SecurityGroup(ec2, groupName, groupDesc, vpcId);
     }
 
     // snippet-start:[ec2.java2.create_security_group.main]
-    public static String createEC2SecurityGroup( Ec2Client ec2,String groupName, String groupDesc, String vpcId) {
+    public static void createEC2SecurityGroup( Ec2Client ec2,String groupName, String groupDesc, String vpcId) {
         try {
 
             CreateSecurityGroupRequest createRequest = CreateSecurityGroupRequest.builder()
@@ -75,7 +71,11 @@ public class CreateSecurityGroup {
                 .vpcId(vpcId)
                 .build();
 
-            CreateSecurityGroupResponse resp= ec2.createSecurityGroup(createRequest);
+            ec2.createSecurityGroup(createRequest);
+
+            System.out.printf(
+                "Successfully created security group named %s",
+                groupName);
 
             IpRange ipRange = IpRange.builder()
                 .cidrIp("0.0.0.0/0").build();
@@ -108,13 +108,8 @@ public class CreateSecurityGroup {
                 "Successfully added ingress policy to security group %s",
                 groupName);
 
-            return resp.groupId();
-
         } catch (Ec2Exception e) {
-            System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+            e.getStackTrace();
         }
-        return "";
     }
 }
-

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/DeleteKeyPair.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/DeleteKeyPair.java
@@ -73,8 +73,7 @@ public class DeleteKeyPair {
                 "Successfully deleted key pair named %s", keyName);
 
         } catch (Ec2Exception e) {
-             System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+            e.getStackTrace();
         }
     }
 }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/DeleteSecurityGroup.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/DeleteSecurityGroup.java
@@ -68,8 +68,7 @@ public class DeleteSecurityGroup {
                 "Successfully deleted security group with ID %s", groupId);
 
         } catch (Ec2Exception e) {
-             System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+            e.getStackTrace();
         }
         // snippet-end:[ec2.java2.delete_security_group.main]
     }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeAccount.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeAccount.java
@@ -71,8 +71,7 @@ public class DescribeAccount {
             System.out.print("Done");
 
         } catch (Ec2Exception e) {
-            System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+            e.getStackTrace();
         }
         // snippet-end:[ec2.java2.describe_account.main]
     }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeInstances.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeInstances.java
@@ -81,8 +81,7 @@ public class DescribeInstances {
             } while (nextToken != null);
 
         } catch (Ec2Exception e) {
-             System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+            e.getStackTrace();
         }
         // snippet-end:[ec2.java2.describe_instances.main]
     }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeKeyPairs.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeKeyPairs.java
@@ -61,8 +61,7 @@ public class DescribeKeyPairs {
              System.out.println("");
             }
         } catch (Ec2Exception e) {
-            System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+            e.getStackTrace();
          }
         // snippet-end:[ec2.java2.describe_key_pairs.main]
     }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeRegionsAndZones.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeRegionsAndZones.java
@@ -77,8 +77,7 @@ public class DescribeRegionsAndZones {
             }
 
         } catch (Ec2Exception e) {
-             System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+            e.getStackTrace();
         }
         // snippet-end:[ec2.java2.describe_region_and_zones.main]
     }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeReservedInstances.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeReservedInstances.java
@@ -77,8 +77,7 @@ public class DescribeReservedInstances {
         }
 
         } catch (Ec2Exception e) {
-             System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+            e.getStackTrace();
     }
       // snippet-end:[ec2.java2.describe_reserved_instances.main]
   }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeSecurityGroups.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeSecurityGroups.java
@@ -80,8 +80,7 @@ public class DescribeSecurityGroups {
                     group.description());
             }
         } catch (Ec2Exception e) {
-             System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+            e.getStackTrace();
         }
          // snippet-end:[ec2.java2.describe_security_groups.main]
     }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeVPCs.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/DescribeVPCs.java
@@ -77,8 +77,7 @@ public class DescribeVPCs {
                     vpc.instanceTenancyAsString());
                 }
             } catch (Ec2Exception e) {
-                System.err.println(e.awsErrorDetails().errorMessage());
-                System.exit(1);
+                e.getStackTrace();
         }
         // snippet-end:[ec2.java2.describe_vpc.main]
     }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/FindRunningInstances.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/FindRunningInstances.java
@@ -92,8 +92,7 @@ public class FindRunningInstances {
             } while (nextToken != null);
 
         } catch (Ec2Exception e) {
-            System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+            e.getStackTrace();
         }
         // snippet-end:[ec2.java2.running_instances.main]
     }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/RebootInstance.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/RebootInstance.java
@@ -65,10 +65,10 @@ public class RebootInstance {
             ec2.rebootInstances(request);
             System.out.printf(
                 "Successfully rebooted instance %s", instanceId);
-    } catch (Ec2Exception e) {
-        System.err.println(e.awsErrorDetails().errorMessage());
-        System.exit(1);
-    }
- }
+    } catch (
+    Ec2Exception e) {
+        e.getStackTrace();
+      }
+  }
     // snippet-end:[ec2.java2.reboot_instance.main]
 }

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/ReleaseAddress.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/ReleaseAddress.java
@@ -64,9 +64,9 @@ public class ReleaseAddress {
 
          System.out.printf(
                 "Successfully released Elastic IP address %s", allocId);
-        } catch (Ec2Exception e) {
-            System.err.println(e.awsErrorDetails().errorMessage());
-            System.exit(1);
+        } catch (
+                Ec2Exception e) {
+            e.getStackTrace();
         }
      }
     // snippet-end:[ec2.java2.release_instance.main]

--- a/javav2/example_code/ec2/src/main/java/com/example/ec2/TerminateInstance.java
+++ b/javav2/example_code/ec2/src/main/java/com/example/ec2/TerminateInstance.java
@@ -72,8 +72,7 @@ public class TerminateInstance {
                     System.out.println("The ID of the terminated instance is "+sc.instanceId());
                 }
             } catch (Ec2Exception e) {
-                 System.err.println(e.awsErrorDetails().errorMessage());
-                 System.exit(1);
+                e.getStackTrace();
             }
          }
     // snippet-end:[ec2.java2.terminate_instance]

--- a/javav2/example_code/ec2/src/test/java/AWSEC2ServiceIntegrationTest.java
+++ b/javav2/example_code/ec2/src/test/java/AWSEC2ServiceIntegrationTest.java
@@ -21,7 +21,6 @@ public class AWSEC2ServiceIntegrationTest {
     private static String keyName="";
     private static String groupName="";
     private static String groupDesc="";
-    private static String groupId="";
     private static String vpcId="";
 
     @BeforeAll
@@ -67,8 +66,13 @@ public class AWSEC2ServiceIntegrationTest {
     @Order(2)
     public void CreateInstance() {
 
-        instanceId = CreateInstance.createEC2Instance(ec2,instanceName,ami);
-        assertTrue(!instanceId.isEmpty());
+        try {
+            instanceId = CreateInstance.createEC2Instance(ec2,instanceName,ami);
+            assertTrue(!instanceId.isEmpty());
+            } catch (Ec2Exception e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
         System.out.println("\n Test 2 passed");
     }
 
@@ -76,7 +80,12 @@ public class AWSEC2ServiceIntegrationTest {
     @Order(3)
     public void CreateKeyPair()
     {
-        CreateKeyPair.createEC2KeyPair(ec2, keyName);
+       try {
+           CreateKeyPair.createEC2KeyPair(ec2, keyName);
+    } catch (Ec2Exception e) {
+        System.err.println(e.awsErrorDetails().errorMessage());
+        System.exit(1);
+    }
         System.out.println("\n Test 3 passed");
     }
 
@@ -84,32 +93,53 @@ public class AWSEC2ServiceIntegrationTest {
     @Order(4)
     public void DescribeKeyPair() {
 
-      DescribeKeyPairs.describeEC2Keys(ec2);
-      System.out.println("\n Test 4 passed");
+     try {
+         DescribeKeyPairs.describeEC2Keys(ec2);
+     } catch (Ec2Exception e) {
+         System.err.println(e.awsErrorDetails().errorMessage());
+         System.exit(1);
+     }
+        System.out.println("\n Test 4 passed");
     }
 
     @Test
     @Order(5)
     public void DeleteKeyPair() {
 
-         DeleteKeyPair.deleteKeys(ec2,keyName);
-         System.out.println("\n Test 5 passed");
+        try {
+            DeleteKeyPair.deleteKeys(ec2,keyName);
+        } catch (Ec2Exception e) {
+            System.err.println(e.awsErrorDetails().errorMessage());
+            System.exit(1);
+        }
+       System.out.println("\n Test 5 passed");
     }
 
     @Test
     @Order(6)
     public void CreateSecurityGroup() {
 
-        groupId = CreateSecurityGroup.createEC2SecurityGroup(ec2,groupName,groupDesc,vpcId);
-       System.out.println("\n Test 6 passed");
+      try {
+          CreateSecurityGroup.createEC2SecurityGroup(ec2,groupName,groupDesc,vpcId);
+      } catch (Ec2Exception e) {
+          System.err.println(e.awsErrorDetails().errorMessage());
+          System.exit(1);
+      }
+
+      System.out.println("\n Test 6 passed");
    }
 
     @Test
     @Order(7)
     public void DescribeSecurityGroup() {
 
-       DescribeSecurityGroups.describeEC2SecurityGroups(ec2,groupId);
-       System.out.println("\n Test 7 passed");
+      try {
+          DescribeSecurityGroups.describeEC2SecurityGroups(ec2,groupName);
+      } catch (Ec2Exception e) {
+          System.err.println(e.awsErrorDetails().errorMessage());
+          System.exit(1);
+      }
+        System.out.println("\n Test 7 passed");
     }
 
 
@@ -117,8 +147,14 @@ public class AWSEC2ServiceIntegrationTest {
     @Order(8)
     public void DeleteSecurityGroup(){
 
-      DeleteSecurityGroup.deleteEC2SecGroup(ec2, groupId);
-      System.out.println("\n Test 8 passed");
+      try {
+          DeleteSecurityGroup.deleteEC2SecGroup(ec2, groupName);
+
+      } catch (Ec2Exception e) {
+          System.err.println(e.awsErrorDetails().errorMessage());
+          System.exit(1);
+      }
+        System.out.println("\n Test 8 passed");
     }
 
 
@@ -126,15 +162,26 @@ public class AWSEC2ServiceIntegrationTest {
     @Order(9)
     public void DescribeAccount() {
 
-     DescribeAccount.describeEC2Account(ec2);
-     System.out.println("\n Test 9 passed");
+      try{
+          DescribeAccount.describeEC2Account(ec2);
+
+      } catch (Ec2Exception e) {
+          System.err.println(e.awsErrorDetails().errorMessage());
+          System.exit(1);
+      }
+        System.out.println("\n Test 9 passed");
     }
 
     @Test
     @Order(10)
     public void DescribeInstances() {
 
-       DescribeInstances.describeEC2Instances(ec2);
+       try {
+           DescribeInstances.describeEC2Instances(ec2);
+       } catch (Ec2Exception e) {
+           System.err.println(e.awsErrorDetails().errorMessage());
+           System.exit(1);
+       }
        System.out.println("\n Test 10 passed");
     }
 
@@ -142,30 +189,52 @@ public class AWSEC2ServiceIntegrationTest {
     @Order(11)
     public void DescribeRegionsAndZones () {
 
-      DescribeRegionsAndZones.describeEC2RegionsAndZones(ec2);
-      System.out.println("\n Test 11 passed");
+      try {
+          DescribeRegionsAndZones.describeEC2RegionsAndZones(ec2);
+
+      } catch (Ec2Exception e) {
+          System.err.println(e.awsErrorDetails().errorMessage());
+          System.exit(1);
+      }
+        System.out.println("\n Test 11 passed");
     }
 
     @Test
     @Order(12)
     public void DescribeVPCs () {
 
-      DescribeVPCs.describeEC2Vpcs(ec2,vpcId);
-      System.out.println("\n Test 12 passed");
+      try {
+          DescribeVPCs.describeEC2Vpcs(ec2,vpcId);
+      } catch (Ec2Exception e) {
+          System.err.println(e.awsErrorDetails().errorMessage());
+          System.exit(1);
+      }
+        System.out.println("\n Test 12 passed");
     }
 
     @Test
     @Order(13)
    public void FindRunningInstances() {
-       FindRunningInstances.findRunningEC2Instances(ec2);
-       System.out.println("\n Test 13 passed");
+      try {
+          FindRunningInstances.findRunningEC2Instances(ec2);
+
+      } catch (Ec2Exception e) {
+          System.err.println(e.awsErrorDetails().errorMessage());
+          System.exit(1);
+      }
+        System.out.println("\n Test 13 passed");
     }
 
     @Test
     @Order(14)
     public void DescribeAddressed() {
 
-       DescribeAddresses.describeEC2Address(ec2);
+        try{
+            DescribeAddresses.describeEC2Address(ec2);
+        } catch (Ec2Exception e) {
+        System.err.println(e.awsErrorDetails().errorMessage());
+        System.exit(1);
+    }
         System.out.println("\n Test 14 passed");
     }
 
@@ -173,7 +242,12 @@ public class AWSEC2ServiceIntegrationTest {
     @Order(15)
    public void  TerminateInstance() {
 
-       TerminateInstance.terminateEC2(ec2, instanceId);
-       System.out.println("\n Test 15 passed");
+       try {
+           TerminateInstance.terminateEC2(ec2, instanceId);
+       } catch (Ec2Exception e) {
+           System.err.println(e.awsErrorDetails().errorMessage());
+           System.exit(1);
+       }
+        System.out.println("\n Test 15 passed");
     }
 }


### PR DESCRIPTION
Reverts awsdocs/aws-doc-sdk-examples#1124

Removal of snippet tag ec2.java2.create_security_group.client broke the doc build. Reverting this PR so I can also revert PR 1119, which is when the tag was removed.