### PR TITLE
Make use of region in parameters for s3 client.

### DIFF
--- a/cpp/example_code/s3/copy_object.cpp
+++ b/cpp/example_code/s3/copy_object.cpp
@@ -17,6 +17,7 @@
  * - objectKey: The name of the object to copy.
  * - fromBucket: The name of the bucket to copy the object from.
  * - toBucket: The name of the bucket to copy the object to.
+ * - region: The AWS Region to create the bucket in.
  *
  * Outputs: true if the object was copied; otherwise, false.
  * ///////////////////////////////////////////////////////////////////////// */
@@ -24,7 +25,15 @@
 bool AwsDoc::S3::CopyObject(const Aws::String& objectKey, 
     const Aws::String& fromBucket, const Aws::String& toBucket, const Aws::String& region)
 {
-    Aws::S3::S3Client s3_client;
+    Aws::Client::ClientConfiguration config;
+
+    if (!region.empty())
+    {
+        config.region = region;
+    }
+
+    Aws::S3::S3Client s3_client(config);
+
     Aws::S3::Model::CopyObjectRequest request;
 
     request.WithCopySource(fromBucket + "/" + objectKey)

--- a/cpp/example_code/s3/copy_object.cpp
+++ b/cpp/example_code/s3/copy_object.cpp
@@ -64,8 +64,9 @@ int main()
         Aws::String object_key = "my-file.txt";
         Aws::String from_bucket = "my-from-bucket";
         Aws::String to_bucket = "my-to-bucket";
+        Aws::String region = "us-east-1";
 
-        if (AwsDoc::S3::CopyObject(object_key, from_bucket, to_bucket))
+        if (AwsDoc::S3::CopyObject(object_key, from_bucket, to_bucket, region))
         {
             std::cout << "Copied object '" << object_key <<
                 "' from '" << from_bucket << "' to '" << to_bucket << "'." << 

--- a/cpp/example_code/s3/create_bucket.cpp
+++ b/cpp/example_code/s3/create_bucket.cpp
@@ -26,17 +26,7 @@
 bool AwsDoc::S3::CreateBucket(const Aws::String& bucketName, 
     const Aws::S3::Model::BucketLocationConstraint& region)
 {
-    Aws::Client::ClientConfiguration config;
-
-    if (!region.empty())
-    {
-        config.region = region;
-    }
-
     Aws::S3::S3Client s3_client(config);
-
-    Aws::S3::Model::CreateBucketRequest request;
-    request.SetBucket(bucketName);
 
     // You only need to set the AWS Region for the bucket if it is 
     // other than US East (N. Virginia) us-east-1.

--- a/cpp/example_code/s3/create_bucket.cpp
+++ b/cpp/example_code/s3/create_bucket.cpp
@@ -26,7 +26,14 @@
 bool AwsDoc::S3::CreateBucket(const Aws::String& bucketName, 
     const Aws::S3::Model::BucketLocationConstraint& region)
 {
-	Aws::S3::S3Client s3_client;
+    Aws::Client::ClientConfiguration config;
+
+    if (!region.empty())
+    {
+        config.region = region;
+    }
+
+    Aws::S3::S3Client s3_client(config);
 
     Aws::S3::Model::CreateBucketRequest request;
     request.SetBucket(bucketName);

--- a/cpp/example_code/s3/delete_bucket_policy.cpp
+++ b/cpp/example_code/s3/delete_bucket_policy.cpp
@@ -25,7 +25,14 @@
  // snippet-start:[s3.cpp.delete_bucket_policy.code]
 bool AwsDoc::S3::DeleteBucketPolicy(const Aws::String& bucketName,const Aws::String& region)
 {
-    Aws::S3::S3Client s3_client;
+    Aws::Client::ClientConfiguration config;
+
+    if (!region.empty())
+    {
+        config.region = region;
+    }
+
+    Aws::S3::S3Client s3_client(config);
 
     Aws::S3::Model::DeleteBucketPolicyRequest request;
     request.SetBucket(bucketName);

--- a/cpp/example_code/s3/delete_bucket_policy.cpp
+++ b/cpp/example_code/s3/delete_bucket_policy.cpp
@@ -55,11 +55,12 @@ bool AwsDoc::S3::DeleteBucketPolicy(const Aws::String& bucketName,const Aws::Str
 int main()
 {
     Aws::String bucket_name = "my-bucket";
+    Aws::String region = "us-east-1";
 
     Aws::SDKOptions options;
     Aws::InitAPI(options);
     {
-        if (AwsDoc::S3::DeleteBucketPolicy(bucket_name))
+        if (AwsDoc::S3::DeleteBucketPolicy(bucket_name, region))
         {
             std::cout << "Deleted bucket policy from '" << bucket_name <<
                 "'." << std::endl;

--- a/cpp/example_code/s3/delete_object.cpp
+++ b/cpp/example_code/s3/delete_object.cpp
@@ -61,11 +61,12 @@ int main()
 {
     Aws::String object_key = "my-key";
     Aws::String from_bucket = "my-bucket";
+    Aws::String region = "us-east-1";
 
     Aws::SDKOptions options;
     Aws::InitAPI(options);
     {
-        if (AwsDoc::S3::DeleteObject(object_key, from_bucket))
+        if (AwsDoc::S3::DeleteObject(object_key, from_bucket, region))
         {
             std::cout << "Deleted object " << object_key <<
                 " from " << from_bucket << "." << std::endl;

--- a/cpp/example_code/s3/delete_object.cpp
+++ b/cpp/example_code/s3/delete_object.cpp
@@ -17,6 +17,7 @@
  * Inputs:
  * - objectKey: The name of the object to delete.
  * - fromBucket: The name of the bucket to delete the object from.
+ * - region: The AWS Region to create the bucket in.
  *
  * Outputs: true if the object was deleted; otherwise, false.
  * ///////////////////////////////////////////////////////////////////////// */
@@ -25,7 +26,15 @@
 bool AwsDoc::S3::DeleteObject(const Aws::String& objectKey, 
     const Aws::String& fromBucket,const Aws::String& region)
 {
-    Aws::S3::S3Client s3_client;
+    Aws::Client::ClientConfiguration config;
+
+    if (!region.empty())
+    {
+        config.region = region;
+    }
+
+    Aws::S3::S3Client s3_client(config);
+
     Aws::S3::Model::DeleteObjectRequest request;
 
     request.WithKey(objectKey)

--- a/cpp/example_code/s3/get_object.cpp
+++ b/cpp/example_code/s3/get_object.cpp
@@ -75,8 +75,9 @@ int main()
     {
         const Aws::String bucket_name = "my-bucket";
         const Aws::String object_name = "my-file.txt";
+        const Aws::String region = "us-east-1";
 
-        if (!AwsDoc::S3::GetObject(object_name, bucket_name))
+        if (!AwsDoc::S3::GetObject(object_name, bucket_name, region))
         {
             return 1;
         }

--- a/cpp/example_code/s3/get_object.cpp
+++ b/cpp/example_code/s3/get_object.cpp
@@ -19,6 +19,7 @@
  * Inputs:
  * - objectKey: The name of the text file.
  * - fromBucket: The name of the bucket that contains the text file.
+ * - region: The AWS Region for the bucket.
  *
  * Outputs: true if the contents of the text file were retrieved; 
  * otherwise, false.
@@ -28,7 +29,15 @@
 bool AwsDoc::S3::GetObject(const Aws::String& objectKey,
     const Aws::String& fromBucket, const Aws::String& region)
 {
-    Aws::S3::S3Client s3_client;
+    Aws::Client::ClientConfiguration config;
+
+    if (!region.empty())
+    {
+        config.region = region;
+    }
+
+    Aws::S3::S3Client s3_client(config);
+
     Aws::S3::Model::GetObjectRequest object_request;
     object_request.SetBucket(fromBucket);
     object_request.SetKey(objectKey);


### PR DESCRIPTION
*Description of changes:*
I'm new to AWS and want to use cpp-sdk for manipulating S3. When going through several basic examples, I ran into an error called `GetObject: PermanentRedirect: Unable to parse ExceptionName: PermanentRedirect Message: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.`. After a closer look at the code I found that the parameter `region` is unused, and my bucket is not in default region which is `us-east-1`.

This PR solved this kind of issue for several files. And makes the comment consistent with the function signature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
