### PR TITLE
Replaced Background with TODO in go v2 context calls

### DIFF
--- a/gov2/cloudwatch/CreateCustomMetric/CreateCustomMetricv2.go
+++ b/gov2/cloudwatch/CreateCustomMetric/CreateCustomMetricv2.go
@@ -72,7 +72,7 @@ func main() {
 		},
 	}
 
-	_, err = CreateCustomMetric(context.Background(), client, input)
+	_, err = CreateCustomMetric(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println()
 		return

--- a/gov2/cloudwatch/CreateCustomMetric/CreateCustomMetricv2_test.go
+++ b/gov2/cloudwatch/CreateCustomMetric/CreateCustomMetricv2_test.go
@@ -98,7 +98,7 @@ func TestCreateCustomMetric(t *testing.T) {
 
 	api := &CWPutMetricDataImpl{}
 
-	_, err = CreateCustomMetric(context.Background(), *api, input)
+	_, err = CreateCustomMetric(context.TODO(), *api, input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/cloudwatch/CreateEnableMetricAlarm/CreateEnableMetricAlarmv2.go
+++ b/gov2/cloudwatch/CreateEnableMetricAlarm/CreateEnableMetricAlarmv2.go
@@ -95,7 +95,7 @@ func main() {
 		},
 	}
 
-	_, err = CreateMetricAlarm(context.Background(), client, putInput)
+	_, err = CreateMetricAlarm(context.TODO(), client, putInput)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -107,7 +107,7 @@ func main() {
 		},
 	}
 
-	_, err = EnableAlarm(context.Background(), client, enableInput)
+	_, err = EnableAlarm(context.TODO(), client, enableInput)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/gov2/cloudwatch/CreateEnableMetricAlarm/CreateEnableMetricAlarmv2_test.go
+++ b/gov2/cloudwatch/CreateEnableMetricAlarm/CreateEnableMetricAlarmv2_test.go
@@ -106,7 +106,7 @@ func TestEnableAlarm(t *testing.T) {
 		},
 	}
 
-	_, err = CreateMetricAlarm(context.Background(), *api, putInput)
+	_, err = CreateMetricAlarm(context.TODO(), *api, putInput)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)
@@ -119,7 +119,7 @@ func TestEnableAlarm(t *testing.T) {
 		},
 	}
 
-	_, err = EnableAlarm(context.Background(), *api, enableInput)
+	_, err = EnableAlarm(context.TODO(), *api, enableInput)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/cloudwatch/DescribeAlarms/DescribeAlarmsv2.go
+++ b/gov2/cloudwatch/DescribeAlarms/DescribeAlarmsv2.go
@@ -43,7 +43,7 @@ func main() {
 
 	input := &cloudwatch.DescribeAlarmsInput{}
 
-	resp, err := ListAlarms(context.Background(), client, input)
+	resp, err := ListAlarms(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error listing alarms:")
 		fmt.Println(err)

--- a/gov2/cloudwatch/DescribeAlarms/DescribeAlarmsv2_test.go
+++ b/gov2/cloudwatch/DescribeAlarms/DescribeAlarmsv2_test.go
@@ -43,7 +43,7 @@ func TestDescribeAlarms(t *testing.T) {
 
 	api := &CWDescribeAlarmsImpl{}
 
-	resp, err := ListAlarms(context.Background(), *api, &input)
+	resp, err := ListAlarms(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/cloudwatch/DisableAlarm/DisableAlarmv2.go
+++ b/gov2/cloudwatch/DisableAlarm/DisableAlarmv2.go
@@ -56,7 +56,7 @@ func main() {
 		},
 	}
 
-	_, err = DisableAlarm(context.Background(), client, input)
+	_, err = DisableAlarm(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Could not disable alarm " + *alarmName)
 	} else {

--- a/gov2/cloudwatch/DisableAlarm/DisableAlarmv2_test.go
+++ b/gov2/cloudwatch/DisableAlarm/DisableAlarmv2_test.go
@@ -65,7 +65,7 @@ func TestDisableAlarm(t *testing.T) {
 
 	api := &CWDisableAlarmImpl{}
 
-	_, err = DisableAlarm(context.Background(), *api, &input)
+	_, err = DisableAlarm(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/cloudwatch/ListMetrics/ListMetricsv2.go
+++ b/gov2/cloudwatch/ListMetrics/ListMetricsv2.go
@@ -44,7 +44,7 @@ func main() {
 
 	input := &cloudwatch.ListMetricsInput{}
 
-	result, err := GetMetrics(context.Background(), client, input)
+	result, err := GetMetrics(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Could not get metrics")
 		return

--- a/gov2/cloudwatch/ListMetrics/ListMetricsv2_test.go
+++ b/gov2/cloudwatch/ListMetrics/ListMetricsv2_test.go
@@ -40,7 +40,7 @@ func TestListMetrics(t *testing.T) {
 
 	api := &CWListMetricsImpl{}
 
-	resp, err := GetMetrics(context.Background(), *api, &input)
+	resp, err := GetMetrics(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/cloudwatch/PutEvent/PutEventv2.go
+++ b/gov2/cloudwatch/PutEvent/PutEventv2.go
@@ -126,7 +126,7 @@ func main() {
 		},
 	}
 
-	_, err = CreateEvent(context.Background(), client, input)
+	_, err = CreateEvent(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Could not create event:")
 		fmt.Println(err)

--- a/gov2/cloudwatch/PutEvent/PutEventv2_test.go
+++ b/gov2/cloudwatch/PutEvent/PutEventv2_test.go
@@ -105,7 +105,7 @@ func TestPutEvents(t *testing.T) {
 
 	api := &CWEPutEventsImpl{}
 
-	_, err = CreateEvent(context.Background(), *api, input)
+	_, err = CreateEvent(context.TODO(), *api, input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/dynamodb/DescribeTable/DescribeTablev2.go
+++ b/gov2/dynamodb/DescribeTable/DescribeTablev2.go
@@ -50,7 +50,7 @@ func main() {
 		TableName: table,
 	}
 
-	resp, err := GetTableInfo(context.Background(), client, input)
+	resp, err := GetTableInfo(context.TODO(), client, input)
 	if err != nil {
 		panic("failed to describe table, " + err.Error())
 	}

--- a/gov2/dynamodb/DescribeTable/DescribeTablev2_test.go
+++ b/gov2/dynamodb/DescribeTable/DescribeTablev2_test.go
@@ -76,7 +76,7 @@ func TestDescribeTable(t *testing.T) {
 
 	api := &DynamoDBDescribeTableImpl{}
 
-	resp, err := GetTableInfo(context.Background(), *api, &input)
+	resp, err := GetTableInfo(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error retrieving the table status:")
 		t.Log(err)

--- a/gov2/dynamodb/ScanItems/ScanItemsv2.go
+++ b/gov2/dynamodb/ScanItems/ScanItemsv2.go
@@ -93,7 +93,7 @@ func main() {
 
 	client := dynamodb.NewFromConfig(cfg)
 
-	resp, err := GetItems(context.Background(), client, input)
+	resp, err := GetItems(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error scanning the table:")
 		fmt.Println(err.Error())

--- a/gov2/dynamodb/ScanItems/ScanItemsv2_test.go
+++ b/gov2/dynamodb/ScanItems/ScanItemsv2_test.go
@@ -155,7 +155,7 @@ func TestDescribeTable(t *testing.T) {
 
 	api := &DynamoDBScanImpl{}
 
-	resp, err := GetItems(context.Background(), *api, input)
+	resp, err := GetItems(context.TODO(), *api, input)
 	if err != nil {
 		t.Log("Got an error retrieving the table items:")
 		t.Log(err)

--- a/gov2/ec2/CreateImage/CreateImagev2.go
+++ b/gov2/ec2/CreateImage/CreateImagev2.go
@@ -75,7 +75,7 @@ func main() {
         },
     }
 
-    resp, err := MakeImage(context.Background(), client, input)
+    resp, err := MakeImage(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error createing image:")
         fmt.Println(err)

--- a/gov2/ec2/CreateImage/CreateImagev2_test.go
+++ b/gov2/ec2/CreateImage/CreateImagev2_test.go
@@ -90,7 +90,7 @@ func TestCreateImage(t *testing.T) {
 
     api := &EC2CreateImageImpl{}
 
-    resp, err := MakeImage(context.Background(), api, input)
+    resp, err := MakeImage(context.TODO(), api, input)
     if err != nil {
         fmt.Println("Got an error createing image:")
         fmt.Println(err)

--- a/gov2/ec2/CreateInstance/CreateInstancev2.go
+++ b/gov2/ec2/CreateInstance/CreateInstancev2.go
@@ -78,7 +78,7 @@ func main() {
         MaxCount:     aws.Int32(1),
     }
 
-    result, err := MakeInstance(context.Background(), client, input)
+    result, err := MakeInstance(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error creating an instance:")
         fmt.Println(err)
@@ -95,7 +95,7 @@ func main() {
         },
     }
 
-    _, err = MakeTags(context.Background(), client, tagInput)
+    _, err = MakeTags(context.TODO(), client, tagInput)
     if err != nil {
         fmt.Println("Got an error tagging the instance:")
         fmt.Println(err)

--- a/gov2/ec2/CreateInstance/CreateInstancev2_test.go
+++ b/gov2/ec2/CreateInstance/CreateInstancev2_test.go
@@ -90,7 +90,7 @@ func TestCreateInstance(t *testing.T) {
         MaxCount:     aws.Int32(1),
     }
 
-    result, err := MakeInstance(context.Background(), api, input)
+    result, err := MakeInstance(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error creating an instance:")
         t.Log(err)
@@ -107,7 +107,7 @@ func TestCreateInstance(t *testing.T) {
         },
     }
 
-    _, err = MakeTags(context.Background(), api, tagInput)
+    _, err = MakeTags(context.TODO(), api, tagInput)
     if err != nil {
         t.Log("Got an error tagging the instance:")
         t.Log(err)

--- a/gov2/ec2/DescribeInstances/DescribeInstancesv2.go
+++ b/gov2/ec2/DescribeInstances/DescribeInstancesv2.go
@@ -43,7 +43,7 @@ func main() {
 
     input := &ec2.DescribeInstancesInput{}
 
-    result, err := GetInstances(context.Background(), client, input)
+    result, err := GetInstances(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error retrieving information about your Amazon EC2 instances:")
         fmt.Println(err)

--- a/gov2/ec2/DescribeInstances/DescribeInstancesv2_test.go
+++ b/gov2/ec2/DescribeInstances/DescribeInstancesv2_test.go
@@ -46,7 +46,7 @@ func TestDescribeInstances(t *testing.T) {
 
     input := &ec2.DescribeInstancesInput{}
 
-    result, err := GetInstances(context.Background(), api, input)
+    result, err := GetInstances(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error retrieving information about your Amazon EC2 instances:")
         t.Log(err)

--- a/gov2/ec2/DescribeVpcEndpoints/DescribeVpcEndpointsv2.go
+++ b/gov2/ec2/DescribeVpcEndpoints/DescribeVpcEndpointsv2.go
@@ -32,7 +32,7 @@ type EC2DescribeVpcEndpointConnectionsAPI interface {
 func GetConnectionInfo(c context.Context,
 	api EC2DescribeVpcEndpointConnectionsAPI,
 	input *ec2.DescribeVpcEndpointConnectionsInput) (*ec2.DescribeVpcEndpointConnectionsOutput, error) {
-	resp, err := api.DescribeVpcEndpointConnections(context.Background(), input)
+	resp, err := api.DescribeVpcEndpointConnections(context.TODO(), input)
 	return resp, err
 }
 
@@ -53,7 +53,7 @@ func main() {
 
 	input := &ec2.DescribeVpcEndpointConnectionsInput{}
 
-	resp, err := GetConnectionInfo(context.Background(), client, input)
+	resp, err := GetConnectionInfo(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error retrieving information about your VPC endpoint:")
 		fmt.Println(err)

--- a/gov2/ec2/DescribeVpcEndpoints/DescribeVpcEndpointsv2_test.go
+++ b/gov2/ec2/DescribeVpcEndpoints/DescribeVpcEndpointsv2_test.go
@@ -70,7 +70,7 @@ func TestMETHOD(t *testing.T) {
 
 	input := &ec2.DescribeVpcEndpointConnectionsInput{}
 
-	resp, err := GetConnectionInfo(context.Background(), api, input)
+	resp, err := GetConnectionInfo(context.TODO(), api, input)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gov2/ec2/MonitorInstances/MonitorInstancesv2.go
+++ b/gov2/ec2/MonitorInstances/MonitorInstancesv2.go
@@ -104,7 +104,7 @@ func main() {
 			DryRun: aws.Bool(true),
 		}
 
-		result, err := EnableMonitoring(context.Background(), client, input)
+		result, err := EnableMonitoring(context.TODO(), client, input)
 		if err != nil {
 			fmt.Println("Got an error enabling monitoring for instance:")
 			fmt.Println(err)
@@ -120,7 +120,7 @@ func main() {
 			DryRun: aws.Bool(true),
 		}
 
-		result, err := DisableMonitoring(context.Background(), client, input)
+		result, err := DisableMonitoring(context.TODO(), client, input)
 		if err != nil {
 			fmt.Println("Got an error disabling monitoring for instance:")
 			fmt.Println(err)

--- a/gov2/ec2/MonitorInstances/MonitorInstancesv2_test.go
+++ b/gov2/ec2/MonitorInstances/MonitorInstancesv2_test.go
@@ -108,7 +108,7 @@ func TestMonitorInstances(t *testing.T) {
             DryRun: aws.Bool(true),
         }
 
-        result, err := EnableMonitoring(context.Background(), api, input)
+        result, err := EnableMonitoring(context.TODO(), api, input)
         if err != nil {
             fmt.Println("Got an error enablying monitoring for instance:")
             fmt.Println(err)
@@ -124,7 +124,7 @@ func TestMonitorInstances(t *testing.T) {
             DryRun: aws.Bool(true),
         }
 
-        result, err := DisableMonitoring(context.Background(), api, input)
+        result, err := DisableMonitoring(context.TODO(), api, input)
         if err != nil {
             fmt.Println("Got an error disablying monitoring for instance:")
             fmt.Println(err)

--- a/gov2/ec2/RebootInstances/RebootInstancesv2.go
+++ b/gov2/ec2/RebootInstances/RebootInstancesv2.go
@@ -67,7 +67,7 @@ func main() {
         DryRun: aws.Bool(true),
     }
 
-    _, err = RebootInstance(context.Background(), client, input)
+    _, err = RebootInstance(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error rebooting the instance")
         fmt.Println(err)

--- a/gov2/ec2/RebootInstances/RebootInstancesv2_test.go
+++ b/gov2/ec2/RebootInstances/RebootInstancesv2_test.go
@@ -75,7 +75,7 @@ func TestStopInstances(t *testing.T) {
 
     api := &EC2RebootInstancesImpl{}
 
-    _, err = RebootInstance(context.Background(), *api, input)
+    _, err = RebootInstance(context.TODO(), *api, input)
     if err != nil {
         t.Log("Got an error ...:")
         t.Log(err)

--- a/gov2/ec2/StartInstances/StartInstancesv2.go
+++ b/gov2/ec2/StartInstances/StartInstancesv2.go
@@ -67,7 +67,7 @@ func main() {
         DryRun: aws.Bool(true),
     }
 
-    _, err = StartInstance(context.Background(), client, input)
+    _, err = StartInstance(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error starting the instance")
         fmt.Println(err)

--- a/gov2/ec2/StartInstances/StartInstancesv2_test.go
+++ b/gov2/ec2/StartInstances/StartInstancesv2_test.go
@@ -87,7 +87,7 @@ func TestStopInstances(t *testing.T) {
 
     api := &EC2StartInstancesImpl{}
 
-    resp, err := StartInstance(context.Background(), *api, input)
+    resp, err := StartInstance(context.TODO(), *api, input)
     if err != nil {
         t.Log("Got an error ...:")
         t.Log(err)

--- a/gov2/ec2/StopInstances/StopInstancesv2.go
+++ b/gov2/ec2/StopInstances/StopInstancesv2.go
@@ -67,7 +67,7 @@ func main() {
         DryRun: aws.Bool(true),
     }
 
-    _, err = StopInstance(context.Background(), client, input)
+    _, err = StopInstance(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error stopping the instance")
         fmt.Println(err)

--- a/gov2/ec2/StopInstances/StopInstancesv2_test.go
+++ b/gov2/ec2/StopInstances/StopInstancesv2_test.go
@@ -87,7 +87,7 @@ func TestStopInstances(t *testing.T) {
 
     api := &EC2StopInstancesImpl{}
 
-    resp, err := StopInstance(context.Background(), *api, input)
+    resp, err := StopInstance(context.TODO(), *api, input)
     if err != nil {
         t.Log("Got an error ...:")
         t.Log(err)

--- a/gov2/iam/AccessKeyLastUsed/AccessKeyLastUsedv2.go
+++ b/gov2/iam/AccessKeyLastUsed/AccessKeyLastUsedv2.go
@@ -54,7 +54,7 @@ func main() {
 		AccessKeyId: keyID,
 	}
 
-	result, err := WhenWasKeyUsed(context.Background(), client, input)
+	result, err := WhenWasKeyUsed(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error retrieving when access key was last used:")
 		fmt.Println(err)

--- a/gov2/iam/AccessKeyLastUsed/AccessKeyLastUsedv2_test.go
+++ b/gov2/iam/AccessKeyLastUsed/AccessKeyLastUsedv2_test.go
@@ -82,7 +82,7 @@ func TestGetAccessKeyLastUsed(t *testing.T) {
         AccessKeyId: &globalConfig.KeyID,
     }
 
-    result, err := WhenWasKeyUsed(context.Background(), api, input)
+    result, err := WhenWasKeyUsed(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error retrieving when access key was last used:")
         t.Log(err)

--- a/gov2/iam/AttachUserPolicy/AttachUserPolicyv2.go
+++ b/gov2/iam/AttachUserPolicy/AttachUserPolicyv2.go
@@ -57,7 +57,7 @@ func main() {
 		RoleName:  roleName,
 	}
 
-	_, err = AttachDynamoFullPolicy(context.Background(), client, input)
+	_, err = AttachDynamoFullPolicy(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Unable to attach DynamoDB full-access role policy to role")
 		return

--- a/gov2/iam/AttachUserPolicy/AttachUserPolicyv2_test.go
+++ b/gov2/iam/AttachUserPolicy/AttachUserPolicyv2_test.go
@@ -77,7 +77,7 @@ func TestAttachRolePolicy(t *testing.T) {
 		RoleName:  &globalConfig.RoleName,
 	}
 
-	_, err = AttachDynamoFullPolicy(context.Background(), api, input)
+	_, err = AttachDynamoFullPolicy(context.TODO(), api, input)
 	if err != nil {
 		t.Log("Unable to attach DynamoDB full-access role policy to role")
 		return

--- a/gov2/iam/CreateAccessKey/CreateAccessKeyv2.go
+++ b/gov2/iam/CreateAccessKey/CreateAccessKeyv2.go
@@ -54,7 +54,7 @@ func main() {
         UserName: userName,
     }
 
-    result, err := MakeAccessKey(context.Background(), client, input)
+    result, err := MakeAccessKey(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error creating a new access key")
         fmt.Println(err)

--- a/gov2/iam/CreateAccessKey/CreateAccessKeyv2_test.go
+++ b/gov2/iam/CreateAccessKey/CreateAccessKeyv2_test.go
@@ -74,7 +74,7 @@ func TestCreateAccessKey(t *testing.T) {
         UserName: &globalConfig.UserName,
     }
 
-    result, err := MakeAccessKey(context.Background(), api, input)
+    result, err := MakeAccessKey(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error creating a new access key")
         t.Log(err)

--- a/gov2/iam/CreateAccountAlias/CreateAccountAliasv2.go
+++ b/gov2/iam/CreateAccountAlias/CreateAccountAliasv2.go
@@ -53,7 +53,7 @@ func main() {
         AccountAlias: alias,
     }
 
-    _, err = MakeAccountAlias(context.Background(), client, input)
+    _, err = MakeAccountAlias(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error creating an account alias")
         fmt.Println(err)

--- a/gov2/iam/CreateAccountAlias/CreateAccountAliasv2_test.go
+++ b/gov2/iam/CreateAccountAlias/CreateAccountAliasv2_test.go
@@ -72,7 +72,7 @@ func TestCreateAccountAlias(t *testing.T) {
         AccountAlias: &globalConfig.Alias,
     }
 
-    _, err = MakeAccountAlias(context.Background(), api, input)
+    _, err = MakeAccountAlias(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error creating an account alias")
         t.Log(err)

--- a/gov2/iam/CreatePolicy/CreatePolicyv2.go
+++ b/gov2/iam/CreatePolicy/CreatePolicyv2.go
@@ -109,7 +109,7 @@ func main() {
         PolicyName:     policyName,
     }
 
-    _, err = MakePolicy(context.Background(), client, input)
+    _, err = MakePolicy(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error creating the policy:")
         fmt.Println(err)

--- a/gov2/iam/CreatePolicy/CreatePolicyv2_test.go
+++ b/gov2/iam/CreatePolicy/CreatePolicyv2_test.go
@@ -76,7 +76,7 @@ func TestCreatePolicy(t *testing.T) {
         PolicyName:     &globalConfig.PolicyName,
     }
 
-    _, err = MakePolicy(context.Background(), api, input)
+    _, err = MakePolicy(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error creating the policy:")
         t.Log(err)

--- a/gov2/iam/CreateUser/CreateUserv2.go
+++ b/gov2/iam/CreateUser/CreateUserv2.go
@@ -54,7 +54,7 @@ func main() {
 		UserName: userName,
 	}
 
-	results, err := MakeUser(context.Background(), client, input)
+	results, err := MakeUser(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error creating user " + *userName)
 	}

--- a/gov2/iam/CreateUser/CreateUserv2_test.go
+++ b/gov2/iam/CreateUser/CreateUserv2_test.go
@@ -80,7 +80,7 @@ func TestCreateUser(t *testing.T) {
         UserName: &globalConfig.UserName,
     }
 
-    results, err := MakeUser(context.Background(), api, input)
+    results, err := MakeUser(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error creating user " + globalConfig.UserName)
     }

--- a/gov2/iam/DeleteAccessKey/DeleteAccessKeyv2.go
+++ b/gov2/iam/DeleteAccessKey/DeleteAccessKeyv2.go
@@ -56,7 +56,7 @@ func main() {
         UserName:    userName,
     }
 
-    _, err = RemoveAccessKey(context.Background(), client, input)
+    _, err = RemoveAccessKey(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Error", err)
         return

--- a/gov2/iam/DeleteAccessKey/DeleteAccessKeyv2_test.go
+++ b/gov2/iam/DeleteAccessKey/DeleteAccessKeyv2_test.go
@@ -69,7 +69,7 @@ func TestDeleteAccessKey(t *testing.T) {
         UserName:    &globalConfig.UserName,
     }
 
-    _, err = RemoveAccessKey(context.Background(), api, input)
+    _, err = RemoveAccessKey(context.TODO(), api, input)
     if err != nil {
         t.Log("Error", err)
         return

--- a/gov2/iam/DeleteAccountAlias/DeleteAccountAliasv2.go
+++ b/gov2/iam/DeleteAccountAlias/DeleteAccountAliasv2.go
@@ -53,7 +53,7 @@ func main() {
 		AccountAlias: alias,
 	}
 
-	_, err = RemoveAccountAlias(context.Background(), client, input)
+	_, err = RemoveAccountAlias(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error deleting an account alias")
 		fmt.Println(err)

--- a/gov2/iam/DeleteAccountAlias/DeleteAccountAliasv2_test.go
+++ b/gov2/iam/DeleteAccountAlias/DeleteAccountAliasv2_test.go
@@ -67,7 +67,7 @@ func TestDeleteAccountAlias(t *testing.T) {
 		AccountAlias: &globalConfig.Alias,
 	}
 
-	_, err = RemoveAccountAlias(context.Background(), api, input)
+	_, err = RemoveAccountAlias(context.TODO(), api, input)
 	if err != nil {
 		t.Log("Got an error deleting an account alias")
 		t.Log(err)

--- a/gov2/iam/DeleteServerCert/DeleteServerCertv2.go
+++ b/gov2/iam/DeleteServerCert/DeleteServerCertv2.go
@@ -54,7 +54,7 @@ func main() {
         ServerCertificateName: certName,
     }
 
-    _, err = DeleteServerCert(context.Background(), client, input)
+    _, err = DeleteServerCert(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error deleting the server certificate:")
         fmt.Println(err)

--- a/gov2/iam/DeleteServerCert/DeleteServerCertv2_test.go
+++ b/gov2/iam/DeleteServerCert/DeleteServerCertv2_test.go
@@ -72,7 +72,7 @@ func TestDeleteServerCertificate(t *testing.T) {
         ServerCertificateName: &globalConfig.CertificateName,
     }
 
-    _, err = DeleteServerCert(context.Background(), api, input)
+    _, err = DeleteServerCert(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error deleting the server certificate:")
         t.Log(err)

--- a/gov2/iam/DeleteUser/DeleteUserv2.go
+++ b/gov2/iam/DeleteUser/DeleteUserv2.go
@@ -54,7 +54,7 @@ func main() {
         UserName: userName,
     }
 
-    _, err = RemoveUser(context.Background(), client, input)
+    _, err = RemoveUser(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error deleting user " + *userName)
     }

--- a/gov2/iam/DeleteUser/DeleteUserv2_test.go
+++ b/gov2/iam/DeleteUser/DeleteUserv2_test.go
@@ -68,7 +68,7 @@ func TestDeleteUser(t *testing.T) {
         UserName: &globalConfig.UserName,
     }
 
-    _, err = RemoveUser(context.Background(), api, input)
+    _, err = RemoveUser(context.TODO(), api, input)
     if err != nil {
         fmt.Println("Got an error deleting user " + globalConfig.UserName)
     }

--- a/gov2/iam/DetachUserPolicy/DetachUserPolicyv2.go
+++ b/gov2/iam/DetachUserPolicy/DetachUserPolicyv2.go
@@ -56,7 +56,7 @@ func main() {
         RoleName:  roleName,
     }
 
-    _, err = DetachDynamoFullPolicy(context.Background(), client, input)
+    _, err = DetachDynamoFullPolicy(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Unable to detach DynamoDB full-access role policy from role")
         return

--- a/gov2/iam/DetachUserPolicy/DetachUserPolicyv2_test.go
+++ b/gov2/iam/DetachUserPolicy/DetachUserPolicyv2_test.go
@@ -70,7 +70,7 @@ func TestDetachRolePolicy(t *testing.T) {
         RoleName:  &globalConfig.RoleName,
     }
 
-    _, err = DetachDynamoFullPolicy(context.Background(), api, input)
+    _, err = DetachDynamoFullPolicy(context.TODO(), api, input)
     if err != nil {
         fmt.Println("Unable to detach DynamoDB full-access role policy from role")
         return

--- a/gov2/iam/GetPolicy/GetPolicyv2.go
+++ b/gov2/iam/GetPolicy/GetPolicyv2.go
@@ -54,7 +54,7 @@ func main() {
 		PolicyArn: policyArn,
 	}
 
-	result, err := GetPolicyDescription(context.Background(), client, input)
+	result, err := GetPolicyDescription(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error retrieving the description:")
 		fmt.Println(err)

--- a/gov2/iam/GetPolicy/GetPolicyv2_test.go
+++ b/gov2/iam/GetPolicy/GetPolicyv2_test.go
@@ -88,7 +88,7 @@ func TestGetPolicy(t *testing.T) {
 		PolicyArn: &globalConfig.PolicyARN,
 	}
 
-	result, err := GetPolicyDescription(context.Background(), api, input)
+	result, err := GetPolicyDescription(context.TODO(), api, input)
 	if err != nil {
 		t.Log("Got an error retrieving the description:")
 		t.Log(err)

--- a/gov2/iam/GetServerCert/GetServerCertv2.go
+++ b/gov2/iam/GetServerCert/GetServerCertv2.go
@@ -54,7 +54,7 @@ func main() {
 		ServerCertificateName: certName,
 	}
 
-	result, err := FindServerCert(context.Background(), client, input)
+	result, err := FindServerCert(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error retrieving the server certificate:")
 		fmt.Println(err)

--- a/gov2/iam/GetServerCert/GetServerCertv2_test.go
+++ b/gov2/iam/GetServerCert/GetServerCertv2_test.go
@@ -86,7 +86,7 @@ func TestGetServerCertificate(t *testing.T) {
         ServerCertificateName: &globalConfig.Certificate,
     }
 
-    result, err := FindServerCert(context.Background(), api, input)
+    result, err := FindServerCert(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error retrieving the server certificate:")
         t.Log(err)

--- a/gov2/iam/ListAccessKeys/ListAccessKeysv2.go
+++ b/gov2/iam/ListAccessKeys/ListAccessKeysv2.go
@@ -61,7 +61,7 @@ func main() {
         UserName: userName,
     }
 
-    result, err := GetAccessKeys(context.Background(), client, input)
+    result, err := GetAccessKeys(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error retrieving user access keys:")
         fmt.Println(err)

--- a/gov2/iam/ListAccessKeys/ListAccessKeysv2_test.go
+++ b/gov2/iam/ListAccessKeys/ListAccessKeysv2_test.go
@@ -91,7 +91,7 @@ func TestListAccessKeys(t *testing.T) {
         UserName: &globalConfig.UserName,
     }
 
-    result, err := GetAccessKeys(context.Background(), api, input)
+    result, err := GetAccessKeys(context.TODO(), api, input)
     if err != nil {
         fmt.Println("Got an error retrieving user access keys:")
         fmt.Println(err)

--- a/gov2/iam/ListAccountAliases/ListAccountAliasesv2.go
+++ b/gov2/iam/ListAccountAliases/ListAccountAliasesv2.go
@@ -54,7 +54,7 @@ func main() {
         MaxItems: aws.Int32(int32(*maxItems)),
     }
 
-    result, err := GetAccountAliases(context.Background(), client, input)
+    result, err := GetAccountAliases(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error retrieving account aliases")
         fmt.Println(err)

--- a/gov2/iam/ListAccountAliases/ListAccountAliasesv2_test.go
+++ b/gov2/iam/ListAccountAliases/ListAccountAliasesv2_test.go
@@ -80,7 +80,7 @@ func TestListAccountAliases(t *testing.T) {
         MaxItems: aws.Int32(int32(maxItems)),
     }
 
-    result, err := GetAccountAliases(context.Background(), api, input)
+    result, err := GetAccountAliases(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error retrieving account aliases")
         t.Log(err)

--- a/gov2/iam/ListAdmins/ListAdminsv2.go
+++ b/gov2/iam/ListAdmins/ListAdminsv2.go
@@ -209,7 +209,7 @@ func main() {
 
 	client := iam.NewFromConfig(cfg)
 
-	users, admins, err := GetNumUsersAndAdmins(context.Background(), client)
+	users, admins, err := GetNumUsersAndAdmins(context.TODO(), client)
 	if err != nil {
 		fmt.Println("Got an error finding users who are admins:")
 		fmt.Println(err)

--- a/gov2/iam/ListAdmins/ListAdminsv2_test.go
+++ b/gov2/iam/ListAdmins/ListAdminsv2_test.go
@@ -60,7 +60,7 @@ func TestListAdmins(t *testing.T) {
 
 	client := iam.NewFromConfig(cfg)
 
-	users, admins, err := GetNumUsersAndAdmins(context.Background(), client)
+	users, admins, err := GetNumUsersAndAdmins(context.TODO(), client)
 	if err != nil {
 		t.Log("Got an error finding users who are admins:")
 		t.Log(err)

--- a/gov2/iam/ListServerCerts/ListServerCertsv2.go
+++ b/gov2/iam/ListServerCerts/ListServerCertsv2.go
@@ -44,7 +44,7 @@ func main() {
 
     input := &iam.ListServerCertificatesInput{}
 
-    result, err := GetServerCerts(context.Background(), client, input)
+    result, err := GetServerCerts(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error retrieving the server certificates:")
         fmt.Println(err)

--- a/gov2/iam/ListServerCerts/ListServerCertsv2_test.go
+++ b/gov2/iam/ListServerCerts/ListServerCertsv2_test.go
@@ -50,7 +50,7 @@ func TestListServerCertificates(t *testing.T) {
 
     input := &iam.ListServerCertificatesInput{}
 
-    result, err := GetServerCerts(context.Background(), api, input)
+    result, err := GetServerCerts(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error retrieving the server certificates:")
         t.Log(err)

--- a/gov2/iam/ListUsers/ListUsersv2.go
+++ b/gov2/iam/ListUsers/ListUsersv2.go
@@ -58,7 +58,7 @@ func main() {
 		MaxItems: aws.Int32(int32((*maxUsers))),
 	}
 
-	result, err := GetUsers(context.Background(), client, input)
+	result, err := GetUsers(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error retrieving users:")
 		fmt.Println(err)

--- a/gov2/iam/ListUsers/ListUsersv2_test.go
+++ b/gov2/iam/ListUsers/ListUsersv2_test.go
@@ -96,7 +96,7 @@ func TestListUsers(t *testing.T) {
         MaxItems: aws.Int32(int32(maxUsers)),
     }
 
-    result, err := GetUsers(context.Background(), api, input)
+    result, err := GetUsers(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error retrieving users:")
         t.Log(err)

--- a/gov2/iam/UpdateAccessKey/UpdateAccessKeyv2.go
+++ b/gov2/iam/UpdateAccessKey/UpdateAccessKeyv2.go
@@ -58,7 +58,7 @@ func main() {
         UserName:    userName,
     }
 
-    _, err = ActivateKey(context.Background(), client, input)
+    _, err = ActivateKey(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Error", err)
         return

--- a/gov2/iam/UpdateAccessKey/UpdateAccessKeyv2_test.go
+++ b/gov2/iam/UpdateAccessKey/UpdateAccessKeyv2_test.go
@@ -76,7 +76,7 @@ func TestUpdateAccessKey(t *testing.T) {
 		UserName:    &globalConfig.UserName,
 	}
 
-	_, err = ActivateKey(context.Background(), api, input)
+	_, err = ActivateKey(context.TODO(), api, input)
 	if err != nil {
 		t.Log("Error", err)
 		return

--- a/gov2/iam/UpdateServerCert/UpdateServerCertv2.go
+++ b/gov2/iam/UpdateServerCert/UpdateServerCertv2.go
@@ -56,7 +56,7 @@ func main() {
         NewServerCertificateName: newName,
     }
 
-    _, err = RenameServerCert(context.Background(), client, input)
+    _, err = RenameServerCert(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error renaming the server certificate:")
         fmt.Println(err)

--- a/gov2/iam/UpdateServerCert/UpdateServerCertv2_test.go
+++ b/gov2/iam/UpdateServerCert/UpdateServerCertv2_test.go
@@ -75,7 +75,7 @@ func TestUpdateServerCertificate(t *testing.T) {
         NewServerCertificateName: &globalConfig.NewName,
     }
 
-    _, err = RenameServerCert(context.Background(), api, input)
+    _, err = RenameServerCert(context.TODO(), api, input)
     if err != nil {
         fmt.Println("Got an error renaming the server certificate:")
         fmt.Println(err)

--- a/gov2/iam/UpdateUser/UpdateUserv2.go
+++ b/gov2/iam/UpdateUser/UpdateUserv2.go
@@ -55,7 +55,7 @@ func main() {
         NewUserName: newName,
     }
 
-    _, err = RenameUser(context.Background(), client, input)
+    _, err = RenameUser(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error updating user " + *userName)
     }

--- a/gov2/iam/UpdateUser/UpdateUserv2_test.go
+++ b/gov2/iam/UpdateUser/UpdateUserv2_test.go
@@ -69,7 +69,7 @@ func TestUpdateUser(t *testing.T) {
         NewUserName: &globalConfig.NewName,
     }
 
-    _, err = RenameUser(context.Background(), api, input)
+    _, err = RenameUser(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error updating user " + globalConfig.UserName)
     }

--- a/gov2/kms/CreateKey/CreateKeyv2.go
+++ b/gov2/kms/CreateKey/CreateKeyv2.go
@@ -43,7 +43,7 @@ func main() {
 
     input := &kms.CreateKeyInput{}
 
-    result, err := MakeKey(context.Background(), client, input)
+    result, err := MakeKey(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got error creating key:")
         fmt.Println(err)

--- a/gov2/kms/CreateKey/CreateKeyv2_test.go
+++ b/gov2/kms/CreateKey/CreateKeyv2_test.go
@@ -84,7 +84,7 @@ func TestCreateKey(t *testing.T) {
         },
     }
 
-    result, err := MakeKey(context.Background(), api, input)
+    result, err := MakeKey(context.TODO(), api, input)
     if err != nil {
         fmt.Println("Got error creating key:")
         fmt.Println(err)

--- a/gov2/kms/DecryptData/DecryptDatav2.go
+++ b/gov2/kms/DecryptData/DecryptDatav2.go
@@ -61,7 +61,7 @@ func main() {
 		CiphertextBlob: blob,
 	}
 
-	result, err := DecodeData(context.Background(), client, input)
+	result, err := DecodeData(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got error decrypting data: ", err)
 		return

--- a/gov2/kms/DecryptData/DecryptDatav2_test.go
+++ b/gov2/kms/DecryptData/DecryptDatav2_test.go
@@ -73,7 +73,7 @@ func TestDecrypt(t *testing.T) {
         CiphertextBlob: blob,
     }
 
-    resp, err := DecodeData(context.Background(), api, input)
+    resp, err := DecodeData(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error ...:")
         t.Log(err)

--- a/gov2/kms/EncryptData/EncryptDatav2.go
+++ b/gov2/kms/EncryptData/EncryptDatav2.go
@@ -58,7 +58,7 @@ func main() {
 		Plaintext: []byte(*text),
 	}
 
-	result, err := EncryptText(context.Background(), client, input)
+	result, err := EncryptText(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got error encrypting data:")
 		fmt.Println(err)

--- a/gov2/kms/EncryptData/EncryptDatav2_test.go
+++ b/gov2/kms/EncryptData/EncryptDatav2_test.go
@@ -73,7 +73,7 @@ func TestEncrypt(t *testing.T) {
         Plaintext: []byte(globalConfig.Text),
     }
 
-    resp, err := EncryptText(context.Background(), api, input)
+    resp, err := EncryptText(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error ...:")
         t.Log(err)

--- a/gov2/kms/ReEncryptData/ReEncryptDatav2.go
+++ b/gov2/kms/ReEncryptData/ReEncryptDatav2.go
@@ -59,7 +59,7 @@ func main() {
         DestinationKeyId: keyID,
     }
 
-    result, err := ReEncryptText(context.Background(), client, input)
+    result, err := ReEncryptText(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got error reencrypting data:")
         fmt.Println(err)

--- a/gov2/kms/ReEncryptData/ReEncryptDatav2_test.go
+++ b/gov2/kms/ReEncryptData/ReEncryptDatav2_test.go
@@ -75,7 +75,7 @@ func TestReEncrypt(t *testing.T) {
         DestinationKeyId: &globalConfig.KeyID,
     }
 
-    resp, err := ReEncryptText(context.Background(), api, input)
+    resp, err := ReEncryptText(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error ...:")
         t.Log(err)

--- a/gov2/s3/CopyObject/CopyObjectv2.go
+++ b/gov2/s3/CopyObject/CopyObjectv2.go
@@ -60,7 +60,7 @@ func main() {
 		Key:        objectName,
 	}
 
-	_, err = CopyItem(context.Background(), client, input)
+	_, err = CopyItem(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error copying item:")
 		fmt.Println(err)

--- a/gov2/s3/CopyObject/CopyObjectv2_test.go
+++ b/gov2/s3/CopyObject/CopyObjectv2_test.go
@@ -86,7 +86,7 @@ func TestCopyObject(t *testing.T) {
 
 	api := &S3CopyObjectImpl{}
 
-	_, err = CopyItem(context.Background(), *api, &input)
+	_, err = CopyItem(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/s3/CreateBucket/CreateBucketv2.go
+++ b/gov2/s3/CreateBucket/CreateBucketv2.go
@@ -54,7 +54,7 @@ func main() {
 		Bucket: bucket,
 	}
 
-	_, err = MakeBucket(context.Background(), client, input)
+	_, err = MakeBucket(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Could not create bucket " + *bucket)
 	}

--- a/gov2/s3/CreateBucket/CreateBucketv2_test.go
+++ b/gov2/s3/CreateBucket/CreateBucketv2_test.go
@@ -72,7 +72,7 @@ func TestCreateBucket(t *testing.T) {
 
 	api := &S3CreateBucketImpl{}
 
-	resp, err := MakeBucket(context.Background(), *api, &input)
+	resp, err := MakeBucket(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/s3/DeleteBucket/DeleteBucketv2.go
+++ b/gov2/s3/DeleteBucket/DeleteBucketv2.go
@@ -54,7 +54,7 @@ func main() {
 		Bucket: bucket,
 	}
 
-	_, err = RemoveBucket(context.Background(), client, input)
+	_, err = RemoveBucket(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Could not delete bucket " + *bucket)
 	}

--- a/gov2/s3/DeleteBucket/DeleteBucketv2_test.go
+++ b/gov2/s3/DeleteBucket/DeleteBucketv2_test.go
@@ -70,7 +70,7 @@ func TestDeleteBucket(t *testing.T) {
 
 	api := &S3DeleteBucketImpl{}
 
-	_, err = RemoveBucket(context.Background(), *api, &input)
+	_, err = RemoveBucket(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/s3/DeleteObject/DeleteObjectv2.go
+++ b/gov2/s3/DeleteObject/DeleteObjectv2.go
@@ -56,7 +56,7 @@ func main() {
 		Key:    objectName,
 	}
 
-	_, err = DeleteItem(context.Background(), client, input)
+	_, err = DeleteItem(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error deleting item:")
 		fmt.Println(err)

--- a/gov2/s3/DeleteObject/DeleteObjectv2_test.go
+++ b/gov2/s3/DeleteObject/DeleteObjectv2_test.go
@@ -70,7 +70,7 @@ func TestDeleteObject(t *testing.T) {
 
 	api := &S3DeleteObjectImpl{}
 
-	_, err = DeleteItem(context.Background(), *api, &input)
+	_, err = DeleteItem(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/s3/GeneratePresignedURL/GeneratePresignedURLv2.go
+++ b/gov2/s3/GeneratePresignedURL/GeneratePresignedURLv2.go
@@ -64,7 +64,7 @@ func main() {
 
 	psClient := s3.NewPresignClient(client)
 
-	resp, err := GetPresignedURL(context.Background(), psClient, input)
+	resp, err := GetPresignedURL(context.TODO(), psClient, input)
 	if err != nil {
 		fmt.Println("Got an error retrieving pre-signed object:")
 		fmt.Println(err)

--- a/gov2/s3/GeneratePresignedURL/GeneratePresignedURLv2_test.go
+++ b/gov2/s3/GeneratePresignedURL/GeneratePresignedURLv2_test.go
@@ -95,7 +95,7 @@ func TestPresignGetObject(t *testing.T) {
 		Key:    &globalConfig.Key,
 	}
 
-	resp, err := GetPresignedURL(context.Background(), *api, input)
+	resp, err := GetPresignedURL(context.TODO(), *api, input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/s3/GetBucketAcl/GetBucketAclv2.go
+++ b/gov2/s3/GetBucketAcl/GetBucketAclv2.go
@@ -54,7 +54,7 @@ func main() {
 		Bucket: bucket,
 	}
 
-	result, err := FindBucketAcl(context.Background(), client, input)
+	result, err := FindBucketAcl(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error retrieving ACL for " + *bucket)
 	}

--- a/gov2/s3/GetBucketAcl/GetBucketAclv2_test.go
+++ b/gov2/s3/GetBucketAcl/GetBucketAclv2_test.go
@@ -76,7 +76,7 @@ func TestGetBucketAcl(t *testing.T) {
 
 	api := &S3GetBucketAclImpl{}
 
-	resp, err := FindBucketAcl(context.Background(), *api, &input)
+	resp, err := FindBucketAcl(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/s3/GetObjectAcl/GetObjectAclv2.go
+++ b/gov2/s3/GetObjectAcl/GetObjectAclv2.go
@@ -56,7 +56,7 @@ func main() {
 		Key:    objectName,
 	}
 
-	result, err := FindObjectAcl(context.Background(), client, input)
+	result, err := FindObjectAcl(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error getting ACL for " + *objectName)
 		return

--- a/gov2/s3/GetObjectAcl/GetObjectAclv2_test.go
+++ b/gov2/s3/GetObjectAcl/GetObjectAclv2_test.go
@@ -77,7 +77,7 @@ func TestGetObjectAcl(t *testing.T) {
 
 	api := &S3GetObjectAclImpl{}
 
-	resp, err := FindObjectAcl(context.Background(), *api, &input)
+	resp, err := FindObjectAcl(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/s3/ListBuckets/ListBucketsv2.go
+++ b/gov2/s3/ListBuckets/ListBucketsv2.go
@@ -43,7 +43,7 @@ func main() {
 
 	input := &s3.ListBucketsInput{}
 
-	result, err := GetAllBuckets(context.Background(), client, input)
+	result, err := GetAllBuckets(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error retrieving buckets:")
 		fmt.Println(err)

--- a/gov2/s3/ListBuckets/ListBucketsv2_test.go
+++ b/gov2/s3/ListBuckets/ListBucketsv2_test.go
@@ -38,7 +38,7 @@ func TestListBuckets(t *testing.T) {
 
 	api := &S3ListBucketsImpl{}
 
-	resp, err := GetAllBuckets(context.Background(), *api, &input)
+	resp, err := GetAllBuckets(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/s3/ListObjects/ListObjectsv2.go
+++ b/gov2/s3/ListObjects/ListObjectsv2.go
@@ -54,7 +54,7 @@ func main() {
 		Bucket: bucket,
 	}
 
-	resp, err := GetObjects(context.Background(), client, input)
+	resp, err := GetObjects(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got error retrieving list of objects:")
 		fmt.Println(err)

--- a/gov2/s3/ListObjects/ListObjectsv2_test.go
+++ b/gov2/s3/ListObjects/ListObjectsv2_test.go
@@ -77,7 +77,7 @@ func TestListObjects(t *testing.T) {
 
 	api := &S3ListObjectsImpl{}
 
-	resp, err := GetObjects(context.Background(), *api, &input)
+	resp, err := GetObjects(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/s3/PutObject/PutObjectv2.go
+++ b/gov2/s3/PutObject/PutObjectv2.go
@@ -67,7 +67,7 @@ func main() {
 		Body:   file,
 	}
 
-	_, err = PutFile(context.Background(), client, input)
+	_, err = PutFile(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got error uploading file:")
 		fmt.Println(err)

--- a/gov2/s3/PutObject/PutObjectv2_test.go
+++ b/gov2/s3/PutObject/PutObjectv2_test.go
@@ -73,7 +73,7 @@ func TestPubObject(t *testing.T) {
 
 	api := &S3PutObjectImpl{}
 
-	resp, err := PutFile(context.Background(), *api, &input)
+	resp, err := PutFile(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/sns/CreateTopic/CreateTopicv2.go
+++ b/gov2/sns/CreateTopic/CreateTopicv2.go
@@ -55,7 +55,7 @@ func main() {
 		Name: topic,
 	}
 
-	results, err := MakeTopic(context.Background(), client, input)
+	results, err := MakeTopic(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println(err.Error())
 		return

--- a/gov2/sns/CreateTopic/CreateTopicv2_test.go
+++ b/gov2/sns/CreateTopic/CreateTopicv2_test.go
@@ -70,7 +70,7 @@ func TestCreateTopic(t *testing.T) {
 
 	api := &SNSCreateTopicImpl{}
 
-	resp, err := MakeTopic(context.Background(), *api, &input)
+	resp, err := MakeTopic(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/sns/ListSubscriptions/ListSubscriptionsv2.go
+++ b/gov2/sns/ListSubscriptions/ListSubscriptionsv2.go
@@ -43,7 +43,7 @@ func main() {
 
 	input := &sns.ListSubscriptionsInput{}
 
-	result, err := GetSubscriptions(context.Background(), client, input)
+	result, err := GetSubscriptions(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error retrieving the subscriptions:")
 		fmt.Println(err)

--- a/gov2/sns/ListSubscriptions/ListSubscriptionsv2_test.go
+++ b/gov2/sns/ListSubscriptions/ListSubscriptionsv2_test.go
@@ -42,7 +42,7 @@ func TestListSubscriptions(t *testing.T) {
 
 	api := &SNSListSubscriptionsImpl{}
 
-	resp, err := GetSubscriptions(context.Background(), *api, &input)
+	resp, err := GetSubscriptions(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/sns/ListTopics/ListTopicsv2.go
+++ b/gov2/sns/ListTopics/ListTopicsv2.go
@@ -43,7 +43,7 @@ func main() {
 
 	input := &sns.ListTopicsInput{}
 
-	results, err := GetTopics(context.Background(), client, input)
+	results, err := GetTopics(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error retrieving information about the SNS topics:")
 		fmt.Println(err)

--- a/gov2/sns/ListTopics/ListTopicsv2_test.go
+++ b/gov2/sns/ListTopics/ListTopicsv2_test.go
@@ -38,7 +38,7 @@ func TestListTopics(t *testing.T) {
 
 	api := &SNSListTopicsImpl{}
 
-	resp, err := GetTopics(context.Background(), *api, &input)
+	resp, err := GetTopics(context.TODO(), *api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/sns/Publish/Publishv2.go
+++ b/gov2/sns/Publish/Publishv2.go
@@ -58,7 +58,7 @@ func main() {
 		TopicArn: topicARN,
 	}
 
-	result, err := PublishMessage(context.Background(), client, input)
+	result, err := PublishMessage(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error publishing the message:")
 		fmt.Println(err)

--- a/gov2/sns/Publish/Publishv2_test.go
+++ b/gov2/sns/Publish/Publishv2_test.go
@@ -73,7 +73,7 @@ func TestPublish(t *testing.T) {
 
 	api := &SNSPublishImpl{}
 
-	resp, err := PublishMessage(context.Background(), api, &input)
+	resp, err := PublishMessage(context.TODO(), api, &input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/sns/Subscribe/Subscribev2.go
+++ b/gov2/sns/Subscribe/Subscribev2.go
@@ -61,7 +61,7 @@ func main() {
 		TopicArn:              topicARN,
 	}
 
-	result, err := SubscribeTopic(context.Background(), client, input)
+	result, err := SubscribeTopic(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error subscribing to the topic:")
 		fmt.Println(err)

--- a/gov2/sns/Subscribe/Subscribev2_test.go
+++ b/gov2/sns/Subscribe/Subscribev2_test.go
@@ -84,7 +84,7 @@ func TestSubscribe(t *testing.T) {
 		TopicArn:              &globalConfig.TopicArn,
 	}
 
-	_, err = SubscribeTopic(context.Background(), *api, input)
+	_, err = SubscribeTopic(context.TODO(), *api, input)
 	if err != nil {
 		t.Log("Got an error ...:")
 		t.Log(err)

--- a/gov2/sqs/ChangeMsgVisibility/ChangeMsgVisibilityv2.go
+++ b/gov2/sqs/ChangeMsgVisibility/ChangeMsgVisibilityv2.go
@@ -85,7 +85,7 @@ func main() {
     }
 
     // Get URL of queue
-    urlResult, err := GetQueueURL(context.Background(), client, gQInput)
+    urlResult, err := GetQueueURL(context.TODO(), client, gQInput)
     if err != nil {
         fmt.Println("Got an error getting the queue URL:")
         fmt.Println(err)
@@ -100,7 +100,7 @@ func main() {
         VisibilityTimeout: aws.Int32(int32(*visibility)),
     }
 
-    _, err = SetMsgVisibility(context.Background(), client, sVInput)
+    _, err = SetMsgVisibility(context.TODO(), client, sVInput)
     if err != nil {
         fmt.Println("Got an error setting the visibility of the message:")
         fmt.Println(err)

--- a/gov2/sqs/ChangeMsgVisibility/ChangeMsgVisibilityv2_test.go
+++ b/gov2/sqs/ChangeMsgVisibility/ChangeMsgVisibilityv2_test.go
@@ -91,7 +91,7 @@ func TestChangeMsgVisibility(t *testing.T) {
 	}
 
 	// Get URL of queue
-	urlResult, err := GetQueueURL(context.Background(), api, gQInput)
+	urlResult, err := GetQueueURL(context.TODO(), api, gQInput)
 	if err != nil {
 		t.Log("Got an error getting the queue URL:")
 		t.Log(err)
@@ -106,7 +106,7 @@ func TestChangeMsgVisibility(t *testing.T) {
 		VisibilityTimeout: aws.Int32(int32(visibility)),
 	}
 
-	_, err = SetMsgVisibility(context.Background(), api, sVInput)
+	_, err = SetMsgVisibility(context.TODO(), api, sVInput)
 	if err != nil {
 		t.Log("Got an error setting the visibility of the message:")
 		t.Log(err)

--- a/gov2/sqs/ConfigureLPQueue/ConfigureLPQueuev2.go
+++ b/gov2/sqs/ConfigureLPQueue/ConfigureLPQueuev2.go
@@ -90,7 +90,7 @@ func main() {
         QueueName: queue,
     }
 
-    result, err := GetQueueURL(context.Background(), client, gQInput)
+    result, err := GetQueueURL(context.TODO(), client, gQInput)
     if err != nil {
         fmt.Println("Got an error getting the queue URL:")
         fmt.Println(err)
@@ -106,7 +106,7 @@ func main() {
         }),
     }
 
-    _, err = ConfigureLPQueue(context.Background(), client, cQInput)
+    _, err = ConfigureLPQueue(context.TODO(), client, cQInput)
     if err != nil {
         fmt.Println("Got an error configuring the queue:")
         fmt.Println(err)

--- a/gov2/sqs/ConfigureLPQueue/ConfigureLPQueuev2_test.go
+++ b/gov2/sqs/ConfigureLPQueue/ConfigureLPQueuev2_test.go
@@ -83,7 +83,7 @@ func TestConfigureLPQueue(t *testing.T) {
         QueueName: &globalConfig.QueueName,
     }
 
-    result, err := GetQueueURL(context.Background(), api, gQInput)
+    result, err := GetQueueURL(context.TODO(), api, gQInput)
     if err != nil {
         fmt.Println("Got an error getting the queue URL:")
         fmt.Println(err)
@@ -99,7 +99,7 @@ func TestConfigureLPQueue(t *testing.T) {
         }),
     }
 
-    _, err = ConfigureLPQueue(context.Background(), api, cQInput)
+    _, err = ConfigureLPQueue(context.TODO(), api, cQInput)
     if err != nil {
         fmt.Println("Got an error configuring the queue:")
         fmt.Println(err)

--- a/gov2/sqs/CreateLPQueue/CreateLPQueuev2.go
+++ b/gov2/sqs/CreateLPQueue/CreateLPQueuev2.go
@@ -68,7 +68,7 @@ func main() {
         }),
     }
 
-    resp, err := CreateLPQueue(context.Background(), client, input)
+    resp, err := CreateLPQueue(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error creating the long polling queue:")
         fmt.Println(err)

--- a/gov2/sqs/CreateLPQueue/CreateLPQueuev2_test.go
+++ b/gov2/sqs/CreateLPQueue/CreateLPQueuev2_test.go
@@ -77,7 +77,7 @@ func TestCreateQueue(t *testing.T) {
         }),
     }
 
-    resp, err := CreateLPQueue(context.Background(), api, input)
+    resp, err := CreateLPQueue(context.TODO(), api, input)
     if err != nil {
         fmt.Println("Got an error creating the long polling queue:")
         fmt.Println(err)

--- a/gov2/sqs/CreateQueue/CreateQueuev2.go
+++ b/gov2/sqs/CreateQueue/CreateQueuev2.go
@@ -59,7 +59,7 @@ func main() {
 		},
 	}
 
-	result, err := CreateQueue(context.Background(), client, input)
+	result, err := CreateQueue(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error creating the queue:")
 		fmt.Println(err)

--- a/gov2/sqs/CreateQueue/CreateQueuev2_test.go
+++ b/gov2/sqs/CreateQueue/CreateQueuev2_test.go
@@ -77,7 +77,7 @@ func TestCreateQueue(t *testing.T) {
 		},
 	}
 
-	result, err := CreateQueue(context.Background(), api, input)
+	result, err := CreateQueue(context.TODO(), api, input)
 	if err != nil {
 		fmt.Println("Got an error creating the queue:")
 		fmt.Println(err)

--- a/gov2/sqs/DeadLetterQueue/DeadLetterQueuev2.go
+++ b/gov2/sqs/DeadLetterQueue/DeadLetterQueuev2.go
@@ -86,7 +86,7 @@ func main() {
 		QueueName: queue,
 	}
 
-	result, err := GetQueueURL(context.Background(), client, gQInput)
+	result, err := GetQueueURL(context.TODO(), client, gQInput)
 	if err != nil {
 		fmt.Println("Got an error getting the queue URL:")
 		fmt.Println(err)
@@ -117,7 +117,7 @@ func main() {
 		},
 	}
 
-	_, err = ConfigureDeadLetterQueue(context.Background(), client, cQInput)
+	_, err = ConfigureDeadLetterQueue(context.TODO(), client, cQInput)
 	if err != nil {
 		fmt.Println("Got an error configuring the dead-letter queue:")
 		fmt.Println(err)

--- a/gov2/sqs/DeadLetterQueue/DeadLetterQueuev2_test.go
+++ b/gov2/sqs/DeadLetterQueue/DeadLetterQueuev2_test.go
@@ -88,7 +88,7 @@ func TestDeadLetterQueue(t *testing.T) {
 		QueueName: &globalConfig.QueueName,
 	}
 
-	qResult, err := GetQueueURL(context.Background(), api, gQInput)
+	qResult, err := GetQueueURL(context.TODO(), api, gQInput)
 	if err != nil {
 		fmt.Println("Got an error getting the queue URL:")
 		fmt.Println(err)
@@ -102,7 +102,7 @@ func TestDeadLetterQueue(t *testing.T) {
 		QueueName: &globalConfig.DLQueueName,
 	}
 
-	dlResult, err := GetQueueURL(context.Background(), api, gDLQInput)
+	dlResult, err := GetQueueURL(context.TODO(), api, gDLQInput)
 	if err != nil {
 		t.Log("Got an error retrieving URL for dead letter queue:")
 		t.Log(err)
@@ -135,7 +135,7 @@ func TestDeadLetterQueue(t *testing.T) {
 		},
 	}
 
-	_, err = ConfigureDeadLetterQueue(context.Background(), api, cQInput)
+	_, err = ConfigureDeadLetterQueue(context.TODO(), api, cQInput)
 	if err != nil {
 		t.Log("Got an error configuring the dead-letter queue:")
 		t.Log(err)

--- a/gov2/sqs/DeleteMessage/DeleteMessagev2.go
+++ b/gov2/sqs/DeleteMessage/DeleteMessagev2.go
@@ -74,7 +74,7 @@ func main() {
     }
 
     // Get URL of queue
-    result, err := GetQueueURL(context.Background(), client, qUInput)
+    result, err := GetQueueURL(context.TODO(), client, qUInput)
     if err != nil {
         fmt.Println("Got an error getting the queue URL:")
         fmt.Println(err)
@@ -88,7 +88,7 @@ func main() {
         ReceiptHandle: messageHandle,
     }
 
-    _, err = RemoveMessage(context.Background(), client, dMInput)
+    _, err = RemoveMessage(context.TODO(), client, dMInput)
     if err != nil {
         fmt.Println("Got an error deleting the message:")
         fmt.Println(err)

--- a/gov2/sqs/DeleteMessage/DeleteMessagev2_test.go
+++ b/gov2/sqs/DeleteMessage/DeleteMessagev2_test.go
@@ -83,7 +83,7 @@ func TestDeleteMessage(t *testing.T) {
 	}
 
 	// Get URL of queue
-	result, err := GetQueueURL(context.Background(), api, qUInput)
+	result, err := GetQueueURL(context.TODO(), api, qUInput)
 	if err != nil {
 		t.Log("Got an error getting the queue URL:")
 		t.Log(err)
@@ -97,7 +97,7 @@ func TestDeleteMessage(t *testing.T) {
 		ReceiptHandle: &globalConfig.MessageHandle,
 	}
 
-	_, err = RemoveMessage(context.Background(), api, dMInput)
+	_, err = RemoveMessage(context.TODO(), api, dMInput)
 	if err != nil {
 		t.Log("Got an error deleting the message:")
 		t.Log(err)

--- a/gov2/sqs/DeleteQueue/DeleteQueuev2.go
+++ b/gov2/sqs/DeleteQueue/DeleteQueuev2.go
@@ -73,7 +73,7 @@ func main() {
     }
 
     // Get the URL for the queue
-    result, err := GetQueueURL(context.Background(), client, qInput)
+    result, err := GetQueueURL(context.TODO(), client, qInput)
     if err != nil {
         fmt.Println("Got an error getting the queue URL:")
         fmt.Println(err)
@@ -86,7 +86,7 @@ func main() {
         QueueUrl: queueURL,
     }
 
-    _, err = DeleteQueue(context.Background(), client, dqInput)
+    _, err = DeleteQueue(context.TODO(), client, dqInput)
     if err != nil {
         fmt.Println("Got an error deleting the queue:")
         fmt.Println(err)

--- a/gov2/sqs/DeleteQueue/DeleteQueuev2_test.go
+++ b/gov2/sqs/DeleteQueue/DeleteQueuev2_test.go
@@ -81,7 +81,7 @@ func TestDeleteQueue(t *testing.T) {
     }
 
     // Get the URL for the queue
-    result, err := GetQueueURL(context.Background(), api, qInput)
+    result, err := GetQueueURL(context.TODO(), api, qInput)
     if err != nil {
         t.Log("Got an error getting the queue URL:")
         t.Log(err)
@@ -94,7 +94,7 @@ func TestDeleteQueue(t *testing.T) {
         QueueUrl: queueURL,
     }
 
-    _, err = DeleteQueue(context.Background(), api, dqInput)
+    _, err = DeleteQueue(context.TODO(), api, dqInput)
     if err != nil {
         t.Log("Got an error deleting the queue:")
         t.Log(err)

--- a/gov2/sqs/GetQueueURL/GetQueueURLv2.go
+++ b/gov2/sqs/GetQueueURL/GetQueueURLv2.go
@@ -54,7 +54,7 @@ func main() {
         QueueName: queue,
     }
 
-    result, err := GetQueueURL(context.Background(), client, input)
+    result, err := GetQueueURL(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error getting the queue URL:")
         fmt.Println(err)

--- a/gov2/sqs/GetQueueURL/GetQueueURLv2_test.go
+++ b/gov2/sqs/GetQueueURL/GetQueueURLv2_test.go
@@ -73,7 +73,7 @@ func TestGetQueueUrl(t *testing.T) {
         QueueName: &globalConfig.QueueName,
     }
 
-    result, err := GetQueueURL(context.Background(), api, input)
+    result, err := GetQueueURL(context.TODO(), api, input)
     if err != nil {
         t.Log("Got an error getting the queue URL:")
         t.Log(err)

--- a/gov2/sqs/ListQueues/ListQueuesv2.go
+++ b/gov2/sqs/ListQueues/ListQueuesv2.go
@@ -43,7 +43,7 @@ func main() {
 
     input := &sqs.ListQueuesInput{}
 
-    result, err := GetQueues(context.Background(), client, input)
+    result, err := GetQueues(context.TODO(), client, input)
     if err != nil {
         fmt.Println("Got an error retrieving queue URLs:")
         fmt.Println(err)

--- a/gov2/sqs/ListQueues/ListQueuesv2_test.go
+++ b/gov2/sqs/ListQueues/ListQueuesv2_test.go
@@ -39,7 +39,7 @@ func TestListQueues(t *testing.T) {
 
     input := &sqs.ListQueuesInput{}
 
-    resp, err := GetQueues(context.Background(), *api, input)
+    resp, err := GetQueues(context.TODO(), *api, input)
     if err != nil {
         t.Log("Got an error ...:")
         t.Log(err)

--- a/gov2/sqs/ReceiveLPMessage/ReceiveLPMessagev2.go
+++ b/gov2/sqs/ReceiveLPMessage/ReceiveLPMessagev2.go
@@ -83,7 +83,7 @@ func main() {
         QueueName: queue,
     }
 
-    result, err := GetQueueURL(context.Background(), client, qInput)
+    result, err := GetQueueURL(context.TODO(), client, qInput)
     if err != nil {
         fmt.Println("Got an error getting the queue URL:")
         fmt.Println(err)
@@ -104,7 +104,7 @@ func main() {
         WaitTimeSeconds: aws.Int32(int32(*waitTime)),
     }
 
-    resp, err := GetLPMessages(context.Background(), client, mInput)
+    resp, err := GetLPMessages(context.TODO(), client, mInput)
     if err != nil {
         fmt.Println("Got an error receiving messages:")
         fmt.Println(err)

--- a/gov2/sqs/ReceiveLPMessage/ReceiveLPMessagev2_test.go
+++ b/gov2/sqs/ReceiveLPMessage/ReceiveLPMessagev2_test.go
@@ -96,7 +96,7 @@ func TestGetLPMsg(t *testing.T) {
         QueueName: &globalConfig.QueueName,
     }
 
-    result, err := GetQueueURL(context.Background(), api, qInput)
+    result, err := GetQueueURL(context.TODO(), api, qInput)
     if err != nil {
         t.Log("Got an error getting the queue URL:")
         t.Log(err)
@@ -117,7 +117,7 @@ func TestGetLPMsg(t *testing.T) {
         WaitTimeSeconds: aws.Int32(int32(waitTime)),
     }
 
-    resp, err := GetLPMessages(context.Background(), api, mInput)
+    resp, err := GetLPMessages(context.TODO(), api, mInput)
     if err != nil {
         t.Log("Got an error receiving messages:")
         t.Log(err)

--- a/gov2/sqs/ReceiveMessage/ReceiveMessagev2.go
+++ b/gov2/sqs/ReceiveMessage/ReceiveMessagev2.go
@@ -84,7 +84,7 @@ func main() {
 	}
 
 	// Get URL of queue
-	urlResult, err := GetQueueURL(context.Background(), client, gQInput)
+	urlResult, err := GetQueueURL(context.TODO(), client, gQInput)
 	if err != nil {
 		fmt.Println("Got an error getting the queue URL:")
 		fmt.Println(err)
@@ -102,7 +102,7 @@ func main() {
 		VisibilityTimeout:   aws.Int32(int32(*timeout)),
 	}
 
-	msgResult, err := GetMessages(context.Background(), client, gMInput)
+	msgResult, err := GetMessages(context.TODO(), client, gMInput)
 	if err != nil {
 		fmt.Println("Got an error receiving messages:")
 		fmt.Println(err)

--- a/gov2/sqs/ReceiveMessage/ReceiveMessagev2_test.go
+++ b/gov2/sqs/ReceiveMessage/ReceiveMessagev2_test.go
@@ -103,7 +103,7 @@ func TestReceiveMessage(t *testing.T) {
     }
 
     // Get URL of queue
-    urlResult, err := GetQueueURL(context.Background(), api, gQInput)
+    urlResult, err := GetQueueURL(context.TODO(), api, gQInput)
     if err != nil {
         t.Log("Got an error getting the queue URL:")
         t.Log(err)
@@ -121,7 +121,7 @@ func TestReceiveMessage(t *testing.T) {
         VisibilityTimeout:   aws.Int32(int32(timeout)),
     }
 
-    msgResult, err := GetMessages(context.Background(), api, gMInput)
+    msgResult, err := GetMessages(context.TODO(), api, gMInput)
     if err != nil {
         t.Log("Got an error receiving messages:")
         t.Log(err)

--- a/gov2/sqs/SendMessage/SendMessagev2.go
+++ b/gov2/sqs/SendMessage/SendMessagev2.go
@@ -77,7 +77,7 @@ func main() {
         QueueName: queue,
     }
 
-    result, err := GetQueueURL(context.Background(), client, gQInput)
+    result, err := GetQueueURL(context.TODO(), client, gQInput)
     if err != nil {
         fmt.Println("Got an error getting the queue URL:")
         fmt.Println(err)
@@ -106,7 +106,7 @@ func main() {
         QueueUrl:    queueURL,
     }
 
-    resp, err := SendMsg(context.Background(), client, sMInput)
+    resp, err := SendMsg(context.TODO(), client, sMInput)
     if err != nil {
         fmt.Println("Got an error sending the message:")
         fmt.Println(err)

--- a/gov2/sqs/SendMessage/SendMessagev2_test.go
+++ b/gov2/sqs/SendMessage/SendMessagev2_test.go
@@ -90,7 +90,7 @@ func TestSendMessage(t *testing.T) {
         QueueName: &globalConfig.QueueName,
     }
 
-    result, err := GetQueueURL(context.Background(), api, gQInput)
+    result, err := GetQueueURL(context.TODO(), api, gQInput)
     if err != nil {
         fmt.Println("Got an error getting the queue URL:")
         fmt.Println(err)
@@ -119,7 +119,7 @@ func TestSendMessage(t *testing.T) {
         QueueUrl:    queueURL,
     }
 
-    resp, err := SendMsg(context.Background(), api, sMInput)
+    resp, err := SendMsg(context.TODO(), api, sMInput)
     if err != nil {
         fmt.Println("Got an error sending the message:")
         fmt.Println(err)

--- a/gov2/ssm/DeleteParameter/DeleteParameterv2.go
+++ b/gov2/ssm/DeleteParameter/DeleteParameterv2.go
@@ -55,7 +55,7 @@ func main() {
         Name: parameterName,
     }
 
-    _, err = RemoveParameter(context.Background(), client, input)
+    _, err = RemoveParameter(context.TODO(), client, input)
     if err != nil {
         fmt.Println(err.Error())
         return

--- a/gov2/ssm/DeleteParameter/DeleteParameterv2_test.go
+++ b/gov2/ssm/DeleteParameter/DeleteParameterv2_test.go
@@ -67,7 +67,7 @@ func TestDeleteParameter(t *testing.T) {
         Name: &globalConfig.ParameterName,
     }
 
-    _, err = RemoveParameter(context.Background(), *api, input)
+    _, err = RemoveParameter(context.TODO(), *api, input)
     if err != nil {
         t.Log("Got an error ...:")
         t.Log(err)

--- a/gov2/ssm/GetParameter/GetParameterv2.go
+++ b/gov2/ssm/GetParameter/GetParameterv2.go
@@ -55,7 +55,7 @@ func main() {
         Name: parameterName,
     }
 
-    results, err := FindParameter(context.Background(), client, input)
+    results, err := FindParameter(context.TODO(), client, input)
     if err != nil {
         fmt.Println(err.Error())
         return

--- a/gov2/ssm/GetParameter/GetParameterv2_test.go
+++ b/gov2/ssm/GetParameter/GetParameterv2_test.go
@@ -73,7 +73,7 @@ func TestGetParameter(t *testing.T) {
         Name: &globalConfig.ParameterName,
     }
 
-    resp, err := FindParameter(context.Background(), *api, input)
+    resp, err := FindParameter(context.TODO(), *api, input)
     if err != nil {
         t.Log("Got an error ...:")
         t.Log(err)

--- a/gov2/ssm/PutParameter/PutParameterv2.go
+++ b/gov2/ssm/PutParameter/PutParameterv2.go
@@ -65,7 +65,7 @@ func main() {
         Type:  types.ParameterTypeString,
     }
 
-    results, err := AddStringParameter(context.Background(), client, input)
+    results, err := AddStringParameter(context.TODO(), client, input)
     if err != nil {
         fmt.Println(err.Error())
         return

--- a/gov2/ssm/PutParameter/PutParameterv2_test.go
+++ b/gov2/ssm/PutParameter/PutParameterv2_test.go
@@ -74,7 +74,7 @@ func TestPutParameter(t *testing.T) {
         Type:  types.ParameterTypeString,
     }
 
-    resp, err := AddStringParameter(context.Background(), *api, input)
+    resp, err := AddStringParameter(context.TODO(), *api, input)
     if err != nil {
         t.Log("Got an error ...:")
         t.Log(err)

--- a/gov2/sts/AssumeRole/AssumeRolev2.go
+++ b/gov2/sts/AssumeRole/AssumeRolev2.go
@@ -56,7 +56,7 @@ func main() {
 		RoleSessionName: sessionName,
 	}
 
-	result, err := TakeRole(context.Background(), client, input)
+	result, err := TakeRole(context.TODO(), client, input)
 	if err != nil {
 		fmt.Println("Got an error assuming the role:")
 		fmt.Println(err)

--- a/gov2/sts/AssumeRole/AssumeRolev2_test.go
+++ b/gov2/sts/AssumeRole/AssumeRolev2_test.go
@@ -79,7 +79,7 @@ func TestAssumeRole(t *testing.T) {
 		RoleSessionName: &globalConfig.SessionName,
 	}
 
-	resp, err := TakeRole(context.Background(), api, input)
+	resp, err := TakeRole(context.TODO(), api, input)
 	if err != nil {
 		fmt.Println("Got an error assuming the role:")
 		fmt.Println(err)


### PR DESCRIPTION
Some API calls were using context.Background()

*Description of changes:*
Replaced with context.TOD()

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
