### PR TITLE
DynamoDB Utilities (V3 parity for DocumentClient) examples

### DIFF
--- a/javascriptv3/example_code/dynamodb/README.md
+++ b/javascriptv3/example_code/dynamodb/README.md
@@ -17,8 +17,8 @@ instructions.
 
 2. Install the dependencies listed in the package.json.
 
-**Note**: These include the client module for the AWS services required in these example, 
-which is *@aws-sdk/client-dynamodb*.
+**Note**: These include the client modules for the AWS services required in these example, 
+which are *@aws-sdk/client-dynamodb* and *@aws-sdk/util-dynamodb*.
 ```
 npm install ts-node -g // If using JavaScript, enter 'npm install node -g' instead
 cd javascriptv3/example_code/dynamodb

--- a/javascriptv3/example_code/dynamodb/README.md
+++ b/javascriptv3/example_code/dynamodb/README.md
@@ -18,7 +18,7 @@ instructions.
 2. Install the dependencies listed in the package.json.
 
 **Note**: These include the client modules for the AWS services required in these example, 
-which are *@aws-sdk/client-dynamodb* and *@aws-sdk/util-dynamodb*.
+which are *@aws-sdk/client-dynamodb*, *@aws-sdk/util-dynamodb*.
 ```
 npm install ts-node -g // If using JavaScript, enter 'npm install node -g' instead
 cd javascriptv3/example_code/dynamodb

--- a/javascriptv3/example_code/dynamodb/package.json
+++ b/javascriptv3/example_code/dynamodb/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^1.0.0-gamma.6",
     "@aws-sdk/node-http-handler": "^1.0.0-gamma.5",
+    "@aws-sdk/util-dynamodb": "^1.0.0-gamma.5",
     "@aws-sdk/types": "^0.1.0-gamma.6",
     "ts-node": "^9.0.0"
   },

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_delete_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_delete_item.ts
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
 which is pending release.  The preview version of the SDK is available
 at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
-https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/dynamodb-example-document-client.html.
+https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/dynamodb-example-dynamodb-utilities.html.
 
 Purpose:
 ddbdoc_get_item.ts demonstrates how to use DynamoDB utilities to delete an item from an Amazon DynamoDB table.
@@ -48,7 +48,7 @@ const params = {
 };
 
 // Create DynamoDB client
-const client = new DynamoDB({ region: "us-east-1" });
+const client = new DynamoDB({ region: "REGION" });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_delete_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_delete_item.ts
@@ -30,9 +30,11 @@ const { marshall, unmarshall } = require("@aws-sdk/util-dynamodb");
 const params = {
   TableName: "TABLE_NAME",
   /*
-  Convert the key JavaScript object you are deleting to the required DynamoDB format. The format of values specifies
-  the datatype. The following list demonstrates different datatype formatting requirements:
-  HashKey: "hashKey",
+  Convert the key JavaScript object you are deleting to the
+  required DynamoDB record. The format of values specifies
+  the datatype. The following list demonstrates different
+  datatype formatting requirements:
+  String: "String",
   NumAttribute: 1,
   BoolAttribute: true,
   ListAttribute: [1, "two", false],
@@ -45,7 +47,7 @@ const params = {
   }),
 };
 
-// Create DynamoDB document client
+// Create DynamoDB client
 const client = new DynamoDB({ region: "us-east-1" });
 
 const run = async () => {

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_delete_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_delete_item.ts
@@ -1,0 +1,60 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+
+ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
+which is pending release.  The preview version of the SDK is available
+at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
+https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/dynamodb-example-document-client.html.
+
+Purpose:
+ddbdoc_get_item.ts demonstrates how to use DynamoDB utilities to delete an item from an Amazon DynamoDB table.
+
+Inputs (replace in code):
+- TABLE_NAME
+- REGION
+- primaryKey
+- sortKey (only required if table has sort key)
+- VALUE_1: Value for the primary key (The format for the datatype must match the schema. For example, if the primaryKey is a number, VALUE_1 has no inverted commas.)
+- VALUE_2: Value for the primary key (The format for the datatype must match the schema.)
+
+Running the code:
+ts-node ddbdoc_get_item.ts
+*/
+// snippet-start:[dynamodb.JavaScript.docClient.deleteV3]
+
+// Import required AWS SDK clients and commands for Node.js
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+const { marshall, unmarshall } = require("@aws-sdk/util-dynamodb");
+
+// Set the parameters
+const params = {
+  TableName: "TABLE_NAME",
+  /*
+  Convert the key JavaScript object you are deleting to the required DynamoDB format. The format of values specifies
+  the datatype. The following list demonstrates different datatype formatting requirements:
+  HashKey: "hashKey",
+  NumAttribute: 1,
+  BoolAttribute: true,
+  ListAttribute: [1, "two", false],
+  MapAttribute: { foo: "bar" },
+  NullAttribute: null
+   */
+  Key: marshall({
+    primaryKey: VALUE_1, // For example, "Season: 2"
+    sortKey: VALUE_2, // For example,  "Episode: 1" (only required if table has sort key)
+  }),
+};
+
+// Create DynamoDB document client
+const client = new DynamoDB({ region: "us-east-1" });
+
+const run = async () => {
+  try {
+    const { Item } = await client.deleteItem(params);
+    console.log("Success -deleted");
+  } catch (err) {
+    console.log("Error", err);
+  }
+};
+run();
+// snippet-end:[dynamodb.JavaScript.docClient.deleteV3]

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_get_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_get_item.ts
@@ -30,9 +30,11 @@ const { marshall, unmarshall } = require("@aws-sdk/util-dynamodb");
 const params = {
   TableName: "TABLE_NAME",
   /*
-  Convert the key JavaScript object you are retrieving to the required DynamoDB format. The format of values specifies
-  the datatype. The following list demonstrates different datatype formatting requirements:
-  HashKey: "hashKey",
+  Convert the key JavaScript object you are retrieving to the
+  required DynamoDB record. The format of values specifies
+  the datatype. The following list demonstrates different
+  datatype formatting requirements:
+  String: "String",
   NumAttribute: 1,
   BoolAttribute: true,
   ListAttribute: [1, "two", false],
@@ -45,14 +47,14 @@ const params = {
   }),
 };
 
-// Create DynamoDB document client
+// Create DynamoDB client
 const client = new DynamoDB({ region: "REGION" });
 
 const run = async () => {
   try {
     const { Item } = await client.getItem(params);
     // Convert the DynamoDB record you retrieved into a JavaScript object
-    unmarshall(Item);
+    const item = unmarshall(Item);
     // Print the JavaScript object to console
     console.log(Item);
   } catch (err) {

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_get_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_get_item.ts
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
 which is pending release.  The preview version of the SDK is available
 at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
-https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/dynamodb-example-document-client.html.
+https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/dynamodb-example-dynamodb-utilities.html.
 
 Purpose:
 ddbdoc_get_item.ts demonstrates how to use DynamoDB utilities to retrieve a set of attributes for an item in an Amazon DynamoDB table..

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_get_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_get_item.ts
@@ -1,0 +1,63 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+
+ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
+which is pending release.  The preview version of the SDK is available
+at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
+https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/dynamodb-example-document-client.html.
+
+Purpose:
+ddbdoc_get_item.ts demonstrates how to use DynamoDB utilities to retrieve a set of attributes for an item in an Amazon DynamoDB table..
+
+Inputs (replace in code):
+- TABLE_NAME
+- REGION
+- primaryKey
+- sortKey (only required if table has sort key)
+- VALUE_1: Value for the primary key (The format for the datatype must match the schema. For example, if the primaryKey is a number, VALUE_1 has no inverted commas.)
+- VALUE_2: Value for the primary key (The format for the datatype must match the schema.)
+
+Running the code:
+ts-node ddbdoc_get_item.ts
+*/
+// snippet-start:[dynamodb.JavaScript.docClient.getV3]
+
+// Import required AWS SDK clients and commands for Node.js
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+const { marshall, unmarshall } = require("@aws-sdk/util-dynamodb");
+
+// Set the parameters
+const params = {
+  TableName: "TABLE_NAME",
+  /*
+  Convert the key JavaScript object you are retrieving to the required DynamoDB format. The format of values specifies
+  the datatype. The following list demonstrates different datatype formatting requirements:
+  HashKey: "hashKey",
+  NumAttribute: 1,
+  BoolAttribute: true,
+  ListAttribute: [1, "two", false],
+  MapAttribute: { foo: "bar" },
+  NullAttribute: null
+   */
+  Key: marshall({
+    primaryKey: VALUE, // For example, "Season: 2"
+    sortKey: VALUE, // For example,  "Episode: 1" (only required if table has sort key)
+  }),
+};
+
+// Create DynamoDB document client
+const client = new DynamoDB({ region: "REGION" });
+
+const run = async () => {
+  try {
+    const { Item } = await client.getItem(params);
+    // Convert the DynamoDB record you retrieved into a JavaScript object
+    unmarshall(Item);
+    // Print the JavaScript object to console
+    console.log(Item);
+  } catch (err) {
+    console.log("Error", err);
+  }
+};
+run();
+// snippet-end:[dynamodb.JavaScript.docClient.getV3]

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_put_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_put_item.ts
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
 which is pending release.  The preview version of the SDK is available
 at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
-https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/dynamodb-example-document-client.html.
+https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/dynamodb-example-dynamodb-utilities.html.
 
 Purpose:
 ddbdoc_put_item.ts demonstrates how to use DynamoDB utilities to create or replace an item in an Amazon DynamoDB table.
@@ -43,8 +43,8 @@ MapAttribute: { foo: "bar" },
 NullAttribute: null
  */
 const input = {
-    primaryKey: VALUE, // For example, "Season: 2"
-    sortKey: VALUE // For example,  "Episode: 2" (only required if table has sort key)
+    primaryKey: VALUE_1, // For example, "Season: 2"
+    sortKey: VALUE_2 // For example,  "Episode: 2" (only required if table has sort key)
     NEW_ATTRIBUTE_1: NEW_ATTRIBUTE_1_VALUE //For example "'Title': 'The Beginning'"
 };
 // Marshall util converts then JavaScript object to DynamoDB format

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_put_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_put_item.ts
@@ -1,0 +1,62 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+
+ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
+which is pending release.  The preview version of the SDK is available
+at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
+https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/dynamodb-example-document-client.html.
+
+Purpose:
+ddbdoc_put_item.ts demonstrates how to use DynamoDB utilities to create or replace an item in an Amazon DynamoDB table.
+
+Inputs (replace in code):
+- TABLE_NAME
+- REGION
+- primaryKey
+- sortKey (only required if table has sort key)
+- VALUE_1: Value for the primary key (The format for the datatype must match the schema. For example, if the primaryKey is a number, VALUE_1 has no inverted commas.)
+- VALUE_2: Value for the primary key (The format for the datatype must match the schema.)
+- NEW_ATTRIBUTE_1
+- NEW_ATTRIBUTE_1_VALUE
+
+Running the code:
+ts-node ddbdoc_put_item.ts
+*/
+// snippet-start:[dynamodb.JavaScript.docClient.putV3]
+
+// Import required AWS SDK clients and commands for Node.js
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+const { marshall, unmarshall } = require("@aws-sdk/util-dynamodb");
+
+// Set the parameters
+const TableName = "TABLE_NAME";
+/*
+Convert the key JavaScript object you are creating or replacing to the required DynamoDB format. The format
+of values specifies the datatype. The following list demonstrates different datatype formatting requirements:
+HashKey: "hashKey",
+NumAttribute: 1,
+BoolAttribute: true,
+ListAttribute: [1, "two", false],
+MapAttribute: { foo: "bar" },
+NullAttribute: null
+ */
+const input = {
+    primaryKey: VALUE, // For example, "Season: 2"
+    sortKey: VALUE // For example,  "Episode: 2" (only required if table has sort key)
+    NEW_ATTRIBUTE_1: NEW_ATTRIBUTE_1_VALUE //For example "'Title': 'The Beginning'"
+};
+// Marshall util converts then JavaScript object to DynamoDB format
+const Item = marshall(input);
+
+// Create DynamoDB document client
+const client = new DynamoDB({ region:"REGION" });
+
+const run = async () => {
+    try {
+        const data = await client.putItem({ TableName, Item });
+        console.log('Success - put')}
+    catch(err){
+        console.log('Error', err)}
+}
+run();
+// snippet-end:[dynamodb.JavaScript.docClient.putV3]

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_put_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_put_item.ts
@@ -31,9 +31,11 @@ const { marshall, unmarshall } = require("@aws-sdk/util-dynamodb");
 // Set the parameters
 const TableName = "TABLE_NAME";
 /*
-Convert the key JavaScript object you are creating or replacing to the required DynamoDB format. The format
-of values specifies the datatype. The following list demonstrates different datatype formatting requirements:
-HashKey: "hashKey",
+Convert the key JavaScript object you are creating or replacing
+to the required DynamoDB record. The format of values specifies
+the datatype. The following list demonstrates different datatype
+formatting requirements:
+String: "String",
 NumAttribute: 1,
 BoolAttribute: true,
 ListAttribute: [1, "two", false],
@@ -48,7 +50,7 @@ const input = {
 // Marshall util converts then JavaScript object to DynamoDB format
 const Item = marshall(input);
 
-// Create DynamoDB document client
+// Create DynamoDB client
 const client = new DynamoDB({ region:"REGION" });
 
 const run = async () => {

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_query_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_query_item.ts
@@ -1,0 +1,63 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+
+ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
+which is pending release.  The preview version of the SDK is available
+at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
+https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/dynamodb-example-document-client.html.
+
+Purpose:
+ddbdoc_update_query.ts demonstrates how to use DynamoDB utilities to retrieve items from an Amazon DynamoDB table.
+
+Inputs (replace in code):
+- TABLE_NAME
+- REGION
+
+Running the code:
+ts-node ddbdoc_update_query.ts
+*/
+// snippet-start:[dynamodb.JavaScript.docClient.queryV3]
+
+// Import required AWS SDK clients and commands for Node.js
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+const { marshall, unmarshall } = require("@aws-sdk/util-dynamodb");
+
+// Set the parameters
+const params = {
+  TableName: "TABLE_NAME",
+  /*
+  Convert the JavaScript object defining the objects to the required DynamoDB format.The format of values
+  specifies the datatype. The following list demonstrates different datatype formatting requirements:
+  HashKey: "hashKey",
+  NumAttribute: 1,
+  BoolAttribute: true,
+  ListAttribute: [1, "two", false],
+  MapAttribute: { foo: "bar" },
+  NullAttribute: null
+   */
+  ExpressionAttributeValues: marshall({
+    ":s": 2,
+    ":e": 9,
+    ":topic": "The Return",
+  }),
+  // Specifies the values that define the range of the retrieved items. In this case, items in Season 2 before episode 9.
+  KeyConditionExpression: "Season = :s and Episode > :e",
+  // Filter that returns only episodes that meet previous criteria and have the subtitle 'The Return'
+  FilterExpression: "contains (Subtitle, :topic)",
+};
+
+// Create DynamoDB document client
+const client = new DynamoDB({ region: "us-east-1" });
+
+const run = async () => {
+  try {
+    const data = await client.query(params);
+    console.log("Success - query");
+    console.log(data.Items);
+  } catch (err) {
+    console.log("Error", err);
+  }
+};
+run();
+
+// snippet-end:[dynamodb.JavaScript.docClient.queryV3]

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_query_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_query_item.ts
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
 which is pending release.  The preview version of the SDK is available
 at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
-https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/dynamodb-example-document-client.html.
+https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/dynamodb-example-dynamodb-utilities.html.
 
 Purpose:
 ddbdoc_update_query.ts demonstrates how to use DynamoDB utilities to retrieve items from an Amazon DynamoDB table.

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_query_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_query_item.ts
@@ -26,9 +26,10 @@ const { marshall, unmarshall } = require("@aws-sdk/util-dynamodb");
 const params = {
   TableName: "TABLE_NAME",
   /*
-  Convert the JavaScript object defining the objects to the required DynamoDB format.The format of values
-  specifies the datatype. The following list demonstrates different datatype formatting requirements:
-  HashKey: "hashKey",
+  Convert the JavaScript object defining the objects to the required
+  DynamoDB record. The format of values specifies the datatype. The
+  following list demonstrates different datatype formatting requirements:
+  String: "String",
   NumAttribute: 1,
   BoolAttribute: true,
   ListAttribute: [1, "two", false],
@@ -46,7 +47,7 @@ const params = {
   FilterExpression: "contains (Subtitle, :topic)",
 };
 
-// Create DynamoDB document client
+// Create DynamoDB client
 const client = new DynamoDB({ region: "us-east-1" });
 
 const run = async () => {

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_update_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_update_item.ts
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
 which is pending release.  The preview version of the SDK is available
 at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
-https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/dynamodb-example-document-client.html.
+https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/dynamodb-example-document-client.html.
 
 Purpose:
 ddbdoc_update_item.ts demonstrates how to use DynamoDB utilities to create or update an item in an Amazon DynamoDB table.
@@ -12,8 +12,8 @@ ddbdoc_update_item.ts demonstrates how to use DynamoDB utilities to create or up
 Inputs (replace in code):
 - TABLE_NAME
 - REGION
-- NEW_ATTRIBUTE_VALUE_1
-- NEW_ATTRIBUTE_VALUE_2
+- VALUE_1
+- VALUE_2
 
 Running the code:
 ts-node ddbdoc_update_item.ts
@@ -29,8 +29,8 @@ const params = {
   TableName: "TABLE_NAME",
   // Convert the key JavaScript object you are deleting to the required DynamoDB format
   Key: marshall({
-    primaryKey: VALUE, // For example, "Season: 2"
-    sortKey: VALUE, // For example,  "Episode: 1" (only required if table has sort key)
+    primaryKey: VALUE_1, // For example, "Season: 2"
+    sortKey: VALUE_2, // For example,  "Episode: 1" (only required if table has sort key)
   }),
   // Define expressions for the new or updated attributes
   UpdateExpression: "set ATTRIBUTE_NAME_1 = :t, ATTRIBUTE_NAME_2 = :s", // For example, "'set Title = :t, Subtitle = :s'"

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_update_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_update_item.ts
@@ -1,0 +1,65 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+
+ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
+which is pending release.  The preview version of the SDK is available
+at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
+https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/dynamodb-example-document-client.html.
+
+Purpose:
+ddbdoc_update_item.ts demonstrates how to use DynamoDB utilities to create or update an item in an Amazon DynamoDB table.
+
+Inputs (replace in code):
+- TABLE_NAME
+- REGION
+- NEW_ATTRIBUTE_VALUE_1
+- NEW_ATTRIBUTE_VALUE_2
+
+Running the code:
+ts-node ddbdoc_update_item.ts
+*/
+// snippet-start:[dynamodb.JavaScript.docClient.updateV3]
+
+// Import required AWS SDK clients and commands for Node.js
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+const { marshall, unmarshall } = require("@aws-sdk/util-dynamodb");
+
+// Set the parameters
+const params = {
+  TableName: "TABLE_NAME",
+  // Convert the key JavaScript object you are deleting to the required DynamoDB format
+  Key: marshall({
+    primaryKey: VALUE, // For example, "Season: 2"
+    sortKey: VALUE, // For example,  "Episode: 1" (only required if table has sort key)
+  }),
+  // Define expressions for the new or updated attributes
+  UpdateExpression: "set ATTRIBUTE_NAME_1 = :t, ATTRIBUTE_NAME_2 = :s", // For example, "'set Title = :t, Subtitle = :s'"
+  /*
+  Convert the attribute JavaScript object you are deleting to the required DynamoDB format. The format of values
+  specifies the datatype. The following list demonstrates different datatype formatting requirements:
+  HashKey: "hashKey",
+  NumAttribute: 1,
+  BoolAttribute: true,
+  ListAttribute: [1, "two", false],
+  MapAttribute: { foo: "bar" },
+  NullAttribute: null
+   */
+  ExpressionAttributeValues: marshall({
+    ":t": NEW_ATTRIBUTE_VALUE_1, // For example "':t' : 'NEW_TITLE'"
+    ":s": NEW_ATTRIBUTE_VALUE_2, // For example " ':s' : 'NEW_SUBTITLE'"
+  }),
+};
+
+// Create DynamoDB document client
+const client = new DynamoDB({ region: "REGION" });
+
+const run = async () => {
+  try {
+    const { Item } = await client.updateItem(params);
+    console.log("Success - updated");
+  } catch (err) {
+    console.log("Error", err);
+  }
+};
+run();
+// snippet-end:[dynamodb.JavaScript.docClient.updateV3]

--- a/javascriptv3/example_code/dynamodb/src/ddbdoc_update_item.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddbdoc_update_item.ts
@@ -35,9 +35,10 @@ const params = {
   // Define expressions for the new or updated attributes
   UpdateExpression: "set ATTRIBUTE_NAME_1 = :t, ATTRIBUTE_NAME_2 = :s", // For example, "'set Title = :t, Subtitle = :s'"
   /*
-  Convert the attribute JavaScript object you are deleting to the required DynamoDB format. The format of values
-  specifies the datatype. The following list demonstrates different datatype formatting requirements:
-  HashKey: "hashKey",
+  Convert the attribute JavaScript object you are updating to the required
+  DynamoDB record. The format of values specifies the datatype. The
+  following list demonstrates different datatype formatting requirements:
+  String: "String",
   NumAttribute: 1,
   BoolAttribute: true,
   ListAttribute: [1, "two", false],
@@ -50,7 +51,7 @@ const params = {
   }),
 };
 
-// Create DynamoDB document client
+// Create DynamoDB client
 const client = new DynamoDB({ region: "REGION" });
 
 const run = async () => {

--- a/javascriptv3/example_code/dynamodb/src/metadata.yaml
+++ b/javascriptv3/example_code/dynamodb/src/metadata.yaml
@@ -34,6 +34,21 @@ files:
   - path: ddb_scan.ts
     services:
       - dynamodb
+  - path: ddbdoc_delete_item.ts
+    services:
+      - dynamodb
+  - path: ddbdoc_get_item.ts
+    services:
+      - dynamodb
+  - path: ddbdoc_put_item.ts
+    services:
+      - dynamodb
+  - path: ddbdoc_update_item.ts
+    services:
+      - dynamodb
+  - path: ddbdoc_query_item.ts
+    services:
+      - dynamodb
   - path: QueryExample/ddb_batchwriteitem_tv.ts
     services:
       - dynamodb

--- a/javascriptv3/example_code/s3/README.md
+++ b/javascriptv3/example_code/s3/README.md
@@ -17,8 +17,9 @@ Amazon S3 is an object storage service that offers industry-leading scalability,
 2. Install the dependencies listed in the package.json.
 
 **Note**: These dependencies include the client modules for the AWS services that this example requires, 
-which is *@aws-sdk/client-s3*, *@aws-sdk/client-cognito-identity*, and 
-*@aws-sdk/credential-provider-cognito-identity*.
+which is *@aws-sdk/client-s3*, *@aws-sdk/client-cognito-identity*, 
+*@aws-sdk/credential-provider-cognito-identity*, *@aws-sdk/s3-request-presigner*, *@aws-sdk/util-create-request*, 
+*@aws-sdk/util-format-url*, and *node-fetch*.
 ```
 npm install ts-node -g // If using JavaScript, enter 'npm install node -g' instead
 cd javascriptv3/example_code/s3

--- a/javascriptv3/example_code/s3/package.json
+++ b/javascriptv3/example_code/s3/package.json
@@ -1,17 +1,21 @@
 {
-  "name": "aws-sdk-v3-iam-examples",
+  "name": "aws-sdk-v3-s3-examples",
   "version": "1.0.0",
   "main": "index.js",
-  "repository": "git@github.com/awsdocs/aws-doc-sdk-examples/tree/master/javascriptv3/example_code/iam.git",
+  "repository": "git@github.com/awsdocs/aws-doc-sdk-examples/tree/master/javascriptv3/example_code/s3.git",
   "author": "Brian Murray <brmur@amazon.com>, Alex Forsyth <alex-git@amazon.com>",
   "license": "MIT",
   "dependencies": {
-    "@aws-sdk/client-s3": "^1.0.0-gamma.6",
-    "@aws-sdk/client-cognito-identity": "^1.0.0-gamma.6",
-    "@aws-sdk/credential-provider-cognito-identity": "^1.0.0-gamma.6",
+    "@aws-sdk/client-s3": "^1.0.0-rc.3",
+    "@aws-sdk/s3-request-presigner": "^1.0.0-rc.3",
+    "@aws-sdk/util-create-request": "^1.0.0-rc.3",
+    "@aws-sdk/util-format-url": "^1.0.0-rc.3",
+    "@aws-sdk/client-cognito-identity": "^1.0.0-rc.4",
+    "@aws-sdk/credential-provider-cognito-identity": "^1.0.0-rc.4",
     "@aws-sdk/node-http-handler": "^1.0.0-gamma.5",
     "@aws-sdk/types": "^0.1.0-gamma.6",
-    "ts-node": "^9.0.0"
+    "ts-node": "^9.0.0",
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@types/node": "^14.0.23",

--- a/javascriptv3/example_code/s3/src/metadata.yaml
+++ b/javascriptv3/example_code/s3/src/metadata.yaml
@@ -55,6 +55,9 @@ files:
   - path: s3_upload_putcommand.ts
     services:
       - s3
+  - path: s3_put_presignedURL.ts
+    services:
+      - s3
   - path: s3.ts
     services:
       - s3

--- a/javascriptv3/example_code/s3/src/put_presignedURL.ts
+++ b/javascriptv3/example_code/s3/src/put_presignedURL.ts
@@ -1,0 +1,102 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+ABOUT THIS NODE.JS EXAMPLE: This example works with AWS SDK for JavaScript version 3 (v3),
+which is pending release.  The preview version of the SDK is available
+at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for JavaScript v3 Developer Guide' at
+https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/s3-example-creating-buckets.html.
+
+Purpose:
+put_presignedURL.ts creates a presigned URL to upload a file to an S3 bucket.
+
+Note: This example immediately deletes the object and bucket.
+
+Inputs (replace in code):
+- BUCKET_NAME
+- KEY
+- BODY
+- FILE_NAME
+- REGION
+Running the code:
+ts-node put_presignedURL.ts
+[Outputs | Returns]:
+Uploads the specified file to the specified bucket.
+*/
+
+// snippet-end:[s3.JavaScript.buckets.presignedurlv3]
+const { S3, PutObjectCommand } = require("@aws-sdk/client-s3");
+const { S3RequestPresigner } = require("@aws-sdk/s3-request-presigner");
+const { createRequest } = require("@aws-sdk/util-create-request");
+const { formatUrl } = require("@aws-sdk/util-format-url");
+const fetch = require("node-fetch");
+
+// Set the AWS Region
+const REGION = "REGION";
+
+// Set parameters
+let signedUrl;
+let response;
+const signatureVersion = "v4";
+// Variable to create random name for S3 bucket
+const Bucket = `test-bucket-${Math.ceil(Math.random() * 10 ** 10)}`;
+// Variable to create random name for object to upload to S3 bucket
+const Key = `test-object-${Math.ceil(Math.random() * 10 ** 10)}`;
+const Body = "Body";
+
+// Create AWS S3 client object
+const v3Client = new S3({ REGION });
+
+const run = async () => {
+  try {
+    //Create an S3 bucket
+    console.log(`Creating bucket ${Bucket}`);
+    await v3Client.createBucket({ Bucket });
+    console.log(`Waiting for "${Bucket}" bucket creation...`);
+  } catch (err) {
+    console.log("Error creating bucket", err);
+  }
+  try {
+    //Create S3RequestPresigner ojbect
+    const signer = new S3RequestPresigner({ ...v3Client.config });
+    // Create request
+    const request = await createRequest(
+      v3Client,
+      new PutObjectCommand({ Key, Bucket })
+    );
+    // Define the duration until expiration of the presigned URL
+    const expiration = new Date(Date.now() + 60 * 60 * 1000);
+
+    // Create and format Presigned URL
+    signedUrl = formatUrl(await signer.presign(request, expiration));
+    console.log(`\nPutting "${Key}" using signedUrl with body "${Body}" in v3`);
+  } catch (err) {
+    console.log("Error creating presigned URL", err);
+  }
+  try {
+    // Upload the object to the S3 bucket using the presigned URL
+    response = await fetch(signedUrl, {
+      method: "PUT",
+      headers: {
+        "content-type": "application/octet-stream",
+      },
+      body: Body,
+    });
+  } catch (err) {
+    console.log("Error uploading object", err);
+  }
+  try {
+    // Delete the object
+    console.log(`\nDeleting object "${Key}" from bucket`);
+    await v3Client.deleteObject({ Bucket, Key });
+  } catch (err) {
+    console.log("Error deleting object", err);
+  }
+  try {
+    // Delete the bucket
+    console.log(`\nDeleting bucket ${Bucket}`);
+    await v3Client.deleteBucket({ Bucket });
+  } catch (err) {
+    console.log("Error deleting bucket", err);
+  }
+};
+run();
+// snippet-end:[s3.JavaScript.buckets.presignedurlv3]

--- a/javascriptv3/example_code/s3/src/s3_put_presignedURL.ts
+++ b/javascriptv3/example_code/s3/src/s3_put_presignedURL.ts
@@ -11,18 +11,17 @@ s3_put_presignedURL.ts creates a presigned URL to upload a file to an S3 bucket.
 Note: This example immediately deletes the object and bucket.
 
 Inputs (replace in code):
-- BUCKET_NAME
+- REGION
 - KEY
 - BODY
-- FILE_NAME
-- REGION
+
 Running the code:
 ts-node s3_put_presignedURL.ts
 [Outputs | Returns]:
 Uploads the specified file to the specified bucket.
 */
 
-// snippet-end:[s3.JavaScript.buckets.presignedurlv3]
+// snippet-start:[s3.JavaScript.buckets.presignedurlv3]
 const { S3, PutObjectCommand } = require("@aws-sdk/client-s3");
 const { S3RequestPresigner } = require("@aws-sdk/s3-request-presigner");
 const { createRequest } = require("@aws-sdk/util-create-request");
@@ -37,10 +36,11 @@ let signedUrl;
 let response;
 const signatureVersion = "v4";
 // Variable to create random name for S3 bucket
-const Bucket = `test-bucket-${Math.ceil(Math.random() * 10 ** 10)}`;
+const BUCKET = `test-bucket-${Math.ceil(Math.random() * 10 ** 10)}`;
 // Variable to create random name for object to upload to S3 bucket
-const Key = `test-object-${Math.ceil(Math.random() * 10 ** 10)}`;
-const Body = "Body";
+const KEY = `test-object-${Math.ceil(Math.random() * 10 ** 10)}`;
+const BODY = "BODY";
+const EXPIRATION = 60 * 60 * 1000;
 
 // Create AWS S3 client object
 const v3Client = new S3({ REGION });
@@ -48,9 +48,9 @@ const v3Client = new S3({ REGION });
 const run = async () => {
   try {
     //Create an S3 bucket
-    console.log(`Creating bucket ${Bucket}`);
-    await v3Client.createBucket({ Bucket });
-    console.log(`Waiting for "${Bucket}" bucket creation...`);
+    console.log(`Creating bucket ${BUCKET}`);
+    await v3Client.createBucket({ BUCKET });
+    console.log(`Waiting for "${BUCKET}" bucket creation...`);
   } catch (err) {
     console.log("Error creating bucket", err);
   }
@@ -60,10 +60,10 @@ const run = async () => {
     // Create request
     const request = await createRequest(
       v3Client,
-      new PutObjectCommand({ Key, Bucket })
+      new PutObjectCommand({ KEY, BUCKET })
     );
     // Define the duration until expiration of the presigned URL
-    const expiration = new Date(Date.now() + 60 * 60 * 1000);
+    const expiration = new Date(Date.now() + EXPIRATION);
 
     // Create and format Presigned URL
     signedUrl = formatUrl(await signer.presign(request, expiration));

--- a/javascriptv3/example_code/s3/src/s3_put_presignedURL.ts
+++ b/javascriptv3/example_code/s3/src/s3_put_presignedURL.ts
@@ -6,7 +6,7 @@ at https://github.com/aws/aws-sdk-js-v3. This example is in the 'AWS SDK for Jav
 https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/s3-example-creating-buckets.html.
 
 Purpose:
-put_presignedURL.ts creates a presigned URL to upload a file to an S3 bucket.
+s3_put_presignedURL.ts creates a presigned URL to upload a file to an S3 bucket.
 
 Note: This example immediately deletes the object and bucket.
 
@@ -17,7 +17,7 @@ Inputs (replace in code):
 - FILE_NAME
 - REGION
 Running the code:
-ts-node put_presignedURL.ts
+ts-node s3_put_presignedURL.ts
 [Outputs | Returns]:
 Uploads the specified file to the specified bucket.
 */


### PR DESCRIPTION
Wrote five new examples that show how to use marshall/unmarshall DynamoDB V3 utilities, which deliver functional parity with V2 DymanoDB Document client.


- [x] The submitter has added the default copyright notice to all files.

- [x] The submitter has run a linter on the code, and all of the submitter's team's minimum rules pass.

- [x] The submitter has added the team's minimum usage documentation to the code.

- [x] The submitter has had the code reviewed, and the submitter has incorporated any and all resulting review comments.

- [x] The submitter has added all of the submitter's team's related API reporting metadata.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.