### PR TITLE
Added snippet tag to exitErrorf method

### DIFF
--- a/go/example_code/sqs/sqs_longpolling_existing_queue.go
+++ b/go/example_code/sqs/sqs_longpolling_existing_queue.go
@@ -99,8 +99,10 @@ func main() {
     // snippet-end:[sqs.go.longpolling_existing_queue.enable]
 }
 
+// snippet-start:[sqs.go.longpolling_existing_queue.error]
 func exitErrorf(msg string, args ...interface{}) {
     fmt.Fprintf(os.Stderr, msg+"\n", args...)
     os.Exit(1)
 }
+// snippet-end:[sqs.go.longpolling_existing_queue.error]
 // snippet-end:[sqs.go.longpolling_existing_queue.complete]


### PR DESCRIPTION
*Issue #, if available:*
Go guide was referring to exitErrorf method using line numbers.

*Description of changes:*
Wrapped method in snippet tag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
