### PR TITLE
Fix cleanup_report.py to handle and skip empty metadata section

### DIFF
--- a/scripts/cleanup_report.py
+++ b/scripts/cleanup_report.py
@@ -129,8 +129,11 @@ def read_metadata(file_path, examples):
         try:
             meta_docs = yaml.safe_load_all(meta_stream)
             for example_meta in meta_docs:
-                example_meta['metadata_path'] = file_path
-                examples.append(example_meta)
+                if example_meta is None:
+                    print(f"Empty section found in {file_path}.")
+                else:
+                    example_meta['metadata_path'] = file_path
+                    examples.append(example_meta)
         except (ScannerError, ParserError) as err:
             print(f"Yaml parser error in {file_path}, skipping.")
             print(err)


### PR DESCRIPTION
An empty section in a metadata.yaml file is technically bad yaml, but I updated the script to handle, report it, and skip it rather than raise an exception and blow up the whole report.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
