### PR TITLE
Removed metadata files from legacy code examples

### DIFF
--- a/go/example_code/cloudformation/metadata.yaml
+++ b/go/example_code/cloudformation/metadata.yaml
@@ -1,8 +1,0 @@
----
-files:
-  - path: CfnCrudOps.go
-    services:
-      - cloudformation
-  - path: CfnCrudOps_test.go
-    services:
-      - cloudformation

--- a/go/example_code/s3/delete-buckets-by-prefix/metadata.yaml
+++ b/go/example_code/s3/delete-buckets-by-prefix/metadata.yaml
@@ -1,8 +1,0 @@
----
-files:
-  - path: s3_delete_buckets.go
-    services:
-      - s3
-  - path: s3_delete_buckets_test.go
-    services:
-      - s3


### PR DESCRIPTION
*Issue #, if available:*
The Go code examples had a metadata.yaml file in cloudformation/ and example_code/cloudformation. The code catalog build system could not handle the duplication.

*Description of changes:*
Deleted all of the metadata.yaml files in example_code/*.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
