### PR TITLE
Replace NAME_WLE with NAME_WE in CMake

### DIFF
--- a/cpp/example_code/s3/CMakeLists.txt
+++ b/cpp/example_code/s3/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 # Find the AWS SDK for C++ package.
 find_package(AWSSDK REQUIRED COMPONENTS s3 sts)
 
-# If the compiler is some version of Microsoft Visual C++, or another compiler simulating C++, 
+# If the compiler is some version of Microsoft Visual C++, or another compiler simulating C++,
 # and building as shared libraries, then dynamically link to those shared libraries.
 if(MSVC AND BUILD_SHARED_LIBS)
     add_definitions(-DUSE_IMPORT_EXPORT)
@@ -50,7 +50,7 @@ if(WIN32)
 endif()
 
 foreach(file ${AWSDOC_S3_SOURCE})
-    get_filename_component(EXAMPLE ${file} NAME_WLE)
+    get_filename_component(EXAMPLE ${file} NAME_WE)
 
     # Build the code example executables.
     set(EXAMPLE_EXE run_${EXAMPLE})
@@ -62,10 +62,10 @@ foreach(file ${AWSDOC_S3_SOURCE})
         target_compile_definitions(${EXAMPLE_EXE} PRIVATE "AWSDOC_S3_EXPORTS")
     endif()
 
-    target_include_directories(${EXAMPLE_EXE} PUBLIC 
+    target_include_directories(${EXAMPLE_EXE} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
-    target_link_libraries(${EXAMPLE_EXE} ${AWSSDK_LINK_LIBRARIES} 
+    target_link_libraries(${EXAMPLE_EXE} ${AWSSDK_LINK_LIBRARIES}
         ${AWSSDK_PLATFORM_DEPS})
 
     if(BUILD_TESTING)
@@ -85,7 +85,7 @@ foreach(file ${AWSDOC_S3_SOURCE})
         target_include_directories(${EXAMPLE_LIB} PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:include>)
-        target_link_libraries(${EXAMPLE_LIB} ${AWSSDK_LINK_LIBRARIES} 
+        target_link_libraries(${EXAMPLE_LIB} ${AWSSDK_LINK_LIBRARIES}
             ${AWSSDK_PLATFORM_DEPS})
 
         # Build the code example unit tests.

--- a/cpp/example_code/s3/get_put_bucket_acl.cpp
+++ b/cpp/example_code/s3/get_put_bucket_acl.cpp
@@ -19,34 +19,34 @@
 /* ////////////////////////////////////////////////////////////////////////////
  * Function: SetGranteePermission
  *
- * Purpose: Converts a human-readable string to a 
+ * Purpose: Converts a human-readable string to a
  * built-in permission enumeration.
- * 
+ *
  * Inputs: A human-readable string.
  *
- * Outputs: A related built-in permission enumeration, if one exists; 
+ * Outputs: A related built-in permission enumeration, if one exists;
  * otherwise, the enumeration Aws::S3::Model::Permission::NOT_SET.
  * ////////////////////////////////////////////////////////////////////////////
  * Function: GetGranteeType
  *
- * Purpose: Converts a built-in permission enumeration to a 
+ * Purpose: Converts a built-in permission enumeration to a
  * human-readable string.
  *
  * Inputs: A built-in permission enumeration.
  *
- * Outputs: A related human-readable string, if one exists; otherwise, 
+ * Outputs: A related human-readable string, if one exists; otherwise,
  * the string "Not set".
  * ////////////////////////////////////////////////////////////////////////////
  * Function: SetGranteeType
  *
- * Purpose: Converts a human-readable string to a 
+ * Purpose: Converts a human-readable string to a
  * built-in type enumeration.
  *
  * Prerequisites:
  *
  * Inputs: A human-readable string.
  *
- * Outputs: A related built-in type enumeration, if one exists; otherwise, 
+ * Outputs: A related built-in type enumeration, if one exists; otherwise,
  * the enumeration Aws::S3::Model::Type::NOT_SET.
  * ////////////////////////////////////////////////////////////////////////////
  * Function: PutBucketAcl
@@ -56,37 +56,37 @@
  * Prerequisites: An existing bucket.
  *
  * Inputs:
- * - bucketName: The name of the bucket to set the ACL for. For example, 
+ * - bucketName: The name of the bucket to set the ACL for. For example,
  *   "my-bucket".
  * - region: The AWS Region identifier for the bucket. For example, "us-east-1".
- * - ownerID: The canonical ID of the bucket owner. For example, 
+ * - ownerID: The canonical ID of the bucket owner. For example,
  *   "b380d412791d395dbcdc1fb1728b32a7cd07edae6467220ac4b7c0769EXAMPLE".
  * - granteePermission: The access level to enable for the grantee. For example:
- *   - "FULL_CONTROL": Can list objects in the bucket, create/overwrite/delete 
+ *   - "FULL_CONTROL": Can list objects in the bucket, create/overwrite/delete
  *     objects in the bucket, and read/write the bucket's permissions.
  *   - "WRITE": Can write to the bucket.
  *   - "READ": Can list objects in the bucket.
  *   - "WRITE_ACP": Can write the bucket's permissions.
  *   - "READ_ACP": Can read the bucket's permissions.
  * - granteeType: The type of grantee. For example:
- *   - "Amazon customer by email": A user identified by the email associated with 
+ *   - "Amazon customer by email": A user identified by the email associated with
  *     their AWS account.
  *   - "Canonical user": A user identified by their canonical ID or display name.
  *   - "Group": A built-in access group. For example, all authenticated users.
- * - granteeID: The canonical ID of the grantee. For example, 
+ * - granteeID: The canonical ID of the grantee. For example,
  *   "51ffd418eb142601651cc9d54984604a32b51a23153b4898fd2224772EXAMPLE".
  * - granteeDisplayName: The display name of the grantee. For example, "janedoe".
- * - granteeEmailAddress: The email address associated with the grantee's AWS 
+ * - granteeEmailAddress: The email address associated with the grantee's AWS
  *   account. For example, "janedoe@example.com".
- * - granteeURI: The URI of a built-in access group. For example, 
- *   "http://acs.amazonaws.com/groups/global/AuthenticatedUsers" 
+ * - granteeURI: The URI of a built-in access group. For example,
+ *   "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
  *   for all authenticated users.
  *
  * Outputs: true if the ACL was set for the bucket; otherwise, false.
  * ////////////////////////////////////////////////////////////////////////////
  * Function: GetBucketAcl
  *
- * Purpose: Gets information about the access control list (ACL) for an 
+ * Purpose: Gets information about the access control list (ACL) for an
  * Amazon S3 bucket.
  *
  * Prerequisites: An existing bucket.
@@ -96,7 +96,7 @@
  *   "my-bucket".
  * - region: The AWS Region identifier for the bucket. For example, "us-east-1".
  *
- * Outputs: true if ACL information was retrieved for the bucket; 
+ * Outputs: true if ACL information was retrieved for the bucket;
  * otherwise, false.
  * ///////////////////////////////////////////////////////////////////////// */
 
@@ -139,14 +139,14 @@ Aws::S3::Model::Type SetGranteeType(const Aws::String& type)
 }
 
 bool AwsDoc::S3::PutBucketAcl(const Aws::String& bucketName,
-    const Aws::String& region, 
-    const Aws::String& ownerID, 
-    const Aws::String& granteePermission, 
-    const Aws::String& granteeType, 
-    Aws::String granteeID = "", 
-    Aws::String granteeDisplayName = "", 
-    Aws::String granteeEmailAddress = "", 
-    Aws::String granteeURI = ""
+    const Aws::String& region,
+    const Aws::String& ownerID,
+    const Aws::String& granteePermission,
+    const Aws::String& granteeType,
+    const Aws::String& granteeID,
+    const Aws::String& granteeDisplayName,
+    const Aws::String& granteeEmailAddress,
+    const Aws::String& granteeURI
 )
 {
     Aws::Client::ClientConfiguration config;
@@ -154,7 +154,7 @@ bool AwsDoc::S3::PutBucketAcl(const Aws::String& bucketName,
 
     Aws::S3::S3Client s3_client(config);
 
-    Aws::S3::Model::Owner owner; 
+    Aws::S3::Model::Owner owner;
     owner.SetID(ownerID);
 
     Aws::S3::Model::Grantee grantee;
@@ -190,12 +190,12 @@ bool AwsDoc::S3::PutBucketAcl(const Aws::String& bucketName,
     Aws::S3::Model::AccessControlPolicy acp;
     acp.SetOwner(owner);
     acp.SetGrants(grants);
-    
+
     Aws::S3::Model::PutBucketAclRequest request;
     request.SetAccessControlPolicy(acp);
     request.SetBucket(bucketName);
 
-    Aws::S3::Model::PutBucketAclOutcome outcome = 
+    Aws::S3::Model::PutBucketAclOutcome outcome =
         s3_client.PutBucketAcl(request);
 
     if (outcome.IsSuccess())
@@ -223,13 +223,13 @@ bool AwsDoc::S3::GetBucketAcl(const Aws::String& bucketName,
     Aws::S3::Model::GetBucketAclRequest request;
     request.SetBucket(bucketName);
 
-    Aws::S3::Model::GetBucketAclOutcome outcome = 
+    Aws::S3::Model::GetBucketAclOutcome outcome =
         s3_client.GetBucketAcl(request);
 
     if (outcome.IsSuccess())
     {
         Aws::S3::Model::Owner owner = outcome.GetResult().GetOwner();
-        Aws::Vector<Aws::S3::Model::Grant> grants = 
+        Aws::Vector<Aws::S3::Model::Grant> grants =
             outcome.GetResult().GetGrants();
 
         std::cout << "Bucket ACL information for bucket '" << bucketName <<
@@ -237,22 +237,22 @@ bool AwsDoc::S3::GetBucketAcl(const Aws::String& bucketName,
 
         std::cout << "Owner:" << std::endl << std::endl;
         std::cout << "Display name:  " << owner.GetDisplayName() << std::endl;
-        std::cout << "ID:            " << owner.GetID() << std::endl << 
+        std::cout << "ID:            " << owner.GetID() << std::endl <<
                                              std::endl;
-        
+
         std::cout << "Grantees:" << std::endl << std::endl;
 
         for (auto it = std::begin(grants); it != end(grants); ++it) {
             auto grantee = it->GetGrantee();
-            std::cout << "Display name:  " << grantee.GetDisplayName() << 
+            std::cout << "Display name:  " << grantee.GetDisplayName() <<
                                                   std::endl;
-            std::cout << "Email address: " << grantee.GetEmailAddress() << 
+            std::cout << "Email address: " << grantee.GetEmailAddress() <<
                                                   std::endl;
             std::cout << "ID:            " << grantee.GetID() << std::endl;
             std::cout << "Type:          " << GetGranteeType(
-                                                  grantee.GetType()) << 
+                                                  grantee.GetType()) <<
                                                   std::endl;
-            std::cout << "URI:           " << grantee.GetURI() << std::endl << 
+            std::cout << "URI:           " << grantee.GetURI() << std::endl <<
                                                   std::endl;
         }
 
@@ -275,29 +275,29 @@ int main()
     {
         const Aws::String bucket_name = "my-bucket";
 
-        // Set the ACL's owner information. 
-        const Aws::String owner_id = 
+        // Set the ACL's owner information.
+        const Aws::String owner_id =
             "b380d412791d395dbcdc1fb1728b32a7cd07edae6467220ac4b7c0769EXAMPLE";
 
         // Set the ACL's grantee information.
         const Aws::String grantee_permission = "READ";
-        
-        // If the grantee is by canonical user, then either the user's ID or 
+
+        // If the grantee is by canonical user, then either the user's ID or
         // display name must be specified:
         const Aws::String grantee_type = "Canonical user";
-        const Aws::String grantee_id = 
+        const Aws::String grantee_id =
             "51ffd418eb142601651cc9d54984604a32b51a23153b4898fd2224772EXAMPLE";
         // const Aws::String grantee_display_name = "janedoe";
 
-        // If the grantee is by Amazon customer by email, then the email 
+        // If the grantee is by Amazon customer by email, then the email
         // address must be specified:
         // const Aws::String grantee_type = "Amazon customer by email";
         // const Aws::String grantee_email_address = "janedoe@example.com";
 
-        // If the grantee is by group, then the predefined group URI must 
+        // If the grantee is by group, then the predefined group URI must
         // be specified:
         // const Aws::String grantee_type = "Group";
-        // const Aws::String grantee_uri = 
+        // const Aws::String grantee_uri =
         //     "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
 
         // Set the bucket's ACL.
@@ -307,13 +307,13 @@ int main()
             grantee_permission,
             grantee_type,
             grantee_id))
-            // grantee_display_name, 
-            // grantee_email_address, 
+            // grantee_display_name,
+            // grantee_email_address,
             // grantee_uri));
         {
             return 1;
         }
-        
+
         // Get the bucket's ACL information that was just set.
         if (!AwsDoc::S3::GetBucketAcl(bucket_name, "us-east-1"))
         {

--- a/cpp/example_code/s3/get_put_object_acl.cpp
+++ b/cpp/example_code/s3/get_put_object_acl.cpp
@@ -52,10 +52,10 @@
  * ////////////////////////////////////////////////////////////////////////////
  * Function: PutObjectAcl
  *
- * Purpose: Set the access control list (ACL) for an object in 
+ * Purpose: Set the access control list (ACL) for an object in
  * an Amazon S3 bucket.
  *
- * Prerequisites: An existing bucket that contains the object you want to set 
+ * Prerequisites: An existing bucket that contains the object you want to set
  * the ACL for.
  *
  * Inputs:
@@ -66,7 +66,7 @@
  * - ownerID: The canonical ID of the bucket owner. For example,
  *   "b380d412791d395dbcdc1fb1728b32a7cd07edae6467220ac4b7c0769EXAMPLE".
  * - granteePermission: The access level to enable for the grantee. For example:
- *   - "FULL_CONTROL": Can read the object's data and its metadata, 
+ *   - "FULL_CONTROL": Can read the object's data and its metadata,
  *     and read/write the object's permissions.
  *   - "READ": Can read the object's data and its metadata.
  *   - "WRITE_ACP": Can write the object's permissions.
@@ -92,13 +92,13 @@
  * Purpose: Gets information about the access control list (ACL) for an
  * object in an Amazon S3 bucket.
  *
- * Prerequisites: An existing bucket that contains the object you want to get 
+ * Prerequisites: An existing bucket that contains the object you want to get
  * information about the ACL for.
  *
  * Inputs:
  * - bucketName: The name of the bucket. For example,
  *   "my-bucket".
- * - objectKey: The name of the key for the object to get the ACL information 
+ * - objectKey: The name of the key for the object to get the ACL information
  *   about. For example, "my-file.txt".
  * - region: The AWS Region identifier for the bucket. For example, "us-east-1".
  *
@@ -145,15 +145,15 @@ Aws::S3::Model::Type SetGranteeType(const Aws::String& type)
 }
 
 bool AwsDoc::S3::PutObjectAcl(const Aws::String& bucketName,
-    const Aws::String& objectKey, 
-    const Aws::String& region, 
-    const Aws::String& ownerID, 
-    const Aws::String& granteePermission, 
-    const Aws::String& granteeType, 
-    Aws::String granteeID = "", 
-    Aws::String granteeDisplayName = "", 
-    Aws::String granteeEmailAddress = "", 
-    Aws::String granteeURI = ""
+    const Aws::String& objectKey,
+    const Aws::String& region,
+    const Aws::String& ownerID,
+    const Aws::String& granteePermission,
+    const Aws::String& granteeType,
+    const Aws::String& granteeID,
+    const Aws::String& granteeDisplayName,
+    const Aws::String& granteeEmailAddress,
+    const Aws::String& granteeURI
 )
 {
     Aws::Client::ClientConfiguration config;
@@ -221,7 +221,7 @@ bool AwsDoc::S3::PutObjectAcl(const Aws::String& bucketName,
 }
 
 bool AwsDoc::S3::GetObjectAcl(const Aws::String& bucketName,
-    const Aws::String& objectKey, 
+    const Aws::String& objectKey,
     const Aws::String& region)
 {
     Aws::Client::ClientConfiguration config;
@@ -286,41 +286,41 @@ int main()
         const Aws::String bucket_name = "my-bucket";
         const Aws::String object_key = "my-file.txt";
 
-        // Set the ACL's owner information. 
-        const Aws::String owner_id = 
+        // Set the ACL's owner information.
+        const Aws::String owner_id =
             "b380d412791d395dbcdc1fb1728b32a7cd07edae6467220ac4b7c0769EXAMPLE";
 
         // Set the ACL's grantee information.
         const Aws::String grantee_permission = "READ";
 
-        // If the grantee is by canonical user, then either the user's ID or 
+        // If the grantee is by canonical user, then either the user's ID or
         // display name must be specified:
         const Aws::String grantee_type = "Canonical user";
-        const Aws::String grantee_id = 
+        const Aws::String grantee_id =
             "51ffd418eb142601651cc9d54984604a32b51a23153b4898fd2224772EXAMPLE";
         // const Aws::String grantee_display_name = "janedoe";
 
-        // If the grantee is by Amazon customer by email, then the email 
+        // If the grantee is by Amazon customer by email, then the email
         // address must be specified:
         // const Aws::String grantee_type = "Amazon customer by email";
         // const Aws::String grantee_email_address = "janedoe@example.com";
 
-        // If the grantee is by group, then the predefined group URI must 
+        // If the grantee is by group, then the predefined group URI must
         // be specified:
         // const Aws::String grantee_type = "Group";
-        // const Aws::String grantee_uri = 
+        // const Aws::String grantee_uri =
         //     "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
 
         // Set the object's ACL.
         if (!AwsDoc::S3::PutObjectAcl(bucket_name,
-            object_key, 
-            "us-east-1", 
-            owner_id, 
-            grantee_permission, 
-            grantee_type, 
+            object_key,
+            "us-east-1",
+            owner_id,
+            grantee_permission,
+            grantee_type,
             grantee_id))
-            // grantee_display_name, 
-            // grantee_email_address, 
+            // grantee_display_name,
+            // grantee_email_address,
             // grantee_uri));
         {
             return 1;

--- a/cpp/example_code/s3/include/awsdoc/s3/s3_examples.h
+++ b/cpp/example_code/s3/include/awsdoc/s3/s3_examples.h
@@ -12,17 +12,16 @@ namespace AwsDoc
     namespace S3
     {
         // Need to fix up implementation for this.
-        AWSDOC_S3_API bool CopyObject(const Aws::String &objectKey, 
+        AWSDOC_S3_API bool CopyObject(const Aws::String &objectKey,
             const Aws::String &fromBucket, const Aws::String &toBucket);
 
-        AWSDOC_S3_API bool CreateBucket(const Aws::String &bucketName, 
+        AWSDOC_S3_API bool CreateBucket(const Aws::String &bucketName,
             const Aws::S3::Model::BucketLocationConstraint &region);
-        
+
         // Need to fix up implementation for these.
         AWSDOC_S3_API bool DeleteBucket(const Aws::String &bucketName,
             const Aws::String &region);
-        AWSDOC_S3_API bool DeleteBucketPolicy(const Aws::String &bucketName,
-            const Aws::String &region);
+        AWSDOC_S3_API bool DeleteBucketPolicy(const Aws::String &bucketName);
         AWSDOC_S3_API bool DeleteObject(const Aws::String &objectKey,
             const Aws::String &fromBucket);
         AWSDOC_S3_API bool DeleteBucketWebsite(const Aws::String &bucketName,
@@ -31,15 +30,21 @@ namespace AwsDoc
             const Aws::String &region);
         AWSDOC_S3_API bool GetBucketPolicy(const Aws::String &bucketName,
             const Aws::String &region);
-        
+
         // Need to create implementations for these.
         AWSDOC_S3_API bool GetObject(const Aws::String &objectKey,
             const Aws::String& fromBucket);
-        AWSDOC_S3_API bool PutBucketAcl(const Aws::String &bucketName, 
-            const Aws::String &granteeId, const Aws::String &permission);
+        AWSDOC_S3_API bool PutBucketAcl(const Aws::String& bucketName,
+            const Aws::String& region, const Aws::String& ownerID,
+            const Aws::String& granteePermission, const Aws::String& granteeType,
+            const Aws::String& granteeID = "", const Aws::String& granteeDisplayName = "",
+            const Aws::String& granteeEmailAddress = "", const Aws::String& granteeURI = "");
         AWSDOC_S3_API bool PutObjectAcl(const Aws::String& bucketName,
-            const Aws::String &objectKey, const Aws::String &granteeId, 
-            const Aws::String &permission);
+            const Aws::String& objectKey, const Aws::String& region,
+            const Aws::String& ownerID, const Aws::String& granteePermission,
+            const Aws::String& granteeType, const Aws::String& granteeID = "",
+            const Aws::String& granteeDisplayName = "", const Aws::String& granteeEmailAddress = "",
+            const Aws::String& granteeURI = "");
 
         // Need to fix up implementation for this.
         AWSDOC_S3_API bool GetObjectAcl(const Aws::String &bucketName,
@@ -58,7 +63,7 @@ namespace AwsDoc
             Aws::String DELETE_BUCKET_POLICY_NAME = "my-bucket";     // test_delete_bucket_policy.cpp
             Aws::String DELETE_FROM_BUCKET = "my-bucket";            // test_delete_object.cpp
             Aws::String DELETE_OBJECT_KEY = "my-key";                // test_delete_object.cpp
- 
+
             // Replace this with a randomly-created bucket already enabled as a bucket website.
             Aws::String DELETE_BUCKET_WEBSITE_NAME = "my-bucket";    // test_delete_website_config.cpp
 

--- a/cpp/example_code/s3/tests/test_copy_object.cpp
+++ b/cpp/example_code/s3/tests/test_copy_object.cpp
@@ -14,7 +14,7 @@
 #include <aws/s3/model/DeleteBucketRequest.h>
 #include <awsdoc/s3/s3_examples.h>
 
-bool CreateBucket(const Aws::S3::S3Client& s3Client, 
+bool CreateBucket(const Aws::S3::S3Client& s3Client,
     const Aws::String& bucketName)
 {
     Aws::S3::Model::CreateBucketRequest request;
@@ -26,10 +26,10 @@ bool CreateBucket(const Aws::S3::S3Client& s3Client,
     if (!outcome.IsSuccess())
     {
         auto err = outcome.GetError();
-        std::cout << "Error: CopyObject test setup: Create bucket '" << 
+        std::cout << "Error: CopyObject test setup: Create bucket '" <<
             bucketName << "': " <<
             err.GetExceptionName() << ": " << err.GetMessage() << std::endl;
-        std::cout << "The other bucket might have already been created. " 
+        std::cout << "The other bucket might have already been created. "
             "To clean up, you need to delete the other bucket if it exists." << std::endl;
 
         return false;
@@ -53,7 +53,7 @@ bool DeleteObject(const Aws::S3::S3Client& s3Client,
     {
         auto err = outcome.GetError();
         std::cout << "Error: CreateBucket test cleanup: Delete object '" <<
-            objectKey << "' from bucket '" << bucketName << "': " << 
+            objectKey << "' from bucket '" << bucketName << "': " <<
             err.GetExceptionName() << ": " << err.GetMessage() << std::endl;
         std::cout << "To clean up, you must delete the bucket '" <<
             bucketName << "' and the other bucket yourself." << std::endl;
@@ -101,29 +101,29 @@ int main()
         config.region = "us-east-1";
         Aws::S3::S3Client s3_client(config);
 
-        char* file_name = "my-file.txt";
+        const char* file_name = "my-file.txt";
 
         // 1/8. Create the bucket to copy the object from.
-        // Create a unique bucket name to increase the chance of success 
+        // Create a unique bucket name to increase the chance of success
         // when trying to create the bucket.
         // Format: "my-from-bucket-" + lowercase UUID.
         Aws::String from_uuid = Aws::Utils::UUID::RandomUUID();
         Aws::String from_bucket_name = "my-from-bucket-" +
             Aws::Utils::StringUtils::ToLower(from_uuid.c_str());
-        
+
         if (!CreateBucket(s3_client, from_bucket_name))
         {
             return 1;
         }
 
-        // 2/8. Create the object to upload, and then upload the object 
-        // to the 'from' bucket. 
+        // 2/8. Create the object to upload, and then upload the object
+        // to the 'from' bucket.
         // For this test, create a text file named 'my-file.txt' in the same
         // directory as this test.
         std::ofstream myFile(file_name);
         myFile << "My content.";
         myFile.close();
-        
+
         Aws::S3::Model::PutObjectRequest put_object_request;
         put_object_request.SetBucket(from_bucket_name);
         put_object_request.SetKey(file_name);
@@ -140,7 +140,7 @@ int main()
         if (!put_object_outcome.IsSuccess())
         {
             auto err = put_object_outcome.GetError();
-            std::cout << "Error: CopyObject test setup: Upload object '" << file_name << "' " << 
+            std::cout << "Error: CopyObject test setup: Upload object '" << file_name << "' " <<
                 "to bucket '" << from_bucket_name << "': " <<
                 err.GetExceptionName() << ": " << err.GetMessage() << std::endl;
             std::cout << "To clean up, you must delete the bucket '" <<
@@ -150,7 +150,7 @@ int main()
         }
 
         // 3/8. Create the bucket to copy the object to.
-        // Create a unique bucket name to increase the chance of success 
+        // Create a unique bucket name to increase the chance of success
         // when trying to create the bucket.
         // Format: "my-to-bucket-" + lowercase UUID.
         Aws::String to_uuid = Aws::Utils::UUID::RandomUUID();
@@ -166,10 +166,10 @@ int main()
         if (!AwsDoc::S3::CopyObject(Aws::String(file_name), from_bucket_name,
             to_bucket_name))
         {
-            std::cout << "Error: CopyObject test: Copy object '" << file_name << "' from bucket '" << 
+            std::cout << "Error: CopyObject test: Copy object '" << file_name << "' from bucket '" <<
                 from_bucket_name << "' to bucket '" << to_bucket_name << "'. To clean up, "
                 "you must delete the buckets '" <<
-                from_bucket_name << "' and '" << 
+                from_bucket_name << "' and '" <<
                 to_bucket_name << "' yourself." << std::endl;
 
             return 1;

--- a/cpp/example_code/s3/tests/test_delete_object.cpp
+++ b/cpp/example_code/s3/tests/test_delete_object.cpp
@@ -17,7 +17,7 @@ int main()
     Aws::SDKOptions options;
     Aws::InitAPI(options);
     {
-        char* file_name = "my-file.txt";
+        const char* file_name = "my-file.txt";
 
         Aws::Client::ClientConfiguration config;
         config.region = "us-east-1";
@@ -25,7 +25,7 @@ int main()
         Aws::S3::S3Client s3_client(config);
 
         // 1/4. Create the bucket to upload the object to.
-        // Create a unique bucket name to increase the chance of success 
+        // Create a unique bucket name to increase the chance of success
         // when trying to create the bucket.
         // Format: "my-bucket-" + lowercase UUID.
         Aws::String uuid = Aws::Utils::UUID::RandomUUID();
@@ -49,8 +49,8 @@ int main()
             return 1;
         }
 
-        // 2/4. Create the object to upload, and then upload the object 
-        // to the bucket. 
+        // 2/4. Create the object to upload, and then upload the object
+        // to the bucket.
         // For this test, create a text file named 'my-file.txt' in the same
         // directory as this test.
         std::ofstream myFile(file_name);

--- a/cpp/example_code/s3/tests/test_get_acl.cpp
+++ b/cpp/example_code/s3/tests/test_get_acl.cpp
@@ -18,7 +18,7 @@ int main()
     Aws::SDKOptions options;
     Aws::InitAPI(options);
     {
-        char* file_name = "my-file.txt";
+        const char* file_name = "my-file.txt";
 
         Aws::Client::ClientConfiguration config;
         config.region = "us-east-1";
@@ -26,7 +26,7 @@ int main()
         Aws::S3::S3Client s3_client(config);
 
         // 1/6. Create the bucket to upload the object to.
-        // Create a unique bucket name to increase the chance of success 
+        // Create a unique bucket name to increase the chance of success
         // when trying to create the bucket.
         // Format: "my-bucket-" + lowercase UUID.
         Aws::String uuid = Aws::Utils::UUID::RandomUUID();
@@ -50,8 +50,8 @@ int main()
             return 1;
         }
 
-        // 2/6. Create the object to upload, and then upload the object 
-        // to the bucket. 
+        // 2/6. Create the object to upload, and then upload the object
+        // to the bucket.
         // For this test, create a text file named 'my-file.txt' in the same
         // directory as this test.
         std::ofstream myFile(file_name);
@@ -102,7 +102,7 @@ int main()
 
             return 1;
         }
-        
+
         // 5/6. Delete the object from the bucket.
         Aws::S3::Model::DeleteObjectRequest delete_object_request;
 
@@ -119,7 +119,7 @@ int main()
                 bucket_name << "':" <<
                 err.GetExceptionName() << ": " << err.GetMessage() << std::endl;
             std::cout << "To clean up, you must delete the bucket '" <<
-                bucket_name << "' yourself." << std::endl; 
+                bucket_name << "' yourself." << std::endl;
 
             return 1;
         }

--- a/cpp/example_code/s3/tests/test_get_object.cpp
+++ b/cpp/example_code/s3/tests/test_get_object.cpp
@@ -26,16 +26,16 @@ int main()
         config.region = "us-east-1";
         Aws::S3::S3Client s3_client(config);
 
-        char* file_name = "my-file.txt";
+        const char* file_name = "my-file.txt";
 
         // 1/5. Create the bucket to upload the object to.
-        // Create a unique bucket name to increase the chance of success 
+        // Create a unique bucket name to increase the chance of success
         // when trying to create the bucket.
         // Format: "my-bucket-" + lowercase UUID.
         Aws::String uuid = Aws::Utils::UUID::RandomUUID();
         Aws::String bucket_name = "my-bucket-" +
             Aws::Utils::StringUtils::ToLower(uuid.c_str());
-        
+
         Aws::S3::Model::CreateBucketRequest create_bucket_request;
         create_bucket_request.SetBucket(bucket_name);
 
@@ -53,14 +53,14 @@ int main()
             return 1;
         }
 
-        // 2/5. Create the object to upload, and then upload the object 
-        // to the bucket. 
+        // 2/5. Create the object to upload, and then upload the object
+        // to the bucket.
         // For this test, create a text file named 'my-file.txt' in the same
         // directory as this test.
         std::ofstream myFile(file_name);
         myFile << "My content.";
         myFile.close();
-        
+
         Aws::S3::Model::PutObjectRequest put_object_request;
         put_object_request.SetBucket(bucket_name);
         put_object_request.SetKey(file_name);
@@ -77,7 +77,7 @@ int main()
         if (!put_object_outcome.IsSuccess())
         {
             auto err = put_object_outcome.GetError();
-            std::cout << "Error: GetObject test setup: Upload object '" << file_name << "' " << 
+            std::cout << "Error: GetObject test setup: Upload object '" << file_name << "' " <<
                 "to bucket '" << bucket_name << "': " <<
                 err.GetExceptionName() << ": " << err.GetMessage() << std::endl;
             std::cout << "To clean up, you must delete the bucket '" <<

--- a/cpp/example_code/s3/tests/test_get_put_object_acl.cpp
+++ b/cpp/example_code/s3/tests/test_get_put_object_acl.cpp
@@ -27,10 +27,10 @@ int main()
         config.region = "us-east-1";
         Aws::S3::S3Client s3_client(config);
 
-        char* file_name = "my-file.txt";
+        const char* file_name = "my-file.txt";
 
         // 1/6. Create the bucket to upload the object to.
-        // Create a unique bucket name to increase the chance of success 
+        // Create a unique bucket name to increase the chance of success
         // when trying to create the bucket.
         // Format: "my-bucket-" + lowercase UUID.
         Aws::String uuid = Aws::Utils::UUID::RandomUUID();
@@ -104,15 +104,15 @@ int main()
             owner_id = list_buckets_outcome.GetResult().GetOwner().GetID();
         }
 
-        if (!AwsDoc::S3::PutObjectAcl(bucket_name, 
-            file_name, 
+        if (!AwsDoc::S3::PutObjectAcl(bucket_name,
+            file_name,
             "us-east-1",
             owner_id,
             "READ",
             "Canonical user",
-            owner_id, 
-            "", 
-            "", 
+            owner_id,
+            "",
+            "",
             ""))
         {
             std::cout << "Error: PutObjectAcl test: Set ACL for object '" <<


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awsdocs/aws-doc-sdk-examples/issues/1255

*Description of changes:*
NAME_WLE in get_filename_component is supported by CMake starting from version 3.14
Replace it with NAME_WE for old versions of CMake supports.

Fixed some other issues to make it build on my local Ubuntu.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
