### PR TITLE
Amazon S3 version-enabled buckets

### DIFF
--- a/python/example_code/s3/metadata.yaml
+++ b/python/example_code/s3/metadata.yaml
@@ -13,9 +13,6 @@ files:
   - path: s3_basics/test/conftest.py
     services:
       - s3
-  - path: s3_basics/test/s3_stub_funcs.py
-    services:
-      - s3
   - path: s3_basics/test/test_bucket_wrapper.py
     services:
       - s3
@@ -39,6 +36,49 @@ files:
     services:
       - s3
   - path: file_transfer/test/test_file_transfer.py
+    services:
+      - s3
+...
+---
+# Amazon S3 versioning demo
+files:
+  - path: s3_versioning/batch_versioning.py
+    services:
+      - iam
+      - s3
+      - s3control
+      - sts
+      - lambda
+  - path: s3_versioning/remove_delete_marker.py
+    services:
+      - s3
+      - lambda
+  - path: s3_versioning/revise_stanza.py
+    services:
+      - s3
+      - lambda
+  - path: s3_versioning/versioning.py
+    services:
+      - s3
+  - path: s3_versioning/test/conftest.py
+    services:
+      - s3
+  - path: s3_versioning/test/test_batch_versioning.py
+    services:
+      - iam
+      - s3
+      - s3control
+      - sts
+      - lambda
+  - path: s3_versioning/test/test_remove_delete_marker.py
+    services:
+      - s3
+      - lambda
+  - path: s3_versioning/test/test_revise_stanza.py
+    services:
+      - s3
+      - lambda
+  - path: s3_versioning/test/test_versioning.py
     services:
       - s3
 ...

--- a/python/example_code/s3/s3_versioning/README.md
+++ b/python/example_code/s3/s3_versioning/README.md
@@ -1,0 +1,122 @@
+# Amazon S3 versioning examples
+
+## Purpose
+
+Demonstrates how to set up an Amazon S3 bucket for versioning, and how to perform
+tasks on a version-enabled bucket.
+
+Demonstrates how to manipulate Amazon S3 versioned objects in batches by creating jobs
+that call Lambda functions to perform processing.
+
+## Prerequisites
+
+- You must have an AWS account, and have your default credentials and AWS Region
+  configured as described in the [AWS Tools and SDKs Shared Configuration and
+  Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
+- Python 3.8.0 or later
+- Boto 3 1.13.2 or later
+- PyTest 5.3.5 or later (to run unit tests)
+
+## Running the code
+
+This module contains two usage demonstrations. 
+
+#### Single-object demo
+
+The `usage_demo_single_object` function in `versioning.py` demonstrates basic requests 
+to manipulate a versioned object. The script performs the following actions.
+
+1. Creates a version-enabled bucket and uploads a stanza from the poem *You Are Old,
+Father William* by Lewis Carroll.
+1. Applies a series of revisions to the stanza object.
+1. Gets and prints the latest version of the stanza.
+1. Gets the full series of versions of the stanza.
+1. Rolls back two revisions and prints the result.
+1. Deletes the stanza.
+1. Revives the stanza.
+1. Permanently deletes all versions of the stanza.
+1. Deletes the bucket.
+
+Run the following command to see the single-object demo.
+
+```
+python -m versioning
+``` 
+
+#### Batch operation demo
+
+The `batch_versioning.py` file contains setup, usage, and teardown functions that 
+demonstrate how to use Lambda functions to perform batch operations on versioned
+objects. The scripts perform the following actions.
+
+`setup_demo`
+1. Creates an AWS IAM role and attached policy that has the permissions needed by
+the Lambda functions used in this demo.
+1. Creates Lambda functions that perform revisions on objects and remove delete markers
+from versioned objects.
+1. Creates a version-enabled bucket and uploads the stanzas from the poem *You Are Old,
+Father William* by Lewis Carroll.
+
+`usage_demo_batch_operations`
+1. Creates a batch job that performs a series of random revisions on each stanza 
+object, using the `revise_stanza` Lambda function.
+1. Creates a batch job that revives any stanzas that were deleted during the revision
+step, using the `remove_delete_marker` Lambda function.
+1. Creates a mess of delete markers and other revisions in the bucket.
+1. Creates a batch job that removes all delete markers from the bucket, using the
+`remove_delete_marker` Lambda function.
+
+`teardown_demo`
+1. Deletes IAM role and policies created during setup.
+1. Deletes Lambda functions created during setup.
+1. Empties and deletes the bucket created during setup.
+
+`revise_stanza.py`
+
+This file contains code that is uploaded as a Lambda handler to perform revisions on
+objects during the demonstration.
+
+`remove_delete_marker.py`
+
+This file contains code that is uploaded as a Lambda handler to remove delete markers
+from versioned objects during the demonstration. 
+
+Run the following command to see the batch operation demo.
+
+```
+python -m batch_versioning
+``` 
+
+*Running this code might result in charges to your AWS account.*
+
+## Running the tests
+
+All tests use the botocore Stubber, which captures requests before they are sent to 
+AWS and returns a mocked response. Run the following in your 
+[GitHub root]/python/example_code/s3/s3_versioning folder.
+
+```
+python -m pytest -o log_cli=1 --log-cli-level=INFO
+```
+
+The `-o log_cli=1 --log-cli-level=INFO flags configure pytest to output
+logs to stdout during the test run. Without them, pytest captures logs and prints
+them only when the test fails.
+
+## Additional information
+
+- [Boto 3 Amazon S3 service reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html)
+- As an AWS best practice, grant this code least privilege, or only the 
+  permissions required to perform a task. For more information, see 
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege) 
+  in the *AWS Identity and Access Management 
+  User Guide*.
+- This code has not been tested in all AWS Regions. Some AWS services are 
+  available only in specific Regions. For more information, see the 
+  "AWS Regional Table" on the AWS website.
+- Running this code might result in charges to your AWS account.
+
+---
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0

--- a/python/example_code/s3/s3_versioning/README.md
+++ b/python/example_code/s3/s3_versioning/README.md
@@ -6,7 +6,7 @@ Demonstrates how to set up an Amazon S3 bucket for versioning, and how to perfor
 tasks on a version-enabled bucket.
 
 Demonstrates how to manipulate Amazon S3 versioned objects in batches by creating jobs
-that call Lambda functions to perform processing.
+that call AWS Lambda functions to perform processing.
 
 ## Prerequisites
 
@@ -19,7 +19,7 @@ that call Lambda functions to perform processing.
 
 ## Running the code
 
-This module contains two usage demonstrations. 
+This module contains two usage demonstrations: single object and batch object. 
 
 #### Single-object demo
 
@@ -50,8 +50,8 @@ demonstrate how to use Lambda functions to perform batch operations on versioned
 objects. The scripts perform the following actions.
 
 `setup_demo`
-1. Creates an AWS IAM role and attached policy that has the permissions needed by
-the Lambda functions used in this demo.
+1. Creates an AWS Access and Identity Management (IAM) role and attached policy that 
+has the permissions needed by the Lambda functions used in this demo.
 1. Creates Lambda functions that perform revisions on objects and remove delete markers
 from versioned objects.
 1. Creates a version-enabled bucket and uploads the stanzas from the poem *You Are Old,
@@ -62,12 +62,12 @@ Father William* by Lewis Carroll.
 object, using the `revise_stanza` Lambda function.
 1. Creates a batch job that revives any stanzas that were deleted during the revision
 step, using the `remove_delete_marker` Lambda function.
-1. Creates a mess of delete markers and other revisions in the bucket.
+1. Creates many delete markers and other revisions in the bucket.
 1. Creates a batch job that removes all delete markers from the bucket, using the
 `remove_delete_marker` Lambda function.
 
 `teardown_demo`
-1. Deletes IAM role and policies created during setup.
+1. Deletes the IAM role and policies created during setup.
 1. Deletes Lambda functions created during setup.
 1. Empties and deletes the bucket created during setup.
 

--- a/python/example_code/s3/s3_versioning/batch_versioning.py
+++ b/python/example_code/s3/s3_versioning/batch_versioning.py
@@ -1,0 +1,644 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Purpose
+
+Demonstrates how to manipulate Amazon S3 versioned objects in batches by creating jobs
+that call Lambda functions to perform processing. The demo has three phases: setup,
+processing, and teardown.
+
+For more detail, including usage and testing instructions, see the README.
+
+Running this demo uses your default AWS credentials to create resources in your
+account and my incur charges.
+"""
+
+import argparse
+from contextlib import contextmanager
+from io import BytesIO
+import json
+import logging
+import random
+from shutil import get_terminal_size
+from sys import stdout
+from time import sleep
+from urllib import parse
+import uuid
+from zipfile import ZipFile
+
+import boto3
+from botocore.exceptions import ClientError
+
+import versioning
+
+logger = logging.getLogger(__name__)
+log_handler = logging.StreamHandler(stdout)
+log_handler.setLevel(logging.INFO)
+logger.addHandler(log_handler)
+logger.setLevel(logging.INFO)
+
+iam = boto3.resource('iam')
+s3 = boto3.resource('s3')
+s3control = boto3.client('s3control')
+sts = boto3.client('sts')
+aws_lambda = boto3.client('lambda')
+
+
+@contextmanager
+def header():
+    """Prints a header wrapped in full-screen rules."""
+    width = get_terminal_size((80, 20))[0]
+    print('-'*width)
+    yield
+    print('-'*width)
+
+
+def custom_retry(callback, error_code, max_tries):
+    """
+    Retries the callback function with an exponential backoff algorithm until
+    the callback succeeds, raises a different error than the expected error,
+    or exceeds the maximum number of tries.
+
+    :param callback: The function to call.
+    :param error_code: The expected error. When this error is raised, the callback is
+                       retried. Otherwise, the error is raised.
+    :param max_tries: The maximum number of times to try the callback function.
+    :return: The response from the callback function when the callback function
+             succeeds. Otherwise, None.
+    """
+    sleepy_time = 1
+    tries = 1
+    response = None
+    while tries <= max_tries:
+        try:
+            response = callback()
+            logger.debug("Successfully ran on try %s.", tries)
+            break
+        except ClientError as error:
+            if error.response['Error']['Code'] == error_code:
+                logger.debug("Got retryable error %s.", error_code)
+                sleep(sleepy_time)
+                sleepy_time = min(sleepy_time*2, 32)
+                tries += 1
+                if tries == max_tries:
+                    logger.error("Call never succeeded after %s tries.", tries)
+                    raise
+            else:
+                raise
+    return response
+
+
+def create_iam_role(role_name):
+    """
+    Creates an AWS IAM role and attached policy that has the permissions needed by
+    the Lambda functions used in this demo.
+
+    :param role_name: The name of the role.
+    :return: The created role object.
+    """
+    policy_name = f'{role_name}-policy'
+
+    try:
+        # Defines the trust relationship that lets Lambda receive batch events.
+        lambda_and_s3_batch_assume_role_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Service": "lambda.amazonaws.com"
+                    },
+                    "Action": "sts:AssumeRole"
+                },
+                {
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Service": "batchoperations.s3.amazonaws.com"
+                    },
+                    "Action": "sts:AssumeRole"
+                }
+            ]
+        }
+
+        role = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(lambda_and_s3_batch_assume_role_policy)
+        )
+        iam.meta.client.get_waiter('role_exists').wait(RoleName=role_name)
+        logger.info("Created role %s.", role.name)
+    except ClientError:
+        logger.exception("Couldn't create role %s.", role_name)
+        raise
+
+    try:
+        # The s3:ListBucket action is needed or Lambda functions receive AccessDenied
+        # instead of NoSuchKey when they call s3.Object.get() on objects
+        # that have been deleted.
+        s3_and_invoke_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "AwsVersionDemoPolicy",
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:PutObject",
+                        "s3:GetObject",
+                        "s3:DeleteObjectVersion",
+                        "s3:ListBucketVersions",
+                        "s3:ListBucket",
+                        "s3:DeleteObject",
+                        "s3:GetObjectVersion",
+                        "lambda:InvokeFunction"
+                    ],
+                    "Resource": "*"
+                }
+            ]
+        }
+
+        policy = iam.create_policy(
+            PolicyName=policy_name,
+            PolicyDocument=json.dumps(s3_and_invoke_policy)
+        )
+        iam.meta.client.get_waiter('policy_exists').wait(PolicyArn=policy.arn)
+        logger.info("Created policy %s with arn %s.", policy_name, policy.arn)
+
+        role.attach_policy(PolicyArn=policy.arn)
+        sleep(1)
+        logger.info("Attached policy %s to role %s.", policy_name, role.name)
+    except ClientError:
+        logger.exception("Couldn't create or attach policy %s.", policy_name)
+        raise
+
+    return role
+
+
+def create_lambda_function(iam_role, function_name, function_file_name, handler,
+                           description):
+    """
+    Creates a Lambda function.
+
+    :param iam_role: The AWS IAM role associated with the function.
+    :param function_name: The name of the function.
+    :param function_file_name: The local file name that contains the function code.
+    :param handler: The fully-qualified name of the handler function.
+    :param description: A friendly description of the function's purpose.
+    :return: The ARN of the created function.
+    """
+    buffer = BytesIO()
+    with ZipFile(buffer, 'w') as zipped:
+        zipped.write(function_file_name)
+    buffer.seek(0)
+    zip_contents = buffer.read()
+
+    try:
+        print(f"Creating Lambda function {function_name}...")
+        response = custom_retry(
+            lambda: aws_lambda.create_function(
+                FunctionName=function_name,
+                Runtime='python3.8',
+                Role=iam_role.arn,
+                Handler=handler,
+                Code={
+                    'ZipFile': zip_contents,
+                },
+                Description=description,
+                Publish=True
+            ), 'InvalidParameterValueException', 5)
+        function_arn = response['FunctionArn']
+        logger.info("Created function '%s' with ARN: '%s'.",
+                    function_name, response['FunctionArn'])
+    except ClientError:
+        logger.exception("Couldn't create function %s.", function_name)
+        raise
+
+    return function_arn
+
+
+def create_and_fill_bucket(file_name, bucket_name, obj_prefix):
+    """
+    Creates a version-enabled bucket and fills it with initial stanza objects.
+
+    :param file_name: The file that contains the poem to upload.
+    :param bucket_name: The name of the bucket to create.
+    :param obj_prefix: The prefix to assign to the uploaded stanzas.
+    :return: The created bucket and stanza objects.
+    """
+    with open(file_name) as file:
+        stanzas = file.read().split('\n\n')
+
+    bucket = versioning.create_versioned_bucket(bucket_name, obj_prefix)
+
+    try:
+        # Fill the bucket with initial stanza objects.
+        stanza_objects = []
+        for index, stanza in enumerate(stanzas):
+            obj = bucket.Object(f"{obj_prefix}stanza-{index}")
+            obj.put(Body=bytes(stanza, 'utf-8'))
+            stanza_objects.append(obj)
+        print(f"Added {len(stanza_objects)} stanzas as objects to {bucket.name}.")
+    except ClientError:
+        logger.exception("Couldn't put initial stanza objects into bucket %s.",
+                         bucket.name)
+        raise
+
+    return bucket, stanza_objects
+
+
+def prepare_for_random_revisions(bucket, stanza_objects):
+    """
+    Makes a manifest to do a series of revisions as a batch.
+
+    The manifest contains randomly picked revision types that are each packed
+    with an object key as a pipe-delimited string.
+
+    :param bucket: The bucket that contains the stanzas.
+    :param stanza_objects: The stanza objects.
+    :return: The manifest as a list of lines in CSV format.
+    """
+    revisions = ['lower', 'upper', 'reverse', 'delete']
+    manifest_lines = []
+    for _ in range(5):
+        for stanza_obj in stanza_objects:
+            revision = parse.quote(
+                f"{stanza_obj.key}|{revisions[random.randrange(0, len(revisions))]}")
+            manifest_lines.append(f"{bucket.name},{revision}")
+    return manifest_lines
+
+
+def prepare_for_revival(bucket, obj_prefix):
+    """
+    Makes a manifest for reviving any deleted objects in the bucket. A deleted
+    object is one that has a delete marker as its latest version.
+
+    :param bucket: The bucket that contains the stanzas.
+    :param obj_prefix: The prefix of the uploaded stanzas.
+    :return: The manifest as a list of lines in CSV format.
+    """
+    try:
+        response = s3.meta.client.list_object_versions(
+            Bucket=bucket.name, Prefix=f'{obj_prefix}stanza')
+        manifest_lines = [
+            f"{bucket.name},{marker['Key']},{marker['VersionId']}"
+            for marker in response['DeleteMarkers']
+            if marker['IsLatest']
+        ]
+    except ClientError:
+        logger.exception("Couldn't get object versions from %s.", bucket.name)
+        raise
+    return manifest_lines
+
+
+def prepare_for_cleanup(bucket, obj_prefix, stanza_objects):
+    """
+    Makes a manifest for cleaning up all delete markers in the bucket. In practice,
+    a large number of delete markers can slow down bucket performance so cleaning
+    them up is a best practice.
+
+    This function first creates a bunch of delete markers interspersed with
+    non-delete marker versions by deleting and putting objects in a loop.
+
+    :param bucket: The bucket that contains the stanzas.
+    :param obj_prefix: The prefix of the uploaded stanzas.
+    :param stanza_objects: The stanza objects.
+    :return: The manifest as a list of lines in CSV format.
+    """
+    try:
+        for stanza in stanza_objects:
+            body = stanza.get()['Body'].read()
+            for index in range(1, 7):
+                if index & 0x1:
+                    stanza.delete()
+                else:
+                    stanza.put(Body=body)
+    except ClientError:
+        logger.exception("Preparation for cleanup phase failed.")
+        raise
+
+    try:
+        response = s3.meta.client.list_object_versions(
+            Bucket=bucket.name, Prefix=f'{obj_prefix}stanza')
+
+        version_count = len(response['Versions']) + len(response['DeleteMarkers'])
+        print(f"Created a mess of delete markers. There are currently {version_count} "
+              f"versions in {bucket.name}.")
+
+        manifest_lines = [
+            f"{bucket.name},{marker['Key']},{marker['VersionId']}"
+            for marker in response['DeleteMarkers']
+        ]
+    except ClientError:
+        logger.exception("Couldn't get object versions from %s.", bucket.name)
+        raise
+    else:
+        return manifest_lines
+
+
+def create_batch_job(job, manifest):
+    """
+    Creates an Amazon S3 batch job. The manifest is uploaded to the S3
+    bucket and the job is created. After the job is created, Amazon S3
+    processes it asynchronously. Jobs can be queried or cancelled by using
+    the returned job ID.
+
+    :param job: The information about the job to create.
+    :param manifest: The manifest that defines the objects affected by the job.
+    :return: The ID of the created job.
+    """
+    manifest_obj = manifest['bucket'].Object(manifest['key'])
+    manifest_e_tag = None
+    try:
+        # Upload the manifest so the batch system can find it.
+        response = manifest_obj.put(Body=bytes('\n'.join(manifest['lines']), 'utf-8'))
+        if 'ETag' in response:
+            manifest_e_tag = response['ETag']
+        logger.info("Uploaded job manifest %s to bucket %s.",
+                    manifest_obj.key, manifest['bucket'].name)
+    except ClientError:
+        logger.exception("Couldn't upload job manifest %s to bucket %s.",
+                         manifest_obj.key, manifest['bucket'].name)
+        raise
+
+    manifest_fields = ['Bucket', 'Key']
+    if manifest['has_versions']:
+        manifest_fields.append('VersionId')
+    try:
+        response = s3control.create_job(
+            AccountId=job['account_id'],
+            ConfirmationRequired=False,
+            Description=job['description'],
+            Priority=1,
+            RoleArn=job['role_arn'],
+            Operation={
+                'LambdaInvoke': {
+                    'FunctionArn': job['function_arn']
+                }
+            },
+            Manifest={
+                'Spec': {
+                    'Format': 'S3BatchOperations_CSV_20180820',
+                    'Fields': manifest_fields
+                },
+                'Location': {
+                    'ObjectArn':
+                        f"arn:aws:s3:::{manifest['bucket'].name}/{manifest['key']}",
+                    'ETag': manifest_e_tag if manifest_e_tag else manifest_obj.e_tag
+                }
+            },
+            Report={
+                'Bucket': f"arn:aws:s3:::{manifest['bucket'].name}",
+                'Format': 'Report_CSV_20180820',
+                'Enabled': True,
+                'Prefix': manifest['obj_prefix'],
+                'ReportScope': 'AllTasks'
+            }
+        )
+        logger.info("Created job %s.", response['JobId'])
+    except ClientError:
+        logger.exception("Couldn't create job to run function %s on manifest %s.",
+                         job['function_arn'], manifest_obj.key)
+        raise
+
+    return response['JobId']
+
+
+def report_job_status(account_id, job_id):
+    """
+    Polls the specified job every second and reports the current status until
+    the job completes.
+
+    :param account_id: The ID of the account that owns the job.
+    :param job_id: The ID of the job.
+    """
+    try:
+        # Get job status until the job is complete, failed, or cancelled.
+        job_status = None
+        print(f"Status of job {job_id}:")
+        while job_status not in ('Complete', 'Failed', 'Cancelled'):
+            prev_job_status = job_status
+            job_status = s3control.describe_job(
+                AccountId=account_id, JobId=job_id)['Job']['Status']
+            if prev_job_status != job_status:
+                print(job_status, end='')
+            else:
+                print('.', end='')
+            stdout.flush()
+            sleep(1)
+        print('')
+    except ClientError:
+        logger.exception("Couldn't get status for job %s.", job_id)
+        raise
+
+
+def setup_demo(role_name, bucket_name, function_info, obj_prefix):
+    """
+    Sets up the demo. Creates the IAM role, Lambda functions, and S3 bucket
+    used by the demo.
+
+    This function also has the side effect of filling the function_info
+    dictionary with the ARNs of the created functions.
+
+    :param role_name: The name to give the IAM role.
+    :param bucket_name: The name to give the S3 bucket.
+    :param function_info: Information about the Lambda functions.
+    :param obj_prefix: The prefix to assign to created resources.
+    :return: The created role, bucket, and stanza objects.
+    """
+    with header():
+        print("Setup phase!")
+
+    print("Creating an IAM role for the Lambda function...")
+    role = create_iam_role(role_name)
+
+    print("Creating Lambda functions to handle batch operations...")
+    for function_name in function_info.keys():
+        info = function_info[function_name]
+        info['arn'] = create_lambda_function(
+            role, function_name, info['file_name'], info['handler'],
+            info['description'])
+
+    print("Creating a version-enabled bucket and filling it with initial stanzas...")
+    bucket, stanza_objects = create_and_fill_bucket(
+        'father_william.txt', bucket_name, obj_prefix)
+
+    return role, bucket, stanza_objects
+
+
+def usage_demo_batch_operations(
+        role_arn, function_info, bucket, stanza_objects, obj_prefix):
+    """
+    Performs the main processing part of the usage demonstration.
+
+    :param role_arn: The ARN of the role used by the created jobs.
+    :param function_info: Information about the Lambda functions used in the demo.
+    :param bucket: The bucket that contains all of the objects created by the demo.
+    :param stanza_objects: The initial set of stanza objects created during setup.
+    :param obj_prefix: The prefix to assign to resources and objects.
+    """
+    with header():
+        print("Main processing phase!")
+
+    account_id = sts.get_caller_identity()['Account']
+    job = {'account_id': account_id, 'role_arn': role_arn}
+    manifest = {'bucket': bucket, 'obj_prefix': obj_prefix, 'has_versions': False}
+
+    with header():
+        print("Creating a batch job to perform a series of random revisions on "
+              "each stanza...")
+    revision_manifest = prepare_for_random_revisions(bucket, stanza_objects)
+    job['description'] = "perform a series of random revisions to each stanza"
+    job['function_arn'] = function_info['revise_stanza']['arn']
+    manifest['key'] = f"{obj_prefix}revision-manifest.csv"
+    manifest['lines'] = revision_manifest
+    job_id = create_batch_job(job, manifest)
+    report_job_status(account_id, job_id)
+
+    try:
+        print("The poetic product, after revisions:")
+        stanza_objs = bucket.objects.filter(Prefix=f'{obj_prefix}stanza')
+        stanza_count = len(list(stanza_objs))
+        if stanza_count == 0:
+            print("We deleted all of our stanzas!")
+        else:
+            print(f"Our poem is now only {stanza_count} stanzas.")
+            for stanza_obj in stanza_objs:
+                print(stanza_obj.get()['Body'].read().decode('utf-8'))
+    except ClientError:
+        logger.exception("Couldn't get stanzas from bucket %s.", bucket.name)
+        raise
+
+    # Revive deleted stanzas.
+    with header():
+        print("Creating a batch job to revive any stanzas that were deleted as part of "
+              "the random revisions...")
+    revival_manifest = prepare_for_revival(bucket, obj_prefix)
+    job['description'] = "remove delete markers"
+    job['function_arn'] = function_info['remove_delete_marker']['arn']
+    manifest['key'] = f"{obj_prefix}revival-manifest.csv"
+    manifest['lines'] = revival_manifest
+    manifest['has_versions'] = True
+    job_id = create_batch_job(job, manifest)
+    report_job_status(account_id, job_id)
+
+    try:
+        stanza_count = len(list(bucket.objects.filter(Prefix=f'{obj_prefix}stanza')))
+        print(f"There are now {stanza_count} stanzas in {bucket.name}.")
+    except ClientError:
+        logger.exception("Couldn't get stanzas from bucket %s.", bucket.name)
+        raise
+
+    # Clean up all the delete markers.
+    with header():
+        print("Creating a batch job to clean up excess delete markers sprinkled "
+              "throughout the bucket...")
+    cleanup_manifest = prepare_for_cleanup(bucket, obj_prefix, stanza_objects)
+    job['description'] = "clean up all delete markers"
+    job['function_arn'] = function_info['remove_delete_marker']['arn']
+    manifest['key'] = f"{obj_prefix}cleanup-manifest.csv"
+    manifest['lines'] = cleanup_manifest
+    job_id = create_batch_job(job, manifest)
+    report_job_status(account_id, job_id)
+
+    try:
+        version_count = len(list(bucket.object_versions.filter(
+            Prefix=f'{obj_prefix}stanza')))
+        print(f"After cleanup, there are now {version_count} versions "
+              f"in {bucket.name}.")
+    except ClientError:
+        logger.exception("Couldn't get stanzas from bucket %s.", bucket.name)
+        raise
+
+
+def teardown_demo(role_name, function_info, bucket_name):
+    """
+    Tears down the demo. Deletes everything created by the demo and returns the
+    AWS account to its initial state. This is a good-faith effort. You should
+    verify that all resources have actually been deleted.
+
+    :param role_name: The name of the IAM role to delete.
+    :param function_info: Information about the Lambda functions to delete.
+    :param bucket_name: The name of the bucket to delete. All objects in this bucket
+                        are also deleted.
+    """
+    with header():
+        print("Teardown phase!")
+
+    print("\nDetaching policies and deleting the IAM role...")
+    role = iam.Role(role_name)
+    try:
+        for policy in role.attached_policies.all():
+            policy_name = policy.policy_name
+            role.detach_policy(PolicyArn=policy.arn)
+            policy.delete()
+            logger.info("Detached and deleted policy %s.", policy_name)
+        role.delete()
+        logger.info("Deleted role %s.", role_name)
+    except ClientError as error:
+        logger.warning("Couldn't delete role %s because %s.", role_name, error)
+
+    print("\nDeleting Lambda functions...")
+    for function_name in function_info.keys():
+        try:
+            aws_lambda.delete_function(FunctionName=function_name)
+            logger.info("Deleted Lambda function %s.", function_name)
+        except ClientError as error:
+            logger.warning(
+                "Couldn't delete Lambda function %s because %s", function_name, error)
+
+    print("\nEmptying and deleting the bucket...")
+    bucket = s3.Bucket(bucket_name)
+    try:
+        bucket.object_versions.delete()
+        print(f"Permanently deleted everything in {bucket.name}.")
+    except ClientError as error:
+        logger.warning("Couldn't empty bucket %s because %s.", bucket.name, error)
+
+    try:
+        bucket.delete()
+        print(f"Deleted bucket {bucket.name}.")
+    except ClientError as error:
+        logger.warning("Couldn't delete bucket %s because %s.", bucket.name, error)
+
+
+def main():
+    """
+    Kicks off the demo.
+    """
+    prefix = 'aws-version-demo'
+    obj_prefix = f'{prefix}/'
+    bucket_name = f'{prefix}-bucket-' + str(uuid.uuid1())
+    role_name = f'{prefix}-s3-batch-role'
+    function_info = {
+        'revise_stanza': {
+            'file_name': 'revise_stanza.py',
+            'handler': 'revise_stanza.lambda_handler',
+            'description': 'Applies a revision to a stanza.',
+            'arn': None},
+        'remove_delete_marker': {
+            'file_name': 'remove_delete_marker.py',
+            'handler': 'remove_delete_marker.lambda_handler',
+            'description': 'Removes a delete marker from an object.',
+            'arn': None}
+    }
+
+    with header():
+        print("Welcome to the usage demonstration of Amazon S3 batch versioning.\n")
+        print("This demonstration manipulates Amazon S3 objects in batches "
+              "by creating jobs that call Lambda functions to perform processing. "
+              "It uses the stanzas from the poem 'You Are Old, Father William' "
+              "by Lewis Carroll, treating each stanza as a separate object.")
+
+    print("Let's do the demo.")
+    role, bucket, stanza_objects = \
+        setup_demo(role_name, bucket_name, function_info, obj_prefix)
+
+    usage_demo_batch_operations(
+        role.arn, function_info, bucket, stanza_objects, obj_prefix)
+
+    teardown_demo(role_name, function_info, bucket_name)
+    with header():
+        print("Demo done!")
+
+
+if __name__ == '__main__':
+    main()

--- a/python/example_code/s3/s3_versioning/batch_versioning.py
+++ b/python/example_code/s3/s3_versioning/batch_versioning.py
@@ -5,7 +5,7 @@
 Purpose
 
 Demonstrates how to manipulate Amazon S3 versioned objects in batches by creating jobs
-that call Lambda functions to perform processing. The demo has three phases: setup,
+that call AWS Lambda functions to perform processing. The demo has three phases: setup,
 processing, and teardown.
 
 For more detail, including usage and testing instructions, see the README.
@@ -89,8 +89,8 @@ def custom_retry(callback, error_code, max_tries):
 
 def create_iam_role(role_name):
     """
-    Creates an AWS IAM role and attached policy that has the permissions needed by
-    the Lambda functions used in this demo.
+    Creates an AWS Identity and Access Management (IAM) role and attached policy
+    that has the permissions needed by the Lambda functions used in this demo.
 
     :param role_name: The name of the role.
     :return: The created role object.
@@ -176,12 +176,12 @@ def create_lambda_function(iam_role, function_name, function_file_name, handler,
     """
     Creates a Lambda function.
 
-    :param iam_role: The AWS IAM role associated with the function.
+    :param iam_role: The IAM role associated with the function.
     :param function_name: The name of the function.
     :param function_file_name: The local file name that contains the function code.
-    :param handler: The fully-qualified name of the handler function.
+    :param handler: The fully qualified name of the handler function.
     :param description: A friendly description of the function's purpose.
-    :return: The ARN of the created function.
+    :return: The Amazon Resource Name (ARN) of the created function.
     """
     buffer = BytesIO()
     with ZipFile(buffer, 'w') as zipped:
@@ -335,9 +335,8 @@ def prepare_for_cleanup(bucket, obj_prefix, stanza_objects):
 def create_batch_job(job, manifest):
     """
     Creates an Amazon S3 batch job. The manifest is uploaded to the S3
-    bucket and the job is created. After the job is created, Amazon S3
-    processes it asynchronously. Jobs can be queried or cancelled by using
-    the returned job ID.
+    bucket and the job is created. Then Amazon S3 processes the job asynchronously.
+    Jobs can be queried or canceled by using the returned job ID.
 
     :param job: The information about the job to create.
     :param manifest: The manifest that defines the objects affected by the job.
@@ -409,7 +408,7 @@ def report_job_status(account_id, job_id):
     :param job_id: The ID of the job.
     """
     try:
-        # Get job status until the job is complete, failed, or cancelled.
+        # Get job status until the job is complete, failed, or canceled.
         job_status = None
         print(f"Status of job {job_id}:")
         while job_status not in ('Complete', 'Failed', 'Cancelled'):
@@ -431,10 +430,10 @@ def report_job_status(account_id, job_id):
 def setup_demo(role_name, bucket_name, function_info, obj_prefix):
     """
     Sets up the demo. Creates the IAM role, Lambda functions, and S3 bucket
-    used by the demo.
+    that the demo uses.
 
     This function also has the side effect of filling the function_info
-    dictionary with the ARNs of the created functions.
+    dictionary with the Amazon Resource Names (ARNs) of the created functions.
 
     :param role_name: The name to give the IAM role.
     :param bucket_name: The name to give the S3 bucket.
@@ -467,7 +466,7 @@ def usage_demo_batch_operations(
     """
     Performs the main processing part of the usage demonstration.
 
-    :param role_arn: The ARN of the role used by the created jobs.
+    :param role_arn: The ARN of the role that the created jobs use.
     :param function_info: Information about the Lambda functions used in the demo.
     :param bucket: The bucket that contains all of the objects created by the demo.
     :param stanza_objects: The initial set of stanza objects created during setup.
@@ -484,7 +483,7 @@ def usage_demo_batch_operations(
         print("Creating a batch job to perform a series of random revisions on "
               "each stanza...")
     revision_manifest = prepare_for_random_revisions(bucket, stanza_objects)
-    job['description'] = "perform a series of random revisions to each stanza"
+    job['description'] = "Perform a series of random revisions to each stanza."
     job['function_arn'] = function_info['revise_stanza']['arn']
     manifest['key'] = f"{obj_prefix}revision-manifest.csv"
     manifest['lines'] = revision_manifest
@@ -510,7 +509,7 @@ def usage_demo_batch_operations(
         print("Creating a batch job to revive any stanzas that were deleted as part of "
               "the random revisions...")
     revival_manifest = prepare_for_revival(bucket, obj_prefix)
-    job['description'] = "remove delete markers"
+    job['description'] = "Remove delete markers."
     job['function_arn'] = function_info['remove_delete_marker']['arn']
     manifest['key'] = f"{obj_prefix}revival-manifest.csv"
     manifest['lines'] = revival_manifest
@@ -530,7 +529,7 @@ def usage_demo_batch_operations(
         print("Creating a batch job to clean up excess delete markers sprinkled "
               "throughout the bucket...")
     cleanup_manifest = prepare_for_cleanup(bucket, obj_prefix, stanza_objects)
-    job['description'] = "clean up all delete markers"
+    job['description'] = "Clean up all delete markers."
     job['function_arn'] = function_info['remove_delete_marker']['arn']
     manifest['key'] = f"{obj_prefix}cleanup-manifest.csv"
     manifest['lines'] = cleanup_manifest
@@ -549,9 +548,9 @@ def usage_demo_batch_operations(
 
 def teardown_demo(role_name, function_info, bucket_name):
     """
-    Tears down the demo. Deletes everything created by the demo and returns the
+    Tears down the demo. Deletes everything the demo created and returns the
     AWS account to its initial state. This is a good-faith effort. You should
-    verify that all resources have actually been deleted.
+    verify that all resources are deleted.
 
     :param role_name: The name of the IAM role to delete.
     :param function_info: Information about the Lambda functions to delete.
@@ -622,7 +621,7 @@ def main():
     with header():
         print("Welcome to the usage demonstration of Amazon S3 batch versioning.\n")
         print("This demonstration manipulates Amazon S3 objects in batches "
-              "by creating jobs that call Lambda functions to perform processing. "
+              "by creating jobs that call AWS Lambda functions to perform processing. "
               "It uses the stanzas from the poem 'You Are Old, Father William' "
               "by Lewis Carroll, treating each stanza as a separate object.")
 

--- a/python/example_code/s3/s3_versioning/batch_versioning.py
+++ b/python/example_code/s3/s3_versioning/batch_versioning.py
@@ -32,11 +32,9 @@ from botocore.exceptions import ClientError
 
 import versioning
 
+logging.basicConfig(
+    format='%(levelname)s:%(message)s', level=logging.INFO, stream=stdout)
 logger = logging.getLogger(__name__)
-log_handler = logging.StreamHandler(stdout)
-log_handler.setLevel(logging.INFO)
-logger.addHandler(log_handler)
-logger.setLevel(logging.INFO)
 
 iam = boto3.resource('iam')
 s3 = boto3.resource('s3')
@@ -279,7 +277,7 @@ def prepare_for_revival(bucket, obj_prefix):
         response = s3.meta.client.list_object_versions(
             Bucket=bucket.name, Prefix=f'{obj_prefix}stanza')
         manifest_lines = [
-            f"{bucket.name},{marker['Key']},{marker['VersionId']}"
+            f"{bucket.name},{parse.quote(marker['Key'])},{marker['VersionId']}"
             for marker in response['DeleteMarkers']
             if marker['IsLatest']
         ]
@@ -324,7 +322,7 @@ def prepare_for_cleanup(bucket, obj_prefix, stanza_objects):
               f"versions in {bucket.name}.")
 
         manifest_lines = [
-            f"{bucket.name},{marker['Key']},{marker['VersionId']}"
+            f"{bucket.name},{parse.quote(marker['Key'])},{marker['VersionId']}"
             for marker in response['DeleteMarkers']
         ]
     except ClientError:

--- a/python/example_code/s3/s3_versioning/father_william.txt
+++ b/python/example_code/s3/s3_versioning/father_william.txt
@@ -1,0 +1,39 @@
+"You are old, Father William," the young man said,
+    "And your hair has become very white;
+And yet you incessantly stand on your head--
+    Do you think, at your age, it is right?"
+
+"In my youth," Father William replied to his son,
+    "I feared it might injure the brain;
+But now that I'm perfectly sure I have none,
+    Why, I do it again and again."
+
+"You are old," said the youth, "as I mentioned before,
+    And have grown most uncommonly fat;
+Yet you turned a back-somersault in at the door--
+    Pray, what is the reason of that?"
+
+"In my youth," said the sage, as he shook his grey locks,
+    "I kept all my limbs very supple
+By the use of this ointment--one shilling the box--
+    Allow me to sell you a couple."
+
+"You are old," said the youth, "and your jaws are too weak
+    For anything tougher than suet;
+Yet you finished the goose, with the bones and the beak--
+    Pray, how did you manage to do it?"
+
+"In my youth," said his father, "I took to the law,
+    And argued each case with my wife;
+And the muscular strength, which it gave to my jaw,
+    Has lasted the rest of my life."
+
+"You are old," said the youth, "one would hardly suppose
+    That your eye was as steady as ever;
+Yet you balanced an eel on the end of your nose--
+    What made you so awfully clever?"
+
+"I have answered three questions, and that is enough,"
+    Said his father; "don't give yourself airs!
+Do you think I can listen all day to such stuff?
+    Be off, or I'll kick you down stairs!"

--- a/python/example_code/s3/s3_versioning/remove_delete_marker.py
+++ b/python/example_code/s3/s3_versioning/remove_delete_marker.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-A Lambda handler that receives an Amazon S3 batch event. The handler unpacks the
+An AWS Lambda handler that receives an Amazon S3 batch event. The handler unpacks the
 event and removes the specified delete marker from the bucket.
 """
 

--- a/python/example_code/s3/s3_versioning/remove_delete_marker.py
+++ b/python/example_code/s3/s3_versioning/remove_delete_marker.py
@@ -1,0 +1,103 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+A Lambda handler that receives an Amazon S3 batch event. The handler unpacks the
+event and removes the specified delete marker from the bucket.
+"""
+
+# snippet-start:[s3.python.lambda.remove_delete_marker]
+import logging
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+logger.setLevel('INFO')
+
+s3 = boto3.client('s3')
+
+
+def lambda_handler(event, context):
+    """
+    Removes a delete marker from the specified bucket.
+
+    :param event: The S3 batch event that contains the ID of the delete marker
+                  to remove.
+    :param context: Context about the event.
+    :return: A result structure that Amazon S3 uses to interpret the result of the
+             operation. When the result code is TemporaryFailure, S3 retries the
+             operation.
+    """
+    # Parse job parameters from Amazon S3 batch operations
+    invocation_id = event['invocationId']
+    invocation_schema_version = event['invocationSchemaVersion']
+
+    results = []
+    result_code = None
+    result_string = None
+
+    task = event['tasks'][0]
+    task_id = task['taskId']
+
+    try:
+        obj_key = task['s3Key']
+        obj_version_id = task['s3VersionId']
+        bucket_name = task['s3BucketArn'].split(':')[-1]
+
+        logger.info("Got task: remove delete marker %s from object %s.",
+                    obj_version_id, obj_key)
+
+        try:
+            # If this call does not raise an error, the object version is not a delete
+            # marker and should not be deleted.
+            response = s3.head_object(
+                Bucket=bucket_name, Key=obj_key, VersionId=obj_version_id)
+            result_code = 'PermanentFailure'
+            result_string = f"Object {obj_key}, ID {obj_version_id} is not " \
+                            f"a delete marker."
+
+            logger.debug(response)
+            logger.warning(result_string)
+        except ClientError as error:
+            delete_marker = error.response['ResponseMetadata']['HTTPHeaders'] \
+                .get('x-amz-delete-marker', 'false')
+            if delete_marker == 'true':
+                logger.info("Object %s, version %s is a delete marker.",
+                            obj_key, obj_version_id)
+                try:
+                    s3.delete_object(
+                        Bucket=bucket_name, Key=obj_key, VersionId=obj_version_id)
+                    result_code = 'Succeeded'
+                    result_string = f"Successfully removed delete marker " \
+                                    f"{obj_version_id} from object {obj_key}."
+                    logger.info(result_string)
+                except ClientError as error:
+                    # Mark request timeout as a temporary failure so it will be retried.
+                    if error.response['Error']['Code'] == 'RequestTimeout':
+                        result_code = 'TemporaryFailure'
+                        result_string = f"Attempt to remove delete marker from  " \
+                                        f"object {obj_key} timed out."
+                        logger.info(result_string)
+                    else:
+                        raise
+            else:
+                raise ValueError(f"The x-amz-delete-marker header is either not "
+                                 f"present or is not 'true'.")
+    except Exception as error:
+        # Mark all other exceptions as permanent failures.
+        result_code = 'PermanentFailure'
+        result_string = error
+        logger.exception(error)
+    finally:
+        results.append({
+            'taskId': task_id,
+            'resultCode': result_code,
+            'resultString': result_string
+        })
+    return {
+        'invocationSchemaVersion': invocation_schema_version,
+        'treatMissingKeysAs': 'PermanentFailure',
+        'invocationId': invocation_id,
+        'results': results
+    }
+# snippet-end:[s3.python.lambda.remove_delete_marker]

--- a/python/example_code/s3/s3_versioning/remove_delete_marker.py
+++ b/python/example_code/s3/s3_versioning/remove_delete_marker.py
@@ -8,6 +8,7 @@ event and removes the specified delete marker from the bucket.
 
 # snippet-start:[s3.python.lambda.remove_delete_marker]
 import logging
+from urllib import parse
 import boto3
 from botocore.exceptions import ClientError
 
@@ -19,7 +20,7 @@ s3 = boto3.client('s3')
 
 def lambda_handler(event, context):
     """
-    Removes a delete marker from the specified bucket.
+    Removes a delete marker from the specified versioned object.
 
     :param event: The S3 batch event that contains the ID of the delete marker
                   to remove.
@@ -40,7 +41,7 @@ def lambda_handler(event, context):
     task_id = task['taskId']
 
     try:
-        obj_key = task['s3Key']
+        obj_key = parse.unquote(task['s3Key'], encoding='utf-8')
         obj_version_id = task['s3VersionId']
         bucket_name = task['s3BucketArn'].split(':')[-1]
 

--- a/python/example_code/s3/s3_versioning/revise_stanza.py
+++ b/python/example_code/s3/s3_versioning/revise_stanza.py
@@ -1,0 +1,95 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+A Lambda handler that receives an Amazon S3 batch event. The handler unpacks the
+event and applies the specified revision to the specified object.
+"""
+
+# snippet-start:[s3.python.lambda.revise_stanza]
+import logging
+from urllib import parse
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+logger.setLevel('INFO')
+
+s3 = boto3.resource('s3')
+
+
+def lambda_handler(event, context):
+    """
+    Applies the specified revision to the specified object.
+
+    :param event: The S3 batch event that contains the ID of the object to revise
+                  and the revision type to apply.
+    :param context: Context about the event.
+    :return: A result structure that Amazon S3 uses to interpret the result of the
+             operation.
+    """
+    # Parse job parameters from Amazon S3 batch operations
+    invocation_id = event['invocationId']
+    invocation_schema_version = event['invocationSchemaVersion']
+
+    results = []
+    result_code = None
+    result_string = None
+
+    task = event['tasks'][0]
+    task_id = task['taskId']
+    # The revision type is packed with the object key as a pipe-delimited string.
+    obj_key, revision = \
+        parse.unquote(task['s3Key'], encoding='utf-8').split('|')
+    bucket_name = task['s3BucketArn'].split(':')[-1]
+
+    logger.info("Got task: apply revision %s to %s.", revision, obj_key)
+
+    try:
+        stanza_obj = s3.Bucket(bucket_name).Object(obj_key)
+        stanza = stanza_obj.get()['Body'].read().decode('utf-8')
+        if revision == 'lower':
+            stanza = stanza.lower()
+        elif revision == 'upper':
+            stanza = stanza.upper()
+        elif revision == 'reverse':
+            stanza = stanza[::-1]
+        elif revision == 'delete':
+            pass
+        else:
+            raise TypeError(f"Can't handle revision type '{revision}'.")
+
+        if revision == 'delete':
+            stanza_obj.delete()
+            result_string = f"Deleted stanza {stanza_obj.key}."
+        else:
+            stanza_obj.put(Body=bytes(stanza, 'utf-8'))
+            result_string = f"Applied revision type '{revision}' to " \
+                            f"stanza {stanza_obj.key}."
+
+        logger.info(result_string)
+        result_code = 'Succeeded'
+    except ClientError as error:
+        if error.response['Error']['Code'] == 'NoSuchKey':
+            result_code = 'Succeeded'
+            result_string = f"Stanza {obj_key} not found, assuming it was deleted " \
+                            f"in an earlier revision."
+            logger.info(result_string)
+        else:
+            result_code = 'PermanentFailure'
+            result_string = f"Got exception when applying revision type '{revision}' " \
+                            f"to {obj_key}: {error}."
+            logger.exception(result_string)
+    finally:
+        results.append({
+            'taskId': task_id,
+            'resultCode': result_code,
+            'resultString': result_string
+        })
+    return {
+        'invocationSchemaVersion': invocation_schema_version,
+        'treatMissingKeysAs': 'PermanentFailure',
+        'invocationId': invocation_id,
+        'results': results
+    }
+# snippet-end:[s3.python.lambda.revise_stanza]

--- a/python/example_code/s3/s3_versioning/revise_stanza.py
+++ b/python/example_code/s3/s3_versioning/revise_stanza.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-A Lambda handler that receives an Amazon S3 batch event. The handler unpacks the
+An AWS Lambda handler that receives an Amazon S3 batch event. The handler unpacks the
 event and applies the specified revision to the specified object.
 """
 
@@ -22,8 +22,8 @@ def lambda_handler(event, context):
     """
     Applies the specified revision to the specified object.
 
-    :param event: The S3 batch event that contains the ID of the object to revise
-                  and the revision type to apply.
+    :param event: The Amazon S3 batch event that contains the ID of the object to
+                  revise and the revision type to apply.
     :param context: Context about the event.
     :return: A result structure that Amazon S3 uses to interpret the result of the
              operation.

--- a/python/example_code/s3/s3_versioning/test/conftest.py
+++ b/python/example_code/s3/s3_versioning/test/conftest.py
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Contains common test fixtures used to run Amazon S3 versioning tests.
+"""
+from urllib import parse
+from botocore.stub import ANY
+
+import sys
+# This is needed so Python can find test_tools on the path.
+sys.path.append('../../..')
+from test_tools.fixtures.common import *
+
+
+@pytest.fixture
+def make_event():
+    """Returns a function that makes an Amazon S3 batch event."""
+    def _func(bucket_name, obj_key, extra_data=None, version_id=None):
+        task = {
+            'taskId': 'test-task-id',
+            's3Key': parse.quote(f'{obj_key}|{extra_data}') if extra_data else obj_key,
+            's3BucketArn': f'arn:aws:::{bucket_name}'
+        }
+        if version_id:
+            task['s3VersionId'] = version_id
+        return {
+            'invocationId': 'test-invocation-id',
+            'invocationSchemaVersion': 'test-schema-version',
+            'tasks': [task]
+        }
+    return _func
+
+
+@pytest.fixture
+def make_result():
+    """Returns a function that makes an Amazon S3 batch result."""
+    def _func(code):
+        return {
+            'invocationSchemaVersion': 'test-schema-version',
+            'treatMissingKeysAs': 'PermanentFailure',
+            'invocationId': 'test-invocation-id',
+            'results': [{
+                'taskId': 'test-task-id',
+                'resultCode': code,
+                'resultString': ANY
+            }]
+        }
+    return _func

--- a/python/example_code/s3/s3_versioning/test/conftest.py
+++ b/python/example_code/s3/s3_versioning/test/conftest.py
@@ -8,7 +8,7 @@ from urllib import parse
 from botocore.stub import ANY
 
 import sys
-# This is needed so Python can find test_tools on the path.
+# This is needed so Python can find test_tools in the path.
 sys.path.append('../../..')
 from test_tools.fixtures.common import *
 

--- a/python/example_code/s3/s3_versioning/test/test_batch_versioning.py
+++ b/python/example_code/s3/s3_versioning/test/test_batch_versioning.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Unit tests for batch_versionin.py functions.
+Unit tests for batch_versioning.py functions.
 """
 
 from unittest.mock import MagicMock
@@ -238,9 +238,9 @@ def test_create_batch_job(make_stubber, make_unique_name):
     bucket_name = make_unique_name('bucket')
     obj_prefix = 'test-prefix'
     manifest = {
-        'name': 'manitest',
+        'name': 'test-manifest',
         'lines': 'bucket,obj\nbucket,obj\n',
-        'key': f'{obj_prefix}manitest.csv',
+        'key': f'{obj_prefix}test-manifest.csv',
         'e_tag': 'test-e-tag',
         'bucket': batch_versioning.s3.Bucket(bucket_name),
         'obj_prefix': obj_prefix,
@@ -271,7 +271,7 @@ def test_create_batch_job_failure(make_stubber, make_unique_name, fail_at):
     obj_prefix = 'test-prefix'
     manifest = {
         'lines': 'bucket,obj\nbucket,obj\n',
-        'key': f'{obj_prefix}manitest.csv',
+        'key': f'{obj_prefix}test-manifest.csv',
         'e_tag': 'test-e-tag',
         'bucket': batch_versioning.s3.Bucket(bucket_name),
         'obj_prefix': obj_prefix,

--- a/python/example_code/s3/s3_versioning/test/test_batch_versioning.py
+++ b/python/example_code/s3/s3_versioning/test/test_batch_versioning.py
@@ -1,0 +1,463 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for batch_versionin.py functions.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from botocore.exceptions import ClientError
+import versioning
+import batch_versioning
+
+
+def test_custom_retry():
+    def callback():
+        return 'Success!'
+    response = batch_versioning.custom_retry(callback, 'test-error', 3)
+    assert response == 'Success!'
+
+
+@pytest.mark.parametrize('error_code', ['test-error', 'garbage-error'])
+def test_custom_retry_failure(error_code):
+    def callback():
+        raise ClientError({'Error': {'Code': 'test-error'}}, 'test-op')
+
+    with pytest.raises(ClientError) as exc_info:
+        batch_versioning.custom_retry(callback, error_code, 3)
+    assert exc_info.value.response['Error']['Code'] == 'test-error'
+
+
+def test_create_iam_role(make_stubber, make_unique_name):
+    iam_stubber = make_stubber(batch_versioning.iam.meta.client)
+    role_name = make_unique_name('role')
+    policy_name = f'{role_name}-policy'
+    policy_arn = f'aws:arn:EXAMPLE:{policy_name}'
+
+    iam_stubber.stub_create_role(role_name)
+    iam_stubber.stub_get_role(role_name)
+    iam_stubber.stub_create_policy(policy_name, policy_arn)
+    iam_stubber.stub_get_policy(policy_arn)
+    iam_stubber.stub_attach_role_policy(role_name, policy_arn)
+
+    role = batch_versioning.create_iam_role(role_name)
+    assert role.name == role_name
+
+
+@pytest.mark.parametrize('fail_at', ['role', 'policy', 'attach'])
+def test_create_iam_role_failures(make_stubber, make_unique_name, fail_at):
+    iam_stubber = make_stubber(batch_versioning.iam.meta.client)
+    role_name = make_unique_name('role')
+    policy_name = f'{role_name}-policy'
+    policy_arn = f'aws:arn:EXAMPLE:{policy_name}'
+    error_code = 'TestException'
+
+    if fail_at == 'role':
+        iam_stubber.stub_create_role(role_name, error_code=error_code)
+    else:
+        iam_stubber.stub_create_role(role_name)
+        iam_stubber.stub_get_role(role_name)
+        if fail_at == 'policy':
+            iam_stubber.stub_create_policy(policy_name, policy_arn,
+                                           error_code=error_code)
+        else:
+            iam_stubber.stub_create_policy(policy_name, policy_arn)
+            iam_stubber.stub_get_policy(policy_arn)
+            if fail_at == 'attach':
+                iam_stubber.stub_attach_role_policy(role_name, policy_arn,
+                                                    error_code=error_code)
+            else:
+                iam_stubber.stub_attach_role_policy(role_name, policy_arn)
+
+    with pytest.raises(ClientError) as exc_info:
+        batch_versioning.create_iam_role(role_name)
+    assert exc_info.value.response['Error']['Code'] == error_code
+
+
+def test_create_lambda_function(make_stubber, make_unique_name):
+    lambda_stubber = make_stubber(batch_versioning.aws_lambda)
+    function_name = make_unique_name('function')
+    function_arn = f'aws:arn:EXAMPLE:{function_name}'
+    mock_role = MagicMock()
+    mock_role.arn = 'aws:arn:EXAMPLE:iam_role'
+    handler = 'test_batch_versioning.test_function'
+
+    lambda_stubber.stub_create_function(
+        function_name, function_arn, mock_role.arn, handler)
+
+    returned_arn = batch_versioning.create_lambda_function(
+        mock_role, function_name, __file__, handler, 'test lambda function')
+    assert returned_arn == function_arn
+
+
+def test_create_lambda_function_failure(make_stubber, make_unique_name):
+    lambda_stubber = make_stubber(batch_versioning.aws_lambda)
+    function_name = make_unique_name('function')
+    function_arn = f'aws:arn:EXAMPLE:{function_name}'
+    mock_role = MagicMock()
+    mock_role.arn = 'aws:arn:EXAMPLE:iam_role'
+    handler = 'test_batch_versioning.test_function'
+
+    lambda_stubber.stub_create_function(
+        function_name, function_arn, mock_role.arn, handler, error_code='TestException')
+
+    with pytest.raises(ClientError) as exc_info:
+        batch_versioning.create_lambda_function(
+            mock_role, function_name, __file__, handler, 'test lambda function')
+    assert exc_info.value.response['Error']['Code'] == 'TestException'
+
+
+def test_create_lambda_function_bad_file():
+    with pytest.raises(IOError):
+        batch_versioning.create_lambda_function(
+            'role', 'func', 'not_a_file.py', 'nonexistent.no_handler', 'None at all')
+
+
+def test_create_and_fill_bucket(make_stubber, make_unique_name, monkeypatch):
+    s3_stubber = make_stubber(batch_versioning.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    monkeypatch.setattr(versioning, 'create_versioned_bucket',
+                        lambda x, y: batch_versioning.s3.Bucket(bucket_name))
+    obj_prefix = 'test-prefix'
+
+    with open(__file__) as file:
+        stanzas = file.read().split('\n\n')
+
+    for index in range(len(stanzas)):
+        s3_stubber.stub_put_object(bucket_name, f"{obj_prefix}stanza-{index}")
+
+    bucket, stanza_objects = \
+        batch_versioning.create_and_fill_bucket(__file__, bucket_name, obj_prefix)
+    assert bucket.name == bucket_name
+    assert len(stanza_objects) == len(stanzas)
+
+
+def test_create_and_fill_bucket_failure(make_stubber, make_unique_name, monkeypatch):
+    s3_stubber = make_stubber(batch_versioning.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    monkeypatch.setattr(versioning, 'create_versioned_bucket',
+                        lambda x, y: batch_versioning.s3.Bucket(bucket_name))
+    obj_prefix = 'test-prefix'
+
+    s3_stubber.stub_put_object(bucket_name, f"{obj_prefix}stanza-0",
+                               error_code='TestException')
+
+    with pytest.raises(ClientError) as exc_info:
+        batch_versioning.create_and_fill_bucket(__file__, bucket_name, obj_prefix)
+    assert exc_info.value.response['Error']['Code'] == 'TestException'
+
+
+def test_prepare_for_random_revisions():
+    manifest_lines = batch_versioning.prepare_for_random_revisions(
+        MagicMock(), [MagicMock(), MagicMock(), MagicMock()])
+    assert len(manifest_lines) == 5 * 3
+
+
+def test_prepare_for_revival(make_stubber, make_unique_name):
+    s3_stubber = make_stubber(batch_versioning.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    obj_prefix = 'test-prefix'
+
+    delete_markers = [s3_stubber.make_version(f'key-{index}', f'version-{index}', True)
+                      for index in range(5)]
+
+    s3_stubber.stub_list_object_versions(
+        bucket_name, f'{obj_prefix}stanza', delete_markers=delete_markers)
+
+    manifest_lines = batch_versioning.prepare_for_revival(
+         batch_versioning.s3.Bucket(bucket_name), obj_prefix)
+    assert len(manifest_lines) == len(delete_markers)
+
+
+def test_prepare_for_revival_failure(make_stubber, make_unique_name):
+    s3_stubber = make_stubber(batch_versioning.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    obj_prefix = 'test-prefix'
+
+    s3_stubber.stub_list_object_versions(
+        bucket_name, f'{obj_prefix}stanza', error_code='TestException')
+
+    with pytest.raises(ClientError) as exc_info:
+        batch_versioning.prepare_for_revival(
+            batch_versioning.s3.Bucket(bucket_name), obj_prefix)
+    assert exc_info.value.response['Error']['Code'] == 'TestException'
+
+
+def test_prepare_for_cleanup(make_stubber, make_unique_name):
+    s3_stubber = make_stubber(batch_versioning.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    obj_prefix = 'test-prefix'
+
+    versions = [s3_stubber.make_version(f'key-{index}', f'version-{index}', True)
+                for index in range(5)]
+    delete_markers = [s3_stubber.make_version(f'key-{index}', f'version-{index}', True)
+                      for index in range(5)]
+    s3_stubber.stub_list_object_versions(
+        bucket_name, f'{obj_prefix}stanza', versions=versions,
+        delete_markers=delete_markers)
+
+    manifest_lines = batch_versioning.prepare_for_cleanup(
+        batch_versioning.s3.Bucket(bucket_name), obj_prefix,
+        [MagicMock(), MagicMock(), MagicMock()]
+    )
+    assert len(manifest_lines) == len(delete_markers)
+
+
+@pytest.mark.parametrize("fail_at", ["put_object", "list_versions"])
+def test_prepare_for_cleanup_failure(make_stubber, make_unique_name, fail_at):
+    s3_stubber = make_stubber(batch_versioning.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    obj_prefix = 'test-prefix'
+    stanzas = [MagicMock(), MagicMock(), MagicMock()]
+
+    if fail_at == 'put_object':
+        stanzas[0].put = MagicMock(side_effect=ClientError(
+            {'Error': {'Code': 'TestException', 'Message': 'hi'}}, 'test-op'))
+    elif fail_at == 'list_versions':
+        s3_stubber.stub_list_object_versions(
+            bucket_name, f'{obj_prefix}stanza', error_code='TestException')
+
+    with pytest.raises(ClientError) as exc_info:
+        batch_versioning.prepare_for_cleanup(
+            batch_versioning.s3.Bucket(bucket_name), obj_prefix, stanzas)
+    assert exc_info.value.response['Error']['Code'] == 'TestException'
+
+
+def test_create_batch_job(make_stubber, make_unique_name):
+    s3_stubber = make_stubber(batch_versioning.s3.meta.client)
+    s3control_stubber = make_stubber(batch_versioning.s3control)
+    bucket_name = make_unique_name('bucket')
+    obj_prefix = 'test-prefix'
+    manifest = {
+        'name': 'manitest',
+        'lines': 'bucket,obj\nbucket,obj\n',
+        'key': f'{obj_prefix}manitest.csv',
+        'e_tag': 'test-e-tag',
+        'bucket': batch_versioning.s3.Bucket(bucket_name),
+        'obj_prefix': obj_prefix,
+        'has_versions': False
+    }
+    job = {
+        'id': 'test-job-id',
+        'description': 'test this function',
+        'account_id': 'test-account-id',
+        'role_arn': 'test-role-arn',
+        'function_arn': 'test-function-arn'
+    }
+
+    s3_stubber.stub_put_object(bucket_name, manifest['key'], e_tag=manifest['e_tag'])
+    s3control_stubber.stub_create_job(
+        job['account_id'], job['role_arn'], job['function_arn'],
+        bucket_name, manifest['key'], manifest['e_tag'], job['id'])
+
+    returned_job_id = batch_versioning.create_batch_job(job, manifest)
+    assert returned_job_id == job['id']
+
+
+@pytest.mark.parametrize("fail_at", ["put_object", "create_job"])
+def test_create_batch_job_failure(make_stubber, make_unique_name, fail_at):
+    s3_stubber = make_stubber(batch_versioning.s3.meta.client)
+    s3control_stubber = make_stubber(batch_versioning.s3control)
+    bucket_name = make_unique_name('bucket')
+    obj_prefix = 'test-prefix'
+    manifest = {
+        'lines': 'bucket,obj\nbucket,obj\n',
+        'key': f'{obj_prefix}manitest.csv',
+        'e_tag': 'test-e-tag',
+        'bucket': batch_versioning.s3.Bucket(bucket_name),
+        'obj_prefix': obj_prefix,
+        'has_versions': False
+    }
+    job = {
+        'id': 'test-job-id',
+        'description': 'test this function',
+        'account_id': 'test-account-id',
+        'role_arn': 'test-role-arn',
+        'function_arn': 'test-function-arn'
+    }
+    error_code = 'TestException'
+
+    if fail_at == 'put_object':
+        s3_stubber.stub_put_object(bucket_name, manifest['key'], error_code=error_code)
+    else:
+        s3_stubber.stub_put_object(
+            bucket_name, manifest['key'], e_tag=manifest['e_tag'])
+        if fail_at == 'create_job':
+            s3control_stubber.stub_create_job(
+                job['account_id'], job['role_arn'], job['function_arn'],
+                bucket_name, manifest['key'], manifest['e_tag'], job['id'],
+                error_code=error_code)
+
+    with pytest.raises(ClientError) as exc_info:
+        batch_versioning.create_batch_job(job, manifest)
+    assert exc_info.value.response['Error']['Code'] == 'TestException'
+
+
+@pytest.mark.parametrize('done_status', ['Complete', 'Failed', 'Cancelled'])
+def test_report_job_status(make_stubber, done_status):
+    s3control_stubber = make_stubber(batch_versioning.s3control)
+    account_id = 'test-account-id'
+    job_id = 'test-job-id'
+
+    s3control_stubber.stub_describe_job(account_id, job_id, status='Preparing')
+    s3control_stubber.stub_describe_job(account_id, job_id, status='Preparing')
+    s3control_stubber.stub_describe_job(account_id, job_id, status=done_status)
+
+    batch_versioning.report_job_status(account_id, job_id)
+
+
+def test_report_job_status_failure(make_stubber):
+    s3control_stubber = make_stubber(batch_versioning.s3control)
+    account_id = 'test-account-id'
+    job_id = 'test-job-id'
+
+    s3control_stubber.stub_describe_job(account_id, job_id, error_code='TestException')
+
+    with pytest.raises(ClientError) as exc_info:
+        batch_versioning.report_job_status(account_id, job_id)
+    assert exc_info.value.response['Error']['Code'] == 'TestException'
+
+
+def test_setup_demo(monkeypatch):
+    role_name = 'test-role'
+    mock_role = MagicMock()
+    mock_role.name = role_name
+    function_info = {
+        'test_function': {
+            'file_name': 'test_file.py',
+            'handler': 'test_file.lambda_handler',
+            'description': 'testing stuff',
+            'arn': None
+        }
+    }
+    test_stanzas = ['stanza1', 'stanza2']
+    monkeypatch.setattr(
+        batch_versioning, 'create_iam_role', lambda x: mock_role)
+    monkeypatch.setattr(
+        batch_versioning, 'create_lambda_function',
+        lambda a, b, c, d, e: 'test-arn'
+    )
+    monkeypatch.setattr(
+        batch_versioning, 'create_and_fill_bucket',
+        lambda x, y, z: ('bucket', test_stanzas)
+    )
+
+    role, bucket, stanza_objects = \
+        batch_versioning.setup_demo(role_name, 'bucket', function_info, 'test-prefix')
+    assert role.name == role_name
+    assert bucket == 'bucket'
+    assert stanza_objects == test_stanzas
+    assert function_info['test_function']['arn'] == 'test-arn'
+
+
+@pytest.mark.parametrize("fail_at", [None, "list1", "list2", "list3"])
+def test_usage_demo_batch_operations(make_stubber, monkeypatch, fail_at):
+    sts_stubber = make_stubber(batch_versioning.sts)
+    s3_stubber = make_stubber(batch_versioning.s3.meta.client)
+    bucket = batch_versioning.s3.Bucket('bucket')
+    obj_prefix = 'test-prefix-'
+    stanza_prefix = f'{obj_prefix}stanza'
+    stanza_key = f'{stanza_prefix}-test'
+    versions = [s3_stubber.make_version(f'key-{index}', f'version-{index}', True)
+                for index in range(5)]
+    delete_markers = [s3_stubber.make_version(f'key-{index}', f'version-{index}', True)
+                      for index in range(5)]
+    error_code = 'TestException'
+
+    monkeypatch.setattr(
+        batch_versioning, 'prepare_for_random_revisions',
+        lambda x, y: 'test-revision-manifest'
+    )
+    monkeypatch.setattr(
+        batch_versioning, 'prepare_for_revival', lambda x, y: 'test-revival-manifest')
+    monkeypatch.setattr(
+        batch_versioning, 'prepare_for_cleanup',
+        lambda x, y, z: 'test-cleanup-manifest')
+    monkeypatch.setattr(
+        batch_versioning, 'create_batch_job', lambda x, y: 'test-job-id')
+    monkeypatch.setattr(batch_versioning, 'report_job_status', lambda x, y: None)
+
+    sts_stubber.stub_get_caller_identity('test-account-id')
+    if fail_at == 'list1':
+        s3_stubber.stub_list_objects(bucket.name, prefix=stanza_prefix,
+                                     object_keys=[stanza_key], error_code=error_code)
+    else:
+        s3_stubber.stub_list_objects(bucket.name, prefix=stanza_prefix,
+                                     object_keys=[stanza_key])
+        s3_stubber.stub_list_objects(bucket.name, prefix=stanza_prefix,
+                                     object_keys=[stanza_key])
+        s3_stubber.stub_get_object(bucket.name, stanza_key, object_data=b'Hey there.')
+        if fail_at == 'list2':
+            s3_stubber.stub_list_objects(
+                bucket.name, prefix=stanza_prefix, object_keys=[stanza_key],
+                error_code=error_code)
+        else:
+            s3_stubber.stub_list_objects(bucket.name, prefix=stanza_prefix,
+                                         object_keys=[stanza_key])
+            if fail_at == 'list3':
+                s3_stubber.stub_list_object_versions(
+                    bucket.name, stanza_prefix, versions=versions,
+                    delete_markers=delete_markers, error_code=error_code)
+            else:
+                s3_stubber.stub_list_object_versions(
+                    bucket.name, stanza_prefix, versions=versions,
+                    delete_markers=delete_markers)
+
+    if fail_at:
+        with pytest.raises(ClientError) as exc_info:
+            batch_versioning.usage_demo_batch_operations(
+                'test-role-arn',
+                {
+                    'revise_stanza': {'arn': 'test-arn'},
+                    'remove_delete_marker': {'arn': 'test-arn'}
+                },
+                bucket, ['stanza1', 'stanza2'], obj_prefix)
+        assert exc_info.value.response['Error']['Code'] == error_code
+    else:
+        batch_versioning.usage_demo_batch_operations(
+            'test-role-arn',
+            {
+                'revise_stanza': {'arn': 'test-arn'},
+                'remove_delete_marker': {'arn': 'test-arn'}
+            },
+            bucket, ['stanza1', 'stanza2'], obj_prefix)
+
+
+@pytest.mark.parametrize(
+    "fail_func",
+    [None, 'stub_delete_role', 'stub_delete_function', 'stub_delete_object_versions',
+     'stub_delete_bucket'])
+def test_teardown_demo(make_stubber, make_unique_name, stub_controller, fail_func):
+    iam_stubber = make_stubber(batch_versioning.iam.meta.client)
+    lambda_stubber = make_stubber(batch_versioning.aws_lambda)
+    s3_stubber = make_stubber(batch_versioning.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    role_name = 'test-role'
+    policy_arn = 'test-arn-must-be-20-characters'
+    function_name = 'test-function'
+    function_info = {function_name: 'test-info'}
+    versions = [{
+        'Key': f'key-{index}',
+        'VersionId': f'version-{index}'
+    } for index in range(5)]
+
+    stub_controller.add(
+        iam_stubber.stub_list_attached_role_policies, (role_name,),
+        {'policies': {'test-policy': policy_arn}})
+    stub_controller.add(iam_stubber.stub_get_policy, (policy_arn,))
+    stub_controller.add(iam_stubber.stub_detach_role_policy, (role_name, policy_arn))
+    stub_controller.add(iam_stubber.stub_delete_policy, (policy_arn,))
+    stub_controller.add(iam_stubber.stub_delete_role, (role_name,))
+    stub_controller.add(lambda_stubber.stub_delete_function, (function_name,))
+    stub_controller.add(
+        s3_stubber.stub_list_object_versions, (bucket_name,),
+        {'prefix': None, 'versions': versions})
+    stub_controller.add(s3_stubber.stub_delete_object_versions, (bucket_name, versions))
+    stub_controller.add(s3_stubber.stub_delete_bucket, (bucket_name,))
+
+    stub_controller.run(fail_func, stop_on_error=False)
+
+    batch_versioning.teardown_demo(role_name, function_info, bucket_name)

--- a/python/example_code/s3/s3_versioning/test/test_remove_delete_marker.py
+++ b/python/example_code/s3/s3_versioning/test/test_remove_delete_marker.py
@@ -5,6 +5,7 @@
 Unit tests for remove_delete_marker.py functions.
 """
 
+from urllib import parse
 import pytest
 
 import remove_delete_marker
@@ -13,10 +14,11 @@ import remove_delete_marker
 def test_remove_delete_marker(make_stubber, make_unique_name, make_event, make_result):
     s3_stubber = make_stubber(remove_delete_marker.s3)
     bucket_name = make_unique_name('bucket')
-    obj_key = make_unique_name('object')
+    # include a space in the object key to verify url-encoding/decoding
+    obj_key = make_unique_name('prefix object')
     version_id = 'test-version-id'
 
-    event = make_event(bucket_name, obj_key, version_id=version_id)
+    event = make_event(bucket_name, parse.quote(obj_key), version_id=version_id)
 
     s3_stubber.stub_head_object(
         bucket_name, obj_key, obj_version_id=version_id, error_code='405',

--- a/python/example_code/s3/s3_versioning/test/test_remove_delete_marker.py
+++ b/python/example_code/s3/s3_versioning/test/test_remove_delete_marker.py
@@ -1,0 +1,85 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for remove_delete_marker.py functions.
+"""
+
+import pytest
+
+import remove_delete_marker
+
+
+def test_remove_delete_marker(make_stubber, make_unique_name, make_event, make_result):
+    s3_stubber = make_stubber(remove_delete_marker.s3)
+    bucket_name = make_unique_name('bucket')
+    obj_key = make_unique_name('object')
+    version_id = 'test-version-id'
+
+    event = make_event(bucket_name, obj_key, version_id=version_id)
+
+    s3_stubber.stub_head_object(
+        bucket_name, obj_key, obj_version_id=version_id, error_code='405',
+        response_meta={'HTTPHeaders': {'x-amz-delete-marker': 'true'}}
+    )
+    s3_stubber.stub_delete_object(bucket_name, obj_key, obj_version_id=version_id)
+
+    result = remove_delete_marker.lambda_handler(event, None)
+    assert result == make_result('Succeeded')
+
+
+def test_remove_delete_marker_not_deleted(
+        make_stubber, make_unique_name, make_event, make_result):
+    s3_stubber = make_stubber(remove_delete_marker.s3)
+    bucket_name = make_unique_name('bucket')
+    obj_key = make_unique_name('object')
+    version_id = 'test-version-id'
+
+    event = make_event(bucket_name, obj_key, version_id=version_id)
+
+    s3_stubber.stub_head_object(bucket_name, obj_key, obj_version_id=version_id)
+
+    result = remove_delete_marker.lambda_handler(event, None)
+    assert result == make_result('PermanentFailure')
+
+
+def test_remove_delete_marker_no_delete_marker(
+    make_stubber, make_unique_name, make_event, make_result):
+    s3_stubber = make_stubber(remove_delete_marker.s3)
+    bucket_name = make_unique_name('bucket')
+    obj_key = make_unique_name('object')
+    version_id = 'test-version-id'
+
+    event = make_event(bucket_name, obj_key, version_id=version_id)
+
+    s3_stubber.stub_head_object(
+        bucket_name, obj_key, obj_version_id=version_id, error_code='405',
+        response_meta={'HTTPHeaders': {'some-other-header': 'nonsense'}}
+    )
+
+    result = remove_delete_marker.lambda_handler(event, None)
+    assert result == make_result('PermanentFailure')
+
+
+@pytest.mark.parametrize('error_code', ['TestException', 'RequestTimeout'])
+def test_remove_delete_marker_delete_fails(
+        make_stubber, make_unique_name, make_event, make_result, error_code):
+    s3_stubber = make_stubber(remove_delete_marker.s3)
+    bucket_name = make_unique_name('bucket')
+    obj_key = make_unique_name('object')
+    version_id = 'test-version-id'
+
+    event = make_event(bucket_name, obj_key, version_id=version_id)
+
+    s3_stubber.stub_head_object(
+        bucket_name, obj_key, obj_version_id=version_id, error_code='405',
+        response_meta={'HTTPHeaders': {'x-amz-delete-marker': 'true'}}
+    )
+    s3_stubber.stub_delete_object(bucket_name, obj_key, obj_version_id=version_id,
+                                  error_code=error_code)
+
+    result = remove_delete_marker.lambda_handler(event, None)
+    if error_code == 'RequestTimeout':
+        assert result == make_result('TemporaryFailure')
+    else:
+        assert result == make_result('PermanentFailure')

--- a/python/example_code/s3/s3_versioning/test/test_revise_stanza.py
+++ b/python/example_code/s3/s3_versioning/test/test_revise_stanza.py
@@ -1,0 +1,73 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for revise_stanza.py functions.
+"""
+
+import pytest
+
+import revise_stanza
+
+
+@pytest.mark.parametrize("revision", ['lower', 'upper', 'reverse', 'delete'])
+def test_revise_stanza(make_stubber, make_unique_name, make_event, make_result,
+                       revision):
+    s3_stubber = make_stubber(revise_stanza.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    obj_key = make_unique_name('object')
+    obj_data = 'Test data!'
+
+    event = make_event(bucket_name, obj_key, revision)
+
+    revised_data = None
+    if revision == 'lower':
+        revised_data = obj_data.lower()
+    elif revision == 'upper':
+        revised_data = obj_data.upper()
+    elif revision == 'reverse':
+        revised_data = obj_data[::-1]
+
+    s3_stubber.stub_get_object(bucket_name, obj_key,
+                               object_data=bytes(obj_data, 'utf-8'))
+    if revision == 'delete':
+        s3_stubber.stub_delete_object(bucket_name, obj_key)
+    else:
+        s3_stubber.stub_put_object(bucket_name, obj_key,
+                                   body=bytes(revised_data, 'utf-8'))
+
+    result = revise_stanza.lambda_handler(event, None)
+    assert result == make_result('Succeeded')
+
+
+def test_revise_stanza_object_not_exist(make_stubber, make_event, make_result):
+    s3_stubber = make_stubber(revise_stanza.s3.meta.client)
+
+    event = make_event('test-bucket', 'test-object', 'lower')
+
+    s3_stubber.stub_get_object('test-bucket', 'test-object', error_code='NoSuchKey')
+
+    result = revise_stanza.lambda_handler(event, None)
+    assert result == make_result('Succeeded')
+
+
+def test_revise_stanza_not_authorized(make_stubber, make_event, make_result):
+    s3_stubber = make_stubber(revise_stanza.s3.meta.client)
+
+    event = make_event('test-bucket', 'test-object', 'lower')
+
+    s3_stubber.stub_get_object('test-bucket', 'test-object', error_code='403')
+
+    result = revise_stanza.lambda_handler(event, None)
+    assert result == make_result('PermanentFailure')
+
+
+def test_revise_stanza_bad_revision(make_stubber, make_event):
+    s3_stubber = make_stubber(revise_stanza.s3.meta.client)
+
+    event = make_event('test-bucket', 'test-object', 'garbage')
+
+    s3_stubber.stub_get_object('test-bucket', 'test-object', object_data=b'Test data')
+
+    with pytest.raises(TypeError):
+        revise_stanza.lambda_handler(event, None)

--- a/python/example_code/s3/s3_versioning/test/test_versioning.py
+++ b/python/example_code/s3/s3_versioning/test/test_versioning.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Unit tests for versionin.py functions.
+Unit tests for versioning.py functions.
 """
 
 from datetime import datetime, timedelta

--- a/python/example_code/s3/s3_versioning/test/test_versioning.py
+++ b/python/example_code/s3/s3_versioning/test/test_versioning.py
@@ -1,0 +1,152 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for versionin.py functions.
+"""
+
+from datetime import datetime, timedelta
+from operator import itemgetter
+import pytest
+
+from botocore.exceptions import ClientError
+from botocore.stub import  ANY
+import versioning
+
+
+@pytest.mark.parametrize("fail_func,error_code,stop_on_error", [
+    (None, None, False),
+    ('stub_create_bucket', 'BucketAlreadyOwnedByYou', False),
+    ('stub_create_bucket', 'TestException', True),
+    ('stub_put_bucket_versioning', 'TestException', True),
+    ('stub_put_bucket_lifecycle_configuration', 'TestException', False)
+])
+def test_create_versioned_bucket(
+        make_stubber, make_unique_name, stub_controller,
+        fail_func, error_code, stop_on_error):
+    s3_stubber = make_stubber(versioning.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    obj_prefix = 'test-prefix'
+
+    stub_controller.add(
+        s3_stubber.stub_create_bucket,
+        (bucket_name, versioning.s3.meta.client.meta.region_name))
+    stub_controller.add(s3_stubber.stub_put_bucket_versioning, (bucket_name, 'Enabled'))
+    stub_controller.add(s3_stubber.stub_put_bucket_lifecycle_configuration, (
+        bucket_name, [{
+            'Status': 'Enabled',
+            'Prefix': obj_prefix,
+            'NoncurrentVersionExpiration': {'NoncurrentDays': ANY}
+        }],))
+
+    stub_controller.run(fail_func, error_code, stop_on_error)
+
+    if error_code and stop_on_error:
+        with pytest.raises(ClientError) as exc_info:
+            versioning.create_versioned_bucket(bucket_name, obj_prefix)
+        assert exc_info.value.response['Error']['Code'] == error_code
+    else:
+        bucket = versioning.create_versioned_bucket(bucket_name, obj_prefix)
+        assert bucket.name == bucket_name
+
+
+def test_rollback_object(make_stubber, make_unique_name, stub_controller):
+    s3_stubber = make_stubber(versioning.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    obj_key = make_unique_name('object')
+    rollback_version = 'version-2'
+    versions = [
+        s3_stubber.make_version(
+            obj_key, f'version-{index}', True,
+            datetime.now() + timedelta(minutes=index))
+        for index in range(5)]
+    delete_markers = [
+        s3_stubber.make_version(
+            obj_key, f'version-{index}', True,
+            datetime.now() + timedelta(minutes=index))
+        for index in range(10, 15)]
+
+    stub_controller.add(
+        s3_stubber.stub_list_object_versions, (bucket_name,),
+        kwargs={'prefix': obj_key, 'versions': versions,
+                'delete_markers': delete_markers})
+    for version in sorted(versions + delete_markers, key=itemgetter('LastModified'),
+                          reverse=True):
+        if version['VersionId'] != rollback_version:
+            stub_controller.add(
+                s3_stubber.stub_delete_object, (bucket_name, obj_key),
+                {'obj_version_id': version['VersionId']})
+        else:
+            break
+    stub_controller.add(
+        s3_stubber.stub_head_object, (bucket_name, obj_key))
+
+    stub_controller.run()
+
+    versioning.rollback_object(
+        versioning.s3.Bucket(bucket_name), obj_key, rollback_version)
+
+
+@pytest.mark.parametrize(
+    'code_path', ['happy', 'not_latest', 'no_deletes', 'no_versions'])
+def test_revive_object(make_stubber, make_unique_name, stub_controller, code_path):
+    s3_stubber = make_stubber(versioning.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    obj_key = make_unique_name('object')
+
+    if code_path == 'not_latest':
+        stub_controller.add(
+            s3_stubber.stub_list_object_versions,
+            (bucket_name, obj_key),
+            {'delete_markers':
+                 [s3_stubber.make_version(obj_key, 'version1', False, datetime.now())],
+             'max_keys': 1})
+    elif code_path == 'no_deletes':
+        stub_controller.add(
+            s3_stubber.stub_list_object_versions, (bucket_name, obj_key),
+            {'versions':
+                 [s3_stubber.make_version(obj_key, 'version1', True, datetime.now())],
+             'max_keys': 1})
+    elif code_path == 'no_versions':
+        stub_controller.add(
+            s3_stubber.stub_list_object_versions, (bucket_name, obj_key),
+            {'max_keys': 1})
+    elif code_path == 'happy':
+        stub_controller.add(
+            s3_stubber.stub_list_object_versions,
+            (bucket_name, obj_key),
+            {'delete_markers':
+                 [s3_stubber.make_version(obj_key, 'version1', True, datetime.now())],
+             'max_keys': 1})
+        stub_controller.add(
+            s3_stubber.stub_delete_object, (bucket_name, obj_key),
+            {'obj_version_id': 'version1'})
+        stub_controller.add(s3_stubber.stub_head_object, (bucket_name, obj_key))
+        stub_controller.add(
+            s3_stubber.stub_get_object, (bucket_name, obj_key),
+            {'object_data': b'Test data', 'version_id': 'version1'})
+
+    stub_controller.run()
+
+    versioning.revive_object(versioning.s3.Bucket(bucket_name), obj_key)
+
+
+@pytest.mark.parametrize('error_code', [None, 'TestException'])
+def test_permanently_delete_object(make_stubber, make_unique_name, error_code):
+    s3_stubber = make_stubber(versioning.s3.meta.client)
+    bucket_name = make_unique_name('bucket')
+    obj_key = make_unique_name('object')
+
+    s3_stubber.stub_list_object_versions(
+        bucket_name, obj_key, delete_markers=
+        [s3_stubber.make_version(obj_key, 'version1', True, datetime.now())])
+    s3_stubber.stub_delete_object_versions(bucket_name,
+        [s3_stubber.make_version(obj_key, 'version1')], error_code=error_code)
+
+    if not error_code:
+        versioning.permanently_delete_object(versioning.s3.Bucket(bucket_name), obj_key)
+    else:
+        with pytest.raises(ClientError) as exc_info:
+            versioning.permanently_delete_object(versioning.s3.Bucket(bucket_name),
+                                                 obj_key)
+        assert exc_info.value.response['Error']['Code'] == error_code

--- a/python/example_code/s3/s3_versioning/versioning.py
+++ b/python/example_code/s3/s3_versioning/versioning.py
@@ -32,7 +32,7 @@ s3 = boto3.resource('s3')
 # snippet-start:[s3.python.versioning.create_versioned_bucket]
 def create_versioned_bucket(bucket_name, prefix):
     """
-    Creates an Amazon S3 bucket, enable it for versioning, and configure a lifecycle
+    Creates an Amazon S3 bucket, enables it for versioning, and configures a lifecycle
     that expires noncurrent object versions after 7 days.
 
     Adding a lifecycle configuration to a versioned bucket is a best practice.

--- a/python/example_code/s3/s3_versioning/versioning.py
+++ b/python/example_code/s3/s3_versioning/versioning.py
@@ -1,0 +1,267 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Purpose
+
+Demonstrates how to set up an Amazon S3 bucket for versioning, and how to perform
+basic tasks on a version-enabled bucket.
+
+For more detail, including usage and testing instructions, see the README.
+
+Running this demo uses your default AWS credentials to create resources in your
+account and my incur charges.
+"""
+
+import logging
+from operator import attrgetter
+from shutil import get_terminal_size
+from sys import stdout
+import uuid
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+log_handler = logging.StreamHandler(stdout)
+log_handler.setLevel(logging.INFO)
+logger.addHandler(log_handler)
+logger.setLevel(logging.INFO)
+
+s3 = boto3.resource('s3')
+
+
+# snippet-start:[s3.python.versioning.create_versioned_bucket]
+def create_versioned_bucket(bucket_name, prefix):
+    """
+    Creates an Amazon S3 bucket, enable it for versioning, and configure a lifecycle
+    that expires noncurrent object versions after 7 days.
+
+    Adding a lifecycle configuration to a versioned bucket is a best practice.
+    It helps prevent objects in the bucket from accumulating a large number of
+    noncurrent versions, which can slow down request performance.
+
+    Usage is shown in the usage_demo_single_object function at the end of this module.
+
+    :param bucket_name: The name of the bucket to create.
+    :return: The newly created bucket.
+    """
+    try:
+        bucket = s3.create_bucket(
+            Bucket=bucket_name,
+            CreateBucketConfiguration={
+                'LocationConstraint': s3.meta.client.meta.region_name
+            }
+        )
+        logger.info("Created bucket %s.", bucket.name)
+    except ClientError as error:
+        if error.response['Error']['Code'] == 'BucketAlreadyOwnedByYou':
+            logger.warning("Bucket %s already exists! Using it.", bucket_name)
+            bucket = s3.Bucket(bucket_name)
+        else:
+            logger.exception("Couldn't create bucket %s.", bucket_name)
+            raise
+
+    try:
+        bucket.Versioning().enable()
+        logger.info("Enabled versioning on bucket %s.", bucket.name)
+    except ClientError:
+        logger.exception("Couldn't enable versioning on bucket %s.", bucket.name)
+        raise
+
+    try:
+        expiration = 7
+        bucket.LifecycleConfiguration().put(
+            LifecycleConfiguration={
+                'Rules': [{
+                    'Status': 'Enabled',
+                    'Prefix': prefix,
+                    'NoncurrentVersionExpiration': {'NoncurrentDays': expiration}
+                }]
+            }
+        )
+        logger.info("Configured lifecycle to expire noncurrent versions after %s days "
+                    "on bucket %s.", expiration, bucket.name)
+    except ClientError as error:
+        logger.warning("Couldn't configure lifecycle on bucket %s because %s. "
+                       "Continuing anyway.", bucket.name, error)
+
+    return bucket
+# snippet-end:[s3.python.versioning.create_versioned_bucket]
+
+
+# snippet-start:[s3.python.versioning.rollback_object]
+def rollback_object(bucket, object_key, version_id):
+    """
+    Rolls back an object to an earlier version by deleting all versions that
+    occurred after the specified rollback version.
+
+    Usage is shown in the usage_demo_single_object function at the end of this module.
+
+    :param bucket: The bucket that holds the object to roll back.
+    :param object_key: The object to roll back.
+    :param version_id: The version ID to roll back to.
+    """
+    # Versions must be sorted by last_modified date because delete markers are
+    # at the end of the list even when they are interspersed in time.
+    versions = sorted(bucket.object_versions.filter(Prefix=object_key),
+                      key=attrgetter('last_modified'), reverse=True)
+
+    logger.debug(
+        "Got versions:\n%s",
+        '\n'.join([f"    {version.version_id}, last modified {version.last_modified}"
+                   for version in versions]))
+
+    print(f"Rolling back to version {version_id}")
+    for version in versions:
+        if version.version_id != version_id:
+            version.delete()
+            print(f"Deleted version {version.version_id}")
+        else:
+            break
+
+    print(f"Active version is now {bucket.Object(object_key).version_id}")
+# snippet-end:[s3.python.versioning.rollback_object]
+
+
+# snippet-start:[s3.python.versioning.revive_object]
+def revive_object(bucket, object_key):
+    """
+    Revives an object that was deleted by removing the object's active delete marker.
+
+    Usage is shown in the usage_demo_single_object function at the end of this module.
+
+    :param bucket: The bucket that contains the object.
+    :param object_key: The object to revive.
+    """
+    # Get the latest version for the object.
+    response = s3.meta.client.list_object_versions(
+        Bucket=bucket.name, Prefix=object_key, MaxKeys=1)
+
+    if 'DeleteMarkers' in response:
+        latest_version = response['DeleteMarkers'][0]
+        if latest_version['IsLatest']:
+            logger.info("Object %s was indeed deleted on %s. Let's revive it.",
+                        object_key, latest_version['LastModified'])
+            obj = bucket.Object(object_key)
+            obj.Version(latest_version['VersionId']).delete()
+            logger.info("Revived %s, active version is now %s  with body '%s'",
+                        object_key, obj.version_id, obj.get()['Body'].read())
+        else:
+            logger.warning("Delete marker is not the latest version for %s!",
+                           object_key)
+    elif 'Versions' in response:
+        logger.warning("Got an active version for %s, nothing to do.", object_key)
+    else:
+        logger.error("Couldn't get any version info for %s.", object_key)
+# snippet-end:[s3.python.versioning.revive_object]
+
+
+# snippet-start:[s3.python.versioning.permanently_delete_object]
+def permanently_delete_object(bucket, object_key):
+    """
+    Permanently deletes a versioned object by deleting all of its versions.
+
+    Usage is shown in the usage_demo_single_object function at the end of this module.
+
+    :param bucket: The bucket that contains the object.
+    :param object_key: The object to delete.
+    """
+    try:
+        bucket.object_versions.filter(Prefix=object_key).delete()
+        logger.info("Permanently deleted all versions of object %s.", object_key)
+    except ClientError:
+        logger.exception("Couldn't delete all versions of %s.", object_key)
+        raise
+# snippet-end:[s3.python.versioning.permanently_delete_object]
+
+
+def usage_demo_single_object(obj_prefix='aws-version-demo/'):
+    """
+    Demonstrates usage of versioned object functions. This demo uploads a stanza
+    of a poem and performs a series of revisions, deletions, and revivals on it.
+
+    :param obj_prefix: The prefix to assign to objects created by this demo.
+    """
+    with open('father_william.txt') as file:
+        stanzas = file.read().split('\n\n')
+
+    width = get_terminal_size((80, 20))[0]
+    print('-'*width)
+    print("Welcome to the usage demonstration of Amazon S3 versioning.")
+    print("This demonstration uploads a single stanza of a poem to an Amazon "
+          "S3 bucket and then applies various revisions to it.")
+    print('-'*width)
+    print("Creating a version-enabled bucket for the demo...")
+    bucket = create_versioned_bucket('bucket-' + str(uuid.uuid1()), obj_prefix)
+
+    print("\nThe initial version of our stanza:")
+    print(stanzas[0])
+
+    # Add the first stanza and revise it a few times.
+    print("\nApplying some revisions to the stanza...")
+    obj_stanza_1 = bucket.Object(f'{obj_prefix}stanza-1')
+    obj_stanza_1.put(Body=bytes(stanzas[0], 'utf-8'))
+    obj_stanza_1.put(Body=bytes(stanzas[0].upper(), 'utf-8'))
+    obj_stanza_1.put(Body=bytes(stanzas[0].lower(), 'utf-8'))
+    obj_stanza_1.put(Body=bytes(stanzas[0][::-1], 'utf-8'))
+    print("The latest version of the stanza is now:",
+          obj_stanza_1.get()['Body'].read().decode('utf-8'),
+          sep='\n')
+
+    # Versions are returned in order, most recent first.
+    obj_stanza_1_versions = bucket.object_versions.filter(Prefix=obj_stanza_1.key)
+    print(
+        "The version data of the stanza revisions:",
+        *[f"    {version.version_id}, last modified {version.last_modified}"
+            for version in obj_stanza_1_versions],
+        sep='\n'
+    )
+
+    # Rollback two versions.
+    print("\nRolling back two versions...")
+    rollback_object(bucket, obj_stanza_1.key, list(obj_stanza_1_versions)[2].version_id)
+    print("The latest version of the stanza:",
+          obj_stanza_1.get()['Body'].read().decode('utf-8'),
+          sep='\n')
+
+    # Delete the stanza
+    print("\nDeleting the stanza...")
+    obj_stanza_1.delete()
+    try:
+        obj_stanza_1.get()
+    except ClientError as error:
+        if error.response['Error']['Code'] == 'NoSuchKey':
+            print("The stanza is now deleted (as expected).")
+        else:
+            raise
+
+    # Revive the stanza
+    print("\nRestoring the stanza...")
+    revive_object(bucket, obj_stanza_1.key)
+    print("The stanza is restored! The latest version is again:",
+          obj_stanza_1.get()['Body'].read().decode('utf-8'),
+          sep='\n')
+
+    # Permanently delete all versions of the object. This cannot be undone!
+    print("\nPermanently deleting all versions of the stanza...")
+    permanently_delete_object(bucket, obj_stanza_1.key)
+    obj_stanza_1_versions = bucket.object_versions.filter(Prefix=obj_stanza_1.key)
+    if len(list(obj_stanza_1_versions)) == 0:
+        print("The stanza has been permanently deleted and now has no versions.")
+    else:
+        print("Something went wrong. The stanza still exists!")
+
+    print(f"\nRemoving {bucket.name}...")
+    bucket.delete()
+    print(f"{bucket.name} deleted.")
+    print("Demo done!")
+
+
+def main():
+    """Kick off the demo."""
+    usage_demo_single_object()
+
+
+if __name__ == '__main__':
+    main()

--- a/python/test_tools/example_stubber.py
+++ b/python/test_tools/example_stubber.py
@@ -53,11 +53,11 @@ class ExampleStubber(Stubber):
 
     def _stub_bifurcator(
             self, method, expected_params=None, response=None, error_code=None):
-        if not expected_params:
+        if expected_params is None:
             expected_params = {}
-        if not response:
+        if response is None:
             response = {}
-        if not error_code:
+        if error_code is None:
             self.add_response(
                 method, expected_params=expected_params, service_response=response)
         else:

--- a/python/test_tools/example_stubber.py
+++ b/python/test_tools/example_stubber.py
@@ -50,3 +50,17 @@ class ExampleStubber(Stubber):
         """When using stubs, verify no more responses are waiting in the queue."""
         if self.use_stubs:
             super().assert_no_pending_responses()
+
+    def _stub_bifurcator(
+            self, method, expected_params=None, response=None, error_code=None):
+        if not expected_params:
+            expected_params = {}
+        if not response:
+            response = {}
+        if not error_code:
+            self.add_response(
+                method, expected_params=expected_params, service_response=response)
+        else:
+            self.add_client_error(
+                method, expected_params=expected_params, service_error_code=error_code)
+

--- a/python/test_tools/fixtures/common.py
+++ b/python/test_tools/fixtures/common.py
@@ -147,3 +147,30 @@ def fixture_make_bucket(request, make_unique_name):
         return bucket
 
     return _make_bucket
+
+
+class StubController:
+    default_error = 'TestException'
+
+    def __init__(self):
+        self.stubs = []
+
+    def add(self, func, args=None, kwargs=None):
+        if not kwargs:
+            kwargs = {}
+        self.stubs.append({'func': func, 'args': args, 'kwargs': kwargs})
+
+    def run(self, func_name=None, error_code=default_error, stop_on_error=True,
+            stop_always=False):
+        for index, stub in enumerate(self.stubs):
+            stub_error = error_code if func_name == stub['func'].__name__ else None
+            stub['func'](*stub['args'], **stub['kwargs'], error_code=stub_error)
+            if stop_always:
+                break
+            elif stop_on_error and stub_error:
+                break
+
+
+@pytest.fixture
+def stub_controller():
+    return StubController()

--- a/python/test_tools/iam_stubber.py
+++ b/python/test_tools/iam_stubber.py
@@ -1,0 +1,188 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Stub functions that are used by the AWS IAM unit tests.
+
+When tests are run against an actual AWS account, the stubber class does not
+set up stubs and passes all calls through to the Boto 3 client.
+"""
+
+from datetime import datetime
+import random
+import string
+from botocore.stub import ANY
+
+from test_tools.example_stubber import ExampleStubber
+
+
+def random_string(length):
+    return ''.join([random.choice(string.ascii_lowercase) for _ in range(length)])
+
+
+class IamStubber(ExampleStubber):
+    """
+    A class that implements a variety of stub functions that are used by the
+    AWS IAM unit tests.
+
+    The stubbed functions all expect certain parameters to be passed to them as
+    part of the tests, and will raise errors when the actual parameters differ from
+    the expected.
+    """
+    def __init__(self, client, use_stubs=True):
+        """
+        Initializes the object with a specific client and configures it for
+        stubbing or AWS passthrough.
+
+        :param client: A Boto 3 IAM client.
+        :param use_stubs: When True, use stubs to intercept requests. Otherwise,
+                          pass requests through to AWS.
+        """
+        super().__init__(client, use_stubs)
+
+    @staticmethod
+    def _add_role(response, role_name):
+        response['Role'] = {
+            'RoleName': role_name,
+            'Path': '/',
+            'RoleId': random_string(16),
+            'Arn': random_string(20),
+            'CreateDate': datetime.now()
+        }
+        return response
+
+    def stub_create_role(self, role_name, assume_role_policy=ANY, error_code=None):
+        expected_params = {
+            'RoleName': role_name,
+            'AssumeRolePolicyDocument': assume_role_policy
+        }
+
+        if not error_code:
+            self.add_response(
+                'create_role',
+                expected_params=expected_params,
+                service_response=self._add_role({}, role_name)
+            )
+        else:
+            self.add_client_error(
+                'create_role',
+                expected_params=expected_params,
+                service_error_code=error_code
+            )
+
+    def stub_get_role(self, role_name, status_code=200, error_code=None):
+        expected_params = {'RoleName': role_name}
+        if not error_code:
+            self.add_response(
+                'get_role',
+                expected_params=expected_params,
+                service_response=self._add_role({
+                    'ResponseMetadata': {'HTTPStatusCode': status_code}
+                }, role_name)
+            )
+        else:
+            self.add_client_error(
+                'get_role',
+                expected_params=expected_params,
+                service_error_code=error_code
+            )
+
+    def stub_delete_role(self, role_name, error_code=None):
+        self._stub_bifurcator(
+            'delete_role',
+            expected_params={'RoleName': role_name},
+            error_code=error_code)
+
+    def stub_create_policy(self, policy_name, policy_arn, policy_document=ANY,
+                           error_code=None):
+        expected_params = {
+            'PolicyName': policy_name,
+            'PolicyDocument': policy_document
+        }
+        if not error_code:
+            self.add_response(
+                'create_policy',
+                expected_params=expected_params,
+                service_response={
+                    'Policy': {
+                        'PolicyName': policy_name,
+                        'Arn': policy_arn
+                    }
+                }
+            )
+        else:
+            self.add_client_error(
+                'create_policy',
+                expected_params=expected_params,
+                service_error_code=error_code
+            )
+
+    def stub_get_policy(self, policy_arn, status_code=200, error_code=None):
+        expected_params = {'PolicyArn': policy_arn}
+        if not error_code:
+            self.add_response(
+                'get_policy',
+                expected_params=expected_params,
+                service_response= {
+                    'ResponseMetadata': {'HTTPStatusCode': status_code},
+                    'Policy': {'PolicyName': policy_arn.split(':')[-1]}
+                }
+            )
+        else:
+            self.add_client_error(
+                'get_policy',
+                expected_params=expected_params,
+                service_error_code=error_code
+            )
+            
+    def stub_delete_policy(self, policy_arn, error_code=None):
+        self._stub_bifurcator(
+            'delete_policy',
+            expected_params={'PolicyArn': policy_arn},
+            error_code=error_code)
+
+    def stub_attach_role_policy(self, role_name, policy_arn, error_code=None):
+        expected_params = {
+            'RoleName': role_name,
+            'PolicyArn': policy_arn
+        }
+        if not error_code:
+            self.add_response(
+                'attach_role_policy',
+                expected_params=expected_params,
+                service_response={}
+            )
+        else:
+            self.add_client_error(
+                'attach_role_policy',
+                expected_params=expected_params,
+                service_error_code=error_code
+            )
+
+    def stub_list_attached_role_policies(self, role_name, policies=None,
+                                         error_code=None):
+        expected_params = {'RoleName': role_name}
+        if not error_code:
+            self.add_response(
+                'list_attached_role_policies',
+                expected_params=expected_params,
+                service_response={
+                    'AttachedPolicies': [{
+                        'PolicyName': name,
+                        'PolicyArn': arn
+                    } for name, arn in policies.items()]
+                }
+            )
+        else:
+            self.add_client_error(
+                'list_attached_role_policies',
+                expected_params=expected_params,
+                service_error_code=error_code
+            )
+
+    def stub_detach_role_policy(self, role_name, policy_arn, error_code=None):
+        self._stub_bifurcator(
+            'detach_role_policy',
+            expected_params={'RoleName': role_name, 'PolicyArn': policy_arn},
+            error_code=error_code
+        )

--- a/python/test_tools/iam_stubber.py
+++ b/python/test_tools/iam_stubber.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Stub functions that are used by the AWS IAM unit tests.
+Stub functions that are used by the AWS Identity and Access Management (IAM) unit tests.
 
 When tests are run against an actual AWS account, the stubber class does not
 set up stubs and passes all calls through to the Boto 3 client.
@@ -23,7 +23,7 @@ def random_string(length):
 class IamStubber(ExampleStubber):
     """
     A class that implements a variety of stub functions that are used by the
-    AWS IAM unit tests.
+    IAM unit tests.
 
     The stubbed functions all expect certain parameters to be passed to them as
     part of the tests, and will raise errors when the actual parameters differ from

--- a/python/test_tools/lambda_stubber.py
+++ b/python/test_tools/lambda_stubber.py
@@ -1,0 +1,66 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Stub functions that are used by the AWS Lambda unit tests.
+
+When tests are run against an actual AWS account, the stubber class does not
+set up stubs and passes all calls through to the Boto 3 client.
+"""
+
+from botocore.stub import ANY
+
+from test_tools.example_stubber import ExampleStubber
+
+
+class LambdaStubber(ExampleStubber):
+    """
+    A class that implements a variety of stub functions that are used by the
+    AWS Lambda unit tests.
+
+    The stubbed functions all expect certain parameters to be passed to them as
+    part of the tests, and will raise errors when the actual parameters differ from
+    the expected.
+    """
+    def __init__(self, client, use_stubs=True):
+        """
+        Initializes the object with a specific client and configures it for
+        stubbing or AWS passthrough.
+
+        :param client: A Boto 3 Lambda client.
+        :param use_stubs: When True, use stubs to intercept requests. Otherwise,
+                          pass requests through to AWS.
+        """
+        super().__init__(client, use_stubs)
+
+    def stub_create_function(self, function_name, function_arn, role_arn,
+                             handler, zip_contents=ANY, error_code=None):
+        expected_params = {
+            'FunctionName': function_name,
+            'Runtime': ANY,
+            'Role': role_arn,
+            'Handler': handler,
+            'Code': {'ZipFile': zip_contents},
+            'Description': ANY,
+            'Publish': True
+        }
+        if not error_code:
+            self.add_response(
+                'create_function',
+                expected_params=expected_params,
+                service_response={
+                    'FunctionArn': function_arn
+                }
+            )
+        else:
+            self.add_client_error(
+                'create_function',
+                expected_params=expected_params,
+                service_error_code=error_code
+            )
+
+    def stub_delete_function(self, function_name, error_code=None):
+        self._stub_bifurcator(
+            'delete_function',
+            expected_params={'FunctionName': function_name},
+            error_code=error_code)

--- a/python/test_tools/s3control_stubber.py
+++ b/python/test_tools/s3control_stubber.py
@@ -1,0 +1,92 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Stub functions that are used by the AWS S3 Control unit tests.
+
+When tests are run against an actual AWS account, the stubber class does not
+set up stubs and passes all calls through to the Boto 3 client.
+"""
+
+import io
+import json
+from botocore.stub import ANY
+
+from test_tools.example_stubber import ExampleStubber
+
+
+class S3ControlStubber(ExampleStubber):
+    """
+    A class that implements a variety of stub functions that are used by the
+    AWS S3 Control unit tests.
+
+    The stubbed functions all expect certain parameters to be passed to them as
+    part of the tests, and will raise errors when the actual parameters differ from
+    the expected.
+    """
+    def __init__(self, client, use_stubs=True):
+        """
+        Initializes the object with a specific client and configures it for
+        stubbing or AWS passthrough.
+
+        :param client: A Boto 3 S3 Control client.
+        :param use_stubs: When True, use stubs to intercept requests. Otherwise,
+                          pass requests through to AWS.
+        """
+        super().__init__(client, use_stubs)
+
+    def stub_create_job(self, account_id, role_arn, function_arn, bucket_name,
+                        manifest_key, manifest_e_tag, job_id, error_code=None):
+        expected_params = {
+            'AccountId': account_id,
+            'ConfirmationRequired': False,
+            'Description': ANY,
+            'Priority': 1,
+            'RoleArn': role_arn,
+            'Operation': {'LambdaInvoke': {'FunctionArn': function_arn}},
+            'Manifest': {
+                'Spec': {
+                    'Format': 'S3BatchOperations_CSV_20180820',
+                    'Fields': ['Bucket', 'Key']
+                },
+                'Location': {
+                    'ObjectArn': f'arn:aws:s3:::{bucket_name}/{manifest_key}',
+                    'ETag': manifest_e_tag
+                }
+            },
+            'Report': {
+                'Bucket': f'arn:aws:s3:::{bucket_name}',
+                'Format': 'Report_CSV_20180820',
+                'Enabled': True,
+                'Prefix': ANY,
+                'ReportScope': 'AllTasks'
+            }
+        }
+        if not error_code:
+            self.add_response(
+                'create_job',
+                expected_params=expected_params,
+                service_response={'JobId': job_id}
+            )
+        else:
+            self.add_client_error(
+                'create_job',
+                expected_params=expected_params,
+                service_error_code=error_code
+            )
+
+    def stub_describe_job(self, account_id, job_id, status='Complete',
+                          error_code=None):
+        expected_params = {'AccountId': account_id, 'JobId': job_id}
+        if not error_code:
+            self.add_response(
+                'describe_job',
+                expected_params=expected_params,
+                service_response={'Job': {'Status': status}}
+            )
+        else:
+            self.add_client_error(
+                'describe_job',
+                expected_params=expected_params,
+                service_error_code=error_code
+            )

--- a/python/test_tools/sts_stubber.py
+++ b/python/test_tools/sts_stubber.py
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Stub functions that are used by the AWS STS unit tests.
+
+When tests are run against an actual AWS account, the stubber class does not
+set up stubs and passes all calls through to the Boto 3 client.
+"""
+
+import io
+import json
+from botocore.stub import ANY
+
+from test_tools.example_stubber import ExampleStubber
+
+
+class StsStubber(ExampleStubber):
+    """
+    A class that implements a variety of stub functions that are used by the
+    AWS STS Control unit tests.
+
+    The stubbed functions all expect certain parameters to be passed to them as
+    part of the tests, and will raise errors when the actual parameters differ from
+    the expected.
+    """
+    def __init__(self, client, use_stubs=True):
+        """
+        Initializes the object with a specific client and configures it for
+        stubbing or AWS passthrough.
+
+        :param client: A Boto 3 STS client.
+        :param use_stubs: When True, use stubs to intercept requests. Otherwise,
+                          pass requests through to AWS.
+        """
+        super().__init__(client, use_stubs)
+
+    def stub_get_caller_identity(self, account_id, error_code=None):
+        if not error_code:
+            self.add_response(
+                'get_caller_identity',
+                expected_params={},
+                service_response={'Account': account_id}
+            )
+        else:
+            self.add_client_error(
+                'get_caller_identity',
+                expected_params={},
+                service_error_code=error_code
+            )

--- a/python/test_tools/stubber_factory.py
+++ b/python/test_tools/stubber_factory.py
@@ -8,10 +8,14 @@ name of the service that is used by Boto 3.
 This factory is used by the make_stubber fixture found in the set of common fixtures.
 """
 
-from test_tools.s3_stubber import S3Stubber
 from test_tools.dynamodb_stubber import DynamoStubber
+from test_tools.iam_stubber import IamStubber
+from test_tools.lambda_stubber import LambdaStubber
 from test_tools.pinpoint_stubber import PinpointStubber
+from test_tools.s3_stubber import S3Stubber
+from test_tools.s3control_stubber import S3ControlStubber
 from test_tools.sqs_stubber import SqsStubber
+from test_tools.sts_stubber import StsStubber
 
 
 class StubberFactoryNotImplemented(Exception):
@@ -19,14 +23,22 @@ class StubberFactoryNotImplemented(Exception):
 
 
 def stubber_factory(service_name):
-    if service_name == 's3':
-        return S3Stubber
-    elif service_name == 'dynamodb':
+    if service_name == 'dynamodb':
         return DynamoStubber
+    elif service_name == 'iam':
+        return IamStubber
+    elif service_name == 'lambda':
+        return LambdaStubber
     elif service_name == 'pinpoint':
         return PinpointStubber
+    elif service_name == 's3':
+        return S3Stubber
+    elif service_name == 's3control':
+        return S3ControlStubber
     elif service_name == 'sqs':
         return SqsStubber
+    elif service_name == 'sts':
+        return StsStubber
     else:
         raise StubberFactoryNotImplemented(
             "If you see this exception, it probably means that you forgot to add "


### PR DESCRIPTION
Demonstration examples for Amazon S3 version-enabled buckets.
The demo includes a single-object version that shows basic usage on a versioned object.
The demo also includes a batch operation version that sets up Lambda functions
and creates batch jobs to perform batch operations on versioned objects.

- [x] The submitter has added the default copyright notice to all files.

- [x] The submitter has added unit tests for all code paths, run all of them, and they all pass.

- [x] The submitter has run a linter on the code, and all of the submitter's team's minimum rules pass.

- [x] The submitter has added the team's minimum usage documentation to the code.

- [x] The submitter has had the code reviewed, and the submitter has incorporated any and all resulting review comments.

- [x] The submitter has had their Editor edit all comments and strings, and the submitter has incorporated any and all resulting edits.

- [x] The submitter has added all of the submitter's team's related API reporting metadata. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
