### PR TITLE
fix: pass region as key in Client constructor

### DIFF
--- a/javascriptv3/example_code/cloudwatch/src/cw_deletealarms.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cw_deletealarms.ts
@@ -31,7 +31,7 @@ const REGION = "REGION"; //e.g., "us-east-1"
 const params = { AlarmNames: "ALARM_NAMES" }; // e.g., "Web_Server_CPU_Utilization"
 
 // Create CloudWatch service object
-const cw = new CloudWatchClient(REGION);
+const cw = new CloudWatchClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cw_describealarms.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cw_describealarms.ts
@@ -30,7 +30,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { StateValue: "INSUFFICIENT_DATA" };
 
 // Create CloudWatch service object
-const cw = new CloudWatchClient(REGION);
+const cw = new CloudWatchClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cw_disablealarmactions.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cw_disablealarmactions.ts
@@ -31,7 +31,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { AlarmNames: "ALARM_NAME" }; // e.g., "Web_Server_CPU_Utilization"
 
 // Create CloudWatch service object
-const cw = new CloudWatchClient(REGION);
+const cw = new CloudWatchClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cw_enablealarmactions.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cw_enablealarmactions.ts
@@ -52,7 +52,7 @@ const params = {
 };
 
 // Create CloudWatch service object
-const cw = new CloudWatchClient(REGION);
+const cw = new CloudWatchClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cw_listmetrics.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cw_listmetrics.ts
@@ -38,7 +38,7 @@ const params = {
 };
 
 // Create CloudWatch service object
-const cw = new CloudWatchClient(REGION);
+const cw = new CloudWatchClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cw_putmetricalarm.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cw_putmetricalarm.ts
@@ -48,7 +48,7 @@ const params = {
 };
 
 // Create CloudWatch service object
-const cw = new CloudWatchClient(REGION);
+const cw = new CloudWatchClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cw_putmetricdata.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cw_putmetricdata.ts
@@ -45,7 +45,7 @@ const params = {
 };
 
 // Create CloudWatch service object
-const cw = new CloudWatchClient(REGION);
+const cw = new CloudWatchClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cwe_putevents.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cwe_putevents.ts
@@ -42,7 +42,7 @@ const params = {
 };
 
 // Create CloudWatch service object
-const cwevents = new CloudWatchEventsClient(REGION);
+const cwevents = new CloudWatchEventsClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cwe_putrule.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cwe_putrule.ts
@@ -35,7 +35,7 @@ const params = {
 };
 
 // Create CloudWatch service object
-const cwevents = new CloudWatchEventsClient(REGION);
+const cwevents = new CloudWatchEventsClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cwe_puttargets.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cwe_puttargets.ts
@@ -39,7 +39,7 @@ const params = {
 };
 
 // Create CloudWatch service object
-const cwevents = new CloudWatchEventsClient(REGION);
+const cwevents = new CloudWatchEventsClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cwl_deletesubscriptionfilter.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cwl_deletesubscriptionfilter.ts
@@ -35,7 +35,7 @@ const params = {
 };
 
 // Create CloudWatch service object
-const cwl = new CloudWatchLogsClient(REGION);
+const cwl = new CloudWatchLogsClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cwl_describesubscriptionfilters.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cwl_describesubscriptionfilters.ts
@@ -34,7 +34,7 @@ const params = {
 };
 
 // Create CloudWatch service object
-const cwl = new CloudWatchLogsClient(REGION);
+const cwl = new CloudWatchLogsClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cloudwatch/src/cwl_putsubscriptionfilter.ts
+++ b/javascriptv3/example_code/cloudwatch/src/cwl_putsubscriptionfilter.ts
@@ -38,7 +38,7 @@ const params = {
 };
 
 // Create CloudWatch service object
-const cwl = new CloudWatchLogsClient(REGION);
+const cwl = new CloudWatchLogsClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cross-services/submit-data-app/src/dynamoApp/add_data.ts
+++ b/javascriptv3/example_code/cross-services/submit-data-app/src/dynamoApp/add_data.ts
@@ -39,7 +39,7 @@ const IDENTITY_POOL_ID = "IDENTITY_POOL_ID";
 const dbclient = new DynamoDB({
   region: REGION,
   credentials: fromCognitoIdentityPool({
-    client: new CognitoIdentityClient({ region }),
+    client: new CognitoIdentityClient({ region: REGION }),
     identityPoolId: IDENTITY_POOL_ID,
   }),
 });
@@ -47,7 +47,7 @@ const dbclient = new DynamoDB({
 const sns = new SNSClient({
   region: REGION,
   credentials: fromCognitoIdentityPool({
-    client: new CognitoIdentityClient({ region }),
+    client: new CognitoIdentityClient({ region: REGION }),
     identityPoolId: IDENTITY_POOL_ID,
   }),
 });

--- a/javascriptv3/example_code/cross-services/submit-data-app/src/dynamoAppHelperFiles/convert-bucket-to-website.ts
+++ b/javascriptv3/example_code/cross-services/submit-data-app/src/dynamoAppHelperFiles/convert-bucket-to-website.ts
@@ -57,7 +57,7 @@ var bucketPolicyParams = {
 };
 
 // Instantiate an S3 client
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cross-services/submit-data-app/src/dynamoAppHelperFiles/create-bucket.ts
+++ b/javascriptv3/example_code/cross-services/submit-data-app/src/dynamoAppHelperFiles/create-bucket.ts
@@ -32,7 +32,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const bucketParams = { Bucket: "BUCKET_NAME" };
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 //Attempt to create the bucket
 const run = async () => {

--- a/javascriptv3/example_code/cross-services/submit-data-app/src/dynamoAppHelperFiles/create-table.ts
+++ b/javascriptv3/example_code/cross-services/submit-data-app/src/dynamoAppHelperFiles/create-table.ts
@@ -56,7 +56,7 @@ const tableParams = {
 };
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/cross-services/submit-data-app/src/dynamoAppHelperFiles/update-table.ts
+++ b/javascriptv3/example_code/cross-services/submit-data-app/src/dynamoAppHelperFiles/update-table.ts
@@ -38,7 +38,7 @@ const params = {
 };
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/dynamodb/src/QueryExample/ddb_batchwriteitem_tv.ts
+++ b/javascriptv3/example_code/dynamodb/src/QueryExample/ddb_batchwriteitem_tv.ts
@@ -25,7 +25,7 @@ const {
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 // Set the parameters
 const params = {

--- a/javascriptv3/example_code/dynamodb/src/QueryExample/ddb_createtable_tv.ts
+++ b/javascriptv3/example_code/dynamodb/src/QueryExample/ddb_createtable_tv.ts
@@ -57,7 +57,7 @@ const params = {
 };
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/dynamodb/src/ddb_batchgetitem.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddb_batchgetitem.ts
@@ -47,7 +47,7 @@ const params = {
 };
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/dynamodb/src/ddb_batchwriteitem.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddb_batchwriteitem.ts
@@ -57,7 +57,7 @@ const params = {
 };
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/dynamodb/src/ddb_createtable.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddb_createtable.ts
@@ -63,7 +63,7 @@ const params = {
 };
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/dynamodb/src/ddb_deleteitem.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddb_deleteitem.ts
@@ -38,7 +38,7 @@ var params = {
 };
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/dynamodb/src/ddb_deletetable.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddb_deletetable.ts
@@ -33,7 +33,7 @@ const params = {
 };
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/dynamodb/src/ddb_describetable.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddb_describetable.ts
@@ -30,7 +30,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { TableName: "TABLE_NAME" }; //TABLE_NAME
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/dynamodb/src/ddb_getitem.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddb_getitem.ts
@@ -35,7 +35,7 @@ const params = {
 };
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   const data = await dbclient.send(new GetItemCommand(params));

--- a/javascriptv3/example_code/dynamodb/src/ddb_listtables.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddb_listtables.ts
@@ -27,7 +27,7 @@ const {
 const REGION = "region"; //e.g. "us-east-1"
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/dynamodb/src/ddb_putitem.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddb_putitem.ts
@@ -34,7 +34,7 @@ const params = {
 };
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/dynamodb/src/ddb_query.ts
+++ b/javascriptv3/example_code/dynamodb/src/ddb_query.ts
@@ -37,7 +37,7 @@ const params = {
 };
 
 // Create DynamoDB service object
-const dbclient = new DynamoDBClient(REGION);
+const dbclient = new DynamoDBClient({ region: REGION });
 const run = async () => {
   try {
     const results = await dbclient.send(new QueryCommand(params));

--- a/javascriptv3/example_code/ec2/src/ec2_allocateaddress.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_allocateaddress.ts
@@ -31,7 +31,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const paramsAllocateAddress = { Domain: "vpc" };
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ec2/src/ec2_createinstances.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_createinstances.ts
@@ -38,7 +38,7 @@ const instanceParams = {
 };
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ec2/src/ec2_createkeypair.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_createkeypair.ts
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { KeyName: "MY_KEY_PAIR" }; //MY_KEY_PAIR
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ec2/src/ec2_createsecuritygroup.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_createsecuritygroup.ts
@@ -37,7 +37,7 @@ const params = { KeyName: "KEY_PAIR_NAME" }; //KEY_PAIR_NAME
 const vpc = null;
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ec2/src/ec2_deletekeypair.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_deletekeypair.ts
@@ -26,7 +26,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { KeyName: "KEY_PAIR_NAME" }; //KEY_PAIR_NAME
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ec2/src/ec2_deletesecuritygroup.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_deletesecuritygroup.ts
@@ -29,7 +29,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { GroupId: "SECURITY_GROUP_ID" }; //SECURITY_GROUP_ID
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ec2/src/ec2_describeaddresses.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_describeaddresses.ts
@@ -29,7 +29,7 @@ const params = {
 };
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ec2/src/ec2_describeinstances.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_describeinstances.ts
@@ -24,7 +24,7 @@ const { EC2Client, DescribeInstancesCommand } = require("@aws-sdk/client-ec2");
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ec2/src/ec2_describekeypairs.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_describekeypairs.ts
@@ -23,7 +23,7 @@ const { EC2Client, DescribeKeyPairsCommand } = require("@aws-sdk/client-ec2");
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ec2/src/ec2_describeregionsandzones.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_describeregionsandzones.ts
@@ -23,7 +23,7 @@ const { EC2Client, DescribeRegionsCommand } = require("@aws-sdk/client-ec2");
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ec2/src/ec2_describesecuritygroups.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_describesecuritygroups.ts
@@ -29,7 +29,7 @@ const {
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 // Set the parameters
 const params = { GroupIds: ["SECURITY_GROUP_ID"] }; //SECURITY_GROUP_ID

--- a/javascriptv3/example_code/ec2/src/ec2_monitorinstances.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_monitorinstances.ts
@@ -30,7 +30,7 @@ const {
 const REGION = "region"; //e.g. "us-east-1"
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 // Set the parameters
 const params = { InstanceIds: "INSTANCE_ID" }; // INSTANCE_ID

--- a/javascriptv3/example_code/ec2/src/ec2_rebootinstances.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_rebootinstances.ts
@@ -27,7 +27,7 @@ const {
 const REGION = "region"; //e.g. "us-east-1"
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 // Set the parameters
 const params = { InstanceIds: "INSTANCE_ID" }; //INSTANCE_ID

--- a/javascriptv3/example_code/ec2/src/ec2_releaseaddress.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_releaseaddress.ts
@@ -25,7 +25,7 @@ const { EC2Client, ReleaseAddressCommand } = require("@aws-sdk/client-ec2");
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 // Set the parameters
 const paramsReleaseAddress = { AllocationId: "ALLOCATION_ID" }; //ALLOCATION_ID

--- a/javascriptv3/example_code/ec2/src/ec2_startstopinstances.ts
+++ b/javascriptv3/example_code/ec2/src/ec2_startstopinstances.ts
@@ -31,7 +31,7 @@ const {
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create EC2 service object
-const ec2client = new EC2Client(REGION);
+const ec2client = new EC2Client({ region: REGION });
 
 // Set the parameters
 const params = { InstanceIds: "INSTANCE_ID" }; //INSTANCE_ID

--- a/javascriptv3/example_code/glacier/src/createVault.ts
+++ b/javascriptv3/example_code/glacier/src/createVault.ts
@@ -29,7 +29,7 @@ const vaultname = "VAULT_NAME"; // VAULT_NAME
 const params = { vaultName: vaultname };
 
 // Instantiate an S3 Glacier client
-const glacier = new GlacierClient(REGION);
+const glacier = new GlacierClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/glacier/src/uploadArchive.ts
+++ b/javascriptv3/example_code/glacier/src/uploadArchive.ts
@@ -32,7 +32,7 @@ const buffer = new Buffer.alloc(2.5 * 1024 * 1024); // 2.5MB buffer
 const params = { vaultName: vaultname, body: buffer };
 
 // Instantiate an S3 Glacier client
-const glacier = new GlacierClient(REGION);
+const glacier = new GlacierClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_accesskeylastused.ts
+++ b/javascriptv3/example_code/iam/src/iam_accesskeylastused.ts
@@ -30,7 +30,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { AccessKeyId: "ACCESS_KEY_ID" }; //ACCESS_KEY_ID
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_attachrolepolicy.ts
+++ b/javascriptv3/example_code/iam/src/iam_attachrolepolicy.ts
@@ -34,10 +34,10 @@ const ROLENAME = "ROLE_NAME";
 const paramsRoleList = { RoleName: ROLENAME }; //ROLE_NAME
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
-  const iam = new IAMClient(REGION);
+  const iam = new IAMClient({ region: REGION });
   try {
     const data = await iam.send(
       new ListAttachedRolePoliciesCommand(paramsRoleList)

--- a/javascriptv3/example_code/iam/src/iam_createaccesskeys.ts
+++ b/javascriptv3/example_code/iam/src/iam_createaccesskeys.ts
@@ -28,7 +28,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const userName = "IAM_USER_NAME"; //IAM_USER_NAME
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_createaccountalias.ts
+++ b/javascriptv3/example_code/iam/src/iam_createaccountalias.ts
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const accountAlias = { AccountAlias: "ACCOUNT_ALIAS" }; //ACCOUNT_ALIAS
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_createpolicy.ts
+++ b/javascriptv3/example_code/iam/src/iam_createpolicy.ts
@@ -25,7 +25,7 @@ const { IAMClient, CreatePolicyCommand } = require("@aws-sdk/client-iam");
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 // Set the parameters
 const myManagedPolicy = {

--- a/javascriptv3/example_code/iam/src/iam_createuser.ts
+++ b/javascriptv3/example_code/iam/src/iam_createuser.ts
@@ -32,7 +32,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { UserName: "USER_NAME" }; //USER_NAME
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_deleteaccesskey.ts
+++ b/javascriptv3/example_code/iam/src/iam_deleteaccesskey.ts
@@ -31,7 +31,7 @@ const params = {
 };
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_deleteaccountalias.ts
+++ b/javascriptv3/example_code/iam/src/iam_deleteaccountalias.ts
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { AccountAlias: "ALIAS" }; // ALIAS
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_deleteservercert.ts
+++ b/javascriptv3/example_code/iam/src/iam_deleteservercert.ts
@@ -30,7 +30,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { ServerCertificateName: "CERTIFICATE_NAME" }; // CERTIFICATE_NAME
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_deleteuser.ts
+++ b/javascriptv3/example_code/iam/src/iam_deleteuser.ts
@@ -31,7 +31,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { UserName: "USER_NAME" }; //USER_NAME
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_detachrolepolicy.ts
+++ b/javascriptv3/example_code/iam/src/iam_detachrolepolicy.ts
@@ -31,7 +31,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const paramsRoleList = { RoleName: "ROLE_NAME" }; //ROLE_NAME
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   // Load the AWS SDK for Node.js

--- a/javascriptv3/example_code/iam/src/iam_getpolicy.ts
+++ b/javascriptv3/example_code/iam/src/iam_getpolicy.ts
@@ -28,7 +28,7 @@ const params = {
 };
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_getservercert.ts
+++ b/javascriptv3/example_code/iam/src/iam_getservercert.ts
@@ -30,7 +30,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { ServerCertificateName: "CERTIFICATE_NAME" }; //CERTIFICATE_NAME
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_listaccesskeys.ts
+++ b/javascriptv3/example_code/iam/src/iam_listaccesskeys.ts
@@ -31,7 +31,7 @@ const params = {
 };
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_listaccountaliases.ts
+++ b/javascriptv3/example_code/iam/src/iam_listaccountaliases.ts
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { MaxItems: 5 };
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_listservercerts.ts
+++ b/javascriptv3/example_code/iam/src/iam_listservercerts.ts
@@ -26,7 +26,7 @@ const {
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_listusers.ts
+++ b/javascriptv3/example_code/iam/src/iam_listusers.ts
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { MaxItems: 10 };
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_updateaccesskey.ts
+++ b/javascriptv3/example_code/iam/src/iam_updateaccesskey.ts
@@ -32,7 +32,7 @@ const params = {
 };
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_updateservercert.ts
+++ b/javascriptv3/example_code/iam/src/iam_updateservercert.ts
@@ -34,7 +34,7 @@ const params = {
 };
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/iam_updateuser.ts
+++ b/javascriptv3/example_code/iam/src/iam_updateuser.ts
@@ -32,7 +32,7 @@ const params = {
 };
 
 // Create IAM service object
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/iam/src/sts_assumerole.ts
+++ b/javascriptv3/example_code/iam/src/sts_assumerole.ts
@@ -28,7 +28,7 @@ const {
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create STS service object
-const sts = new STSClient(REGION);
+const sts = new STSClient({ region: REGION });
 
 // Set the parameters
 const roleToAssume = {

--- a/javascriptv3/example_code/lambda/src/MyLambdaApp/index.ts
+++ b/javascriptv3/example_code/lambda/src/MyLambdaApp/index.ts
@@ -30,7 +30,7 @@ const REGION = "REGION"; // e.g., 'us-east-2'
 const lambda = new LambdaClient({
   region: REGION,
   credentials: fromCognitoIdentityPool({
-    client: new CognitoIdentityClient({ region }),
+    client: new CognitoIdentityClient({ region: REGION }),
     identityPoolId: "IDENTITY_POOL_ID", // IDENTITY_POOL_ID e.g., eu-west-1:xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx
   }),
 });

--- a/javascriptv3/example_code/lambda/src/ddb-table-create.ts
+++ b/javascriptv3/example_code/lambda/src/ddb-table-create.ts
@@ -27,7 +27,7 @@ const {
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Instantiate a DynamoDB client
-const ddb = new DynamoDBClient(REGION);
+const ddb = new DynamoDBClient({ region: REGION });
 
 // Define the table schema
 const tableParams = {

--- a/javascriptv3/example_code/lambda/src/ddb-table-populate.ts
+++ b/javascriptv3/example_code/lambda/src/ddb-table-populate.ts
@@ -25,7 +25,7 @@ const { DynamoDBClient, PutItemCommand } = require("@aws-sdk/client-dynamodb");
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Instantiate a DynamoDB client
-const ddb = new DynamoDBClient(REGION);
+const ddb = new DynamoDBClient({ region: REGION });
 //Set the parameters
 const myTable = "TABLE_NAME"; //TABLE_NAME
 

--- a/javascriptv3/example_code/lambda/src/lambda-function-setup.ts
+++ b/javascriptv3/example_code/lambda/src/lambda-function-setup.ts
@@ -29,7 +29,7 @@ const {
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Instantiate a Lambda client
-const lambda = new LambdaClient(REGION);
+const lambda = new LambdaClient({ region: REGION });
 
 //Set the parameters
 const params = {

--- a/javascriptv3/example_code/lambda/src/lambda-role-setup.ts
+++ b/javascriptv3/example_code/lambda/src/lambda-role-setup.ts
@@ -28,7 +28,7 @@ const {
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Instantiate the IAM client
-const iam = new IAMClient(REGION);
+const iam = new IAMClient({ region: REGION });
 
 // Set the parameters
 const ROLE = "NEW_ROLENAME"; //NEW_ROLENAME

--- a/javascriptv3/example_code/lambda/src/s3-bucket-setup-non-modular.ts
+++ b/javascriptv3/example_code/lambda/src/s3-bucket-setup-non-modular.ts
@@ -43,7 +43,7 @@ const staticHostParams = {
 };
 
 // Instantiate the S3 client
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   // Call S3 to create the bucket

--- a/javascriptv3/example_code/lambda/src/s3-bucket-setup.ts
+++ b/javascriptv3/example_code/lambda/src/s3-bucket-setup.ts
@@ -72,7 +72,7 @@ const bucketPolicyParams = {
 };
 
 // Instantiate an S3 client
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/lambda/src/slotpull.ts
+++ b/javascriptv3/example_code/lambda/src/slotpull.ts
@@ -25,7 +25,7 @@ const { DynamoDBClient, GetItemCommand } = require("@aws-sdk/client-dynamodb");
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Instantiate a DynamoDB client
-const ddb = new DynamoDBClient(REGION);
+const ddb = new DynamoDBClient({ region: REGION });
 
 // Set the parameters
 const tableName = "TABLE_NAME";

--- a/javascriptv3/example_code/nodegetstarted/src/sample.ts
+++ b/javascriptv3/example_code/nodegetstarted/src/sample.ts
@@ -36,7 +36,7 @@ const keyName = "hello_world.txt";
 const objectParams = { Bucket: bucketName, Key: keyName, Body: "Hello World!" };
 
 // Create an S3 client service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   // Create S3 bucket

--- a/javascriptv3/example_code/pinpoint/src/pinpoint_send_email_message.ts
+++ b/javascriptv3/example_code/pinpoint/src/pinpoint_send_email_message.ts
@@ -114,7 +114,7 @@ const params = {
 };
 
 // Create a new Pinpoint client object.
-const pinpointClient = new PinpointClient(REGION);
+const pinpointClient = new PinpointClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/pinpoint/src/pinpoint_send_sms_message.ts
+++ b/javascriptv3/example_code/pinpoint/src/pinpoint_send_sms_message.ts
@@ -86,7 +86,7 @@ var params = {
 };
 
 //Create a new Pinpoint client object.
-const pinpointClient = new PinpointClient(REGION);
+const pinpointClient = new PinpointClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/redshift/src/redshift-create-cluster.ts
+++ b/javascriptv3/example_code/redshift/src/redshift-create-cluster.ts
@@ -48,7 +48,7 @@ const params = {
 };
 
 // Create an Amazon Redshift client service object
-const redshift = new RedshiftClient(REGION);
+const redshift = new RedshiftClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/redshift/src/redshift-delete-cluster.ts
+++ b/javascriptv3/example_code/redshift/src/redshift-delete-cluster.ts
@@ -38,7 +38,7 @@ const params = {
 };
 
 // Create an Amazon Redshift client service object
-const redshift = new RedshiftClient(REGION);
+const redshift = new RedshiftClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/redshift/src/redshift-describe-clusters.ts
+++ b/javascriptv3/example_code/redshift/src/redshift-describe-clusters.ts
@@ -35,7 +35,7 @@ const params = {
 };
 
 // Create an Amazon Redshift client service object
-const redshift = new RedshiftClient(REGION);
+const redshift = new RedshiftClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/redshift/src/redshift-modify-cluster.ts
+++ b/javascriptv3/example_code/redshift/src/redshift-modify-cluster.ts
@@ -35,7 +35,7 @@ const params = {
 };
 
 // Create an Amazon Redshift client service object
-const redshift = new RedshiftClient(REGION);
+const redshift = new RedshiftClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/s3/photoExample/src/s3_PhotoExample.ts
+++ b/javascriptv3/example_code/s3/photoExample/src/s3_PhotoExample.ts
@@ -29,7 +29,7 @@ const REGION = "REGION"; //REGION
 const s3 = new S3Client({
   region: REGION,
   credentials: fromCognitoIdentityPool({
-    client: new CognitoIdentityClient({ region }),
+    client: new CognitoIdentityClient({ region: REGION }),
     identityPoolId: "IDENTITY_POOL_ID", // IDENTITY_POOL_ID
   }),
 });

--- a/javascriptv3/example_code/s3/photoViewer/src/s3_PhotoViewer.ts
+++ b/javascriptv3/example_code/s3/photoViewer/src/s3_PhotoViewer.ts
@@ -30,7 +30,7 @@ const REGION = "region"; //e.g., 'us-east-1'
 const s3 = new S3Client({
   region: REGION,
   credentials: fromCognitoIdentityPool({
-    client: new CognitoIdentityClient({ REGION }),
+    client: new CognitoIdentityClient({ region: REGION }),
     identityPoolId: "IDENTITY_POOL_ID", // IDENTITY_POOL_ID e.g., eu-west-1:xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx
   }),
 });

--- a/javascriptv3/example_code/s3/src/s3.ts
+++ b/javascriptv3/example_code/s3/src/s3.ts
@@ -38,7 +38,7 @@ const async = require("async"); // To call AWS operations asynchronously.
 const bucket_name = process.argv[2];
 const region = process.argv[3];
 
-const s3 = new S3Client({ region });
+const s3 = new S3Client({ region: REGION });
 
 const create_bucket_params = {
   Bucket: bucket_name,

--- a/javascriptv3/example_code/s3/src/s3_createbucket.ts
+++ b/javascriptv3/example_code/s3/src/s3_createbucket.ts
@@ -26,7 +26,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const bucketParams = { Bucket: "BUCKET_NAME" };
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 //Attempt to create the bucket
 const run = async () => {

--- a/javascriptv3/example_code/s3/src/s3_deletebucketpolicy.ts
+++ b/javascriptv3/example_code/s3/src/s3_deletebucketpolicy.ts
@@ -24,7 +24,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const bucketParams = { Bucket: "BUCKET_NAME" };
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/s3/src/s3_deletebucketwebsite.ts
+++ b/javascriptv3/example_code/s3/src/s3_deletebucketwebsite.ts
@@ -25,7 +25,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const bucketParams = { Bucket: "BUCKET_NAME" };
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/s3/src/s3_getbucketacl.ts
+++ b/javascriptv3/example_code/s3/src/s3_getbucketacl.ts
@@ -25,7 +25,7 @@ const REGION = "region"; //e.g. "us-east-1"
 const bucketParams = { Bucket: "BUCKET_NAME" };
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/s3/src/s3_getbucketpolicy.ts
+++ b/javascriptv3/example_code/s3/src/s3_getbucketpolicy.ts
@@ -23,7 +23,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const bucketParams = { Bucket: "BUCKET_NAME" };
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/s3/src/s3_getbucketwebsite.ts
+++ b/javascriptv3/example_code/s3/src/s3_getbucketwebsite.ts
@@ -24,7 +24,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const bucketParams = { Bucket: "BUCKET_NAME" };
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/s3/src/s3_getcors.ts
+++ b/javascriptv3/example_code/s3/src/s3_getcors.ts
@@ -24,7 +24,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const bucketParams = { Bucket: "BUCKET_NAME" };
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/s3/src/s3_list1000plusobjects.ts
+++ b/javascriptv3/example_code/s3/src/s3_list1000plusobjects.ts
@@ -23,7 +23,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const bucketParams = { Bucket: "BUCKET_NAME" };
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 async function run() {
   // Declare truncated as a flag that we will base our while loop on

--- a/javascriptv3/example_code/s3/src/s3_listobjects.ts
+++ b/javascriptv3/example_code/s3/src/s3_listobjects.ts
@@ -23,7 +23,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const bucketParams = { Bucket: "BUCKET_NAME" };
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/s3/src/s3_put_presignedURL.ts
+++ b/javascriptv3/example_code/s3/src/s3_put_presignedURL.ts
@@ -45,7 +45,7 @@ const BODY = "BODY";
 const EXPIRATION = 60 * 60 * 1000;
 
 // Create Amazon S3 client object
-const v3Client = new S3({ REGION });
+const v3Client = new S3({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/s3/src/s3_setbucketwebsite.ts
+++ b/javascriptv3/example_code/s3/src/s3_setbucketwebsite.ts
@@ -35,7 +35,7 @@ const staticHostParams = {
 };
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 const run = async () => {
   // Insert specified bucket name and index and error documents into params JSON

--- a/javascriptv3/example_code/s3/src/s3_setcors.ts
+++ b/javascriptv3/example_code/s3/src/s3_setcors.ts
@@ -67,7 +67,7 @@ async function run() {
   };
 
   // Create S3 service object
-  const s3 = new S3Client(REGION);
+  const s3 = new S3Client({ region: REGION });
 
   try {
     const data = await s3.send(new PutBucketCorsCommand(corsParams));

--- a/javascriptv3/example_code/s3/src/s3_upload.ts
+++ b/javascriptv3/example_code/s3/src/s3_upload.ts
@@ -32,7 +32,7 @@ const uploadParams = { Bucket: "BUCKET_NAME", Key: "KEY", Body: "BODY" }; //BUCK
 const file = "FILE_NAME"; //FILE_NAME (the name of the file to upload (if you don't specify KEY))
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 // call S3 to retrieve upload file to specified bucket
 const run = async () => {

--- a/javascriptv3/example_code/s3/src/s3_upload_putcommand.ts
+++ b/javascriptv3/example_code/s3/src/s3_upload_putcommand.ts
@@ -27,7 +27,7 @@ const uploadParams = { Bucket: "BUCKET_NAME", Key: "KEY", Body: "BODY" }; //BUCK
 // BODY (the contents of the uploaded file)
 
 // Create S3 service object
-const s3 = new S3Client(REGION);
+const s3 = new S3Client({ region: REGION });
 
 // call S3 to retrieve upload file to specified bucket
 const run = async () => {

--- a/javascriptv3/example_code/secrets/src/secrets_getsecretvalue.ts
+++ b/javascriptv3/example_code/secrets/src/secrets_getsecretvalue.ts
@@ -33,7 +33,7 @@ const params = {
   SecretId: "SECRET_ID", //e.g. arn:aws:secretsmanager:REGION:XXXXXXXXXXXX:secret:mysecret-XXXXXX
 };
 // Create SES service object
-const secretsManagerClient = new SecretsManagerClient(REGION);
+const secretsManagerClient = new SecretsManagerClient({ region: REGION });
 
 const run = async () => {
   let data;

--- a/javascriptv3/example_code/ses/src/ses_createreceiptfilter.ts
+++ b/javascriptv3/example_code/ses/src/ses_createreceiptfilter.ts
@@ -41,7 +41,7 @@ const params = {
 };
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_createreceiptrule.ts
+++ b/javascriptv3/example_code/ses/src/ses_createreceiptrule.ts
@@ -51,7 +51,7 @@ const params = {
 };
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_createreceiptruleset.ts
+++ b/javascriptv3/example_code/ses/src/ses_createreceiptruleset.ts
@@ -30,7 +30,7 @@ const REGION = "region"; //e.g. "us-east-1" // REGION
 const params = { RuleSetName: "RULE_SET_NAME" }; //RULE_SET_NAME
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_createtemplate.ts
+++ b/javascriptv3/example_code/ses/src/ses_createtemplate.ts
@@ -39,7 +39,7 @@ const params = {
 };
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_deleteidentity.ts
+++ b/javascriptv3/example_code/ses/src/ses_deleteidentity.ts
@@ -31,7 +31,7 @@ const params = {
 }; // IDENTITY_NAME
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_deletereceiptfilter.ts
+++ b/javascriptv3/example_code/ses/src/ses_deletereceiptfilter.ts
@@ -30,7 +30,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { FilterName: "FILTER_NAME" }; //FILTER_NAME
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_deletereceiptrule.ts
+++ b/javascriptv3/example_code/ses/src/ses_deletereceiptrule.ts
@@ -32,7 +32,7 @@ var params = {
 };
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_deletereceiptruleset.ts
+++ b/javascriptv3/example_code/ses/src/ses_deletereceiptruleset.ts
@@ -28,7 +28,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { RuleSetName: "RULE_SET_NAME" }; //RULE_SET_NAME
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_deletetemplate.ts
+++ b/javascriptv3/example_code/ses/src/ses_deletetemplate.ts
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { TemplateName: "TEMPLATE_NAME" };
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_gettemplate.ts
+++ b/javascriptv3/example_code/ses/src/ses_gettemplate.ts
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { TemplateName: "TEMPLATE_NAME" };
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_listidentities.ts
+++ b/javascriptv3/example_code/ses/src/ses_listidentities.ts
@@ -30,7 +30,7 @@ var params = {
 };
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_listreceiptfilters.ts
+++ b/javascriptv3/example_code/ses/src/ses_listreceiptfilters.ts
@@ -23,7 +23,7 @@ const { SESClient, ListReceiptFiltersCommand } = require("@aws-sdk/client-ses");
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_listtemplates.ts
+++ b/javascriptv3/example_code/ses/src/ses_listtemplates.ts
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { MaxItems: "ITEMS_COUNT" }; //ITEMS_COUNT
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_sendbulktemplatedemail.ts
+++ b/javascriptv3/example_code/ses/src/ses_sendbulktemplatedemail.ts
@@ -54,7 +54,7 @@ var params = {
 };
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_sendemail.ts
+++ b/javascriptv3/example_code/ses/src/ses_sendemail.ts
@@ -64,7 +64,7 @@ const params = {
 };
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_sendtemplatedemail.ts
+++ b/javascriptv3/example_code/ses/src/ses_sendtemplatedemail.ts
@@ -46,7 +46,7 @@ const params = {
 };
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_updatetemplate.ts
+++ b/javascriptv3/example_code/ses/src/ses_updatetemplate.ts
@@ -37,7 +37,7 @@ const params = {
 };
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_verifydomainidentity.ts
+++ b/javascriptv3/example_code/ses/src/ses_verifydomainidentity.ts
@@ -30,7 +30,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { Domain: "DOMAIN_NAME" }; //DOMAIN_NAME
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/ses/src/ses_verifyemailidentity.ts
+++ b/javascriptv3/example_code/ses/src/ses_verifyemailidentity.ts
@@ -31,7 +31,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { EmailAddress: "ADDRESS@DOMAIN.EXT" }; //ADDRESS@DOMAIN.EXT; e.g., name@example.com
 
 // Create SES service object
-const ses = new SESClient(REGION);
+const ses = new SESClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_checkphoneoptout.ts
+++ b/javascriptv3/example_code/sns/src/sns_checkphoneoptout.ts
@@ -30,7 +30,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { phoneNumber: "PHONE_NUMBER" }; //PHONE_NUMBER, in the E.164 phone number structure
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_confirmsubscription.ts
+++ b/javascriptv3/example_code/sns/src/sns_confirmsubscription.ts
@@ -38,7 +38,7 @@ const params = {
 };
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_createtopic.ts
+++ b/javascriptv3/example_code/sns/src/sns_createtopic.ts
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { Name: "TOPIC_NAME" }; //TOPIC_NAME
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_deletetopic.ts
+++ b/javascriptv3/example_code/sns/src/sns_deletetopic.ts
@@ -23,7 +23,7 @@ ts-node sns_deletetopic.ts
 const { SNSClient, DeleteTopicCommand } = require("@aws-sdk/client-sns");
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 // Set the AWS Region
 const REGION = "REGION"; //e.g. "us-east-1"

--- a/javascriptv3/example_code/sns/src/sns_getsmstype.ts
+++ b/javascriptv3/example_code/sns/src/sns_getsmstype.ts
@@ -33,7 +33,7 @@ var params = {
 };
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_gettopicattributes.ts
+++ b/javascriptv3/example_code/sns/src/sns_gettopicattributes.ts
@@ -27,7 +27,7 @@ const REGION = "region"; //e.g. "us-east-1"
 const params = { TopicArn: "TOPIC_ARN" }; // TOPIC_ARN
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_listnumbersoptedout.ts
+++ b/javascriptv3/example_code/sns/src/sns_listnumbersoptedout.ts
@@ -24,7 +24,7 @@ const { SNSClient, ListPhoneNumbersOptedOutCommand } = require("@aws-sdk/client-
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_listsubscriptions.ts
+++ b/javascriptv3/example_code/sns/src/sns_listsubscriptions.ts
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { TopicArn: "TOPIC_ARN" }; //TOPIC_ARN
 
 //Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_listtopics.ts
+++ b/javascriptv3/example_code/sns/src/sns_listtopics.ts
@@ -23,7 +23,7 @@ const { SNSClient, ListTopicsCommand } = require("@aws-sdk/client-sns");
 const REGION = "REGION"; //e.g. "us-east-1"
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_publishsms.ts
+++ b/javascriptv3/example_code/sns/src/sns_publishsms.ts
@@ -31,7 +31,7 @@ const params = {
 };
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_publishtotopic.ts
+++ b/javascriptv3/example_code/sns/src/sns_publishtotopic.ts
@@ -31,7 +31,7 @@ var params = {
 };
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_setsmstype.ts
+++ b/javascriptv3/example_code/sns/src/sns_setsmstype.ts
@@ -33,7 +33,7 @@ const params = {
 };
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_settopicattributes.ts
+++ b/javascriptv3/example_code/sns/src/sns_settopicattributes.ts
@@ -34,7 +34,7 @@ const params = {
 };
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_subscribeapp.ts
+++ b/javascriptv3/example_code/sns/src/sns_subscribeapp.ts
@@ -32,7 +32,7 @@ const params = {
 };
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_subscribeemail.ts
+++ b/javascriptv3/example_code/sns/src/sns_subscribeemail.ts
@@ -33,7 +33,7 @@ const params = {
 };
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_subscribelambda.ts
+++ b/javascriptv3/example_code/sns/src/sns_subscribelambda.ts
@@ -33,7 +33,7 @@ const params = {
 };
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sns/src/sns_unsubscribe.ts
+++ b/javascriptv3/example_code/sns/src/sns_unsubscribe.ts
@@ -27,7 +27,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { SubscriptionArn: "TOPIC_SUBSCRIPTION_ARN" }; //TOPIC_SUBSCRIPTION_ARN
 
 // Create SNS service object
-const sns = new SNSClient(REGION);
+const sns = new SNSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sqs/src/sqs_changingvisibility.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_changingvisibility.ts
@@ -38,7 +38,7 @@ const params = {
 };
 
 // Create SQS service object
-const sqs = new SQSClient(REGION);
+const sqs = new SQSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sqs/src/sqs_createqueue.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_createqueue.ts
@@ -35,7 +35,7 @@ const params = {
 };
 
 // Create SQS service object
-const sqs = new SQSClient(REGION);
+const sqs = new SQSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sqs/src/sqs_deadletterqueue.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_deadletterqueue.ts
@@ -35,7 +35,7 @@ var params = {
 };
 
 // Create SQS service object
-const sqs = new SQSClient(REGION);
+const sqs = new SQSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sqs/src/sqs_deletequeue.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_deletequeue.ts
@@ -27,7 +27,7 @@ const REGION = "region"; //e.g. "us-east-1"
 const params = { QueueUrl: "SQS_QUEUE_URL" }; //SQS_QUEUE_URL e.g., 'https://sqs.REGION.amazonaws.com/ACCOUNT-ID/QUEUE-NAME'
 
 // Create SQS service object
-const sns = new SQSClient(REGION);
+const sns = new SQSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sqs/src/sqs_getqueueurl.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_getqueueurl.ts
@@ -28,7 +28,7 @@ const REGION = "REGION"; //e.g. "us-east-1"
 const params = { QueueName: "SQS_QUEUE_NAME" }; //SQS_QUEUE_NAME
 
 // Create SQS service object
-const sns = new SQSClient(REGION);
+const sns = new SQSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sqs/src/sqs_listqueues.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_listqueues.ts
@@ -23,7 +23,7 @@ const { SQSClient, ListQueuesCommand } = require("@aws-sdk/client-sqs");
 const REGION = "region"; //e.g. "us-east-1"
 
 // Create SQS service object
-const sqs = new SQSClient(REGION);
+const sqs = new SQSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sqs/src/sqs_longpolling_createqueue.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_longpolling_createqueue.ts
@@ -32,7 +32,7 @@ const params = {
 };
 
 // Create SQS service object
-const sqs = new SQSClient(REGION);
+const sqs = new SQSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sqs/src/sqs_longpolling_existingqueue.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_longpolling_existingqueue.ts
@@ -34,7 +34,7 @@ const params = {
 };
 
 // Create SQS service object
-const sqs = new SQSClient(REGION);
+const sqs = new SQSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sqs/src/sqs_longpolling_receivemessage.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_longpolling_receivemessage.ts
@@ -37,7 +37,7 @@ const params = {
 };
 
 // Create SQS service object
-const sqs = new SQSClient(REGION);
+const sqs = new SQSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sqs/src/sqs_receivemessage.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_receivemessage.ts
@@ -40,7 +40,7 @@ const params = {
 };
 
 // Create SQS service object
-const sqs = new SQSClient(REGION);
+const sqs = new SQSClient({ region: REGION });
 
 const run = async () => {
   try {

--- a/javascriptv3/example_code/sqs/src/sqs_sendmessage.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_sendmessage.ts
@@ -48,7 +48,7 @@ const params = {
 };
 
 // Create SQS service object
-const sqs = new SQSClient(REGION);
+const sqs = new SQSClient({ region: REGION });
 
 const run = async () => {
   try {


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/awsdocs/aws-sdk-for-javascript-v3/pull/11

*Description of changes:*
The region needs to be passed as `region` key when constructor is created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
