### PR TITLE
Remove superfluous slashes

### DIFF
--- a/javascript/example_code/s3/s3_photoExample.js
+++ b/javascript/example_code/s3/s3_photoExample.js
@@ -93,7 +93,7 @@ function createAlbum(albumName) {
   if (albumName.indexOf("/") !== -1) {
     return alert("Album names cannot contain slashes.");
   }
-  var albumKey = encodeURIComponent(albumName) + "/";
+  var albumKey = encodeURIComponent(albumName);
   s3.headObject({ Key: albumKey }, function(err, data) {
     if (!err) {
       return alert("Album already exists.");
@@ -114,7 +114,7 @@ function createAlbum(albumName) {
 
 // snippet-start:[s3.JavaScript.photoAlbumExample.viewAlbum]
 function viewAlbum(albumName) {
-  var albumPhotosKey = encodeURIComponent(albumName) + "//";
+  var albumPhotosKey = encodeURIComponent(albumName) + "/";
   s3.listObjects({ Prefix: albumPhotosKey }, function(err, data) {
     if (err) {
       return alert("There was an error viewing your album: " + err.message);
@@ -178,7 +178,7 @@ function addPhoto(albumName) {
   }
   var file = files[0];
   var fileName = file.name;
-  var albumPhotosKey = encodeURIComponent(albumName) + "//";
+  var albumPhotosKey = encodeURIComponent(albumName) + "/";
 
   var photoKey = albumPhotosKey + fileName;
 


### PR DESCRIPTION
I noticed extra slashes which were causing additional directories to be created when creating albums and preventing albums from correctly listing images or allowing new images to be uploaded.

*Description of changes:*
I have removed the extra slashes when creating an album, retrieving the contents, or pushing new images so that the example now works properly (for me, at least). I hope this saves some time for the next person to use these examples :) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
