### PR TITLE
Correct typos

### DIFF
--- a/aws-cli/bash-linux/ec2/change-ec2-instance-type/test_change_ec2_instance_type.sh
+++ b/aws-cli/bash-linux/ec2/change-ec2-instance-type/test_change_ec2_instance_type.sh
@@ -65,7 +65,7 @@ if [ "$INTERACTIVE" == "true" ]; then iecho "Tests running in interactive mode."
 
 iecho ""
 iecho "***************SETUP STEPS******************"
-    # First, get the AMI ID for the one running the latest Amazon Linix 2.
+    # First, get the AMI ID for the one running the latest Amazon Linux 2.
     iecho -n "Retrieving the AMI ID for the latest Amazon Linux 2 AMI..."
     AMI_ID=$(aws ec2 describe-images \
                 --owners 'amazon' \

--- a/cloudformation/codepipeline/template-codepipeline-codecommit-events-json.json
+++ b/cloudformation/codepipeline/template-codepipeline-codecommit-events-json.json
@@ -28,7 +28,7 @@
             "Default": "master"
         },
         "RepositoryName": {
-            "Description": "CodeComit repository name",
+            "Description": "CodeCommit repository name",
             "Type": "String",
             "Default": "myrepo"
         },

--- a/cloudformation/codepipeline/template-codepipeline-codecommit-events-yaml.yml
+++ b/cloudformation/codepipeline/template-codepipeline-codecommit-events-yaml.yml
@@ -26,7 +26,7 @@ Parameters:
     Type: String
     Default: master
   RepositoryName:
-    Description: CodeComit repository name
+    Description: CodeCommit repository name
     Type: String
     Default: myrepo
   ApplicationName:

--- a/cloudformation/codepipeline/template-codepipeline-s3-cloudtrail-yaml.yml
+++ b/cloudformation/codepipeline/template-codepipeline-s3-cloudtrail-yaml.yml
@@ -22,7 +22,7 @@
 
 ###################################################################################
 # Prerequisites: 
-#   - S3 SoureBucket and SourceObjectKey must exist
+#   - S3 SourceBucket and SourceObjectKey must exist
 ###################################################################################
 
 Parameters:

--- a/cpp/example_code/neptune/describe_db_clusters.cpp
+++ b/cpp/example_code/neptune/describe_db_clusters.cpp
@@ -1,5 +1,5 @@
  
-//snippet-sourcedescription:[describe_db_clusers.cpp demonstrates how to retrieve information about Amazon Neptune provisioned DB clusters.]
+//snippet-sourcedescription:[describe_db_clusters.cpp demonstrates how to retrieve information about Amazon Neptune provisioned DB clusters.]
 //snippet-keyword:[C++]
 //snippet-sourcesyntax:[cpp]
 //snippet-keyword:[Code Sample]

--- a/cpp/example_code/s3/get_put_bucket_acl.cpp
+++ b/cpp/example_code/s3/get_put_bucket_acl.cpp
@@ -92,7 +92,7 @@
  * Prerequisites: An existing bucket.
  *
  * Inputs:
- * - bucketName: The name of the bucket to get ACL informaton for. For example,
+ * - bucketName: The name of the bucket to get ACL information for. For example,
  *   "my-bucket".
  * - region: The AWS Region identifier for the bucket. For example, "us-east-1".
  *

--- a/cpp/example_code/s3encryption/s3Encryption.cpp
+++ b/cpp/example_code/s3encryption/s3Encryption.cpp
@@ -332,7 +332,7 @@ int main(int argc, char** argv)
         Aws::String objectKey(OBJECT_KEY_PREFIX);
         AwsDoc::S3Encryption::KMSWithContextEncryptionMaterialsExample(BUCKET, (objectKey + "-kms-with-context-encryption-materials").c_str(), MASTER_KEY_ID);
         std::cout << std::endl;
-        AwsDoc::S3Encryption::SimpleEncryptionMaterialsWithGCMAADExample(BUCKET, (objectKey + "-simplie-encryption-materials-with-gcm-aad").c_str());
+        AwsDoc::S3Encryption::SimpleEncryptionMaterialsWithGCMAADExample(BUCKET, (objectKey + "-simple-encryption-materials-with-gcm-aad").c_str());
         std::cout << std::endl;
         AwsDoc::S3Encryption::DecryptObjectsEncryptedWithLegacyEncryptionExample(BUCKET, (objectKey + "-decrypt-objects-encrypted-with-legacy-encryption").c_str());
         std::cout << std::endl;

--- a/cpp/example_code/s3encryption/tests/test_s3Encryption.cpp
+++ b/cpp/example_code/s3encryption/tests/test_s3Encryption.cpp
@@ -162,7 +162,7 @@ int main()
             return 1;
         }
         std::cout << std::endl;
-        if (!AwsDoc::S3Encryption::SimpleEncryptionMaterialsWithGCMAADExample(bucketName.c_str(), (objectKey + "simplie-encryption-materials-with-gcm-aad").c_str()))
+        if (!AwsDoc::S3Encryption::SimpleEncryptionMaterialsWithGCMAADExample(bucketName.c_str(), (objectKey + "simple-encryption-materials-with-gcm-aad").c_str()))
         {
             return 1;
         }

--- a/cpp/example_code/transfer-manager/transferOnStream.cpp
+++ b/cpp/example_code/transfer-manager/transferOnStream.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
 {
     if (argc < 4) 
     {
-        std::cout << "This program is used to demostrate how transfer manager transfers large object in memory without copying it to a local file." << std::endl
+        std::cout << "This program is used to demonstrate how transfer manager transfers large object in memory without copying it to a local file." << std::endl
             << "It first uploads [LocalFilePath] to your S3 [Bucket] with object name [Key], then downloads the object to memory." << std::endl
             << "To verify the correctness of the file content in memory, we will dump the data to a local file [LocalFilePath]_copy." << std::endl
             << "You can use md5sum [LocalFilePath] [LocalFilePath]_copy to verify they have the same content." << std::endl

--- a/dotnet/example_code/DynamoDB/GettingStarted/DynamoDB_intro/DynamoDB_intro/06_UpdatingItem.cs
+++ b/dotnet/example_code/DynamoDB/GettingStarted/DynamoDB_intro/DynamoDB_intro/06_UpdatingItem.cs
@@ -61,7 +61,7 @@ namespace DynamoDB_intro
       }
       if( report )
       {
-        Console.WriteLine( "     Here is the updated movie informtion:" );
+        Console.WriteLine( "     Here is the updated movie information:" );
         Console.WriteLine( movieAttributesToJson( updateResponse.Attributes ) );
       }
       operationSucceeded = true;

--- a/dotnet/example_code_legacy/CloudWatch/AwsCloudWatchSample1/Program.cs
+++ b/dotnet/example_code_legacy/CloudWatch/AwsCloudWatchSample1/Program.cs
@@ -99,7 +99,7 @@ namespace AWSSDKDocSamples.CloudWatch
                         {
                             "RESOURCE_ARN"
                         },
-                        Source = "com.compnay.myapp"
+                        Source = "com.company.myapp"
                     }
                 }
             };

--- a/dotnet/example_code_legacy/IAM/AwsInstanceProfile1/Program.cs
+++ b/dotnet/example_code_legacy/IAM/AwsInstanceProfile1/Program.cs
@@ -308,7 +308,7 @@ namespace AwsInstanceProfile1
                 request.NewServerCertificateName = "NEW_Certificate_NAME";
                 var response = iamClient.UpdateServerCertificate(request);
                 if (response.HttpStatusCode.ToString() == "OK")
-                    Console.WriteLine("Update succesful");
+                    Console.WriteLine("Update successful");
                 else
                     Console.WriteLine("HTTpStatusCode returned = " + response.HttpStatusCode.ToString());
             }

--- a/go/cloudtrail/cloudtrailOps.go
+++ b/go/cloudtrail/cloudtrailOps.go
@@ -265,7 +265,7 @@ func listTrailEvents(sess *session.Session, trailName string, userName string) e
             fmt.Println("ID:     ", aws.StringValue(event.EventId))
             fmt.Println("Time:   ", aws.TimeValue(event.EventTime))
 
-            fmt.Println("Resourcs:")
+            fmt.Println("Resources:")
 
             for _, resource := range event.Resources {
                 fmt.Println("  Name:", aws.StringValue(resource.ResourceName))

--- a/go/cloudtrail/cloudtrailOps_test.go
+++ b/go/cloudtrail/cloudtrailOps_test.go
@@ -172,7 +172,7 @@ func showEvents(t *testing.T, sess *session.Session, trailName string, userName 
                 t.Log("Time:   ", aws.TimeValue(event.EventTime))
             }
 
-            t.Log("Resourcs:")
+            t.Log("Resources:")
 
             for _, resource := range event.Resources {
                 if nil != resource.ResourceName {

--- a/go/cloudwatch/CreateTarget/CreateTarget.go
+++ b/go/cloudwatch/CreateTarget/CreateTarget.go
@@ -28,7 +28,7 @@ import (
 // Inputs:
 //     sess is the current session, which provides configuration for the SDK's service clients
 //     rule is the name of the rule
-//     lammbdaARN is the ARN of the Lambda function that is invoked
+//     lambdaARN is the ARN of the Lambda function that is invoked
 //     targetID is the identifier for the target
 // Output:
 //     If successful, a PutTargetsOutput and nil

--- a/go/dynamodb/ScanItems/ScanItems.go
+++ b/go/dynamodb/ScanItems/ScanItems.go
@@ -99,7 +99,7 @@ func ScanTableItems(sess *session.Session, year *int, table *string, minRating *
 func main() {
     // snippet-start:[dynamodb.go.scan_table_items.args]
     tableName := flag.String("t", "", "The name of the table")
-    minRating := flag.Float64("r", -1.0, "The minumum rating of the movies to retrieve")
+    minRating := flag.Float64("r", -1.0, "The minimum rating of the movies to retrieve")
     year := flag.Int("y", -1, "The year the movies to retrieve were released")
     flag.Parse()
 

--- a/go/ec2/CreateImage/CreateImage.go
+++ b/go/ec2/CreateImage/CreateImage.go
@@ -78,7 +78,7 @@ func main() {
 
     resp, err := MakeImage(svc, description, instanceID, name)
     if err != nil {
-        fmt.Println("Got an error createing image:")
+        fmt.Println("Got an error creating image:")
         fmt.Println(err)
         return
     }

--- a/go/ec2/DescribeInstances/DescribeInstances.go
+++ b/go/ec2/DescribeInstances/DescribeInstances.go
@@ -17,7 +17,7 @@ import (
 //     sess is the current session, which provides configuration for the SDK's service clients
 // Output:
 //     If success, a list of Amazon EC2 instances and nil
-//     Otherwise, nil and an error from the call to DescibeInstances
+//     Otherwise, nil and an error from the call to DescribeInstances
 func GetInstances(sess *session.Session) (*ec2.DescribeInstancesOutput, error) {
     // snippet-start:[ec2.go.describe_instances.call]
     svc := ec2.New(sess)

--- a/go/example_code/cloudformation/CfnCrudOps_test.go
+++ b/go/example_code/cloudformation/CfnCrudOps_test.go
@@ -31,7 +31,7 @@ type Config struct {
 
 var configFileName = "config.json"
 
-// Gloval variable for configuration set in config.json
+// Global variable for configuration set in config.json
 var globalConfig Config
 
 func PopulateConfiguration() error {

--- a/go/example_code/cloudtrail/lookup_events.go
+++ b/go/example_code/cloudtrail/lookup_events.go
@@ -81,7 +81,7 @@ func main() {
         fmt.Println("Time:   ", aws.TimeValue(event.EventTime))
         fmt.Println("User:   ", aws.StringValue(event.Username))
 
-        fmt.Println("Resourcs:")
+        fmt.Println("Resources:")
 
         for _, resource := range event.Resources {
             fmt.Println("  Name:", aws.StringValue(resource.ResourceName))

--- a/go/example_code/iam/iam_updateuser.go
+++ b/go/example_code/iam/iam_updateuser.go
@@ -1,6 +1,6 @@
 // snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 // snippet-sourceauthor:[Doug-AWS]
-// snippet-sourcedescription:[Udates an IAM user.]
+// snippet-sourcedescription:[Updates an IAM user.]
 // snippet-keyword:[AWS Identity and Access Management]
 // snippet-keyword:[UpdateUser function]
 // snippet-keyword:[Go]

--- a/go/example_code/rds/rds_copy_snapshot_to_s3.go
+++ b/go/example_code/rds/rds_copy_snapshot_to_s3.go
@@ -65,7 +65,7 @@ func main() {
 	IndentifierSanpshotTime := currentTime.Format("20060102")
 	exportIdentifier := exportRDSSnapshotName + IndentifierSanpshotTime
 
-	// Getting latest snapsnot from rds snapshot list
+	// Getting latest snapshot from rds snapshot list
 	for _, s := range result.DBSnapshots {
 
 		if strings.Contains(*s.DBSnapshotArn, rdsSnapshot) {

--- a/go/lambda/RunFunction/RunFunction.go
+++ b/go/lambda/RunFunction/RunFunction.go
@@ -98,7 +98,7 @@ func main() {
 
     result, err := CallFunction(svc, maxItems, function)
     if err != nil {
-        fmt.Println("Got drror calling " + *function + ":")
+        fmt.Println("Got error calling " + *function + ":")
         fmt.Println(err)
         return
     }

--- a/go/polly/SynthesizeSpeech/SynthesizeSpeech.go
+++ b/go/polly/SynthesizeSpeech/SynthesizeSpeech.go
@@ -49,7 +49,7 @@ func MakeSpeech(svc pollyiface.PollyAPI, fileName *string) (*polly.SynthesizeSpe
 
 func main() {
     // snippet-start:[polly.go.synthesize_speech.args]
-    fileName := flag.String("f", "", "The file to tranlate into speech")
+    fileName := flag.String("f", "", "The file to translate into speech")
     flag.Parse()
 
     if *fileName == "" {

--- a/go/rds/CreateClusterSnapshot/CreateClusterSnapshot.go
+++ b/go/rds/CreateClusterSnapshot/CreateClusterSnapshot.go
@@ -62,7 +62,7 @@ func main() {
 
     err := MakeClusterSnapshot(svc, clusterID)
     if err != nil {
-        fmt.Println("Got an error creating snapshop for cluster " + *clusterID)
+        fmt.Println("Got an error creating snapshot for cluster " + *clusterID)
         return
     }
 
@@ -75,7 +75,7 @@ func main() {
     })
     // snippet-end:[rds.go.create_db_cluster_snapshot.wait]
     if err != nil {
-        fmt.Println("Got an error waiting for snapshop for cluster " + *clusterID)
+        fmt.Println("Got an error waiting for snapshot for cluster " + *clusterID)
         return
     }
 

--- a/go/rds/ListInstanceSnapshots/ListInstanceSnapshots.go
+++ b/go/rds/ListInstanceSnapshots/ListInstanceSnapshots.go
@@ -16,7 +16,7 @@ import (
 // Inputs:
 //     sess is the current session, which provides configuration for the SDK's service clients
 // Output:
-//     If success, the list of snapshopts and nil
+//     If success, the list of snapshots and nil
 //     Otherwise, nil and an error from the call to DescribeDBSnapshots
 func GetInstanceSnapShots(sess *session.Session) (*rds.DescribeDBSnapshotsOutput, error) {
     svc := rds.New(sess)

--- a/java/example_code/guardduty/src/main/java/aws/example/guardduty/ListDetectors.java
+++ b/java/example_code/guardduty/src/main/java/aws/example/guardduty/ListDetectors.java
@@ -47,7 +47,7 @@ public class ListDetectors {
             }
         } catch (AmazonServiceException ase) {
                 System.out.println("Caught Exception: " + ase.getMessage());
-                System.out.println("Reponse Status Code: " + ase.getStatusCode());
+                System.out.println("Response Status Code: " + ase.getStatusCode());
                 System.out.println("Error Code: " + ase.getErrorCode());
                 System.out.println("Request ID: " + ase.getRequestId());
         }

--- a/java/example_code/guardduty/src/main/java/aws/example/guardduty/ListFindingsWithFindingCriteria.java
+++ b/java/example_code/guardduty/src/main/java/aws/example/guardduty/ListFindingsWithFindingCriteria.java
@@ -63,7 +63,7 @@ public class ListFindingsWithFindingCriteria {
             }
         } catch (AmazonServiceException ase) {
                 System.out.println("Caught Exception: " + ase.getMessage());
-                System.out.println("Reponse Status Code: " + ase.getStatusCode());
+                System.out.println("Response Status Code: " + ase.getStatusCode());
                 System.out.println("Error Code: " + ase.getErrorCode());
                 System.out.println("Request ID: " + ase.getRequestId());
         }

--- a/java/example_code/lambda/src/main/java/com/example/lambda/DeleteFunction.java
+++ b/java/example_code/lambda/src/main/java/com/example/lambda/DeleteFunction.java
@@ -54,7 +54,7 @@ public class DeleteFunction {
             DeleteFunctionRequest delFunc = new DeleteFunctionRequest();
             delFunc.withFunctionName(functionName);
 
-            //Delete the functiom
+            //Delete the function
             awsLambda.deleteFunction(delFunc);
             System.out.println("The function is deleted");
 

--- a/java/example_code/pinpoint/src/main/java/com/example/pinpoint/ImportSegment.java
+++ b/java/example_code/pinpoint/src/main/java/com/example/pinpoint/ImportSegment.java
@@ -39,7 +39,7 @@ public class ImportSegment {
                 "Usage: ImportSegment <appId> <bucket> <key> <roleArn> \n\n" +
                 "Where:\n" +
                 "  appId - the ID the application to create a segment for.\n\n" +
-                "  bucket - name of the s3 bucket that contains the segment definitons.\n\n" +
+                "  bucket - name of the s3 bucket that contains the segment definitions.\n\n" +
                 "  key - key of the s3 object " +
                 "  roleArn - ARN of the role that allows pinpoint to access S3";
 

--- a/java/example_code/redshift/CreateAndDescribeSnapshot.java
+++ b/java/example_code/redshift/CreateAndDescribeSnapshot.java
@@ -108,7 +108,7 @@ public class CreateAndDescribeSnapshot {
 
     private static Boolean waitForSnapshotAvailable(String snapshotId) throws InterruptedException {
         Boolean snapshotAvailable = false;
-        System.out.println("Wating for snapshot to become available.");
+        System.out.println("Waiting for snapshot to become available.");
         while (!snapshotAvailable) {
             DescribeClusterSnapshotsResult result = client.describeClusterSnapshots(new DescribeClusterSnapshotsRequest()
                 .withSnapshotIdentifier(snapshotId));

--- a/java/example_code/redshift/CreateAndModifyCluster.java
+++ b/java/example_code/redshift/CreateAndModifyCluster.java
@@ -105,7 +105,7 @@ public class CreateAndModifyCluster {
 
     private static void waitForClusterReady() throws InterruptedException {
         Boolean clusterReady = false;
-        System.out.println("Wating for cluster to become available.");
+        System.out.println("Waiting for cluster to become available.");
         while (!clusterReady) {
             DescribeClustersResult result = client.describeClusters(new DescribeClustersRequest()
         .withClusterIdentifier(clusterIdentifier));

--- a/javascript/example_code/cognito/cognito_getcreds.html
+++ b/javascript/example_code/cognito/cognito_getcreds.html
@@ -32,7 +32,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>Amazon Cognito Credenials Example</title>
+<title>Amazon Cognito Credentials Example</title>
 <meta charset="utf-8">
 <script src="https://sdk.amazonaws.com/js/aws-sdk-2.244.1.min.js"></script>
 </head>

--- a/javascript/example_code/ec2/ec2_describeregionsandzones.js
+++ b/javascript/example_code/ec2/ec2_describeregionsandzones.js
@@ -12,7 +12,7 @@
  * specific language governing permissions and limitations under the License.
 */
 
-//snippet-sourcedescription:[ec2_describeresionsandzones.js demonstrates how to retrieve information about Amazon EC2 regions and availability zones.]
+//snippet-sourcedescription:[ec2_describeregionsandzones.js demonstrates how to retrieve information about Amazon EC2 regions and availability zones.]
 //snippet-service:[ec2]
 //snippet-keyword:[JavaScript]
 //snippet-sourcesyntax:[javascript]

--- a/javascriptv3/example_code/cognito/getCredentials/src/cognito_getcreds.html
+++ b/javascriptv3/example_code/cognito/getCredentials/src/cognito_getcreds.html
@@ -18,7 +18,7 @@ See https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/javascriptv3/exa
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Amazon Cognito credenials example</title>
+    <title>Amazon Cognito credentials example</title>
     <meta charset="utf-8" />
     <script src="./main.ts"></script>
     <script>

--- a/javascriptv3/example_code/cognito/getCredentials/src/cognito_getcreds.js
+++ b/javascriptv3/example_code/cognito/getCredentials/src/cognito_getcreds.js
@@ -32,7 +32,7 @@ const {
   fromCognitoIdentityPool,
 } = require("@aws-sdk/credential-provider-cognito-identity");
 
-// Set the paramerter
+// Set the parameter
 const IDENTITY_POOL_ID = "IDENTITY_POOL_ID";
 const ACCOUNT_ID = "ACCOUNT_ID";
 

--- a/javascriptv3/example_code/ec2/src/ec2_describeregionsandzones.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_describeregionsandzones.ts
@@ -7,13 +7,13 @@ at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for Jav
 https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/ec2-example-security-groups.html
 
 Purpose:
-ec2_describeresionsandzones.ts demonstrates how to retrieve information about Amazon EC2 regions and availability zones.
+ec2_describeregionsandzones.ts demonstrates how to retrieve information about Amazon EC2 regions and availability zones.
 
 Inputs (replace in code):
 - REGION
 
 Running the code:
-ts-node ec2_describeresionsandzones.ts
+ts-node ec2_describeregionsandzones.ts
 */
 // snippet-start:[ec2.JavaScript.Regions.describeRegionsV3]
 // Import required AWS SDK clients and commands for Node.js

--- a/javascriptv3/example_code/glacier/src/uploadArchive.ts
+++ b/javascriptv3/example_code/glacier/src/uploadArchive.ts
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
 which is pending release.  The preview version of the SDK is available
 at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
-https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/glacier-example-uploadrchive.html.
+https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/glacier-example-uploadarchive.html.
 
 Purpose:
 uploadArchive.js demonstrates how to upload an archive to Amazon S3 Glacier.

--- a/javascriptv3/example_code/iam/src/iam_updateuser.ts
+++ b/javascriptv3/example_code/iam/src/iam_updateuser.ts
@@ -11,7 +11,7 @@ iam_updateuser.js demonstrates how to update the name of an IAM user.
 
 Inputs :
 - REGION
-- ORIGINGAL_USER_NAME
+- ORIGINAL_USER_NAME
 - NEW_USER_NAME
 
 Running the code:
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 
 // Set the parameters
 const params = {
-  UserName: "ORIGINGAL_USER_NAME", //ORIGINGAL_USER_NAME
+  UserName: "ORIGINAL_USER_NAME", //ORIGINAL_USER_NAME
   NewUserName: "NEW_USER_NAME", //NEW_USER_NAME
 };
 

--- a/javascriptv3/example_code/kinesis/src/blog_page.html
+++ b/javascriptv3/example_code/kinesis/src/blog_page.html
@@ -15,7 +15,7 @@
 
 <!--
  snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
- snippet-sourcedescription:[blog_page.html contains the HTML for the scroll-progress exmaple]
+ snippet-sourcedescription:[blog_page.html contains the HTML for the scroll-progress example]
  snippet-service:[kinesis]
  snippet-keyword:[HTML]
  snippet-keyword:[Amazon Kinesis]

--- a/javascriptv3/example_code/redshift/src/redshift-create-cluster.ts
+++ b/javascriptv3/example_code/redshift/src/redshift-create-cluster.ts
@@ -39,7 +39,7 @@ const params = {
   ClusterIdentifier: "CLUSTER_NAME", // Required
   NodeType: "NODE_TYPE", //Required
   MasterUsername: "MASTER_USER_NAME", // Required - must be lowercase
-  MasterUserPassword: "MASTER_USER_PASSWORD", // Required - must contain at least one uppercase leeter, and one number
+  MasterUserPassword: "MASTER_USER_PASSWORD", // Required - must contain at least one uppercase letter, and one number
   ClusterType: "CLUSTER_TYPE", // Required
   IAMRoleARN: "IAM_ROLE_ARN", // Optional - the ARN of an IAM role with permissions your cluster needs to access other AWS services on your behalf, such as Amazon S3.
   ClusterSubnetGroupName: "CLUSTER_SUBNET_GROUPNAME", //Optional - the name of a cluster subnet group to be associated with this cluster. Defaults to 'default' if not specified.

--- a/javascriptv3/example_code/s3/src/s3_setbucketwebsite.ts
+++ b/javascriptv3/example_code/s3/src/s3_setbucketwebsite.ts
@@ -5,7 +5,7 @@ which is pending release.  The preview version of the SDK is available
 at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
 https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/s3-example-static-web-host.html.
 Purpose:
-s3_setbucketwebsite.ts applies a bucket website configuration to a selected bucket, and is part of an exmample
+s3_setbucketwebsite.ts applies a bucket website configuration to a selected bucket, and is part of an example
 of using an Amazon S3 bucket as a static web host.
 Inputs (replace in code):
 - INDEX_PAGE

--- a/javascriptv3/example_code/sns/src/sns_confirmsubscription.ts
+++ b/javascriptv3/example_code/sns/src/sns_confirmsubscription.ts
@@ -18,7 +18,7 @@ https://sns.us-east-1.amazonaws.com/confirmation.html?TopicArn=arn:aws:sns:us-ea
 - AuthenticateOnUnsubscribe: either 'true' or 'false'
 
 Running the code:
-ts-node sns_confirmsubsrciption.ts
+ts-node sns_confirmsubscription.ts
 */
 // snippet-start:[sns.JavaScript.subscriptions.confirmSubscriptionV3]
 // Import required AWS SDK clients and commands for Node.js

--- a/javascriptv3/example_code/tests/iam/iam_deleteaccountalias.test.js
+++ b/javascriptv3/example_code/tests/iam/iam_deleteaccountalias.test.js
@@ -7,7 +7,7 @@ jest.mock("@aws-sdk/client-iam/commands/DeleteAccountAliasCommand", () => ({
 const { params, run } = require("../../iam/src/iam_deleteaccountalias.js");
 
 //test function
-test("has to mock iam#deleteaccontalias", async (done) => {
+test("has to mock iam#deleteaccountalias", async (done) => {
   await run();
   expect(mockDeleteAccountAlias).toHaveBeenCalled;
   done();

--- a/javascriptv3/example_code/tests/ses/ses_createreceiptfilter.test.js
+++ b/javascriptv3/example_code/tests/ses/ses_createreceiptfilter.test.js
@@ -7,7 +7,7 @@ jest.mock("@aws-sdk/client-ses/commands/CreateReceiptFilterCommand", () => ({
 const { run } = require("../../ses/src/ses_createreceiptfilter");
 
 //test function
-test("has to mock SES#createRecepiptFilter", async (done) => {
+test("has to mock SES#createReceiptFilter", async (done) => {
   await run();
   expect(mockCreateReceiptFilter).toHaveBeenCalled;
   done();

--- a/javascriptv3/example_code/tests/ses/ses_deleteidentity.test.js
+++ b/javascriptv3/example_code/tests/ses/ses_deleteidentity.test.js
@@ -7,7 +7,7 @@ jest.mock("@aws-sdk/client-ses/commands/DeleteIdentityCommand", () => ({
 const { run } = require("../../ses/src/ses_deleteidentity.js");
 
 //test function
-test("has to mock SES#createRecepiptFilter", async (done) => {
+test("has to mock SES#createReceiptFilter", async (done) => {
   await run();
   expect(mockDeleteIdentity).toHaveBeenCalled;
   done();

--- a/javascriptv3/example_code/tests/ses/ses_deletereceiptfilter.test.js
+++ b/javascriptv3/example_code/tests/ses/ses_deletereceiptfilter.test.js
@@ -7,7 +7,7 @@ jest.mock("@aws-sdk/client-ses/commands/DeleteReceiptFilterCommand", () => ({
 const { run } = require("../../ses/src/ses_deletereceiptfilter.js");
 
 //test function
-test("has to mock SES#deleteRecepiptFilter", async (done) => {
+test("has to mock SES#deleteReceiptFilter", async (done) => {
   await run();
   expect(mockDeleteReceiptFilter).toHaveBeenCalled;
   done();

--- a/javav2/example_code/cognito/src/main/java/com/example/cognito/DeleteIdentityPool.java
+++ b/javav2/example_code/cognito/src/main/java/com/example/cognito/DeleteIdentityPool.java
@@ -41,21 +41,21 @@ public class DeleteIdentityPool {
                 "Where:\n" +
                 "    identityPoolId  - The AWS Region and GUID of your identity pool.\n\n" ;
 
-        String identityPoold = args[0];
+        String identityPoolId = args[0];
 
         CognitoIdentityClient cognitoIdclient = CognitoIdentityClient.builder()
                 .region(Region.US_EAST_1)
                 .build();
 
-        deleteIdPool(cognitoIdclient, identityPoold);
+        deleteIdPool(cognitoIdclient, identityPoolId);
     }
 
     //snippet-start:[cognito.java2.deleteidpool.main]
-    public static void deleteIdPool(CognitoIdentityClient cognitoIdclient, String identityPoold) {
+    public static void deleteIdPool(CognitoIdentityClient cognitoIdclient, String identityPoolId) {
         try {
 
         DeleteIdentityPoolRequest identityPoolRequest = DeleteIdentityPoolRequest.builder()
-                .identityPoolId(identityPoold)
+                .identityPoolId(identityPoolId)
                 .build();
 
         cognitoIdclient.deleteIdentityPool(identityPoolRequest);

--- a/javav2/example_code/cognito/src/main/java/com/example/cognito/ListIdentityPools.java
+++ b/javav2/example_code/cognito/src/main/java/com/example/cognito/ListIdentityPools.java
@@ -55,8 +55,8 @@ public class ListIdentityPools {
                 .maxResults(15)
                 .build();
 
-            ListIdentityPoolsResponse poolReponse = cognitoclient.listIdentityPools(poolsRequest);
-            List<IdentityPoolShortDescription> pools = poolReponse.identityPools();
+            ListIdentityPoolsResponse poolResponse = cognitoclient.listIdentityPools(poolsRequest);
+            List<IdentityPoolShortDescription> pools = poolResponse.identityPools();
 
             for (IdentityPoolShortDescription pool: pools) {
                 System.out.println("Pool ID: "+pool.identityPoolId());

--- a/javav2/example_code/dynamodb/src/main/java/com/example/dynamodb/Query.java
+++ b/javav2/example_code/dynamodb/src/main/java/com/example/dynamodb/Query.java
@@ -87,7 +87,7 @@ public class Query {
                 new HashMap<String,AttributeValue>();
         attrValues.put(":"+partitionKeyName, AttributeValue.builder().s(partitionKeyVal).build());
 
-        // Cretae a QueryRequest object
+        // Create a QueryRequest object
         QueryRequest queryReq = QueryRequest.builder()
                 .tableName(tableName)
                 .keyConditionExpression(partitionAlias + " = :" + partitionKeyName)

--- a/javav2/example_code/dynamodb/src/main/java/com/example/enhanced/dynamodb/DynamoDbBeanExample.java
+++ b/javav2/example_code/dynamodb/src/main/java/com/example/enhanced/dynamodb/DynamoDbBeanExample.java
@@ -62,7 +62,7 @@ public class DynamoDbBeanExample {
             //Create a DynamoDbTable object
             DynamoDbTable<Customer> custTable = enhancedClient.table("Customer", TableSchema.fromBean(Customer.class));
 
-            //Create am Instat
+            //Create an Instant
             LocalDate localDate = LocalDate.parse("2020-04-07");
             LocalDateTime localDateTime = localDate.atStartOfDay();
             Instant instant = localDateTime.toInstant(ZoneOffset.UTC);

--- a/javav2/example_code/iam/src/test/java/IAMServiceIntegrationTest.java
+++ b/javav2/example_code/iam/src/test/java/IAMServiceIntegrationTest.java
@@ -57,7 +57,7 @@ public class IAMServiceIntegrationTest {
 
     @Test
     @Order(2)
-    public void CreatUser() {
+    public void CreateUser() {
 
         String result = CreateUser.createIAMUser(iam, userName);
         assertTrue(!result.isEmpty());

--- a/javav2/example_code/kinesis/src/main/java/com/example/kinesis/KinesisStreamEx.java
+++ b/javav2/example_code/kinesis/src/main/java/com/example/kinesis/KinesisStreamEx.java
@@ -158,7 +158,7 @@ public class KinesisStreamEx {
 
             @Override
             public void responseReceived(SubscribeToShardResponse response) {
-                System.out.println("Receieved initial response");
+                System.out.println("Received initial response");
             }
 
             @Override

--- a/javav2/example_code/pinpoint/src/main/java/com/example/pinpoint/ImportSegment.java
+++ b/javav2/example_code/pinpoint/src/main/java/com/example/pinpoint/ImportSegment.java
@@ -41,7 +41,7 @@ public class ImportSegment {
                 "Usage: ImportSegment <appId> <bucket> <key> <roleArn> \n\n" +
                 "Where:\n" +
                 "  appId - the application ID to create a segment for.\n\n" +
-                "  bucket - the name of the Amazon S3 bucket that contains the segment definitons.\n\n" +
+                "  bucket - the name of the Amazon S3 bucket that contains the segment definitions.\n\n" +
                 "  key - the key of the S3 object. " +
                 "  roleArn - ARN of the role that allows Amazon Pinpoint to access S3. You need to set trust management for this to work. See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html";
 

--- a/javav2/example_code/pinpoint/src/main/java/com/example/pinpoint/ListSegments.java
+++ b/javav2/example_code/pinpoint/src/main/java/com/example/pinpoint/ListSegments.java
@@ -1,4 +1,4 @@
-//snippet-sourcedescription:[ListSegements.java demonstrates how to list segments in an application.]
+//snippet-sourcedescription:[ListSegments.java demonstrates how to list segments in an application.]
 //snippet-keyword:[Java]
 //snippet-sourcesyntax:[java]
 //snippet-keyword:[Code Sample]
@@ -70,7 +70,7 @@ public class ListSegments {
             List<SegmentResponse> segments = response.segmentsResponse().item();
 
             for(SegmentResponse segment: segments) {
-                System.out.println("Segement " + segment.id() + " " + segment.name() + " " + segment.lastModifiedDate());
+                System.out.println("Segment " + segment.id() + " " + segment.name() + " " + segment.lastModifiedDate());
             }
         } catch ( PinpointException e) {
             System.err.println(e.awsErrorDetails().errorMessage());

--- a/javav2/example_code/transcribe/src/main/java/com/amazonaws/transcribestreaming/retryclient/TranscribeStreamingRetryClient.java
+++ b/javav2/example_code/transcribe/src/main/java/com/amazonaws/transcribestreaming/retryclient/TranscribeStreamingRetryClient.java
@@ -167,7 +167,7 @@ public class TranscribeStreamingRetryClient {
                 getResponseHandler(responseHandler));
         result.whenComplete((r, e) -> {
             if (e != null) {
-                log.debug("Error occured:", e);
+                log.debug("Error occurred:", e);
 
                 if (retryAttempt <= maxRetries && isExceptionRetriable(e)) {
                     log.debug("Retriable error occurred and will be retried.");

--- a/javav2/usecases/creating_dynamodb_web_app/Readme.md
+++ b/javav2/usecases/creating_dynamodb_web_app/Readme.md
@@ -1488,7 +1488,7 @@ The **WriteExcel** class dynamically creates an Excel report with the data marke
         workbook.write();
         workbook.close();
 
-        // Get an InputStram that represents the report
+        // Get an InputStream that represents the report
         java.io.ByteArrayOutputStream stream = new java.io.ByteArrayOutputStream();
         stream = (java.io.ByteArrayOutputStream)os;
         byte[] myBytes = stream.toByteArray();
@@ -2193,7 +2193,7 @@ The following JavaScript code represents the **items.js** file that is used in t
 	function loadMods(event) {
 
     	var msg = event.target.responseText;
-    	alert("You have successfully modfied item "+msg)
+    	alert("You have successfully modified item "+msg)
 
     	$('#id').val("");
     	$('#description').val("");
@@ -2406,7 +2406,7 @@ The following JavaScript code represents the **items.js** file that is used in t
 	function onArch(event) {
 
     	 var xml = event.target.responseText;
-    	 alert("Item "+xml +" is achived now");
+    	 alert("Item "+xml +" is archived now");
 
     	// Refresh the grid
     	GetItems();

--- a/javav2/usecases/creating_dynamodb_web_app/src/main/java/com/example/services/WriteExcel.java
+++ b/javav2/usecases/creating_dynamodb_web_app/src/main/java/com/example/services/WriteExcel.java
@@ -68,7 +68,7 @@ public class WriteExcel {
         workbook.write();
         workbook.close();
 
-        // Get an inputStram that represents the Report
+        // Get an inputStream that represents the Report
         java.io.ByteArrayOutputStream stream = new java.io.ByteArrayOutputStream();
         stream = (java.io.ByteArrayOutputStream)os;
         byte[] myBytes = stream.toByteArray();

--- a/javav2/usecases/creating_dynamodb_web_app/src/main/resources/public/js/items.js
+++ b/javav2/usecases/creating_dynamodb_web_app/src/main/resources/public/js/items.js
@@ -66,7 +66,7 @@ function modItem()
 function loadMods(event) {
 
     var msg = event.target.responseText;
-    alert("You have successfully modfied item "+msg)
+    alert("You have successfully modified item "+msg)
 
     $('#id').val("");
     $('#description').val("");
@@ -214,7 +214,7 @@ function GetArcItems()
 
 function loadArcItems(event) {
 
-    // Disable buttons when Achive button
+    // Disable buttons when Archive button
     $('#reportbutton').prop("disabled",true);
     $('#reportbutton').css("color", "#0d010d");
     $('#singlebutton').prop("disabled",true);
@@ -286,7 +286,7 @@ function archiveItem()
 function onArch(event) {
 
     var xml = event.target.responseText;
-    alert("Item "+xml +" is achived now");
+    alert("Item "+xml +" is archived now");
     //Refresh the grid
     GetItems();
 }

--- a/javav2/usecases/creating_photo_analyzer_app/src/main/java/com/example/photo/WriteExcel.java
+++ b/javav2/usecases/creating_photo_analyzer_app/src/main/java/com/example/photo/WriteExcel.java
@@ -64,7 +64,7 @@ public class WriteExcel {
         workbook.write();
         workbook.close();
 
-        // Get an inputStram that represents the Report
+        // Get an inputStream that represents the Report
         java.io.ByteArrayOutputStream stream = new java.io.ByteArrayOutputStream();
         stream = (java.io.ByteArrayOutputStream)os;
         byte[] myBytes = stream.toByteArray();

--- a/javav2/usecases/creating_secure_spring_app/Readme.md
+++ b/javav2/usecases/creating_secure_spring_app/Readme.md
@@ -1456,7 +1456,7 @@ The **WriteExcel** class dynamically creates an Excel report with the MySQL data
         workbook.write();
         workbook.close();
 
-        // Get an inputStram that represents the Report
+        // Get an inputStream that represents the Report
         java.io.ByteArrayOutputStream stream = new java.io.ByteArrayOutputStream();
         stream = (java.io.ByteArrayOutputStream)os;
         byte[] myBytes = stream.toByteArray();
@@ -2164,7 +2164,7 @@ The following JavaScript code represents the **items.js** file that is used in t
      function loadMods(event) {
 
     var msg = event.target.responseText;
-    alert("You have successfully modfied item "+msg)
+    alert("You have successfully modified item "+msg)
 
     $('#id').val("");
     $('#description').val("");
@@ -2373,7 +2373,7 @@ The following JavaScript code represents the **items.js** file that is used in t
 	function onArch(event) {
 
     	var xml = event.target.responseText;
-    	alert("Item "+xml +" is achived now");
+    	alert("Item "+xml +" is archived now");
     	//Refresh the grid
     	GetItems();
 	}

--- a/javav2/usecases/creating_secure_spring_app/src/main/java/com/aws/services/WriteExcel.java
+++ b/javav2/usecases/creating_secure_spring_app/src/main/java/com/aws/services/WriteExcel.java
@@ -64,7 +64,7 @@ public class WriteExcel {
         workbook.write();
         workbook.close();
 
-        // Get an inputStram that represents the Report
+        // Get an inputStream that represents the Report
         java.io.ByteArrayOutputStream stream = new java.io.ByteArrayOutputStream();
         stream = (java.io.ByteArrayOutputStream)os;
         byte[] myBytes = stream.toByteArray();

--- a/javav2/usecases/creating_secure_spring_app/src/main/resources/public/js/items.js
+++ b/javav2/usecases/creating_secure_spring_app/src/main/resources/public/js/items.js
@@ -66,7 +66,7 @@ function modItem()
 function loadMods(event) {
 
     var msg = event.target.responseText;
-    alert("You have successfully modfied item "+msg)
+    alert("You have successfully modified item "+msg)
 
     $('#id').val("");
     $('#description').val("");
@@ -266,7 +266,7 @@ function archiveItem()
 function onArch(event) {
 
     var xml = event.target.responseText;
-    alert("Item "+xml +" is achived now");
+    alert("Item "+xml +" is archived now");
     //Refresh the grid
     GetItems();
 }

--- a/javav2/usecases/creating_workflows_stepfunctions/Readme.md
+++ b/javav2/usecases/creating_workflows_stepfunctions/Readme.md
@@ -492,7 +492,7 @@ The following class uses the Amazon DynamoDB API to store the data in a table. F
             // Create a DynamoDbTable object
             DynamoDbTable<Case> caseTable = enhancedClient.table("Case", TableSchema.fromBean(Case.class));
 
-            // Create an Instat object
+            // Create an Instant object
             LocalDate localDate = LocalDate.parse("2020-04-07");
             LocalDateTime localDateTime = localDate.atStartOfDay();
             Instant instant = localDateTime.toInstant(ZoneOffset.UTC);

--- a/javav2/usecases/creating_workflows_stepfunctions/src/main/java/example/PersistCase.java
+++ b/javav2/usecases/creating_workflows_stepfunctions/src/main/java/example/PersistCase.java
@@ -52,7 +52,7 @@ public class PersistCase {
             // Create a DynamoDbTable object
             DynamoDbTable<Case> caseTable = enhancedClient.table("Case", TableSchema.fromBean(Case.class));
 
-            // Create an Instat object
+            // Create an Instant object
             LocalDate localDate = LocalDate.parse("2020-04-07");
             LocalDateTime localDateTime = localDate.atStartOfDay();
             Instant instant = localDateTime.toInstant(ZoneOffset.UTC);

--- a/php/example_code/cloudwatch/ListMetrics.php
+++ b/php/example_code/cloudwatch/ListMetrics.php
@@ -42,7 +42,7 @@ function listMetrics($cloudWatchClient)
                 foreach($result['Metrics'] as $metric) 
                 {
                     $message .= 'For metric ' . $metric['MetricName'] . 
-                        ' in namepsace ' . $metric['Namespace'] . ":\n";
+                        ' in namespace ' . $metric['Namespace'] . ":\n";
                     
                     if ((isset($metric['Dimensions'])) and 
                         (count($metric['Dimensions']) > 0))

--- a/php/example_code/cloudwatch/tests/DeleteAlarmsTest.php
+++ b/php/example_code/cloudwatch/tests/DeleteAlarmsTest.php
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 /*
-Relies on PHPUnit to test the functionality in ./DeleteAlams.php.
+Relies on PHPUnit to test the functionality in ./DeleteAlarms.php.
 Related custom constants are defined in ./phpunit.xml.
 Example PHPUnit run command from this file's parent directory:
 ./vendor/bin/phpunit --testsuite cloudwatch-deletealarms

--- a/python/example_code/ec2/ec2_basics/test/test_ec2_setup.py
+++ b/python/example_code/ec2/ec2_basics/test/test_ec2_setup.py
@@ -100,7 +100,7 @@ def test_setup_security_group(
     [(None, None),
      (['test-security-group'], None),
      (None, 'TestException')])
-def test_create_intances(
+def test_create_instances(
         make_stubber, make_unique_name, security_groups, error_code):
     ec2_stubber = make_stubber(ec2_setup.ec2.meta.client)
     image_id = 'ami-1234567890EXAMPLE'

--- a/python/example_code/emr/emr_usage_demo.py
+++ b/python/example_code/emr/emr_usage_demo.py
@@ -63,7 +63,7 @@ def status_poller(intro, done_status, func):
 
 def setup_bucket(bucket_name, script_file_name, script_key, s3_resource):
     """
-    Creates an Amazon S3 bucket and uploads the specfied script file to it.
+    Creates an Amazon S3 bucket and uploads the specified script file to it.
 
     :param bucket_name: The name of the bucket to create.
     :param script_file_name: The name of the script file to upload.

--- a/python/example_code/emr/emrfs_step.py
+++ b/python/example_code/emr/emrfs_step.py
@@ -5,7 +5,7 @@
 Purpose
 
 Shows how to run an EMRFS command as a job step on an Amazon EMR cluster. This
-can be used to automate ERMFS commands and is an alternative to connecting through
+can be used to automate EMRFS commands and is an alternative to connecting through
 SSH to run the commands manually.
 """
 

--- a/python/example_code/iam/iam_basics/account_wrapper.py
+++ b/python/example_code/iam/iam_basics/account_wrapper.py
@@ -63,7 +63,7 @@ def list_aliases():
         else:
             logger.info("Got no aliases for your account.")
     except ClientError:
-        logger.exception("Coudn't list aliases for your account.")
+        logger.exception("Couldn't list aliases for your account.")
         raise
     else:
         return response['AccountAliases']

--- a/python/example_code/textract/textract_python_async.py
+++ b/python/example_code/textract/textract_python_async.py
@@ -12,7 +12,7 @@
 # snippet-sourcedate:[2019-8-26]
 # snippet-sourceauthor:[reesch (AWS)]
 # snippet-start:[textract.python.textract_python_async.complete]
-#Asyncrhonously processes text in a document stored in an S3 bucket. For set up information, see https://docs.aws.amazon.com/textract/latest/dg/async.html
+#Asynchronously processes text in a document stored in an S3 bucket. For set up information, see https://docs.aws.amazon.com/textract/latest/dg/async.html
 import boto3
 import json
 import sys

--- a/typescript/example_code/cdk/SecretsManager.ts
+++ b/typescript/example_code/cdk/SecretsManager.ts
@@ -1,7 +1,7 @@
 // snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
 // snippet-comment:[This is a full sample when you include SecretsManager-stack.ts, which goes in the lib dir.]
 // snippet-sourceauthor:[Doug-AWS]
-// snippet-sourcedescription:[SecretsManager.ts creates a stack using SecrectsManager-stack.ts.]
+// snippet-sourcedescription:[SecretsManager.ts creates a stack using SecretsManager-stack.ts.]
 // snippet-keyword:[CDK V1.0.0]
 // snippet-keyword:[TypeScript]
 // snippet-sourcesyntax:[javascript]


### PR DESCRIPTION
Words with 1 letter added, 1 letter removed, or 2 letters transposed.

Usually in comments/descriptions. In a few cases, in the name of a variable
or member function. (If the typo was repeated in references to the variable
or function, I fixed it in both places.)

I don't have the familiarity with all the programming environments to recompile
and doublecheck. I found the typos by running a statistical analysis on the 'rare'
words in the source code.

*Issue #, if available:*

*Description of changes:*

Minor changes to typos, as described above.

I'm an Amazon employee (johrss) despite my github handle.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
