### PR TITLE
Update examples to use new S3EC syntax.

### DIFF
--- a/ruby/example_code/s3/s3-ruby-example-add-cspk-item.rb
+++ b/ruby/example_code/s3/s3-ruby-example-add-cspk-item.rb
@@ -36,7 +36,12 @@ key = OpenSSL::PKey::RSA.new(public_key)
 
 begin
   # encryption client
-  enc_client = Aws::S3::EncryptionV2::Client.new(encryption_key: key)
+  enc_client = Aws::S3::EncryptionV2::Client.new(
+    encryption_key: key,
+    key_wrap_schema: :rsa_oaep_sha1, # the key_wrap_schema must be rsa_oaep_sha1 for asymmetric keys
+    content_encryption_schema: :aes_gcm_no_padding,
+    security_profile: :v2 # use :v2_and_legacy to allow reading/decrypting objects encrypted by the V1 encryption client
+  )
 
   # Add encrypted item to bucket
   enc_client.put_object(

--- a/ruby/example_code/s3/s3-ruby-example-get-cspk-item.rb
+++ b/ruby/example_code/s3/s3-ruby-example-get-cspk-item.rb
@@ -40,7 +40,12 @@ begin
   key = OpenSSL::PKey::RSA.new(private_key, pass_phrase)
 
   # encryption client
-  enc_client = Aws::S3::EncryptionV2::Client.new(encryption_key: key)
+  enc_client = Aws::S3::EncryptionV2::Client.new(
+    encryption_key: key,
+    key_wrap_schema: :rsa_oaep_sha1, # the key_wrap_schema must be rsa_oaep_sha1 for asymmetric keys
+    content_encryption_schema: :aes_gcm_no_padding,
+    security_profile: :v2 # use :v2_and_legacy to allow reading/decrypting objects encrypted by the V1 encryption client
+  )
 
   resp = enc_client.get_object(bucket: bucket, key: item)
 

--- a/ruby/example_code/s3/s3_add_csaes_encrypt_item.rb
+++ b/ruby/example_code/s3/s3_add_csaes_encrypt_item.rb
@@ -40,7 +40,13 @@ item = 'my_item'
 contents = File.read(item)
 
 # Create S3 encryption client
-client = Aws::S3::EncryptionV2::Client.new(region: 'us-west-2', encryption_key: key)
+client = Aws::S3::EncryptionV2::Client.new(
+  region: 'us-west-2',
+  encryption_key: key,
+  key_wrap_schema: :aes_gcm, # the key_wrap_schema must be aes_gcm for symmetric keys
+  content_encryption_schema: :aes_gcm_no_padding,
+  security_profile: :v2 # use :v2_and_legacy to allow reading/decrypting objects encrypted by the V1 encryption client
+)
 
 # Add encrypted item to bucket
 client.put_object(

--- a/ruby/example_code/s3/s3_add_cskms_encrypt_item.rb
+++ b/ruby/example_code/s3/s3_add_cskms_encrypt_item.rb
@@ -42,8 +42,11 @@ kms = Aws::KMS::Client.new
 
 # Create encryption client
 client = Aws::S3::EncryptionV2::Client.new(
-  kms_key_id: key,
-  kms_client: kms
+  kms_key_id: key_id,
+  kms_client: kms,
+  key_wrap_schema: :kms_context, # the key_wrap_schema must be kms_context for KMS
+  content_encryption_schema: :aes_gcm_no_padding,
+  security_profile: :v2 # use :v2_and_legacy to allow reading/decrypting objects encrypted by the V1 encryption client
 )
 
 # Add encrypted item to bucket

--- a/ruby/example_code/s3/s3_get_csaes_decrypt_item.rb
+++ b/ruby/example_code/s3/s3_get_csaes_decrypt_item.rb
@@ -36,7 +36,13 @@ bucket = 'my_bucket'
 item = 'my_item'
 
 # Create S3 encryption client
-client = Aws::S3::EncryptionV2::Client.new(region: 'us-west-2', encryption_key: key)
+client = Aws::S3::EncryptionV2::Client.new(
+  region: 'us-west-2',
+  encryption_key: key,
+  key_wrap_schema: :aes_gcm, # the key_wrap_schema must be aes_gcm for symmetric keys
+  content_encryption_schema: :aes_gcm_no_padding,
+  security_profile: :v2 # use :v2_and_legacy to allow reading/decrypting objects encrypted by the V1 encryption client
+)
 
 # Get item and print it out
 resp = client.get_object(bucket: bucket, key: item)

--- a/ruby/example_code/s3/s3_get_cskms_decrypt_item.rb
+++ b/ruby/example_code/s3/s3_get_cskms_decrypt_item.rb
@@ -39,8 +39,11 @@ kms = Aws::KMS::Client.new
 
 # Create S3 encryption client
 client = Aws::S3::EncryptionV2::Client.new(
-  kms_key_id: key,
+  kms_key_id: key_id,
   kms_client: kms,
+  key_wrap_schema: :kms_context, # the key_wrap_schema must be kms_context for KMS
+  content_encryption_schema: :aes_gcm_no_padding,
+  security_profile: :v2 # use :v2_and_legacy to allow reading/decrypting objects encrypted by the V1 encryption client
 )
 
 # Get item


### PR DESCRIPTION

*Description of changes:*
Changes to the S3EC were released that require adding additional parameters on client construction, see the updated API Docs: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/EncryptionV2.html and the migration guide: https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/s3-encryption-migration.html


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
