### PR TITLE
Pass deleteParams to DeleteMessageCommand method

### DIFF
--- a/javascriptv3/example_code/sqs/src/sqs_receivemessage.ts
+++ b/javascriptv3/example_code/sqs/src/sqs_receivemessage.ts
@@ -50,7 +50,7 @@ const run = async () => {
         ReceiptHandle: data.Messages[0].ReceiptHandle,
       };
       try {
-        const data = await sqs.send(new DeleteMessageCommand({}));
+        const data = await sqs.send(new DeleteMessageCommand(deleteParams));
       } catch (err) {
         console.log("Message Deleted", data);
       }


### PR DESCRIPTION
*Description of changes:*

This is a very small PR to fix a typo in the javascriptv3/example_code/sqs code.  There is a [sqs_receivemessage.ts ](https://github.com/awsdocs/aws-doc-sdk-examples/blob/cb5e3c0d5d54237596d064ac9296622f91e829d9/javascriptv3/example_code/sqs/src/sqs_receivemessage.ts#L48) file where a `deleteParams` object is declared but not used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
