### PR TITLE
Fixed variable name mismatch

### DIFF
--- a/javascript/example_code/sqs/sqs_sendmessage.js
+++ b/javascript/example_code/sqs/sqs_sendmessage.js
@@ -52,7 +52,7 @@ var params = {
   },
   MessageBody: "Information about current NY Times fiction bestseller for week of 12/11/2016.",
   // MessageDeduplicationId: "TheWhistler",  // Required for FIFO queues
-  // MessageId: "Group1",  // Required for FIFO queues
+  // MessageGroupId: "Group1",  // Required for FIFO queues
   QueueUrl: "SQS_QUEUE_URL"
 };
 


### PR DESCRIPTION
*Description of changes:*
Variable's name in commented line was wrong in the params object according to the official documentation. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
