### PR TITLE
Updated test for dry run in EC2 code examples in go v2

### DIFF
--- a/gov2/ec2/MonitorInstances/MonitorInstancesv2.go
+++ b/gov2/ec2/MonitorInstances/MonitorInstancesv2.go
@@ -106,7 +106,7 @@ func main() {
 
 		result, err := EnableMonitoring(context.Background(), client, input)
 		if err != nil {
-			fmt.Println("Got an error enablying monitoring for instance:")
+			fmt.Println("Got an error enabling monitoring for instance:")
 			fmt.Println(err)
 			return
 		}
@@ -122,7 +122,7 @@ func main() {
 
 		result, err := DisableMonitoring(context.Background(), client, input)
 		if err != nil {
-			fmt.Println("Got an error disablying monitoring for instance:")
+			fmt.Println("Got an error disabling monitoring for instance:")
 			fmt.Println(err)
 			return
 		}

--- a/gov2/ec2/MonitorInstances/MonitorInstancesv2.go
+++ b/gov2/ec2/MonitorInstances/MonitorInstancesv2.go
@@ -4,26 +4,27 @@
 package main
 
 import (
-    "context"
-    "flag"
-    "fmt"
-    "strings"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
 
-    "github.com/aws/aws-sdk-go-v2/aws"
-    "github.com/aws/aws-sdk-go-v2/config"
-    "github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/awslabs/smithy-go"
 )
 
 // EC2MonitorInstancesAPI defines the interface for the MonitorInstances and UnmonitorInstances functions.
 // We use this interface to test the function using a mocked service.
 type EC2MonitorInstancesAPI interface {
-    MonitorInstances(ctx context.Context,
-        params *ec2.MonitorInstancesInput,
-        optFns ...func(*ec2.Options)) (*ec2.MonitorInstancesOutput, error)
+	MonitorInstances(ctx context.Context,
+		params *ec2.MonitorInstancesInput,
+		optFns ...func(*ec2.Options)) (*ec2.MonitorInstancesOutput, error)
 
-    UnmonitorInstances(ctx context.Context,
-        params *ec2.UnmonitorInstancesInput,
-        optFns ...func(*ec2.Options)) (*ec2.UnmonitorInstancesOutput, error)
+	UnmonitorInstances(ctx context.Context,
+		params *ec2.UnmonitorInstancesInput,
+		optFns ...func(*ec2.Options)) (*ec2.UnmonitorInstancesOutput, error)
 }
 
 // EnableMonitoring enables monitoring for an Amazon EC2 instance.
@@ -35,18 +36,19 @@ type EC2MonitorInstancesAPI interface {
 //     If success, a MonitorInstancesOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to MonitorInstances.
 func EnableMonitoring(c context.Context, api EC2MonitorInstancesAPI, input *ec2.MonitorInstancesInput) (*ec2.MonitorInstancesOutput, error) {
-    resp, err := api.MonitorInstances(c, input)
-    //fmt.Println("Error response from dry run:")
-    //fmt.Println(err)
-    if strings.Contains(err.Error(), "DryRunOperation") {
-        fmt.Println("User has permission to enable monitoring.")
-        input.DryRun = aws.Bool(false)
-        result, err := api.MonitorInstances(c, input)
+	resp, err := api.MonitorInstances(c, input)
 
-        return result, err
-    }
+	// Do we have a DryRunOperation error?
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "DryRunOperation" {
+		fmt.Println("User has permission to enable monitoring.")
+		input.DryRun = aws.Bool(false)
+		result, err := api.MonitorInstances(c, input)
 
-    return resp, err
+		return result, err
+	}
+
+	return resp, err
 }
 
 // DisableMonitoring disables monitoring for an Amazon EC2 instance.
@@ -58,72 +60,75 @@ func EnableMonitoring(c context.Context, api EC2MonitorInstancesAPI, input *ec2.
 //     If success, a UnmonitorInstancesOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to UnmonitorInstances.
 func DisableMonitoring(c context.Context, api EC2MonitorInstancesAPI, input *ec2.UnmonitorInstancesInput) (*ec2.UnmonitorInstancesOutput, error) {
-    resp, err := api.UnmonitorInstances(c, input)
-    if strings.Contains(err.Error(), "DryRunOperation") {
-        fmt.Println("User has permission to disable monitoring.")
-        input.DryRun = aws.Bool(false)
-        result, err := api.UnmonitorInstances(c, input)
+	resp, err := api.UnmonitorInstances(c, input)
 
-        return result, err
-    }
+	// Do we have a DryRunOperation error?
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "DryRunOperation" {
+		fmt.Println("User has permission to disable monitoring.")
+		input.DryRun = aws.Bool(false)
+		result, err := api.UnmonitorInstances(c, input)
 
-    return resp, err
+		return result, err
+	}
+
+	return resp, err
 }
 
 func main() {
-    monitor := flag.String("m", "", "ON to enable monitoring; OFF to disable monitoring")
-    instanceID := flag.String("i", "", "The ID of the instance to monitor")
-    flag.Parse()
+	monitor := flag.String("m", "", "ON to enable monitoring; OFF to disable monitoring")
+	instanceID := flag.String("i", "", "The ID of the instance to monitor")
+	flag.Parse()
 
-    fmt.Println("Monitor:    " + *monitor)
-    fmt.Println("InstanceID: " + *instanceID)
+	fmt.Println("Monitor:    " + *monitor)
+	fmt.Println("InstanceID: " + *instanceID)
 
-    if *instanceID == "" || (*monitor != "ON" && *monitor != "OFF") {
-        fmt.Println("You must supply the ID of the instance to enable/disable monitoring (-i INSTANCE-ID)")
-        fmt.Println("and whether to enable monitoring (-m ON) or disable monitoring (-m OFF)")
-        return
-    }
+	if *instanceID == "" || (*monitor != "ON" && *monitor != "OFF") {
+		fmt.Println("You must supply the ID of the instance to enable/disable monitoring (-i INSTANCE-ID)")
+		fmt.Println("and whether to enable monitoring (-m ON) or disable monitoring (-m OFF)")
+		return
+	}
 
-    cfg, err := config.LoadDefaultConfig()
-    if err != nil {
-        panic("configuration error, " + err.Error())
-    }
+	cfg, err := config.LoadDefaultConfig()
+	if err != nil {
+		panic("configuration error, " + err.Error())
+	}
 
-    client := ec2.NewFromConfig(cfg)
+	client := ec2.NewFromConfig(cfg)
 
-    // Turn monitoring on
-    if *monitor == "ON" {
-        input := &ec2.MonitorInstancesInput{
-            InstanceIds: []*string{
-                instanceID,
-            },
-            DryRun: aws.Bool(true),
-        }
+	if *monitor == "ON" {
+		input := &ec2.MonitorInstancesInput{
+			InstanceIds: []*string{
+				instanceID,
+			},
+			DryRun: aws.Bool(true),
+		}
 
-        result, err := EnableMonitoring(context.Background(), client, input)
-        if err != nil {
-            fmt.Println("Got an error enablying monitoring for instance:")
-            fmt.Println(err)
-            return
-        }
+		result, err := EnableMonitoring(context.Background(), client, input)
+		if err != nil {
+			fmt.Println("Got an error enablying monitoring for instance:")
+			fmt.Println(err)
+			return
+		}
 
-        fmt.Println("Success", result.InstanceMonitorings)
-    } else if *monitor == "OFF" {
-        input := &ec2.UnmonitorInstancesInput{
-            InstanceIds: []*string{
-                instanceID,
-            },
-            DryRun: aws.Bool(true),
-        }
+		fmt.Println("Successfully enabled monitoring for instance: " + *result.InstanceMonitorings[0].InstanceId)
+	} else if *monitor == "OFF" {
+		input := &ec2.UnmonitorInstancesInput{
+			InstanceIds: []*string{
+				instanceID,
+			},
+			DryRun: aws.Bool(true),
+		}
 
-        result, err := DisableMonitoring(context.Background(), client, input)
-        if err != nil {
-            fmt.Println("Got an error disablying monitoring for instance:")
-            fmt.Println(err)
-            return
-        }
+		result, err := DisableMonitoring(context.Background(), client, input)
+		if err != nil {
+			fmt.Println("Got an error disablying monitoring for instance:")
+			fmt.Println(err)
+			return
+		}
 
-        fmt.Println("Success", *result.InstanceMonitorings[0].InstanceId)
-    }
+		fmt.Println("Successfully disabled monitoring for instance: " + *result.InstanceMonitorings[0].InstanceId)
+	}
 }
+
 // snippet-end:[ec2.go-v2.MonitorInstances]

--- a/gov2/ec2/MonitorInstances/MonitorInstancesv2_test.go
+++ b/gov2/ec2/MonitorInstances/MonitorInstancesv2_test.go
@@ -29,7 +29,7 @@ func (dt EC2MonitorInstancesImpl) MonitorInstances(ctx context.Context,
     }
 
     if *params.DryRun {
-        return output, errors.New("DryRunOperation")
+        return output, errors.New("api error DryRunOperation")
     }
 
     return output, nil
@@ -48,7 +48,7 @@ func (dt EC2MonitorInstancesImpl) UnmonitorInstances(ctx context.Context,
     }
 
     if *params.DryRun {
-        return output, errors.New("DryRunOperation")
+        return output, errors.New("api error DryRunOperation")
     }
 
     return output, nil

--- a/gov2/ec2/RebootInstances/RebootInstancesv2.go
+++ b/gov2/ec2/RebootInstances/RebootInstancesv2.go
@@ -33,7 +33,7 @@ type EC2RebootInstancesAPI interface {
 func RebootInstance(c context.Context, api EC2RebootInstancesAPI, input *ec2.RebootInstancesInput) (*ec2.RebootInstancesOutput, error) {
     resp, err := api.RebootInstances(c, input)
 
-    if strings.Contains(err.Error(), "DryRunOperation") {
+    if strings.Contains(err.Error(), "api error DryRunOperation") {
         fmt.Println("User has permission to reboot instances.")
         input.DryRun = aws.Bool(false)
         result, err := api.RebootInstances(c, input)

--- a/gov2/ec2/RebootInstances/RebootInstancesv2_test.go
+++ b/gov2/ec2/RebootInstances/RebootInstancesv2_test.go
@@ -21,7 +21,7 @@ func (dt EC2RebootInstancesImpl) RebootInstances(ctx context.Context,
     output := &ec2.RebootInstancesOutput{}
 
     if *params.DryRun {
-        return output, errors.New("DryRunOperation")
+        return output, errors.New("api error DryRunOperation")
     }
 
     return output, nil

--- a/gov2/ec2/StartInstances/StartInstancesv2.go
+++ b/gov2/ec2/StartInstances/StartInstancesv2.go
@@ -33,7 +33,7 @@ type EC2StartInstancesAPI interface {
 func StartInstance(c context.Context, api EC2StartInstancesAPI, input *ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error) {
     resp, err := api.StartInstances(c, input)
 
-    if strings.Contains(err.Error(), "DryRunOperation") {
+    if strings.Contains(err.Error(), "api error DryRunOperation") {
         fmt.Println("User has permission to start an instance.")
         input.DryRun = aws.Bool(false)
         result, err := api.StartInstances(c, input)

--- a/gov2/ec2/StartInstances/StartInstancesv2_test.go
+++ b/gov2/ec2/StartInstances/StartInstancesv2_test.go
@@ -33,7 +33,7 @@ func (dt EC2StartInstancesImpl) StartInstances(ctx context.Context,
     }
 
     if *params.DryRun {
-        return output, errors.New("DryRunOperation")
+        return output, errors.New("api error DryRunOperation")
     }
 
     return output, nil

--- a/gov2/ec2/StopInstances/StopInstancesv2.go
+++ b/gov2/ec2/StopInstances/StopInstancesv2.go
@@ -33,7 +33,7 @@ type EC2StopInstancesAPI interface {
 func StopInstance(c context.Context, api EC2StopInstancesAPI, input *ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error) {
     resp, err := api.StopInstances(c, input)
 
-    if strings.Contains(err.Error(), "DryRunOperation") {
+    if strings.Contains(err.Error(), "api error DryRunOperation") {
         fmt.Println("User has permission to stop instances.")
         input.DryRun = aws.Bool(false)
         result, err := api.StopInstances(c, input)

--- a/gov2/ec2/StopInstances/StopInstancesv2_test.go
+++ b/gov2/ec2/StopInstances/StopInstancesv2_test.go
@@ -33,7 +33,7 @@ func (dt EC2StopInstancesImpl) StopInstances(ctx context.Context,
     }
 
     if *params.DryRun {
-        return output, errors.New("DryRunOperation")
+        return output, errors.New("api error DryRunOperation")
     }
 
     return output, nil


### PR DESCRIPTION
*Issue #, if available:*
I was comparing strings to test whether the EC2 code example was a dry run.

*Description of changes:*
I now cast the error to a smithy error and test it's Code value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
