### PR TITLE
Added 'using Amazon' to S3 C# code example

### DIFF
--- a/dotnet/example_code_legacy/S3/S3Examples/UploadObjectUsingPresignedURLTest.cs
+++ b/dotnet/example_code_legacy/S3/S3Examples/UploadObjectUsingPresignedURLTest.cs
@@ -1,30 +1,7 @@
-/*
-** Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-*
-* This file is licensed under the Apache License, Version 2.0 (the "License").
-* You may not use this file except in compliance with the License. A copy of
-* the License is located at
-*
-* http://aws.amazon.com/apache2.0/
-*
-* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-* CONDITIONS OF ANY KIND, either express or implied. See the License for the
-* specific language governing permissions and limitations under the License.
-*/
-
-// snippet-sourcedescription:[UploadObjectUsingPresignedURLTest.cs demonstrates how to upload an object to an S3 bucket using a presigned URL.]
-// snippet-service:[s3]
-// snippet-keyword:[dotNET]
-// snippet-keyword:[Amazon S3]
-// snippet-keyword:[Code Sample]
-// snippet-keyword:[PUT Object]
-// snippet-keyword:[WebRequest]
-// snippet-keyword:[GetPreSignedURL]
-// snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2018-04-30]
-// snippet-sourceauthor:[AWS] 
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+// SPDX-License-Identifier: MIT-0
 // snippet-start:[s3.dotNET.UploadObjectUsingPresignedURLTest]
-
+using Amazon;
 using Amazon.S3;
 using Amazon.S3.Model;
 using System;


### PR DESCRIPTION
*Issue #, if available:*
.NET C# example was missing a "using Amazon;" directive.

*Description of changes:*
Added the directive.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
