### PR TITLE
Updated Python example prerequisite version to 3.7

### DIFF
--- a/python/example_code/acm/README.md
+++ b/python/example_code/acm/README.md
@@ -15,7 +15,7 @@ to request, import, and manage certificates.
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto3 1.14.47 or later
 - PyTest 5.3.5 or later (to run unit tests)
 

--- a/python/example_code/dynamodb/GettingStarted/README.md
+++ b/python/example_code/dynamodb/GettingStarted/README.md
@@ -11,7 +11,7 @@ and update and query movies in various ways.
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto 3 1.11.10 or later
 - PyTest 5.3.5 or later (to run unit tests)
 - Download and extract the 

--- a/python/example_code/dynamodb/TryDax/README.md
+++ b/python/example_code/dynamodb/TryDax/README.md
@@ -20,7 +20,7 @@ information, see [In-Memory Acceleration with DynamoDB Accelerator (DAX)](https:
 - A DAX cluster set up in your VPC 
 - An Amazon Elastic Compute Cloud (Amazon EC2) instance running in your VPC with the
   following installed:
-    - Python 3.6 or later
+    - Python 3.7 or later
     - Boto3 1.11.10 or later
     - Amazon DAX Client for Python 1.1.7 or later
 - PyTest 5.3.5 or later (to run unit tests)

--- a/python/example_code/dynamodb/batching/README.md
+++ b/python/example_code/dynamodb/batching/README.md
@@ -16,7 +16,7 @@ duplicates, and retrying unprocessed items.
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto3 1.11.10 or later
 - PyTest 5.3.5 or later (to run unit tests)
 - Download and extract the 

--- a/python/example_code/ec2/ec2_basics/README.md
+++ b/python/example_code/ec2/ec2_basics/README.md
@@ -16,7 +16,7 @@ groups.
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto3 1.11.10 or later
 - PyTest 5.3.5 or later (to run unit tests)
 - An SSH client, such as Open SSH (to connect to demo instances)

--- a/python/example_code/emr/README.md
+++ b/python/example_code/emr/README.md
@@ -22,7 +22,7 @@ and manage clusters and job steps. Learn to accomplish the following tasks:
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto3 1.11.10 or later
 - PyTest 5.3.5 or later (to run unit tests)
 - PySpark 3.0.0 or later (optional, to run Spark scripts locally)

--- a/python/example_code/iam/iam_basics/README.md
+++ b/python/example_code/iam/iam_basics/README.md
@@ -17,7 +17,7 @@ Management (IAM) resources. Learn to accomplish the following tasks:
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto3 1.11.10 or later
 - PyTest 5.3.5 or later (to run unit tests)
 

--- a/python/example_code/lambda/boto_client_examples/README.md
+++ b/python/example_code/lambda/boto_client_examples/README.md
@@ -23,7 +23,7 @@ to achieve similar results more easily and with additional features.
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto3 1.11.10 or later
 - PyTest 5.3.5 or later (to run unit tests)
 - Requests 2.23.0 or later

--- a/python/example_code/organizations/README.md
+++ b/python/example_code/organizations/README.md
@@ -10,7 +10,7 @@ policies.
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto3 1.14.47 or later
 - PyTest 5.3.5 or later (to run unit tests)
 

--- a/python/example_code/rds/lending_library/README.md
+++ b/python/example_code/rds/lending_library/README.md
@@ -19,7 +19,7 @@ and out of the database.
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto3 1.14.47 or later
 - Chalice 1.20.0 or later
 - AWS CLI 1.18.147 or later

--- a/python/example_code/rekognition/README.md
+++ b/python/example_code/rekognition/README.md
@@ -17,7 +17,7 @@ detection job has completed.
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto3 1.14.47 or later
 - Requests 2.23.0 or later
 - Pillow 7.2.0 or later 

--- a/python/example_code/s3/file_transfer/README.md
+++ b/python/example_code/s3/file_transfer/README.md
@@ -15,7 +15,7 @@ thread usage and time to transfer.
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto 3 1.11.10 or later
 - PyTest 5.3.5 or later (to run unit tests)
 - An Amazon S3 bucket to hold uploaded objects

--- a/python/example_code/s3/s3_basics/ReadMe.md
+++ b/python/example_code/s3/s3_basics/ReadMe.md
@@ -11,7 +11,7 @@ Learn to create, get, remove, and configure buckets and objects.
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto 3 1.11.10 or later
 - PyTest 5.3.5 or later (to run unit tests)
 

--- a/python/example_code/ses/README.md
+++ b/python/example_code/ses/README.md
@@ -16,7 +16,7 @@ Shows how to use the AWS SDK for Python (Boto3) with Amazon Simple Email Service
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto3 1.15.4 or later
 - PyTest 6.0.2 or later (to run unit tests)
 

--- a/python/example_code/sqs/ReadMe.md
+++ b/python/example_code/sqs/ReadMe.md
@@ -12,7 +12,7 @@ send, receive, and delete messages from a queue.
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto 3 1.11.10 or later
 - PyTest 5.3.5 or later (to run unit tests)
 

--- a/python/example_code/transcribe/README.md
+++ b/python/example_code/transcribe/README.md
@@ -14,7 +14,7 @@ transcribe an audio file to a text file. Learn how to:
 - You must have an AWS account, and have your default credentials and AWS Region
   configured as described in the [AWS Tools and SDKs Shared Configuration and
   Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-- Python 3.6 or later
+- Python 3.7 or later
 - Boto3 1.14.47 or later
 - Requests 2.23.0 or later 
 - PyTest 5.3.5 or later (to run unit tests)


### PR DESCRIPTION
Many examples use `time.time_ns`, which was introduced in 3.7, so updating example READMEs to reflect this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
