### PR TITLE
Fixed bug in legacy GameLift .NET code example

### DIFF
--- a/dotnet/example_code_legacy/GameLift/GameLift-Unity-game-server.cs
+++ b/dotnet/example_code_legacy/GameLift/GameLift-Unity-game-server.cs
@@ -100,9 +100,9 @@ public class GameLiftServerExampleBehavior : MonoBehaviour
 
     void OnApplicationQuit()
     {
-        //Make sure to call GameLiftServerAPI.Destroy() when the application quits. 
+        //Make sure to call GameLiftServerAPI.ProcessEnding() when the application quits. 
         //This resets the local connection with GameLift's agent.
-        GameLiftServerAPI.Destroy();
+        GameLiftServerAPI.ProcessEnding();
     }
 }
 // snippet-end:[gamelift.dotnet.game-server.unity]


### PR DESCRIPTION
*Issue #, if available:*
GameLift code example was calling Destroy(), which is deprecated.

See: https://forums.awsgametech.com/t/server-process-exited-without-calling-processending/5762/17

*Description of changes:*
Replaced Destroy() with ProcessEnding().

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
