### PR TITLE
Add examples for V2 S3 Encryption Client with V2 Crypto Configuration.

### DIFF
--- a/cpp/example_code/s3encryption/CMakeLists.txt
+++ b/cpp/example_code/s3encryption/CMakeLists.txt
@@ -1,29 +1,116 @@
-#   Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
-#   This file is licensed under the Apache License, Version 2.0 (the "License").
-#   You may not use this file except in compliance with the License. A copy of
-#   the License is located at
+# Set the minimum required version of CMake for this project.
+cmake_minimum_required(VERSION 3.8)
 
-#   http://aws.amazon.com/apache2.0/
+# Set this project's name.
+project("s3-encryption-examples")
 
-#   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
-#   specific language governing permissions and limitations under the License.
+# Set the C++ standard to use to build this target.
+set(CMAKE_CXX_STANDARD 11)
 
-cmake_minimum_required(VERSION 3.2)
-project(s3Encryption)
-set (CMAKE_CXX_STANDARD 11)
+# Enable CTest for testing these code examples.
+include(CTest)
 
+# Build shared libraries by default.
+if(NOT BUILD_SHARED_LIBS)
+    set(BUILD_SHARED_LIBS ON)
+endif()
+
+# Build in Debug mode by default
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+# Find the AWS SDK for C++ package.
 find_package(AWSSDK REQUIRED COMPONENTS s3-encryption)
 
-if (WIN32)
-# Link to shared libraries.
-add_definitions(-DUSE_IMPORT_EXPORT)
+# If the compiler is some version of Microsoft Visual C++, or another compiler simulating C++,
+# and building as shared libraries, then dynamically link to those shared libraries.
+if(MSVC AND BUILD_SHARED_LIBS)
+    add_definitions(-DUSE_IMPORT_EXPORT)
+    # Copy relevant AWS SDK for C++ libraries into the current binary directory for running and debugging.
+    list(APPEND SERVICE_LIST s3-encryption)
+    message(STATUS "CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}")
+    AWSSDK_CPY_DYN_LIBS(SERVICE_LIST "" ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE})
 endif()
 
-if (APPLE)
-    add_definitions(-DUNDER_MACOS)
+# Add the code example-specific header files.
+file(GLOB AWSDOC_S3_ENCRYPTION_HEADERS
+    "include/awsdoc/s3-encryption/*.h"
+)
+
+# Add the code example-specific source files.
+file(GLOB AWSDOC_S3_ENCRYPTION_SOURCE
+    "*.cpp"
+)
+
+# Check whether the target system is Windows, including Win64.
+if(WIN32)
+    # Check whether the compiler is some version of Microsoft Visual C++, or another compiler simulating C++.
+    if(MSVC)
+        source_group("Header Files\\awsdoc\\s3-encryption" FILES ${AWSDOC_S3_ENCRYPTION_HEADERS})
+        source_group("Source Files" FILES ${AWSDOC_S3_ENCRYPTION_SOURCE})
+    endif(MSVC)
 endif()
 
-add_executable(s3Encryption s3Encryption.cpp)
-target_link_libraries(s3Encryption ${AWSSDK_LINK_LIBRARIES})
+foreach(file ${AWSDOC_S3_ENCRYPTION_SOURCE})
+    get_filename_component(EXAMPLE ${file} NAME_WE)
+
+    # Build the code example executables.
+    set(EXAMPLE_EXE run_${EXAMPLE})
+
+    add_executable(${EXAMPLE_EXE} ${AWSDOC_S3_ENCRYPTION_HEADERS} ${file})
+
+    if(MSVC AND BUILD_SHARED_LIBS)
+        target_compile_definitions(${EXAMPLE_EXE} PUBLIC "USE_IMPORT_EXPORT")
+        target_compile_definitions(${EXAMPLE_EXE} PRIVATE "AWSDOC_S3ENCRYPTION_EXPORTS")
+    endif()
+    if(NOT MSVC)
+        list(APPEND AWS_COMPILER_WARNINGS "-Wall" "-pedantic" "-Wextra")
+        target_compile_options(${EXAMPLE_EXE} PRIVATE "${AWS_COMPILER_WARNINGS}")
+    endif()
+
+    target_include_directories(${EXAMPLE_EXE} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>)
+    target_link_libraries(${EXAMPLE_EXE} ${AWSSDK_LINK_LIBRARIES}
+        ${AWSSDK_PLATFORM_DEPS})
+
+    if(BUILD_TESTING)
+        # Enable testing for this directory and below.
+        enable_testing()
+
+        # Build the code example libraries.
+        set(EXAMPLE_LIB ${EXAMPLE})
+
+        add_library(${EXAMPLE_LIB} ${AWSDOC_S3_ENCRYPTION_HEADERS} ${file})
+
+        if(MSVC AND BUILD_SHARED_LIBS)
+            target_compile_definitions(${EXAMPLE_LIB} PUBLIC "USE_IMPORT_EXPORT")
+            target_compile_definitions(${EXAMPLE_LIB} PRIVATE "AWSDOC_S3ENCRYPTION_EXPORTS")
+        endif()
+
+        target_include_directories(${EXAMPLE_LIB} PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include>)
+        target_link_libraries(${EXAMPLE_LIB} ${AWSSDK_LINK_LIBRARIES}
+            ${AWSSDK_PLATFORM_DEPS})
+
+        # Build the code example unit tests.
+        set(EXAMPLE_TEST test_${EXAMPLE})
+        set(EXAMPLE_TEST_FILE ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_${EXAMPLE}.cpp)
+
+        if(EXISTS ${EXAMPLE_TEST_FILE})
+            add_executable(${EXAMPLE_TEST} ${EXAMPLE_TEST_FILE} )
+
+            target_include_directories(${EXAMPLE_TEST} PUBLIC
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                $<INSTALL_INTERFACE:include>)
+            target_link_libraries(${EXAMPLE_TEST} ${EXAMPLE_LIB} )
+            add_test(${EXAMPLE_TEST} ${EXAMPLE_TEST})
+        endif()
+
+    endif()
+endforeach()

--- a/cpp/example_code/s3encryption/include/awsdoc/s3-encryption/s3Encryption_EXPORTS.h
+++ b/cpp/example_code/s3encryption/include/awsdoc/s3-encryption/s3Encryption_EXPORTS.h
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifdef _MSC_VER
+	// Disable Windows complaining about max template size.
+	#pragma warning (disable : 4503)
+#endif // _MSC_VER
+
+#if defined (_WIN32)
+	#ifdef _MSC_VER
+		#pragma warning (disable : 4251)
+	#endif // _MSC_VER
+
+	#ifdef USE_IMPORT_EXPORT
+		#ifdef AWSDOC_S3ENCRYPTION_EXPORTS
+			#define AWSDOC_S3ENCRYPTION_API __declspec(dllexport)
+		#else
+			#define AWSDOC_S3ENCRYPTION_API __declspec(dllimport)
+		#endif // AWSDOC_S3_EXPORTS
+	#else
+		#define AWSDOC_S3ENCRYPTION_API
+	#endif // USE_IMPORT_EXPORT
+#else // defined (WIN32)
+	#define AWSDOC_S3ENCRYPTION_API
+#endif // defined (WIN32)

--- a/cpp/example_code/s3encryption/include/awsdoc/s3-encryption/s3_encryption_examples.h
+++ b/cpp/example_code/s3encryption/include/awsdoc/s3-encryption/s3_encryption_examples.h
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX - License - Identifier: Apache - 2.0
+
+#pragma once
+
+#include <aws/core/Aws.h>
+#include <awsdoc/s3-encryption/s3Encryption_EXPORTS.h>
+
+namespace AwsDoc
+{
+    namespace S3Encryption
+    {
+        AWSDOC_S3ENCRYPTION_API bool KMSWithContextEncryptionMaterialsExample(
+            const char* bucket,
+            const char* objectKey,
+            const char* masterKeyId
+        );
+
+        AWSDOC_S3ENCRYPTION_API bool SimpleEncryptionMaterialsWithGCMAADExample(
+            const char* bucket,
+            const char* objectKey
+        );
+
+        AWSDOC_S3ENCRYPTION_API bool DecryptObjectsEncryptedWithLegacyEncryptionExample(
+            const char* bucket,
+            const char* objectKey
+        );
+
+        AWSDOC_S3ENCRYPTION_API bool DecryptObjectsWithRangeExample(
+            const char* bucket,
+            const char* objectKey
+        );
+
+        AWSDOC_S3ENCRYPTION_API bool DecryptObjectsWithAnyCMKExample(
+            const char* bucket,
+            const char* objectKey,
+            const char* masterKeyId
+        );
+    }
+}

--- a/cpp/example_code/s3encryption/s3Encryption.cpp
+++ b/cpp/example_code/s3encryption/s3Encryption.cpp
@@ -1,4 +1,3 @@
- 
 //snippet-sourcedescription:[s3Encryption.cpp demonstrates how to perform client-side encryption on an Amazon S3 bucket object using AWS KMS.]
 //snippet-keyword:[C++]
 //snippet-sourcesyntax:[cpp]
@@ -9,48 +8,302 @@
 //snippet-sourcedate:[]
 //snippet-sourceauthor:[AWS]
 
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX - License - Identifier: Apache - 2.0
 
-/*
-   Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-   This file is licensed under the Apache License, Version 2.0 (the "License").
-   You may not use this file except in compliance with the License. A copy of
-   the License is located at
-
-    http://aws.amazon.com/apache2.0/
-
-    This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-    CONDITIONS OF ANY KIND, either express or implied. See the License for the
-    specific language governing permissions and limitations under the License.
-*/
-#include <aws/core/auth/AWSCredentialsProviderChain.h>
-#include <aws/core/http/Scheme.h>
+#define AWS_DISABLE_DEPRECATION
+#include <awsdoc/s3-encryption/s3_encryption_examples.h>
 #include <aws/s3-encryption/S3EncryptionClient.h>
 #include <aws/s3-encryption/CryptoConfiguration.h>
 #include <aws/s3-encryption/materials/KMSEncryptionMaterials.h>
+#include <aws/s3-encryption/materials/SimpleEncryptionMaterials.h>
+#include <aws/s3/S3Client.h>
 #include <aws/s3/model/CreateBucketRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/s3/model/GetObjectRequest.h>
-#include <aws/s3/S3Client.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/utils/crypto/Cipher.h>
 
 using namespace Aws::S3;
 using namespace Aws::S3::Model;
 using namespace Aws::S3Encryption;
 using namespace Aws::S3Encryption::Materials;
 
+static const char ALLOCATION_TAG[] = "s3-encryption-examples";
+
+bool AwsDoc::S3Encryption::KMSWithContextEncryptionMaterialsExample(const char* bucket, const char* objectKey, const char* masterKeyId)
+{
+    Aws::Client::ClientConfiguration clientConfig;
+    clientConfig.region = Aws::Region::US_EAST_1;
+    const auto kmsWithContextEncryptionMaterials = Aws::MakeShared<KMSWithContextEncryptionMaterials>(ALLOCATION_TAG, masterKeyId, clientConfig);
+    CryptoConfigurationV2 cryptoConfig(kmsWithContextEncryptionMaterials);
+    S3EncryptionClientV2 s3EncryptionClient(cryptoConfig, clientConfig);
+
+    Aws::String content = "Hello from KMSWithContextEncryptionMaterials";
+    auto contentStream = Aws::MakeShared<Aws::StringStream>("s3Encryption");
+    *contentStream << content;
+
+    // Put an encrypted object to S3
+    PutObjectRequest putObjectRequest;
+    putObjectRequest.WithBucket(bucket).WithKey(objectKey).SetBody(contentStream);
+
+    Aws::Map<Aws::String, Aws::String> kmsContextMap;
+    kmsContextMap.emplace("client", "aws-sdk-cpp");
+    kmsContextMap.emplace("version", "1.8.0");
+    auto putObjectOutcome = s3EncryptionClient.PutObject(putObjectRequest, kmsContextMap /* Or {} as an empty map */);
+
+    if (putObjectOutcome.IsSuccess()) {
+        std::cout << "Put object with KMSWithContextEncryptionMaterials succeeded" << std::endl;
+    } else {
+        std::cout << "Error while putting object with KMSWithContextEncryptionMaterials: \n"
+                  << putObjectOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    // Get an encrypted object from S3
+    GetObjectRequest getRequest;
+    getRequest.WithBucket(bucket).WithKey(objectKey);
+    Aws::String decryptedContent;
+
+    auto getObjectOutcome = s3EncryptionClient.GetObject(getRequest);
+    if (getObjectOutcome.IsSuccess()) {
+        Aws::StringStream ss;
+        ss << getObjectOutcome.GetResult().GetBody().rdbuf();
+        decryptedContent = ss.str();
+        std::cout << "Successfully retrieved object with content: "
+                  << decryptedContent << std::endl;;
+    } else {
+        std::cout << "Error while getting object: \n"
+                  << getObjectOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    return decryptedContent == content;
+}
+
+bool AwsDoc::S3Encryption::SimpleEncryptionMaterialsWithGCMAADExample(const char* bucket, const char* objectKey)
+{
+    Aws::Client::ClientConfiguration clientConfig;
+    clientConfig.region = Aws::Region::US_EAST_1;
+    auto symmetricKey = Aws::Utils::Crypto::SymmetricCipher::GenerateKey();
+    const auto simpleEncryptionMaterialsWithGCMAAD = Aws::MakeShared<SimpleEncryptionMaterialsWithGCMAAD>(ALLOCATION_TAG, symmetricKey);
+    CryptoConfigurationV2 cryptoConfig(simpleEncryptionMaterialsWithGCMAAD);
+    S3EncryptionClientV2 s3EncryptionClient(cryptoConfig, clientConfig);
+
+    Aws::String content = "Hello from SimpleEncryptionMaterialsWithGCMAAD";
+    auto contentStream = Aws::MakeShared<Aws::StringStream>("s3Encryption");
+    *contentStream << content;
+
+    // Put an encrypted object to S3
+    PutObjectRequest putObjectRequest;
+    putObjectRequest.WithBucket(bucket).WithKey(objectKey).SetBody(contentStream);
+
+    // Has to specify an empty map here for SimpleEncryptionMaterialsWithGCMAAD.
+    auto putObjectOutcome = s3EncryptionClient.PutObject(putObjectRequest, {});
+
+    if (putObjectOutcome.IsSuccess()) {
+        std::cout << "Put object with SimpleEncryptionMaterialsWithGCMAAD succeeded" << std::endl;
+    } else {
+        std::cout << "Error while putting object with KMSWithContextEncryptionMaterials: \n"
+                  << putObjectOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    //get an encrypted object from S3
+    GetObjectRequest getRequest;
+    getRequest.WithBucket(bucket).WithKey(objectKey);
+    Aws::String decryptedContent;
+
+    auto getObjectOutcome = s3EncryptionClient.GetObject(getRequest);
+    if (getObjectOutcome.IsSuccess()) {
+        Aws::StringStream ss;
+        ss << getObjectOutcome.GetResult().GetBody().rdbuf();
+        decryptedContent = ss.str();
+        std::cout << "Successfully retrieved object with content: "
+                  << decryptedContent << std::endl;
+    } else {
+        std::cout << "Error while getting object: \n"
+                  << getObjectOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    return decryptedContent == content;
+}
+
+bool AwsDoc::S3Encryption::DecryptObjectsEncryptedWithLegacyEncryptionExample(const char* bucket, const char* objectKey)
+{
+    Aws::Client::ClientConfiguration clientConfig;
+    clientConfig.region = Aws::Region::US_EAST_1;
+    auto symmetricKey = Aws::Utils::Crypto::SymmetricCipher::GenerateKey();
+    const auto simpleEncryptionMaterials = Aws::MakeShared<SimpleEncryptionMaterials>(ALLOCATION_TAG, symmetricKey);
+    CryptoConfiguration cryptoConfig(CryptoMode::ENCRYPTION_ONLY);
+    S3EncryptionClient s3EncryptionClient(simpleEncryptionMaterials, cryptoConfig, clientConfig);
+
+    Aws::String content = "Hello from DecryptObjectsEncryptedWithLegacyEncryption";
+    auto contentStream = Aws::MakeShared<Aws::StringStream>("s3Encryption");
+    *contentStream << content;
+
+    // Put an encrypted object to S3
+    PutObjectRequest putObjectRequest;
+    putObjectRequest.WithBucket(bucket).WithKey(objectKey).SetBody(contentStream);
+
+    // Has to specify an empty map here for SimpleEncryptionMaterialsWithGCMAAD.
+    auto putObjectOutcome = s3EncryptionClient.PutObject(putObjectRequest);
+
+    if (putObjectOutcome.IsSuccess()) {
+        std::cout << "Put object with SimpleEncryptionMaterials and EncryptionOnly crypto mode succeeded" << std::endl;
+    } else {
+        std::cout << "Error while putting object with SimpleEncryptionMaterials and EncryptionOnly crypto mode: \n"
+                  << putObjectOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    const auto simpleEncryptionMaterialsWithGCMAAD = Aws::MakeShared<SimpleEncryptionMaterialsWithGCMAAD>(ALLOCATION_TAG, symmetricKey);
+    CryptoConfigurationV2 cryptoConfigV2(simpleEncryptionMaterialsWithGCMAAD);
+    // By default, SecurityProfile is V2 for CryptoConfigurationV2. You need to specify V2_AND_LEGACY explicitly.
+    // Otherwise S3EncryptionClientV2 is not able to decrypt objects encrypted with legacy (less secure) encryption.
+    cryptoConfigV2.SetSecurityProfile(SecurityProfile::V2_AND_LEGACY);
+    S3EncryptionClientV2 s3EncryptionClientV2(cryptoConfigV2, clientConfig);
+
+    //get an encrypted object from S3
+    GetObjectRequest getRequest;
+    getRequest.WithBucket(bucket).WithKey(objectKey);
+    Aws::String decryptedContent;
+
+    auto getObjectOutcome = s3EncryptionClientV2.GetObject(getRequest);
+    if (getObjectOutcome.IsSuccess()) {
+        Aws::StringStream ss;
+        ss << getObjectOutcome.GetResult().GetBody().rdbuf();
+        decryptedContent = ss.str();
+        std::cout << "Successfully retrieved object with content: "
+                  << decryptedContent << std::endl;
+    } else {
+        std::cout << "Error while getting object: \n"
+                  << getObjectOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    return decryptedContent == content;
+}
+
+bool AwsDoc::S3Encryption::DecryptObjectsWithRangeExample(const char* bucket, const char* objectKey)
+{
+    Aws::Client::ClientConfiguration clientConfig;
+    clientConfig.region = Aws::Region::US_EAST_1;
+    auto symmetricKey = Aws::Utils::Crypto::SymmetricCipher::GenerateKey();
+    const auto simpleEncryptionMaterialsWithGCMAAD = Aws::MakeShared<SimpleEncryptionMaterialsWithGCMAAD>(ALLOCATION_TAG, symmetricKey);
+    CryptoConfigurationV2 cryptoConfig(simpleEncryptionMaterialsWithGCMAAD);
+    // By default, RangeGetMode is DISABLED for CryptoConfigurationV2. You need to specify RangeGetMode::ALL explicitly.
+    // Otherwise S3EncryptionClientV2 is not able to decrypt objects with range.
+    cryptoConfig.SetUnAuthenticatedRangeGet(RangeGetMode::ALL);
+    S3EncryptionClientV2 s3EncryptionClient(cryptoConfig, clientConfig);
+
+    Aws::String content = "Hello from DecryptObjectsWithRange";
+    auto contentStream = Aws::MakeShared<Aws::StringStream>("s3Encryption");
+    *contentStream << content;
+
+    // Put an encrypted object to S3
+    PutObjectRequest putObjectRequest;
+    putObjectRequest.WithBucket(bucket).WithKey(objectKey).SetBody(contentStream);
+
+    // Has to specify an empty map here for SimpleEncryptionMaterialsWithGCMAAD.
+    auto putObjectOutcome = s3EncryptionClient.PutObject(putObjectRequest, {});
+
+    if (putObjectOutcome.IsSuccess()) {
+        std::cout << "Put object with SimpleEncryptionMaterialsWithGCMAAD succeeded" << std::endl;
+    } else {
+        std::cout << "Error while putting object with KMSWithContextEncryptionMaterials: \n"
+                  << putObjectOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    //get an encrypted object from S3
+    GetObjectRequest getRequest;
+    getRequest.WithBucket(bucket).WithKey(objectKey).WithRange("bytes=11-24");
+    Aws::String decryptedContent;
+
+    auto getObjectOutcome = s3EncryptionClient.GetObject(getRequest);
+    if (getObjectOutcome.IsSuccess()) {
+        Aws::StringStream ss;
+        ss << getObjectOutcome.GetResult().GetBody().rdbuf();
+        decryptedContent = ss.str();
+        std::cout << "Successfully retrieved object with content range \"bytes=11-24\": "
+                  << decryptedContent << std::endl;
+    } else {
+        std::cout << "Error while getting object: \n"
+                  << getObjectOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    return decryptedContent == content.substr(11, 24-11+1);
+}
+
+bool AwsDoc::S3Encryption::DecryptObjectsWithAnyCMKExample(const char* bucket, const char* objectKey, const char* masterKeyId)
+{
+    Aws::Client::ClientConfiguration clientConfig;
+    clientConfig.region = Aws::Region::US_EAST_1;
+    const auto kmsWithContextEncryptionMaterials = Aws::MakeShared<KMSWithContextEncryptionMaterials>(ALLOCATION_TAG, masterKeyId, clientConfig);
+    CryptoConfigurationV2 cryptoConfig(kmsWithContextEncryptionMaterials);
+    S3EncryptionClientV2 s3EncryptionClient(cryptoConfig, clientConfig);
+
+    Aws::String content = "Hello from KMSWithContextEncryptionMaterials";
+    auto contentStream = Aws::MakeShared<Aws::StringStream>("s3Encryption");
+    *contentStream << content;
+
+    // Put an encrypted object to S3
+    PutObjectRequest putObjectRequest;
+    putObjectRequest.WithBucket(bucket).WithKey(objectKey).SetBody(contentStream);
+
+    auto putObjectOutcome = s3EncryptionClient.PutObject(putObjectRequest, {});
+
+    if (putObjectOutcome.IsSuccess()) {
+        std::cout << "Put object with KMSWithContextEncryptionMaterials succeeded" << std::endl;
+    } else {
+        std::cout << "Error while putting object with KMSWithContextEncryptionMaterials: \n"
+                  << putObjectOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    const auto kmsWithContextEncryptionMaterialsWithAnyCMK = Aws::MakeShared<KMSWithContextEncryptionMaterials>(ALLOCATION_TAG, ""/* empty master key ID */, clientConfig);
+    kmsWithContextEncryptionMaterialsWithAnyCMK->SetKMSDecryptWithAnyCMK(true);
+    CryptoConfigurationV2 cryptoConfigWithAnyCMK(kmsWithContextEncryptionMaterialsWithAnyCMK);
+    S3EncryptionClientV2 s3DecryptionClient(cryptoConfigWithAnyCMK, clientConfig);
+
+    // Get an encrypted object from S3
+    GetObjectRequest getRequest;
+    getRequest.WithBucket(bucket).WithKey(objectKey);
+    Aws::String decryptedContent;
+
+    auto getObjectOutcome = s3DecryptionClient.GetObject(getRequest);
+    if (getObjectOutcome.IsSuccess()) {
+        Aws::StringStream ss;
+        ss << getObjectOutcome.GetResult().GetBody().rdbuf();
+        decryptedContent = ss.str();
+        std::cout << "Successfully retrieved object with any CMK with content: "
+                  << decryptedContent << std::endl;;
+    } else {
+        std::cout << "Error while getting object: \n"
+                  << getObjectOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    return decryptedContent == content;
+}
 
 int main(int argc, char** argv)
 {
-    if (argc < 4) {
+    if (argc != 4)
+    {
         std::cout << "\n" <<
-            "To run this example, supply the name (key) of an S3 object,\n"
-            "the bucket name that it's contained within,\n"
-            "and the master key id created from IAM\n\n"
-            "Ex: s3Encryption <objectname> <bucketname> <master_key_id>\n";
+            "To run this example, supply: \n"
+            "(1) The name (key) prefix of an S3 object. The actual object key name will be generated based on the prefix, for example \"<key-prefix>-kms-with-context-encryption-materials\".\n"
+            "(2) The bucket name that it's contained within.\n"
+            "(3) And the KMS master key ID used for KMS encryption materials.\n\n"
+            "Ex: run_s3Encryption my-key-prefix my-bucket 1234abcd-12ab-34cd-56ef-1234567890ab" << std::endl;
         exit(1);
     }
 
-    const char* KEY = argv[1];
+    const char* OBJECT_KEY_PREFIX = argv[1];
     const char* BUCKET = argv[2];
     const char* MASTER_KEY_ID = argv[3];
 
@@ -60,58 +313,32 @@ int main(int argc, char** argv)
     Aws::InitAPI(options);
     {
         // Create the specified bucket using vanilla S3 client first
-        S3Client s3Client;
+        Aws::Client::ClientConfiguration config;
+        config.region = Aws::Region::US_EAST_1;
+        S3Client s3Client(config);
         CreateBucketRequest createBucketRequest;
         createBucketRequest.SetBucket(BUCKET);
         createBucketRequest.SetACL(BucketCannedACL::private_);
         CreateBucketOutcome createBucketOutcome = s3Client.CreateBucket(createBucketRequest);
 
         if (!createBucketOutcome.IsSuccess()) {
-            std::cout << "Bucket Creation failed: " << createBucketOutcome.GetError() << "\n";
+            std::cout << "Bucket Creation failed: \n"
+                      << createBucketOutcome.GetError() << std::endl;
             exit(-1);
         } else {
-            std::cout << "Bucket Creation succeeded!\n";
+            std::cout << "Bucket Creation succeeded!\n" << std::endl;
         }
 
-        const auto kmsMaterials = Aws::MakeShared<KMSEncryptionMaterials>("", MASTER_KEY_ID);
-        const auto credentials = Aws::MakeShared<Aws::Auth::DefaultAWSCredentialsProviderChain>("");
-
-#ifdef UNDER_MACOS
-        CryptoConfiguration cryptoConfiguration(StorageMethod::INSTRUCTION_FILE, CryptoMode::ENCRYPTION_ONLY);
-#else
-        CryptoConfiguration cryptoConfiguration(StorageMethod::INSTRUCTION_FILE,
-                CryptoMode::STRICT_AUTHENTICATED_ENCRYPTION);
-#endif
-
-        //construct S3 encryption client
-        S3EncryptionClient encryptionClient(kmsMaterials, cryptoConfiguration, credentials);
-
-        auto requestStream = Aws::MakeShared<Aws::StringStream>("s3Encryption");
-        *requestStream << "Hello from the S3 Encryption Client!";
-
-        //put an encrypted object to S3
-        PutObjectRequest putObjectRequest;
-        putObjectRequest.WithBucket(BUCKET).WithKey(KEY).SetBody(requestStream);
-
-        auto putObjectOutcome = encryptionClient.PutObject(putObjectRequest);
-
-        if (putObjectOutcome.IsSuccess()) {
-            std::cout << "Put object succeeded\n";
-        } else {
-            std::cout << "Error while putting Object " << putObjectOutcome.GetError() << "\n";
-        }
-
-        //get an encrypted object from S3
-        GetObjectRequest getRequest;
-        getRequest.WithBucket(BUCKET).WithKey(KEY);
-
-        auto getObjectOutcome = encryptionClient.GetObject(getRequest);
-        if (getObjectOutcome.IsSuccess()) {
-            std::cout << "Successfully retrieved object with avalue: \n";
-            std::cout << getObjectOutcome.GetResult().GetBody().rdbuf() << "\n";
-        } else {
-            std::cout << "Error while getting object " << getObjectOutcome.GetError() << "\n";
-        }
+        Aws::String objectKey(OBJECT_KEY_PREFIX);
+        AwsDoc::S3Encryption::KMSWithContextEncryptionMaterialsExample(BUCKET, (objectKey + "-kms-with-context-encryption-materials").c_str(), MASTER_KEY_ID);
+        std::cout << std::endl;
+        AwsDoc::S3Encryption::SimpleEncryptionMaterialsWithGCMAADExample(BUCKET, (objectKey + "-simplie-encryption-materials-with-gcm-aad").c_str());
+        std::cout << std::endl;
+        AwsDoc::S3Encryption::DecryptObjectsEncryptedWithLegacyEncryptionExample(BUCKET, (objectKey + "-decrypt-objects-encrypted-with-legacy-encryption").c_str());
+        std::cout << std::endl;
+        AwsDoc::S3Encryption::DecryptObjectsWithRangeExample(BUCKET, (objectKey + "-decrypt-objects-with-range").c_str());
+        std::cout << std::endl;
+        AwsDoc::S3Encryption::DecryptObjectsWithAnyCMKExample(BUCKET, (objectKey + "-decrypt-objects-with-any-cmk").c_str(), MASTER_KEY_ID);
     }
     Aws::ShutdownAPI(options);
     return 0;

--- a/cpp/example_code/s3encryption/tests/test_s3Encryption.cpp
+++ b/cpp/example_code/s3encryption/tests/test_s3Encryption.cpp
@@ -1,0 +1,210 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX - License - Identifier: Apache - 2.0
+
+#define AWS_DISABLE_DEPRECATION
+#include <awsdoc/s3-encryption/s3_encryption_examples.h>
+#include <aws/core/Aws.h>
+#include <aws/core/utils/UUID.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/CreateBucketRequest.h>
+#include <aws/s3/model/DeleteBucketRequest.h>
+#include <aws/s3/model/ListObjectsRequest.h>
+#include <aws/s3/model/DeleteObjectRequest.h>
+#include <aws/kms/KMSClient.h>
+#include <aws/kms/model/CreateKeyRequest.h>
+#include <aws/kms/model/ScheduleKeyDeletionRequest.h>
+
+static const char AWSDOC_S3ENCRYPTION_BUCKET_PREFIX[] = "awsdoc-s3encryption-bucket-";
+static const char AWSDOC_S3ENCRYPTION_OBJECT_KEY_PREFIX[] = "awsdoc-s3encryption-key-";
+static const int TIMEOUT_MAX = 20;
+
+bool CreateBucket(const Aws::S3::S3Client& s3Client, const Aws::String& bucketName)
+{
+    Aws::S3::Model::CreateBucketRequest createBucketRequest;
+    createBucketRequest.SetBucket(bucketName);
+
+    auto createBucketOutcome = s3Client.CreateBucket(createBucketRequest);
+
+    if (!createBucketOutcome.IsSuccess())
+    {
+        std::cout << "Failed to create bucket: " << bucketName << "\n" << createBucketOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    // Wait for bucket to propagate
+    unsigned timeoutCount = 0;
+    while (timeoutCount++ < TIMEOUT_MAX)
+    {
+        Aws::S3::Model::ListObjectsRequest listObjectsRequest;
+        listObjectsRequest.SetBucket(bucketName);
+        auto listObjectsOutcome = s3Client.ListObjects(listObjectsRequest);
+        if (listObjectsOutcome.IsSuccess())
+        {
+            return true;
+        }
+
+        std::this_thread::sleep_for(std::chrono::seconds(10));
+    }
+
+    return false;
+}
+
+bool DeleteBucket(const Aws::S3::S3Client& s3Client, const Aws::String& bucketName)
+{
+    // Empty bucket
+    Aws::S3::Model::ListObjectsRequest listObjectsRequest;
+    listObjectsRequest.SetBucket(bucketName);
+
+    auto listObjectsOutcome = s3Client.ListObjects(listObjectsRequest);
+    if (!listObjectsOutcome.IsSuccess())
+    {
+        std::cout << "Failed to list objects in bucket: " << bucketName << "\n" << listObjectsOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    for (const auto& object : listObjectsOutcome.GetResult().GetContents())
+    {
+        Aws::S3::Model::DeleteObjectRequest deleteObjectRequest;
+        deleteObjectRequest.SetBucket(bucketName);
+        deleteObjectRequest.SetKey(object.GetKey());
+        auto deleteObjectOutcome = s3Client.DeleteObject(deleteObjectRequest);
+        if (!deleteObjectOutcome.IsSuccess())
+        {
+            std::cout << "Failed to delete object with key name: " << object.GetKey() << "\n" << deleteObjectOutcome.GetError() << std::endl;
+            return false;
+        }
+    }
+
+    // Then delete bucket
+    Aws::S3::Model::DeleteBucketRequest deleteBucketRequest;
+    deleteBucketRequest.SetBucket(bucketName);
+
+    auto deleteBucketOutcome = s3Client.DeleteBucket(deleteBucketRequest);
+
+    if (!deleteBucketOutcome.IsSuccess())
+    {
+        std::cout << "Failed to delete bucket: " << bucketName << "\n" << deleteBucketOutcome.GetError() << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+Aws::String CreateKMSMasterKey(const Aws::KMS::KMSClient& kmsClient)
+{
+    Aws::KMS::Model::CreateKeyRequest createKeyRequest;
+    auto createKeyOutcome = kmsClient.CreateKey(createKeyRequest);
+    if (!createKeyOutcome.IsSuccess())
+    {
+        std::cout << "Failed to create KMS master key.\n" << createKeyOutcome.GetError() << std::endl;
+        return {};
+    }
+    else
+    {
+        const Aws::String& masterKeyId = createKeyOutcome.GetResult().GetKeyMetadata().GetKeyId();
+        return masterKeyId;
+    }
+
+}
+
+bool DeleteKMSMasterKey(const Aws::KMS::KMSClient& kmsClient, const Aws::String& kmsMasterKeyId)
+{
+    Aws::KMS::Model::ScheduleKeyDeletionRequest scheduleKeyDeletationRequest;
+    scheduleKeyDeletationRequest.SetKeyId(kmsMasterKeyId);
+    scheduleKeyDeletationRequest.SetPendingWindowInDays(7);
+    auto scheduleKeyDeletationOutcome = kmsClient.ScheduleKeyDeletion(scheduleKeyDeletationRequest);
+    if (!scheduleKeyDeletationOutcome.IsSuccess())
+    {
+        std::cout << "Failed to schedule KMS master key deletation with ID: " << kmsMasterKeyId << std::endl;
+        return false;
+    }
+    return true;
+}
+
+int main()
+{
+    Aws::SDKOptions options;
+    Aws::InitAPI(options);
+    {
+        // Tests setup
+        Aws::Client::ClientConfiguration clientConfig;
+        clientConfig.region = Aws::Region::US_EAST_1;
+        Aws::S3::S3Client s3Client(clientConfig);
+
+        Aws::String bucketName(AWSDOC_S3ENCRYPTION_BUCKET_PREFIX);
+        bucketName += Aws::Utils::StringUtils::ToLower(static_cast<Aws::String>(Aws::Utils::UUID::RandomUUID()).c_str());
+        if (CreateBucket(s3Client, bucketName))
+        {
+            std::cout << "Succeeded to create bucket:" << bucketName << std::endl;
+        }
+        else
+        {
+            return 1;
+        }
+
+        Aws::KMS::KMSClient kmsClient(clientConfig);
+        Aws::String masterKeyId = CreateKMSMasterKey(kmsClient);
+        if (!masterKeyId.empty())
+        {
+            std::cout << "Succeeded to create KMS master key: " << masterKeyId << std::endl;
+            std::cout << std::endl;
+        }
+        else
+        {
+            return 1;
+        }
+
+        Aws::String objectKey(AWSDOC_S3ENCRYPTION_OBJECT_KEY_PREFIX);
+
+        if (!AwsDoc::S3Encryption::KMSWithContextEncryptionMaterialsExample(bucketName.c_str(), (objectKey + "kms-with-context-encryption-materials").c_str(), masterKeyId.c_str()))
+        {
+            return 1;
+        }
+        std::cout << std::endl;
+        if (!AwsDoc::S3Encryption::SimpleEncryptionMaterialsWithGCMAADExample(bucketName.c_str(), (objectKey + "simplie-encryption-materials-with-gcm-aad").c_str()))
+        {
+            return 1;
+        }
+        std::cout << std::endl;
+        if (!AwsDoc::S3Encryption::DecryptObjectsEncryptedWithLegacyEncryptionExample(bucketName.c_str(), (objectKey + "decrypt-objects-encrypted-with-legacy-encryption").c_str()))
+        {
+            return 1;
+        }
+        std::cout << std::endl;
+        if (!AwsDoc::S3Encryption::DecryptObjectsWithRangeExample(bucketName.c_str(), (objectKey + "decrypt-objects-with-range").c_str()))
+        {
+            return 1;
+        }
+        std::cout << std::endl;
+        if (!AwsDoc::S3Encryption::DecryptObjectsWithAnyCMKExample(bucketName.c_str(), (objectKey + "decrypt-objects-with-any-cmk").c_str(), masterKeyId.c_str()))
+        {
+            return 1;
+        }
+        std::cout << std::endl;
+
+        // Tests cleanup
+        if (DeleteBucket(s3Client, bucketName))
+        {
+            std::cout << "Succeeded to delete bucket: " << bucketName << std::endl;
+        }
+        else
+        {
+            return 1;
+        }
+
+        if (DeleteKMSMasterKey(kmsClient, masterKeyId))
+        {
+            std::cout << "Succeeded to schedule KMS master key deletation with ID: " << masterKeyId << std::endl;
+        }
+        else
+        {
+            return 1;
+        }
+
+
+    }
+    ShutdownAPI(options);
+
+    return 0;
+}

--- a/scripts/checkin_tests.py
+++ b/scripts/checkin_tests.py
@@ -59,7 +59,7 @@ IGNORE_FILES = {'AssemblyInfo.cs', 'metadata.yaml', '.travis.yml'}
 DENY_LIST = {'alpha-docs-aws.amazon.com', 'integ-docs-aws.amazon.com'}
 
 # whitelist of 20- or 40-character strings to allow
-ALLOW_LIST = {    
+ALLOW_LIST = {
     'AKIAIOSFODNN7EXAMPLE',
     'AppStreamUsageReportsCFNGlueAthenaAccess',
     'aws/acm/model/DescribeCertificateRequest',
@@ -84,6 +84,8 @@ ALLOW_LIST = {
     'aws/neptune/model/CreateDBClusterRequest',
     'aws/neptune/model/DeleteDBClusterRequest',
     'aws/neptune/model/ModifyDBClusterRequest',
+    'aws/kms/model/ScheduleKeyDeletionRequest',
+    'KMSWithContextEncryptionMaterialsExample',
     'CertificateTransparencyLoggingPreference',
     'ChangeMessageVisibilityBatchRequestEntry',
     'com/greengrass/latest/developerguide/lra',


### PR DESCRIPTION
*Description of changes:*
Add the following examples:
1. Using KMSWithContextEncryptionMaterials.
2. Using SimpleEncryptionMaterialsWithGCMAAD.
3. Using S3EncryptionClientV2 to decrypt objects encrypted with legacy encryption.
4. Using S3EncryptionClientV2 to decrypt objects with range.
5. Using S3EncryptionClientV2 to decrypt objects with any CMK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
