### PR TITLE
Fixed snippet tags for JavaScript V3 delete item code example

### DIFF
--- a/javascript/example_code_v3/dynamodb/ddb_deleteitem.js
+++ b/javascript/example_code_v3/dynamodb/ddb_deleteitem.js
@@ -18,7 +18,7 @@ Running the code:
 node.js ddb_deletetable.js
 
 */
-// snippet-start:[dynamodb.JavaScript.item.deleteTableV3]
+// snippet-start:[dynamodb.JavaScript.item.deleteItemV3]
 
 // Import required AWS SDK clients and commands for Node.js
 const {
@@ -45,6 +45,6 @@ const run = async () => {
   }
 };
 run();
-// snippet-end:[dynamodb.JavaScript.item.deleteTableV3]
+// snippet-end:[dynamodb.JavaScript.item.deleteItemV3]
 //for unit tests only
 exports.run = run; //for unit tests only


### PR DESCRIPTION
*Issue #, if available:*
Snippet tag was: dynamodb.JavaScript.item.deleteTableV3

*Description of changes:*
It's now dynamodb.JavaScript.item.deleteItemV3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
