### PR TITLE
Removes 'aws' and 'amazon' from example names of AWS resources.

### DIFF
--- a/python/example_code/dynamodb/batching/dynamo_batching.py
+++ b/python/example_code/dynamodb/batching/dynamo_batching.py
@@ -288,8 +288,8 @@ def usage_demo():
     ]
 
     print(f"Creating movie and actor tables and waiting until they exist...")
-    movie_table = create_table(f'aws-demo-batch-movies-{time.time_ns()}', movie_schema)
-    actor_table = create_table(f'aws-demo-batch-actors-{time.time_ns()}', actor_schema)
+    movie_table = create_table(f'demo-batch-movies-{time.time_ns()}', movie_schema)
+    actor_table = create_table(f'demo-batch-actors-{time.time_ns()}', actor_schema)
     print(f"Created {movie_table.name} and {actor_table.name}.")
 
     print(f"Putting {len(movie_data)} movies into {movie_table.name}.")

--- a/python/example_code/ec2/ec2_basics/ec2_basics_demo.py
+++ b/python/example_code/ec2/ec2_basics/ec2_basics_demo.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 def make_unique_name(name):
-    return f'aws-ec2-demo-{name}-{time.time_ns()}'
+    return f'demo-ec2-{name}-{time.time_ns()}'
 
 
 def setup_demo(current_ip_address, ami_image_id, key_file_name):

--- a/python/example_code/emr/emr_usage_demo.py
+++ b/python/example_code/emr/emr_usage_demo.py
@@ -351,7 +351,7 @@ def demo_short_lived_cluster():
     print(f"Welcome to the Amazon EMR short-lived cluster demo.")
     print('-'*88)
 
-    prefix = f'aws-demo-short-emr'
+    prefix = f'demo-short-emr'
 
     s3_resource = boto3.resource('s3')
     iam_resource = boto3.resource('iam')
@@ -440,7 +440,7 @@ def demo_long_lived_cluster():
     print(f"Welcome to the Amazon EMR long-lived cluster demo.")
     print('-'*88)
 
-    prefix = 'aws-demo-long-emr'
+    prefix = 'demo-long-emr'
 
     s3_resource = boto3.resource('s3')
     iam_resource = boto3.resource('iam')
@@ -488,7 +488,7 @@ def demo_long_lived_cluster():
         '20', 'Grocery', 'cheese', cluster_id, bucket, script_key, emr_client)
 
     review_bucket_folders = s3_resource.meta.client.list_objects_v2(
-        Bucket='amazon-reviews-pds', Prefix='parquet/', Delimiter='/', MaxKeys=100)
+        Bucket='demo-reviews-pds', Prefix='parquet/', Delimiter='/', MaxKeys=100)
     categories = [
         cat['Prefix'].split('=')[1][:-1] for cat in
         review_bucket_folders['CommonPrefixes']]

--- a/python/example_code/iam/iam_basics/policy_wrapper.py
+++ b/python/example_code/iam/iam_basics/policy_wrapper.py
@@ -233,7 +233,7 @@ def usage_demo():
           "other IAM resources, like users and roles.")
     bucket_arn = f'arn:aws:s3:::made-up-bucket-name'
     policy = create_policy(
-        'aws-iam-demo-policy', 'Policy for IAM demonstration.',
+        'demo-iam-policy', 'Policy for IAM demonstration.',
         ['s3:ListObjects'], bucket_arn)
     print(f"Created policy {policy.policy_name}.")
     policies = list_policies('Local')

--- a/python/example_code/iam/iam_basics/role_wrapper.py
+++ b/python/example_code/iam/iam_basics/role_wrapper.py
@@ -102,7 +102,7 @@ def usage_demo():
     print("Roles let you define sets of permissions and can be assumed by "
           "other entities, like users and services.")
     role = create_role(
-        'aws-iam-demo-role',
+        'demo-iam-role',
         ['lambda.amazonaws.com', 'batchoperations.s3.amazonaws.com'])
     print(f"Created role {role.name}, with trust policy:")
     pprint.pprint(role.assume_role_policy_document)

--- a/python/example_code/iam/iam_basics/user_wrapper.py
+++ b/python/example_code/iam/iam_basics/user_wrapper.py
@@ -133,17 +133,17 @@ def usage_demo():
           "permissions.")
     s3 = boto3.resource('s3')
     bucket = s3.create_bucket(
-        Bucket=f'aws-iam-demo-bucket-{time.time_ns()}',
+        Bucket=f'demo-iam-bucket-{time.time_ns()}',
         CreateBucketConfiguration={
             'LocationConstraint': s3.meta.client.meta.region_name
         }
     )
     print(f"Created an Amazon S3 bucket named {bucket.name}.")
-    user_writer = create_user('aws-iam-demo-writer')
-    user_reader = create_user('aws-iam-demo-reader')
+    user_writer = create_user('demo-iam-writer')
+    user_reader = create_user('demo-iam-reader')
     print(f"Created two IAM users: {user_writer.name} and {user_reader.name}")
-    update_user(user_writer.name, 'aws-iam-demo-creator')
-    update_user(user_reader.name, 'aws-iam-demo-getter')
+    update_user(user_writer.name, 'demo-iam-creator')
+    update_user(user_reader.name, 'demo-iam-getter')
     users = list_users()
     user_writer = next(user for user in users if user.user_id == user_writer.user_id)
     user_reader = next(user for user in users if user.user_id == user_reader.user_id)
@@ -151,14 +151,14 @@ def usage_demo():
           f"and {user_reader.name}.")
 
     write_policy = policy_wrapper.create_policy(
-        'aws-iam-demo-write-policy',
+        'demo-iam-write-policy',
         'Grants rights to create an object in the demo bucket.',
         's3:PutObject',
         f'arn:aws:s3:::{bucket.name}/*')
     print(f"Created policy {write_policy.policy_name} with ARN: {write_policy.arn}")
     print(write_policy.description)
     read_policy = policy_wrapper.create_policy(
-        'aws-iam-demo-read-policy',
+        'demo-iam-read-policy',
         'Grants rights to get an object from the demo bucket.',
         's3:GetObject',
         f'arn:aws:s3:::{bucket.name}/*')

--- a/python/example_code/lambda/boto_client_examples/api_gateway_rest.py
+++ b/python/example_code/lambda/boto_client_examples/api_gateway_rest.py
@@ -121,7 +121,7 @@ def create_rest_api(
         f'{account_id}:{api_id}/*/*/{api_base_path}'
     try:
         lambda_client.add_permission(
-            FunctionName=lambda_function_arn, StatementId=f'aws-demo-invoke',
+            FunctionName=lambda_function_arn, StatementId=f'demo-invoke',
             Action='lambda:InvokeFunction', Principal='apigateway.amazonaws.com',
             SourceArn=source_arn)
         logger.info("Granted permission to let Amazon API Gateway invoke function %s "
@@ -178,9 +178,9 @@ def usage_demo():
 
     lambda_filename = 'lambda_handler_rest.py'
     lambda_handler_name = 'lambda_handler_rest.lambda_handler'
-    lambda_role_name = 'aws-demo-lambda-role'
-    lambda_function_name = 'aws-demo-lambda-rest'
-    api_name = 'aws-demo-lambda-rest-api'
+    lambda_role_name = 'demo-lambda-role'
+    lambda_function_name = 'demo-lambda-rest'
+    api_name = 'demo-lambda-rest-api'
 
     iam_resource = boto3.resource('iam')
     lambda_client = boto3.client('lambda')

--- a/python/example_code/lambda/boto_client_examples/lambda_basics.py
+++ b/python/example_code/lambda/boto_client_examples/lambda_basics.py
@@ -190,8 +190,8 @@ def usage_demo():
 
     lambda_function_filename = 'lambda_handler_basic.py'
     lambda_handler_name = 'lambda_handler_basic.lambda_handler'
-    lambda_role_name = 'aws-demo-lambda-role'
-    lambda_function_name = 'aws-demo-lambda-function'
+    lambda_role_name = 'demo-lambda-role'
+    lambda_function_name = 'demo-lambda-function'
 
     iam_resource = boto3.resource('iam')
     lambda_client = boto3.client('lambda')

--- a/python/example_code/lambda/boto_client_examples/scheduled_lambda.py
+++ b/python/example_code/lambda/boto_client_examples/scheduled_lambda.py
@@ -154,9 +154,9 @@ def usage_demo():
 
     lambda_function_filename = 'lambda_handler_scheduled.py'
     lambda_handler_name = 'lambda_handler_scheduled.lambda_handler'
-    lambda_role_name = 'aws-demo-lambda-role'
-    lambda_function_name = 'aws-demo-lambda-scheduled'
-    event_rule_name = 'aws-demo-event-scheduled'
+    lambda_role_name = 'demo-lambda-role'
+    lambda_function_name = 'demo-lambda-scheduled'
+    event_rule_name = 'demo-event-scheduled'
     event_schedule = 'rate(1 minute)'
 
     iam_resource = boto3.resource('iam')

--- a/python/example_code/s3/s3_basics/test/test_object_wrapper.py
+++ b/python/example_code/s3/s3_basics/test/test_object_wrapper.py
@@ -26,7 +26,7 @@ def test_put_get_delete_object(stub_and_patch, make_unique_name, make_bucket,
     stubber.stub_head_object(bucket.name, object_key)
     stubber.stub_get_object(bucket.name, object_key, object_data)
     stubber.stub_delete_object(bucket.name, object_key)
-    stubber.stub_head_object(bucket.name, object_key, 404)
+    stubber.stub_head_object(bucket.name, object_key, status_code=404)
     stubber.stub_get_object(bucket.name, object_key, error_code='NoSuchKey')
 
     object_wrapper.put_object(bucket, object_key, object_data)

--- a/python/example_code/s3/s3_versioning/batch_versioning.py
+++ b/python/example_code/s3/s3_versioning/batch_versioning.py
@@ -601,7 +601,7 @@ def main():
     """
     Kicks off the demo.
     """
-    prefix = 'aws-version-demo'
+    prefix = 'demo-versioning'
     obj_prefix = f'{prefix}/'
     bucket_name = f'{prefix}-bucket-' + str(uuid.uuid1())
     role_name = f'{prefix}-s3-batch-role'

--- a/python/example_code/s3/s3_versioning/versioning.py
+++ b/python/example_code/s3/s3_versioning/versioning.py
@@ -184,7 +184,7 @@ def permanently_delete_object(bucket, object_key):
 # snippet-end:[s3.python.versioning.permanently_delete_object]
 
 
-def usage_demo_single_object(obj_prefix='aws-version-demo/'):
+def usage_demo_single_object(obj_prefix='demo-versioning/'):
     """
     Demonstrates usage of versioned object functions. This demo uploads a stanza
     of a poem and performs a series of revisions, deletions, and revivals on it.

--- a/python/example_code/sts/sts_temporary_credentials/assume_role.py
+++ b/python/example_code/sts/sts_temporary_credentials/assume_role.py
@@ -24,7 +24,7 @@ def progress_bar(seconds):
 
 
 def unique_name(base_name):
-    return f'aws-assume-role-demo-{base_name}-{time.time_ns()}'
+    return f'demo-assume-role-{base_name}-{time.time_ns()}'
 
 
 def setup(iam_resource):

--- a/python/example_code/sts/sts_temporary_credentials/assume_role_mfa.py
+++ b/python/example_code/sts/sts_temporary_credentials/assume_role_mfa.py
@@ -27,7 +27,7 @@ def progress_bar(seconds):
 
 
 def unique_name(base_name):
-    return f'aws-assume-role-demo-{base_name}-{time.time_ns()}'
+    return f'demo-assume-role-{base_name}-{time.time_ns()}'
 
 
 def setup(iam_resource):
@@ -233,10 +233,10 @@ def usage_demo():
     try:
         sts_client = boto3.client(
             'sts', aws_access_key_id=user_key.id, aws_secret_access_key=user_key.secret)
-        try_to_assume_role_without_mfa(role.arn, 'aws-sts-demo-session', sts_client)
+        try_to_assume_role_without_mfa(role.arn, 'demo-sts-session', sts_client)
         mfa_totp = input('Enter the code from your registered MFA device: ')
         list_buckets_from_assumed_role_with_mfa(
-            role.arn, 'aws-sts-demo-session', virtual_mfa_device.serial_number,
+            role.arn, 'demo-sts-session', virtual_mfa_device.serial_number,
             mfa_totp, sts_client)
     finally:
         teardown(user, virtual_mfa_device, role)

--- a/python/example_code/sts/sts_temporary_credentials/federated_url.py
+++ b/python/example_code/sts/sts_temporary_credentials/federated_url.py
@@ -27,7 +27,7 @@ def progress_bar(seconds):
 
 
 def unique_name(base_name):
-    return f'aws-assume-role-demo-{base_name}-{time.time_ns()}'
+    return f'demo-assume-role-{base_name}-{time.time_ns()}'
 
 
 def setup(iam_resource):

--- a/python/example_code/sts/sts_temporary_credentials/session_token.py
+++ b/python/example_code/sts/sts_temporary_credentials/session_token.py
@@ -27,7 +27,7 @@ def progress_bar(seconds):
 
 
 def unique_name(base_name):
-    return f'aws-assume-role-demo-{base_name}-{time.time_ns()}'
+    return f'demo-assume-role-{base_name}-{time.time_ns()}'
 
 
 def setup(iam_resource):


### PR DESCRIPTION
Remove the strings 'aws' and 'amazon' from AWS resources used in examples.

- [x] The submitter has added unit tests for all code paths, run all of them, and they all pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
