### PR TITLE
Update to v2 namespace

### DIFF
--- a/ruby/example_code/s3/s3-ruby-example-add-cspk-item.rb
+++ b/ruby/example_code/s3/s3-ruby-example-add-cspk-item.rb
@@ -36,7 +36,7 @@ key = OpenSSL::PKey::RSA.new(public_key)
 
 begin
   # encryption client
-  enc_client = Aws::S3::Encryption::Client.new(encryption_key: key)
+  enc_client = Aws::S3::EncryptionV2::Client.new(encryption_key: key)
 
   # Add encrypted item to bucket
   enc_client.put_object(

--- a/ruby/example_code/s3/s3-ruby-example-get-cspk-item.rb
+++ b/ruby/example_code/s3/s3-ruby-example-get-cspk-item.rb
@@ -40,7 +40,7 @@ begin
   key = OpenSSL::PKey::RSA.new(private_key, pass_phrase)
 
   # encryption client
-  enc_client = Aws::S3::Encryption::Client.new(encryption_key: key)
+  enc_client = Aws::S3::EncryptionV2::Client.new(encryption_key: key)
 
   resp = enc_client.get_object(bucket: bucket, key: item)
 

--- a/ruby/example_code/s3/s3_add_csaes_encrypt_item.rb
+++ b/ruby/example_code/s3/s3_add_csaes_encrypt_item.rb
@@ -40,7 +40,7 @@ item = 'my_item'
 contents = File.read(item)
 
 # Create S3 encryption client
-client = Aws::S3::Encryption::Client.new(region: 'us-west-2', encryption_key: key)
+client = Aws::S3::EncryptionV2::Client.new(region: 'us-west-2', encryption_key: key)
 
 # Add encrypted item to bucket
 client.put_object(

--- a/ruby/example_code/s3/s3_add_cskms_encrypt_item.rb
+++ b/ruby/example_code/s3/s3_add_cskms_encrypt_item.rb
@@ -41,7 +41,7 @@ contents = File.read(item)
 kms = Aws::KMS::Client.new
 
 # Create encryption client
-client = Aws::S3::Encryption::Client.new(
+client = Aws::S3::EncryptionV2::Client.new(
   kms_key_id: key,
   kms_client: kms
 )

--- a/ruby/example_code/s3/s3_get_csaes_decrypt_item.rb
+++ b/ruby/example_code/s3/s3_get_csaes_decrypt_item.rb
@@ -36,7 +36,7 @@ bucket = 'my_bucket'
 item = 'my_item'
 
 # Create S3 encryption client
-client = Aws::S3::Encryption::Client.new(region: 'us-west-2', encryption_key: key)
+client = Aws::S3::EncryptionV2::Client.new(region: 'us-west-2', encryption_key: key)
 
 # Get item and print it out
 resp = client.get_object(bucket: bucket, key: item)

--- a/ruby/example_code/s3/s3_get_cskms_decrypt_item.rb
+++ b/ruby/example_code/s3/s3_get_cskms_decrypt_item.rb
@@ -38,7 +38,7 @@ item = 'my_item'
 kms = Aws::KMS::Client.new
 
 # Create S3 encryption client
-client = Aws::S3::Encryption::Client.new(
+client = Aws::S3::EncryptionV2::Client.new(
   kms_key_id: key,
   kms_client: kms,
 )


### PR DESCRIPTION

*Description of changes:*
We have just released V2 of the S3 Encryption Client in [PR #2336](https://github.com/aws/aws-sdk-ruby/pull/2336).  V2 provides support for more modern encryption algorithms by default and is backwards compatible with the V1 client.  This PR updates the sdk examples to use the new version of the encryption client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
