### PR TITLE
Updated .NET example to include info on exception when bucket or object does not exist

### DIFF
--- a/dotnet/example_code_legacy/S3/S3Examples/GetObjectTest.cs
+++ b/dotnet/example_code_legacy/S3/S3Examples/GetObjectTest.cs
@@ -1,29 +1,6 @@
-/**
-* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-*
-* This file is licensed under the Apache License, Version 2.0 (the "License").
-* You may not use this file except in compliance with the License. A copy of
-* the License is located at
-*
-* http://aws.amazon.com/apache2.0/
-*
-* This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-* CONDITIONS OF ANY KIND, either express or implied. See the License for the
-* specific language governing permissions and limitations under the License.
-*/
-
-// snippet-sourcedescription:[GetObjectTest.cs demonstrates how to download an object from an S3 bucket.]
-// snippet-service:[s3]
-// snippet-keyword:[dotNET]
-// snippet-keyword:[Amazon S3]
-// snippet-keyword:[Code Sample]
-// snippet-keyword:[GET Object]
-// snippet-keyword:[GetObjectRequest]
-// snippet-sourcetype:[full-example]
-// snippet-sourcedate:[2018-04-30]
-// snippet-sourceauthor:[AWS]
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+// SPDX-License-Identifier: MIT-0
 // snippet-start:[s3.dotNET.GetObjectTest]
-
 using Amazon.S3;
 using Amazon.S3.Model;
 using System;
@@ -70,11 +47,12 @@ namespace Amazon.DocSamples.S3
             }
             catch (AmazonS3Exception e)
             {
-                Console.WriteLine("Error encountered ***. Message:'{0}' when writing an object", e.Message);
+                // If bucket or object does not exist
+                Console.WriteLine("Error encountered ***. Message:'{0}' when reading object", e.Message);
             }
             catch (Exception e)
             {
-                Console.WriteLine("Unknown encountered on server. Message:'{0}' when writing an object", e.Message);
+                Console.WriteLine("Unknown encountered on server. Message:'{0}' when reading object", e.Message);
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
Example did not indicate which exception would raised if bucket or object did not exist.

*Description of changes:*
Added the information.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
