### PR TITLE
update POM dependencies for S3 examples

### DIFF
--- a/java/example_code/s3/pom.xml
+++ b/java/example_code/s3/pom.xml
@@ -16,7 +16,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.828</version>
+                <version>1.11.837</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
*Description of changes:* Updated SDK for Java dependency from 1.11.828 to 1.11.837 (latest), so that the default maven build won't fail

Verified Maven build process working as expected after change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
