### PR TITLE
New Java SDK DynamoDB Enhanced example for query with sort keys

### DIFF
--- a/javav2/example_code/dynamodb/src/main/java/com/example/dynamodb/EnhancedGetItem.java
+++ b/javav2/example_code/dynamodb/src/main/java/com/example/dynamodb/EnhancedGetItem.java
@@ -57,6 +57,7 @@ public class EnhancedGetItem {
             //Create a KEY object
             Key key = Key.builder()
                     .partitionValue("id110")
+                    .sortValue("Fred Pink")
                     .build();
 
             // Get the item by using the key

--- a/javav2/example_code/dynamodb/src/main/java/com/example/dynamodb/EnhancedQueryRecordsWithSortKey.java
+++ b/javav2/example_code/dynamodb/src/main/java/com/example/dynamodb/EnhancedQueryRecordsWithSortKey.java
@@ -1,0 +1,114 @@
+/*
+   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0
+*/
+package com.example.dynamodb;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Iterator;
+import java.util.HashMap;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+
+public class EnhancedQueryRecordsWithSortKey {
+
+    public static void main(String[] args) {
+
+        Region region = Region.US_EAST_1;
+        DynamoDbClient ddb = DynamoDbClient.builder()
+                .region(region)
+                .build();
+
+        DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder()
+                .dynamoDbClient(ddb)
+                .build();
+
+        queryTableSortKeyBetween(enhancedClient);
+        ddb.close();
+    }
+
+    public static void queryTableSortKeyBetween(DynamoDbEnhancedClient enhancedClient) {
+
+        try {
+            DynamoDbTable<Customer> mappedTable =
+                    enhancedClient.table("Customer", TableSchema.fromBean(Customer.class));
+
+            // Querying the sort key Name between two values
+            Key fromKey = Key.builder().partitionValue("id101").sortValue("S").build();
+            Key toKey = Key.builder().partitionValue("id101").sortValue("T").build();
+
+            QueryConditional queryConditional = QueryConditional.sortBetween(fromKey, toKey);
+
+            PageIterable<Customer> customers =
+                    mappedTable.query(r -> r.queryConditional(queryConditional));
+
+            customers.stream()
+                     .forEach(p -> p.items().forEach(item -> System.out.println(item.getCustName())));
+
+        } catch (DynamoDbException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
+        System.out.println("Done");
+    }
+
+
+    @DynamoDbBean
+    public static class Customer {
+
+        private String id;
+        private String name;
+        private String email;
+        private Instant regDate;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return this.id;
+        };
+
+        public void setId(String id) {
+
+            this.id = id;
+        }
+
+        @DynamoDbSortKey
+        public String getCustName() {
+            return this.name;
+
+        }
+
+        public void setCustName(String name) {
+
+            this.name = name;
+        }
+
+        public String getEmail() {
+            return this.email;
+        }
+
+        public void setEmail(String email) {
+
+            this.email = email;
+        }
+
+        public Instant getRegistrationDate() {
+            return regDate;
+        }
+        public void setRegistrationDate(Instant registrationDate) {
+
+            this.regDate = registrationDate;
+        }
+    }
+}

--- a/javav2/example_code/dynamodb/src/main/java/com/example/dynamodb/EnhancedQueryRecordsWithSortKey.java
+++ b/javav2/example_code/dynamodb/src/main/java/com/example/dynamodb/EnhancedQueryRecordsWithSortKey.java
@@ -1,3 +1,11 @@
+//snippet-sourcedescription:[EnhancedQueryRecordsWithSortKey.java demonstrates how to query a table with a sort key.]
+//snippet-keyword:[SDK for Java v2]
+//snippet-keyword:[Code Sample]
+//snippet-service:[Amazon DynamoDB]
+//snippet-sourcetype:[full-example]
+//snippet-sourcedate:[12/16/2020]
+//snippet-sourceauthor:[debito - aws]
+
 /*
    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0
@@ -5,18 +13,14 @@
 package com.example.dynamodb;
 
 import java.time.Instant;
-import java.util.Map;
-import java.util.Iterator;
-import java.util.HashMap;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
-import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;


### PR DESCRIPTION
*Description of changes:*
1) Created a new example `EnhancedQueryRecordsWithSortKey` after feedback received in the Java v2 repo. The example shows how to execute a query operation with a `between` operator for sort keys.
   - Tried to keep this example consistent with the other examples
   - Didn't add the documentation snippet annotations
2) Fixed the `EnhancedGetItem` example: when the DynamoDB table contains partition key and sort key, the `GetItem` request must contain both.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
