### PR TITLE
Testing framework for C++ examples

### DIFF
--- a/cpp/example_code/new_s3/CMakeLists.txt
+++ b/cpp/example_code/new_s3/CMakeLists.txt
@@ -20,11 +20,13 @@ if(NOT BUILD_SHARED_LIBS)
     set(BUILD_SHARED_LIBS ON)
 endif()
 
+# Link to shared libraries.
+if(MSVC AND BUILD_SHARED_LIBS)
+    add_definitions(-DUSE_IMPORT_EXPORT)
+endif()
+
 # Locate the aws sdk for c++ package.
 find_package(AWSSDK REQUIRED COMPONENTS s3)
-
-# Link to shared libraries.
-add_definitions(-DUSE_IMPORT_EXPORT)
 
 # Header files
 file(GLOB AWSDOC_S3_HEADERS
@@ -49,11 +51,11 @@ foreach(file ${AWSDOC_S3_SOURCE})
     # Build example executables
     set(EXAMPLE_EXE run_${EXAMPLE})
 
-    if(USE_WINDOWS_DLL_SEMANTICS AND BUILD_SHARED_LIBS)
+    add_executable(${EXAMPLE_EXE} ${AWSDOC_S3_HEADERS} ${file})
+    if(MSVC AND BUILD_SHARED_LIBS)
+        target_compile_definitions(${EXAMPLE_EXE} PUBLIC "USE_IMPORT_EXPORT")
         target_compile_definitions(${EXAMPLE_EXE} PRIVATE "AWSDOC_S3_EXPORTS")
     endif()
-
-    add_executable(${EXAMPLE_EXE} ${AWSDOC_S3_HEADERS} ${file})
     target_include_directories(${EXAMPLE_EXE} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
@@ -64,11 +66,11 @@ foreach(file ${AWSDOC_S3_SOURCE})
         # Build example libs
         set(EXAMPLE_LIB ${EXAMPLE})
 
-        if(USE_WINDOWS_DLL_SEMANTICS AND BUILD_SHARED_LIBS)
+        add_library(${EXAMPLE_LIB} ${AWSDOC_S3_HEADERS} ${file})
+        if(MSVC AND BUILD_SHARED_LIBS)
+            target_compile_definitions(${EXAMPLE_LIB} PUBLIC "USE_IMPORT_EXPORT")
             target_compile_definitions(${EXAMPLE_LIB} PRIVATE "AWSDOC_S3_EXPORTS")
         endif()
-
-        add_library(${EXAMPLE_LIB} ${AWSDOC_S3_HEADERS} ${file})
         target_include_directories(${EXAMPLE_LIB} PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:include>)

--- a/cpp/example_code/new_s3/CMakeLists.txt
+++ b/cpp/example_code/new_s3/CMakeLists.txt
@@ -1,11 +1,5 @@
-# This file is licensed under the Apache License, Version 2.0 (the "License").
-# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# You may not use this file except in compliance with the License. A copy of
-# the License is located at
-# http://aws.amazon.com/apache2.0/
-# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the
-# specific language governing permissions and limitations under the License.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.2)
 project(s3-examples)

--- a/cpp/example_code/new_s3/CMakeLists.txt
+++ b/cpp/example_code/new_s3/CMakeLists.txt
@@ -1,0 +1,88 @@
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at
+# http://aws.amazon.com/apache2.0/
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+project(s3-examples)
+
+set (CMAKE_CXX_STANDARD 11)
+
+# Enable CTest
+include(CTest)
+
+# Build as dynamic libraries by default
+if(NOT BUILD_SHARED_LIBS)
+    set(BUILD_SHARED_LIBS ON)
+endif()
+
+# Locate the aws sdk for c++ package.
+find_package(AWSSDK REQUIRED COMPONENTS s3)
+
+# Link to shared libraries.
+add_definitions(-DUSE_IMPORT_EXPORT)
+
+# Header files
+file(GLOB AWSDOC_S3_HEADERS
+    "include/awsdoc/s3/*.h"
+)
+
+# Source files
+file(GLOB AWSDOC_S3_SOURCE
+    "source/*.cpp"
+)
+
+if(WIN32)
+    if(MSVC)
+        source_group("Header Files\\awsdoc\\s3" FILES ${AWSDOC_S3_HEADERS})
+        source_group("Source Files" FILES ${AWSDOC_S3_SOURCE})
+    endif(MSVC)
+endif()
+
+foreach(file ${AWSDOC_S3_SOURCE})
+    get_filename_component(EXAMPLE ${file} NAME_WLE)
+
+    # Build example executables
+    set(EXAMPLE_EXE run_${EXAMPLE})
+
+    if(USE_WINDOWS_DLL_SEMANTICS AND BUILD_SHARED_LIBS)
+        target_compile_definitions(${EXAMPLE_EXE} PRIVATE "AWSDOC_S3_EXPORTS")
+    endif()
+
+    add_executable(${EXAMPLE_EXE} ${AWSDOC_S3_HEADERS} ${file})
+    target_include_directories(${EXAMPLE_EXE} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>)
+    target_link_libraries(${EXAMPLE_EXE} ${AWSSDK_LINK_LIBRARIES} ${AWSSDK_PLATFORM_DEPS})
+
+    if(BUILD_TESTING)
+        enable_testing()
+        # Build example libs
+        set(EXAMPLE_LIB ${EXAMPLE})
+
+        if(USE_WINDOWS_DLL_SEMANTICS AND BUILD_SHARED_LIBS)
+            target_compile_definitions(${EXAMPLE_LIB} PRIVATE "AWSDOC_S3_EXPORTS")
+        endif()
+
+        add_library(${EXAMPLE_LIB} ${AWSDOC_S3_HEADERS} ${file})
+        target_include_directories(${EXAMPLE_LIB} PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include>)
+        target_link_libraries(${EXAMPLE_LIB} ${AWSSDK_LINK_LIBRARIES} ${AWSSDK_PLATFORM_DEPS})
+
+        # Build example tests
+        set(EXAMPLE_TEST test_${EXAMPLE})
+
+        add_executable(${EXAMPLE_TEST} tests/test_${EXAMPLE}.cpp)
+        target_include_directories(${EXAMPLE_TEST} PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include>)
+        target_link_libraries(${EXAMPLE_TEST} ${EXAMPLE_LIB})
+        add_test(${EXAMPLE_TEST} ${EXAMPLE_TEST})
+    endif()
+endforeach()
+

--- a/cpp/example_code/new_s3/include/awsdoc/s3/S3_EXPORTS.h
+++ b/cpp/example_code/new_s3/include/awsdoc/s3/S3_EXPORTS.h
@@ -20,7 +20,7 @@
     #pragma warning (disable : 4503)
 #endif // _MSC_VER
 
-#if defined (USE_WINDOWS_DLL_SEMANTICS) || defined (_WIN32)
+#if defined (_WIN32)
     #ifdef _MSC_VER
         #pragma warning(disable : 4251)
     #endif // _MSC_VER
@@ -34,6 +34,6 @@
     #else
         #define AWSDOC_S3_API
     #endif // USE_IMPORT_EXPORT
-#else // defined (USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32)
+#else // defined (WIN32)
     #define AWSDOC_S3_API
-#endif // defined (USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32)
+#endif // defined (WIN32)

--- a/cpp/example_code/new_s3/include/awsdoc/s3/S3_EXPORTS.h
+++ b/cpp/example_code/new_s3/include/awsdoc/s3/S3_EXPORTS.h
@@ -1,0 +1,39 @@
+/*
+* Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#pragma once
+
+#ifdef _MSC_VER
+    //disable windows complaining about max template size.
+    #pragma warning (disable : 4503)
+#endif // _MSC_VER
+
+#if defined (USE_WINDOWS_DLL_SEMANTICS) || defined (_WIN32)
+    #ifdef _MSC_VER
+        #pragma warning(disable : 4251)
+    #endif // _MSC_VER
+
+    #ifdef USE_IMPORT_EXPORT
+        #ifdef AWSDOC_S3_EXPORTS
+            #define AWSDOC_S3_API __declspec(dllexport)
+        #else
+            #define AWSDOC_S3_API __declspec(dllimport)
+        #endif /* AWSDOC_S3_EXPORTS */
+    #else
+        #define AWSDOC_S3_API
+    #endif // USE_IMPORT_EXPORT
+#else // defined (USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32)
+    #define AWSDOC_S3_API
+#endif // defined (USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32)

--- a/cpp/example_code/new_s3/include/awsdoc/s3/S3_EXPORTS.h
+++ b/cpp/example_code/new_s3/include/awsdoc/s3/S3_EXPORTS.h
@@ -1,17 +1,7 @@
-/*
-* Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at
-*
-*  http://aws.amazon.com/apache2.0
-*
-* or in the "license" file accompanying this file. This file is distributed
-* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-* express or implied. See the License for the specific language governing
-* permissions and limitations under the License.
-*/
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 

--- a/cpp/example_code/new_s3/include/awsdoc/s3/s3_examples.h
+++ b/cpp/example_code/new_s3/include/awsdoc/s3/s3_examples.h
@@ -1,3 +1,8 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 #include <awsdoc/s3/S3_EXPORTS.h>
 

--- a/cpp/example_code/new_s3/include/awsdoc/s3/s3_examples.h
+++ b/cpp/example_code/new_s3/include/awsdoc/s3/s3_examples.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <awsdoc/s3/S3_EXPORTS.h>
+
+namespace AwsDoc
+{
+    namespace S3
+    {
+        AWSDOC_S3_API bool ListBuckets();
+        AWSDOC_S3_API bool ListObjects(const char* bucketName);
+    }
+}

--- a/cpp/example_code/new_s3/source/list_buckets.cpp
+++ b/cpp/example_code/new_s3/source/list_buckets.cpp
@@ -1,0 +1,41 @@
+#include <awsdoc/s3/s3_examples.h>
+#include <aws/core/Aws.h>
+#include <aws/s3/S3Client.h>
+
+bool AwsDoc::S3::ListBuckets()
+{
+    Aws::S3::S3Client s3_client;
+    auto outcome = s3_client.ListBuckets();
+
+    if (outcome.IsSuccess())
+    {
+        std::cout << "Your Amazon S3 buckets:" << std::endl;
+
+        Aws::Vector<Aws::S3::Model::Bucket> bucket_list =
+            outcome.GetResult().GetBuckets();
+
+        for (auto const &bucket : bucket_list)
+        {
+            std::cout << "  * " << bucket.GetName() << std::endl;
+        }
+        return true;
+    }
+    else
+    {
+        std::cout << "ListBuckets error: "
+            << outcome.GetError().GetExceptionName() << " - "
+            << outcome.GetError().GetMessage() << std::endl;
+        return true;
+    }
+}
+
+int main(int argc, char** argv)
+{
+    Aws::SDKOptions options;
+    Aws::InitAPI(options);
+    {
+        AwsDoc::S3::ListBuckets();
+    }
+    Aws::ShutdownAPI(options);
+    return 0;
+}

--- a/cpp/example_code/new_s3/source/list_buckets.cpp
+++ b/cpp/example_code/new_s3/source/list_buckets.cpp
@@ -1,3 +1,19 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * snippet-sourcedescription:[list_buckets.cpp demonstrates how to list all the buckets in an AWS account.]
+ * snippet-keyword:[C++]
+ * snippet-sourcesyntax:[cpp]
+ * snippet-keyword:[Code Sample]
+ * snippet-keyword:[Amazon S3]
+ * snippet-service:[s3]
+ * snippet-sourcetype:[full-example]
+ * snippet-sourcedate:[]
+ * snippet-sourceauthor:[AWS]
+ */
+
 #include <awsdoc/s3/s3_examples.h>
 #include <aws/core/Aws.h>
 #include <aws/s3/S3Client.h>

--- a/cpp/example_code/new_s3/source/list_objects.cpp
+++ b/cpp/example_code/new_s3/source/list_objects.cpp
@@ -1,0 +1,56 @@
+#include <awsdoc/s3/s3_examples.h>
+#include <aws/core/Aws.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/ListObjectsRequest.h>
+
+bool AwsDoc::S3::ListObjects(const char* bucketName)
+{
+    std::cout << "Objects in S3 bucket: " << bucketName << std::endl;
+
+    Aws::S3::S3Client s3Client;
+
+    Aws::S3::Model::ListObjectsRequest listObjectsRequest;
+    listObjectsRequest.WithBucket(bucketName);
+
+    auto listObjectsOutcome = s3Client.ListObjects(listObjectsRequest);
+
+    if (listObjectsOutcome.IsSuccess())
+    {
+        Aws::Vector<Aws::S3::Model::Object> objectList =
+            listObjectsOutcome.GetResult().GetContents();
+
+        for (auto const &s3Object : objectList)
+        {
+            std::cout << "* " << s3Object.GetKey() << std::endl;
+        }
+        return true;
+    }
+    else
+    {
+        std::cout << "ListObjects error: " <<
+            listObjectsOutcome.GetError().GetExceptionName() << " " <<
+            listObjectsOutcome.GetError().GetMessage() << std::endl;
+        return false;
+    }
+}
+
+int main(int argc, char** argv)
+{
+    Aws::SDKOptions options;
+    Aws::InitAPI(options);
+    {
+        if (argc < 2)
+        {
+            std::cout << std::endl <<
+                "To run this example, supply the name of a bucket to list!" <<
+                std::endl << "Ex: run_list_objects <bucket-name>" << std::endl
+                << std::endl;
+            return 1;
+        }
+        const char* bucketName = argv[1];
+        AwsDoc::S3::ListObjects(bucketName);
+    }
+    Aws::ShutdownAPI(options);
+    return 0;
+}

--- a/cpp/example_code/new_s3/source/list_objects.cpp
+++ b/cpp/example_code/new_s3/source/list_objects.cpp
@@ -1,3 +1,18 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * snippet-sourcedescription:[list_objects.cpp demonstrates how to list the objects in an Amazon S3 bucket.]
+ * snippet-keyword:[C++]
+ * snippet-sourcesyntax:[cpp]
+ * snippet-keyword:[Code Sample]
+ * snippet-keyword:[Amazon S3]
+ * snippet-service:[s3]
+ * snippet-sourcetype:[full-example]
+ * snippet-sourcedate:[]
+ * snippet-sourceauthor:[AWS]
+ */
+
 #include <awsdoc/s3/s3_examples.h>
 #include <aws/core/Aws.h>
 #include <aws/core/utils/memory/stl/AWSString.h>

--- a/cpp/example_code/new_s3/tests/test_list_buckets.cpp
+++ b/cpp/example_code/new_s3/tests/test_list_buckets.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <awsdoc/s3/s3_examples.h>
 #include <aws/core/Aws.h>
 

--- a/cpp/example_code/new_s3/tests/test_list_buckets.cpp
+++ b/cpp/example_code/new_s3/tests/test_list_buckets.cpp
@@ -1,0 +1,16 @@
+#include <awsdoc/s3/s3_examples.h>
+#include <aws/core/Aws.h>
+
+int main(int argc, char** argv)
+{
+    Aws::SDKOptions options;
+    Aws::InitAPI(options);
+    {
+        if (!AwsDoc::S3::ListBuckets())
+        {
+            return 1;
+        }
+    }
+    Aws::ShutdownAPI(options);
+    return 0;
+}

--- a/cpp/example_code/new_s3/tests/test_list_objects.cpp
+++ b/cpp/example_code/new_s3/tests/test_list_objects.cpp
@@ -1,3 +1,8 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <awsdoc/s3/s3_examples.h>
 #include <aws/core/Aws.h>
 

--- a/cpp/example_code/new_s3/tests/test_list_objects.cpp
+++ b/cpp/example_code/new_s3/tests/test_list_objects.cpp
@@ -6,7 +6,7 @@ int main(int argc, char** argv)
     Aws::SDKOptions options;
     Aws::InitAPI(options);
     {
-        const char bucketName[] = "wangpush";
+        const char bucketName[] = "";
         if (!AwsDoc::S3::ListObjects(bucketName))
         {
             return 1;

--- a/cpp/example_code/new_s3/tests/test_list_objects.cpp
+++ b/cpp/example_code/new_s3/tests/test_list_objects.cpp
@@ -1,0 +1,17 @@
+#include <awsdoc/s3/s3_examples.h>
+#include <aws/core/Aws.h>
+
+int main(int argc, char** argv)
+{
+    Aws::SDKOptions options;
+    Aws::InitAPI(options);
+    {
+        const char bucketName[] = "wangpush";
+        if (!AwsDoc::S3::ListObjects(bucketName))
+        {
+            return 1;
+        }
+    }
+    Aws::ShutdownAPI(options);
+    return 0;
+}


### PR DESCRIPTION
**Description of changes:**
Adding unit tests for C++ examples.
Using CTest, which is integrated with CMake, so no extra code needed.

With this change, build process will creating the following targets for each example. Let's take `list_buckets` for example:
1. `run_list_buckets`: executables to run the example, with the entry point of `main()` function in `list_buckets.cpp`
2. `list_buckets`: the library that have function: `ListBuckets`.
3. `test_list_buckets`: the test executables, linking to `list_buckets` lib and the entry point is the `main()` function in `test_list_buckets.cpp`

**How to run the tests:**
With `make`:
```
# after make
make test
```
With `MSBuild`:
```
# After MSBuild ALL_BUILD.vcxproj
MSBuild RUN_TESTS.vcxproj
```

**How to turn off tests when building examples:**
```
cmake -DCMAKE_PREFIX_PATH="<SDK install path>" /awsdocs/aws-doc-sdk-examples/cpp/example_code/<SERVICE> -DBUILD_TESTING=OFF
```

It has not been finalized so I am trying to get some suggestions and feedbacks from this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
