### PR TITLE
Cleanup DynamoDB TryDAX example

### DIFF
--- a/python/example_code/dynamodb/TryDax/01-create-table.py
+++ b/python/example_code/dynamodb/TryDax/01-create-table.py
@@ -1,65 +1,51 @@
-# snippet-sourcedescription:[ ]
-# snippet-service:[dynamodb]
-# snippet-keyword:[Python]
-# snippet-sourcesyntax:[python]
-# snippet-sourcesyntax:[python]
-# snippet-keyword:[Amazon DynamoDB]
-# snippet-keyword:[Code Sample]
-# snippet-keyword:[ ]
-# snippet-sourcetype:[full-example]
-# snippet-sourcedate:[ ]
-# snippet-sourceauthor:[AWS]
-# snippet-start:[dynamodb.Python.TryDax.01-create-table] 
-
-#
-#  Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#  This file is licensed under the Apache License, Version 2.0 (the "License").
-#  You may not use this file except in compliance with the License. A copy of
-#  the License is located at
-# 
-#  http://aws.amazon.com/apache2.0/
-# 
-#  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-#  CONDITIONS OF ANY KIND, either express or implied. See the License for the
-#  specific language governing permissions and limitations under the License.
-#
 #!/usr/bin/env python3
-from __future__ import print_function
 
-import os
-import amazondax
-import botocore.session
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
-region = os.environ.get('AWS_DEFAULT_REGION', 'us-west-2')
+"""
+Purpose
 
-session = botocore.session.get_session()
-dynamodb = session.create_client('dynamodb', region_name=region) # low-level client
+Creates an Amazon DynamoDB table to use for the demonstration.
+"""
 
-table_name = "TryDaxTable"
+# snippet-start:[dynamodb.Python.TryDax.01-create-table]
+import boto3
 
-params = {
-    'TableName' : table_name,
-    'KeySchema': [       
-        { 'AttributeName': "pk", 'KeyType': "HASH"},    # Partition key
-        { 'AttributeName': "sk", 'KeyType': "RANGE" }   # Sort key
-    ],
-    'AttributeDefinitions': [       
-        { 'AttributeName': "pk", 'AttributeType': "N" },
-        { 'AttributeName': "sk", 'AttributeType': "N" }
-    ],
-    'ProvisionedThroughput': {       
-        'ReadCapacityUnits': 10, 
-        'WriteCapacityUnits': 10
+
+def create_dax_table(dyn_resource=None):
+    """
+    Creates a DynamoDB table.
+
+    :param dyn_resource: Either a Boto3 or DAX resource.
+    :return: The newly created table.
+    """
+    if dyn_resource is None:
+        dyn_resource = boto3.resource('dynamodb')
+
+    table_name = 'TryDaxTable'
+    params = {
+        'TableName': table_name,
+        'KeySchema': [
+            {'AttributeName': 'partition_key', 'KeyType': 'HASH'},
+            {'AttributeName': 'sort_key', 'KeyType': 'RANGE'}
+        ],
+        'AttributeDefinitions': [
+            {'AttributeName': 'partition_key', 'AttributeType': 'N'},
+            {'AttributeName': 'sort_key', 'AttributeType': 'N'}
+        ],
+        'ProvisionedThroughput': {
+            'ReadCapacityUnits': 10,
+            'WriteCapacityUnits': 10
+        }
     }
-}
+    table = dyn_resource.create_table(**params)
+    print(f"Creating {table_name}...")
+    table.wait_until_exists()
+    return table
 
-# Create the table
-dynamodb.create_table(**params)
 
-# Wait for the table to exist before exiting
-print('Waiting for', table_name, '...')
-waiter = dynamodb.get_waiter('table_exists')
-waiter.wait(TableName=table_name)
-
-# snippet-end:[dynamodb.Python.TryDax.01-create-table] 
+if __name__ == '__main__':
+    dax_table = create_dax_table()
+    print(f"Created table.")
+# snippet-end:[dynamodb.Python.TryDax.01-create-table]

--- a/python/example_code/dynamodb/TryDax/02-write-data.py
+++ b/python/example_code/dynamodb/TryDax/02-write-data.py
@@ -1,51 +1,47 @@
-# snippet-sourcedescription:[ ]
-# snippet-service:[dynamodb]
-# snippet-keyword:[Amazon DynamoDB]
-# snippet-keyword:[Python]
-# snippet-sourcesyntax:[python]
-# snippet-sourcesyntax:[python]
-# snippet-keyword:[Code Sample]
-# snippet-sourcetype:[full-example]
-# snippet-sourcedate:[ ]
-# snippet-sourceauthor:[AWS]
+#!/usr/bin/env python3
 
-#  Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#  This file is licensed under the Apache License, Version 2.0 (the "License").
-#  You may not use this file except in compliance with the License. A copy of
-#  the License is located at
-#
-#  http://aws.amazon.com/apache2.0/
-#
-#  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-#  CONDITIONS OF ANY KIND, either express or implied. See the License for the
-#  specific language governing permissions and limitations under the License.
-#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Purpose
+
+Writes test data to the Amazon DynamoDB table, in preparation for the demonstration.
+"""
 
 # snippet-start:[dynamodb.Python.TryDax.02-write-data]
-
-import os
 import boto3
 
-table_name = 'TryDaxTable'
-some_data = 'X' * 1000
-pk_max = 10
-sk_max = 10
 
-region = os.environ.get('AWS_DEFAULT_REGION', 'us-west-2')
-dynamodb = boto3.client('dynamodb', region_name=region)
-for ipk in range(1, pk_max+1):
-    for isk in range(1, sk_max+1):
-        params = {
-            'TableName': table_name,
-            'Item': {
-                'pk': {'N': str(ipk)},
-                'sk': {'N': str(isk)},
-                'someData': {'S': some_data}
-            }
-        }
+def write_data_to_dax_table(key_count, item_size, dyn_resource=None):
+    """
+    Writes test data to the demonstration table.
 
-        dynamodb.put_item(**params)
-        print(f'PutItem ({ipk}, {isk}) succeeded')
+    :param key_count: The number of partition and sort keys to use to populate the
+                      table. The total number of items is key_count * key_count.
+    :param item_size: The size of non-key data for each test item.
+    :param dyn_resource: Either a Boto3 or DAX resource.
+    """
+    if dyn_resource is None:
+        dyn_resource = boto3.resource('dynamodb')
 
+    table = dyn_resource.Table('TryDaxTable')
+    some_data = 'X' * item_size
+
+    for partition_key in range(1, key_count + 1):
+        for sort_key in range(1, key_count + 1):
+            table.put_item(Item={
+                'partition_key': partition_key,
+                'sort_key': sort_key,
+                'some_data': some_data
+            })
+            print(f"Put item ({partition_key}, {sort_key}) succeeded.")
+
+
+if __name__ == '__main__':
+    write_key_count = 10
+    write_item_size = 1000
+    print(f"Writing {write_key_count*write_key_count} items to the table. "
+          f"Each item is {write_item_size} characters.")
+    write_data_to_dax_table(write_key_count, write_item_size)
 # snippet-end:[dynamodb.Python.TryDax.02-write-data]

--- a/python/example_code/dynamodb/TryDax/03-getitem-test.py
+++ b/python/example_code/dynamodb/TryDax/03-getitem-test.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
                 test_key_count, test_iterations, dyn_resource=dax)
     else:
         print(f"Getting each item from the table {test_iterations} times, "
-              f"using the Boto 3 client.")
+              f"using the Boto3 client.")
         test_start, test_end = get_item_test(
             test_key_count, test_iterations)
     print(f"Total time: {test_end - test_start:.4f} sec. Average time: "

--- a/python/example_code/dynamodb/TryDax/03-getitem-test.py
+++ b/python/example_code/dynamodb/TryDax/03-getitem-test.py
@@ -1,71 +1,77 @@
-# snippet-sourcedescription:[ ]
-# snippet-service:[dynamodb]
-# snippet-keyword:[Python]
-# snippet-sourcesyntax:[python]
-# snippet-sourcesyntax:[python]
-# snippet-keyword:[Amazon DynamoDB]
-# snippet-keyword:[Code Sample]
-# snippet-keyword:[ ]
-# snippet-sourcetype:[full-example]
-# snippet-sourcedate:[ ]
-# snippet-sourceauthor:[AWS]
-# snippet-start:[dynamodb.Python.TryDax.03-getitem-test] 
+#!/usr/bin/env python3
 
-#
-#  Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#  This file is licensed under the Apache License, Version 2.0 (the "License").
-#  You may not use this file except in compliance with the License. A copy of
-#  the License is located at
-# 
-#  http://aws.amazon.com/apache2.0/
-# 
-#  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-#  CONDITIONS OF ANY KIND, either express or implied. See the License for the
-#  specific language governing permissions and limitations under the License.
-#
-#!/usr/bin/env python
-from __future__ import print_function
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
-import os, sys, time
+"""
+Purpose
+
+Gets items out of an Amazon DynamoDB table for a specified number of iterations.
+The total amount of time spent retrieving items is measured and reported. When
+no arguments are specified, this script is run with the Boto3 client. When a DAX
+cluster endpoint is specified, the script uses the DAX client. Running in each
+mode lets you compare the performance of the two clients.
+"""
+
+# snippet-start:[dynamodb.Python.TryDax.03-getitem-test]
+import argparse
+import sys
+import time
 import amazondax
-import botocore.session
+import boto3
 
-region = os.environ.get('AWS_DEFAULT_REGION', 'us-west-2')
 
-session = botocore.session.get_session()
-dynamodb = session.create_client('dynamodb', region_name=region) # low-level client
+def get_item_test(key_count, iterations, dyn_resource=None):
+    """
+    Gets items from the table a specified number of times. The time before the
+    first iteration and the time after the last iteration are both captured
+    and reported.
 
-table_name = "TryDaxTable"
+    :param key_count: The number of items to get from the table in each iteration.
+    :param iterations: The number of iterations to run.
+    :param dyn_resource: Either a Boto3 or DAX resource.
+    :return: The start and end times of the test.
+    """
+    if dyn_resource is None:
+        dyn_resource = boto3.resource('dynamodb')
 
-if len(sys.argv) > 1:
-    endpoint = sys.argv[1]
-    dax = amazondax.AmazonDaxClient(session, region_name=region, endpoints=[endpoint])
-    client = dax
-else:
-    client = dynamodb
+    table = dyn_resource.Table('TryDaxTable')
+    start = time.perf_counter()
+    for _ in range(iterations):
+        for partition_key in range(1, key_count + 1):
+            for sort_key in range(1, key_count + 1):
+                table.get_item(Key={
+                    'partition_key': partition_key,
+                    'sort_key': sort_key
+                })
+                print('.', end='')
+                sys.stdout.flush()
+    print()
+    end = time.perf_counter()
+    return start, end
 
-pk = 10
-sk = 10
-iterations = 50
 
-start = time.time()
-for i in range(iterations):
-    for ipk in range(1, pk+1):
-        for isk in range(1, sk+1):
-            params = {
-                'TableName': table_name,
-                'Key': {
-                    "pk": {'N': str(ipk)},
-                    "sk": {'N': str(isk)}
-                }
-            }
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'endpoint_url', nargs='?',
+        help="When specified, the DAX cluster endpoint. Otherwise, DAX is not used.")
+    args = parser.parse_args()
 
-            result = client.get_item(**params)
-            print('.', end='', file=sys.stdout); sys.stdout.flush()
-print()
-
-end = time.time()
-print('Total time: {} sec - Avg time: {} sec'.format(end - start, (end-start)/iterations))
-
-# snippet-end:[dynamodb.Python.TryDax.03-getitem-test] 
+    test_key_count = 10
+    test_iterations = 50
+    if args.endpoint_url:
+        print(f"Getting each item from the table {test_iterations} times, "
+              f"using the DAX client.")
+        # Use a with statement so the DAX client closes the cluster after completion.
+        with amazondax.AmazonDaxClient.resource(endpoint_url=args.endpoint_url) as dax:
+            test_start, test_end = get_item_test(
+                test_key_count, test_iterations, dyn_resource=dax)
+    else:
+        print(f"Getting each item from the table {test_iterations} times, "
+              f"using the Boto 3 client.")
+        test_start, test_end = get_item_test(
+            test_key_count, test_iterations)
+    print(f"Total time: {test_end - test_start:.4f} sec. Average time: "
+          f"{(test_end - test_start)/ test_iterations}.")
+# snippet-end:[dynamodb.Python.TryDax.03-getitem-test]

--- a/python/example_code/dynamodb/TryDax/04-query-test.py
+++ b/python/example_code/dynamodb/TryDax/04-query-test.py
@@ -71,7 +71,7 @@ if __name__ == '__main__':
             test_start, test_end = query_test(
                 test_partition_key, test_sort_keys, test_iterations, dyn_resource=dax)
     else:
-        print(f"Querying the table {test_iterations} times, using the Boto 3 client.")
+        print(f"Querying the table {test_iterations} times, using the Boto3 client.")
         test_start, test_end = query_test(
             test_partition_key, test_sort_keys, test_iterations)
 

--- a/python/example_code/dynamodb/TryDax/05-scan-test.py
+++ b/python/example_code/dynamodb/TryDax/05-scan-test.py
@@ -1,60 +1,66 @@
-# snippet-sourcedescription:[ ]
-# snippet-service:[dynamodb]
-# snippet-keyword:[Python]
-# snippet-sourcesyntax:[python]
-# snippet-sourcesyntax:[python]
-# snippet-keyword:[Amazon DynamoDB]
-# snippet-keyword:[Code Sample]
-# snippet-keyword:[ ]
-# snippet-sourcetype:[full-example]
-# snippet-sourcedate:[ ]
-# snippet-sourceauthor:[AWS]
-# snippet-start:[dynamodb.Python.TryDax.05-scan-test] 
+#!/usr/bin/env python3
 
-#
-#  Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#  This file is licensed under the Apache License, Version 2.0 (the "License").
-#  You may not use this file except in compliance with the License. A copy of
-#  the License is located at
-# 
-#  http://aws.amazon.com/apache2.0/
-# 
-#  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-#  CONDITIONS OF ANY KIND, either express or implied. See the License for the
-#  specific language governing permissions and limitations under the License.
-#
-#!/usr/bin/env python
-from __future__ import print_function
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
-import os, sys, time
+"""
+Purpose
+
+Scans an Amazon DynamoDB table for a specified number of iterations.
+The total amount of time spent scanning is measured and reported. When
+no arguments are specified, this script is run with the Boto3 client. When a DAX
+cluster endpoint is specified, the script uses the DAX client. Running in each
+mode lets you compare the performance of the two clients.
+"""
+
+# snippet-start:[dynamodb.Python.TryDax.05-scan-test]
+import argparse
+import time
+import sys
 import amazondax
-import botocore.session
+import boto3
 
-region = os.environ.get('AWS_DEFAULT_REGION', 'us-west-2')
 
-session = botocore.session.get_session()
-dynamodb = session.create_client('dynamodb', region_name=region) # low-level client
+def scan_test(iterations, dyn_resource=None):
+    """
+    Scans the table a specified number of times. The time before the
+    first iteration and the time after the last iteration are both captured
+    and reported.
 
-table_name = "TryDaxTable"
+    :param iterations: The number of iterations to run.
+    :param dyn_resource: Either a Boto3 or DAX resource.
+    :return: The start and end times of the test.
+    """
+    if dyn_resource is None:
+        dyn_resource = boto3.resource('dynamodb')
 
-if len(sys.argv) > 1:
-    endpoint = sys.argv[1]
-    dax = amazondax.AmazonDaxClient(session, region_name=region, endpoints=[endpoint])
-    client = dax
-else:
-    client = dynamodb
+    table = dyn_resource.Table('TryDaxTable')
+    start = time.perf_counter()
+    for _ in range(iterations):
+        table.scan()
+        print('.', end='')
+        sys.stdout.flush()
+    print()
+    end = time.perf_counter()
+    return start, end
 
-iterations = 5
 
-params = {
-    'TableName': table_name
-}
-start = time.time()
-for i in range(iterations):
-    result = client.scan(**params)
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'endpoint_url', nargs='?',
+        help="When specified, the DAX cluster endpoint. Otherwise, DAX is not used.")
+    args = parser.parse_args()
 
-end = time.time()
-print('Total time: {} sec - Avg time: {} sec'.format(end - start, (end-start)/iterations))
-
-# snippet-end:[dynamodb.Python.TryDax.05-scan-test] 
+    test_iterations = 100
+    if args.endpoint_url:
+        print(f"Scanning the table {test_iterations} times, using the DAX client.")
+        # Use a with statement so the DAX client closes the cluster after completion.
+        with amazondax.AmazonDaxClient.resource(endpoint_url=args.endpoint_url) as dax:
+            test_start, test_end = scan_test(test_iterations, dyn_resource=dax)
+    else:
+        print(f"Scanning the table {test_iterations} times, using the Boto 3 client.")
+        test_start, test_end = scan_test(test_iterations)
+    print(f"Total time: {test_end - test_start:.4f} sec. Average time: "
+          f"{(test_end - test_start)/test_iterations}.")
+# snippet-end:[dynamodb.Python.TryDax.05-scan-test]

--- a/python/example_code/dynamodb/TryDax/05-scan-test.py
+++ b/python/example_code/dynamodb/TryDax/05-scan-test.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
         with amazondax.AmazonDaxClient.resource(endpoint_url=args.endpoint_url) as dax:
             test_start, test_end = scan_test(test_iterations, dyn_resource=dax)
     else:
-        print(f"Scanning the table {test_iterations} times, using the Boto 3 client.")
+        print(f"Scanning the table {test_iterations} times, using the Boto3 client.")
         test_start, test_end = scan_test(test_iterations)
     print(f"Total time: {test_end - test_start:.4f} sec. Average time: "
           f"{(test_end - test_start)/test_iterations}.")

--- a/python/example_code/dynamodb/TryDax/06-delete-table.py
+++ b/python/example_code/dynamodb/TryDax/06-delete-table.py
@@ -1,53 +1,35 @@
-# snippet-sourcedescription:[ ]
-# snippet-service:[dynamodb]
-# snippet-keyword:[Python]
-# snippet-sourcesyntax:[python]
-# snippet-sourcesyntax:[python]
-# snippet-keyword:[Amazon DynamoDB]
-# snippet-keyword:[Code Sample]
-# snippet-keyword:[ ]
-# snippet-sourcetype:[full-example]
-# snippet-sourcedate:[ ]
-# snippet-sourceauthor:[AWS]
-# snippet-start:[dynamodb.Python.TryDax.06-delete-table] 
-
-#
-#  Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#  This file is licensed under the Apache License, Version 2.0 (the "License").
-#  You may not use this file except in compliance with the License. A copy of
-#  the License is located at
-# 
-#  http://aws.amazon.com/apache2.0/
-# 
-#  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-#  CONDITIONS OF ANY KIND, either express or implied. See the License for the
-#  specific language governing permissions and limitations under the License.
-#
 #!/usr/bin/env python3
-from __future__ import print_function
 
-import os
-import amazondax
-import botocore.session
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
-region = os.environ.get('AWS_DEFAULT_REGION', 'us-west-2')
+"""
+Purpose
 
-session = botocore.session.get_session()
-dynamodb = session.create_client('dynamodb', region_name=region) # low-level client
+Deletes the Amazon DynamoDB table used in the demonstration.
+"""
 
-table_name = "TryDaxTable"
+# snippet-start:[dynamodb.Python.TryDax.06-delete-table]
+import boto3
 
-params = {
-    'TableName' : table_name
-}
 
-# Delete the table
-dynamodb.delete_table(**params)
+def delete_dax_table(dyn_resource=None):
+    """
+    Deletes the demonstration table.
 
-# Wait for the table to be deleted before exiting
-print('Waiting for', table_name, '...')
-waiter = dynamodb.get_waiter('table_not_exists')
-waiter.wait(TableName=table_name)
+    :param dyn_resource: Either a Boto3 or DAX resource.
+    """
+    if dyn_resource is None:
+        dyn_resource = boto3.resource('dynamodb')
 
-# snippet-end:[dynamodb.Python.TryDax.06-delete-table] 
+    table = dyn_resource.Table('TryDaxTable')
+    table.delete()
+
+    print(f"Deleting {table.name}...")
+    table.wait_until_not_exists()
+
+
+if __name__ == '__main__':
+    delete_dax_table()
+    print("Table deleted!")
+# snippet-end:[dynamodb.Python.TryDax.06-delete-table]

--- a/python/example_code/dynamodb/TryDax/README.md
+++ b/python/example_code/dynamodb/TryDax/README.md
@@ -16,12 +16,12 @@ information, see [In-Memory Acceleration with DynamoDB Accelerator (DAX)](https:
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- An Amazon Virtual Private Cloud (VPC)
+- An Amazon Virtual Private Cloud (Amazon VPC)
 - A DAX cluster set up in your VPC 
-- An Amazon Elastic Compute Cloud (EC2) instance running in your VPC with the
-  following installed
+- An Amazon Elastic Compute Cloud (Amazon EC2) instance running in your VPC with the
+  following installed:
     - Python 3.6 or later
-    - Boto 3 1.11.10 or later
+    - Boto3 1.11.10 or later
     - Amazon DAX Client for Python 1.1.7 or later
 - PyTest 5.3.5 or later (to run unit tests)
 
@@ -33,8 +33,8 @@ application tutorial in the
 section of the *Amazon DynamoDB Developer Guide*.
 
 When run on your local computer, only the Boto3 client works. To run the 
-scripts with the DAX client, you must run them on an EC2 instance within your VPC, 
-as described in the tutorial.
+scripts with the DAX client, you must run them on an Amazon EC2 instance within your 
+VPC, as described in the tutorial.
 
 Each file can be run separately at a command prompt. For example, create the
 table by running the following from a command prompt window.
@@ -65,8 +65,8 @@ python -m pytest
 
 ## Additional information
 
-- [Boto 3 Amazon DynamoDB examples](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/dynamodb.html)
-- [Boto 3 Amazon DynamoDB service reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html)
+- [Boto3 Amazon DynamoDB examples](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/dynamodb.html)
+- [Boto3 Amazon DynamoDB service reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html)
 - As an AWS best practice, grant this code least privilege, or only the 
   permissions required to perform a task. For more information, see 
   [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege) 

--- a/python/example_code/dynamodb/TryDax/README.md
+++ b/python/example_code/dynamodb/TryDax/README.md
@@ -1,0 +1,83 @@
+# Amazon DynamoDB Accelerator (DAX) examples
+
+## Purpose
+
+Demonstrates how to use the AWS SDK for Python (Boto3) and the Amazon DAX Client for  
+Python to read items from an Amazon DynamoDB table. Retrieval, query, and scan speeds
+are measured for both Boto3 and DAX clients to show some of the performance 
+advantages of using DAX.
+
+DAX is a DynamoDB-compatible caching service that provides fast in-memory performance 
+and high availability for applications that demand microsecond latency. For more
+information, see [In-Memory Acceleration with DynamoDB Accelerator (DAX)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAX.html). 
+
+## Prerequisites
+
+- You must have an AWS account, and have your default credentials and AWS Region
+  configured as described in the [AWS Tools and SDKs Shared Configuration and
+  Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
+- An Amazon Virtual Private Cloud (VPC)
+- A DAX cluster set up in your VPC 
+- An Amazon Elastic Compute Cloud (EC2) instance running in your VPC with the
+  following installed
+    - Python 3.6 or later
+    - Boto 3 1.11.10 or later
+    - Amazon DAX Client for Python 1.1.7 or later
+- PyTest 5.3.5 or later (to run unit tests)
+
+## Running the code
+
+The files in this example are designed to be used as part of the Python sample 
+application tutorial in the  
+[Developing with the DAX Client](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAX.client.html) 
+section of the *Amazon DynamoDB Developer Guide*.
+
+When run on your local computer, only the Boto3 client works. To run the 
+scripts with the DAX client, you must run them on an EC2 instance within your VPC, 
+as described in the tutorial.
+
+Each file can be run separately at a command prompt. For example, create the
+table by running the following from a command prompt window.
+
+```
+python 01-create-table.py
+```  
+
+On an EC2 instance, run the get item, query, and scan test scripts with the DAX client
+by specifying a DAX cluster endpoint as the first positional argument. For example,
+to run the query test script with the DAX client, run the following from a command 
+prompt window.
+
+```
+python 04-query-test.py YOUR-CLUSTER-NAME.111111.clustercfg.dax.usw2.cache.amazonaws.com:8111
+```
+
+## Running the tests
+
+The unit tests in this module use the botocore Stubber, which captures requests before 
+they are sent to AWS and returns a mocked response. To run all of the tests, 
+run the following in your [GitHub root]/python/example_code/dynamodb/TryDax 
+folder from a command prompt window.
+
+```    
+python -m pytest
+```
+
+## Additional information
+
+- [Boto 3 Amazon DynamoDB examples](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/dynamodb.html)
+- [Boto 3 Amazon DynamoDB service reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html)
+- As an AWS best practice, grant this code least privilege, or only the 
+  permissions required to perform a task. For more information, see 
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege) 
+  in the *AWS Identity and Access Management 
+  User Guide*.
+- This code has not been tested in all AWS Regions. Some AWS services are 
+  available only in specific Regions. For more information, see the 
+  "AWS Regional Table" on the AWS website.
+- Running this code might result in charges to your AWS account.
+
+---
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0

--- a/python/example_code/dynamodb/TryDax/test/conftest.py
+++ b/python/example_code/dynamodb/TryDax/test/conftest.py
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Contains common test fixtures used to run Amazon DynamoDB Accelerator (DAX) tests.
+"""
+
+import sys
+# This is needed so Python can find test_tools on the path.
+sys.path.append('../../..')
+from test_tools.fixtures.common import *

--- a/python/example_code/dynamodb/TryDax/test/test_try_dax.py
+++ b/python/example_code/dynamodb/TryDax/test/test_try_dax.py
@@ -1,0 +1,132 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for Amazon DynamoDB TryDax code example.
+"""
+
+import importlib
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+# import_module is needed because the file names are not valid Python identifiers.
+create_table = importlib.import_module('01-create-table')
+write_data = importlib.import_module('02-write-data')
+getitem_test = importlib.import_module('03-getitem-test')
+query_test = importlib.import_module('04-query-test')
+scan_test = importlib.import_module('05-scan-test')
+delete_table = importlib.import_module('06-delete-table')
+
+TRY_DAX_TABLE = 'TryDaxTable'
+
+
+def test_create_dax_table(make_stubber):
+    dyn = boto3.resource('dynamodb')
+    dyn_stubber = make_stubber(dyn.meta.client)
+
+    dyn_stubber.stub_create_table(
+        TRY_DAX_TABLE, [
+            {'name': 'partition_key', 'type': 'N', 'key_type': 'HASH'},
+            {'name': 'sort_key', 'type': 'N', 'key_type': 'RANGE'}
+        ],
+        {'read': 10, 'write': 10}
+    )
+    dyn_stubber.stub_describe_table(TRY_DAX_TABLE)
+
+    table = create_table.create_dax_table(dyn)
+    assert table.name == TRY_DAX_TABLE
+
+
+def test_write_data_to_dax_table(make_stubber):
+    dyn = boto3.resource('dynamodb')
+    dyn_stubber = make_stubber(dyn.meta.client)
+    key_count = 7
+    item_size = 42
+    data = 'X'*item_size
+
+    for partition in range(1, key_count + 1):
+        for sort in range(1, key_count + 1):
+            dyn_stubber.stub_put_item(
+                TRY_DAX_TABLE, {
+                    'partition_key': partition,
+                    'sort_key': sort,
+                    'some_data': data
+                })
+
+    write_data.write_data_to_dax_table(key_count, item_size, dyn)
+
+
+def test_getitem_test(make_stubber):
+    dyn = boto3.resource('dynamodb')
+    dyn_stubber = make_stubber(dyn.meta.client)
+    key_count = 9
+    iterations = 35
+    data = 'X'*100
+
+    for _ in range(iterations):
+        for partition in range(1, key_count + 1):
+            for sort in range(1, key_count + 1):
+                dyn_stubber.stub_get_item(
+                    TRY_DAX_TABLE, {
+                        'partition_key': partition,
+                        'sort_key': sort
+                    }, {
+                        'partition_key': partition,
+                        'sort_key': sort,
+                        'some_data': data
+                    }
+                )
+
+    start, end = getitem_test.get_item_test(key_count, iterations, dyn)
+    assert end > start
+
+
+def test_query_test(make_stubber):
+    dyn = boto3.resource('dynamodb')
+    dyn_stubber = make_stubber(dyn.meta.client)
+    partition = 3
+    sorts = (5, 10)
+    iterations = 15
+
+    for _ in range(iterations):
+        dyn_stubber.stub_query(TRY_DAX_TABLE, [{
+                'partition_key': partition,
+                'sort_key': sort,
+                'some_data': 'X'*100
+            } for sort in range(sorts[0], sorts[1])],
+            key_condition=
+                Key('partition_key').eq(partition) &
+                Key('sort_key').between(*sorts)
+        )
+
+    start, end = query_test.query_test(partition, sorts, iterations, dyn)
+    assert end > start
+
+
+def test_scan_test(make_stubber):
+    dyn = boto3.resource('dynamodb')
+    dyn_stubber = make_stubber(dyn.meta.client)
+    iterations = 13
+
+    for _ in range(iterations):
+        dyn_stubber.stub_scan(TRY_DAX_TABLE, [{
+                'partition_key': key,
+                'sort_key': key,
+                'some_data': 'X' * 100
+            } for key in range(1, 10)])
+
+    start, end = scan_test.scan_test(iterations, dyn)
+    assert end > start
+
+
+def test_delete_table(make_stubber):
+    dyn = boto3.resource('dynamodb')
+    dyn_stubber = make_stubber(dyn.meta.client)
+
+    dyn_stubber.stub_delete_table(TRY_DAX_TABLE)
+    # The table_not_exists waiter waits until this error is returned.
+    dyn_stubber.stub_describe_table(
+        TRY_DAX_TABLE, error_code='ResourceNotFoundException')
+
+    delete_table.delete_dax_table(dyn)

--- a/python/example_code/dynamodb/metadata.yaml
+++ b/python/example_code/dynamodb/metadata.yaml
@@ -50,3 +50,31 @@ files:
     services:
       - dynamodb
 ...
+---
+# Amazon DynamoDB Accelerator (DAX) examples
+files:
+  - path: TryDax/01-create-table.py
+    services:
+      - dynamodb
+  - path: TryDax/02-write-data.py
+    services:
+      - dynamodb
+  - path: TryDax/03-getitem-test.py
+    services:
+      - dynamodb
+  - path: TryDax/04-query-test.py
+    services:
+      - dynamodb
+  - path: TryDax/05-scan-test.py
+    services:
+      - dynamodb
+  - path: TryDax/06-delete-table.py
+    services:
+      - dynamodb
+  - path: TryDax/test/conftest.py
+    services:
+      - dynamodb
+  - path: TryDax/test/test_try_dax.py
+    services:
+      - dynamodb
+...

--- a/python/test_tools/dynamodb_stubber.py
+++ b/python/test_tools/dynamodb_stubber.py
@@ -188,14 +188,17 @@ class DynamoStubber(ExampleStubber):
         self._stub_bifurcator('scan', expected_params, response, error_code=error_code)
 
     def stub_query(self, table_name, output_items, key_condition=None,
-                   projection=None, expression_attrs=None, error_code=None):
+                   projection=None, expression_attrs=None, expression_attr_vals=None,
+                   error_code=None):
         expected_params = {'TableName': table_name}
-        if key_condition:
+        if key_condition is not None:
             expected_params['KeyConditionExpression'] = key_condition
-        if projection:
+        if projection is not None:
             expected_params['ProjectionExpression'] = projection
-        if expression_attrs:
+        if expression_attrs is not None:
             expected_params['ExpressionAttributeNames'] = expression_attrs
+        if expression_attr_vals is not None:
+            expected_params['ExpressionAttributeValues'] = expression_attr_vals
         response_items = [
             self._build_out_item(output_item) for output_item in output_items
         ]


### PR DESCRIPTION
Cleaned up DynamoDB TryDax examples.
Updated to use Boto3 and DAX resource instead of client objects.
Added unit tests.
Commented and documented.

- [x] The submitter has added the default copyright notice to all files.

- [x] The submitter has added unit tests for all code paths, run all of them, and they all pass.

- [x] The submitter has run a linter on the code, and all of the submitter's team's minimum rules pass.

- [x] The submitter has added the team's minimum usage documentation to the code.

- [x] The submitter has had their Editor edit all comments and strings, and the submitter has incorporated any and all resulting edits.

- [x] The submitter has added all of the submitter's team's related API reporting metadata. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
