### PR TITLE
Removed unnecessary variables from API calls

### DIFF
--- a/gov2/cloudwatch/CreateCustomMetric/CreateCustomMetricv2.go
+++ b/gov2/cloudwatch/CreateCustomMetric/CreateCustomMetricv2.go
@@ -30,9 +30,7 @@ type CWPutMetricDataAPI interface {
 //     If success, a PutMetricDataOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to PutMetricData
 func CreateCustomMetric(c context.Context, api CWPutMetricDataAPI, input *cloudwatch.PutMetricDataInput) (*cloudwatch.PutMetricDataOutput, error) {
-	resp, err := api.PutMetricData(c, input)
-
-	return resp, err
+	return api.PutMetricData(c, input)
 }
 
 func main() {

--- a/gov2/cloudwatch/CreateEnableMetricAlarm/CreateEnableMetricAlarmv2.go
+++ b/gov2/cloudwatch/CreateEnableMetricAlarm/CreateEnableMetricAlarmv2.go
@@ -34,9 +34,7 @@ type CWEnableAlarmAPI interface {
 //     If success, a PutMetricAlarmOutput object containing the result of the service call and nil
 //     Otherwise, the error from a call to PutMetricAlarm
 func CreateMetricAlarm(c context.Context, api CWEnableAlarmAPI, input *cloudwatch.PutMetricAlarmInput) (*cloudwatch.PutMetricAlarmOutput, error) {
-	resp, err := api.PutMetricAlarm(c, input)
-
-	return resp, err
+	return api.PutMetricAlarm(c, input)
 }
 
 // EnableAlarm enables the specified Amazon CloudWatch alarm

--- a/gov2/cloudwatch/DescribeAlarms/DescribeAlarmsv2.go
+++ b/gov2/cloudwatch/DescribeAlarms/DescribeAlarmsv2.go
@@ -28,9 +28,7 @@ type CWDescribeAlarmsAPI interface {
 //     If success, a DescribeAlarmsOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to DescribeAlarms
 func ListAlarms(c context.Context, api CWDescribeAlarmsAPI, input *cloudwatch.DescribeAlarmsInput) (*cloudwatch.DescribeAlarmsOutput, error) {
-	resp, err := api.DescribeAlarms(c, input)
-
-	return resp, err
+	return api.DescribeAlarms(c, input)
 }
 
 func main() {

--- a/gov2/cloudwatch/DisableAlarm/DisableAlarmv2.go
+++ b/gov2/cloudwatch/DisableAlarm/DisableAlarmv2.go
@@ -29,9 +29,7 @@ type CWDisableAlarmAPI interface {
 //     If success, a DisableAlarmActionsOutput object containing the result of the service call and nil
 //     Otherwise, nil and the error from the call to DisableAlarmActions
 func DisableAlarm(c context.Context, api CWDisableAlarmAPI, input *cloudwatch.DisableAlarmActionsInput) (*cloudwatch.DisableAlarmActionsOutput, error) {
-	resp, err := api.DisableAlarmActions(c, input)
-
-	return resp, err
+	return api.DisableAlarmActions(c, input)
 }
 
 func main() {

--- a/gov2/cloudwatch/ListMetrics/ListMetricsv2.go
+++ b/gov2/cloudwatch/ListMetrics/ListMetricsv2.go
@@ -29,9 +29,7 @@ type CWListMetricsAPI interface {
 //     If success, a ListMetricsOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to ListMetrics
 func GetMetrics(c context.Context, api CWListMetricsAPI, input *cloudwatch.ListMetricsInput) (*cloudwatch.ListMetricsOutput, error) {
-	result, err := api.ListMetrics(c, input)
-
-	return result, err
+	return api.ListMetrics(c, input)
 }
 
 func main() {

--- a/gov2/cloudwatch/PutEvent/PutEventv2.go
+++ b/gov2/cloudwatch/PutEvent/PutEventv2.go
@@ -77,9 +77,7 @@ func getEventInfo(eventFile string) (Event, error) {
 //     If success, a PutEventsOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to PutEvents
 func CreateEvent(c context.Context, api CWEPutEventsAPI, input *cloudwatchevents.PutEventsInput) (*cloudwatchevents.PutEventsOutput, error) {
-	resp, err := api.PutEvents(c, input)
-
-	return resp, err
+	return api.PutEvents(c, input)
 }
 
 func main() {

--- a/gov2/dynamodb/DescribeTable/DescribeTablev2.go
+++ b/gov2/dynamodb/DescribeTable/DescribeTablev2.go
@@ -22,9 +22,7 @@ type DynamoDBDescribeTableAPI interface {
 
 // GetTableInfo retrieves information about the table.
 func GetTableInfo(c context.Context, api DynamoDBDescribeTableAPI, input *dynamodb.DescribeTableInput) (*dynamodb.DescribeTableOutput, error) {
-	resp, err := api.DescribeTable(c, input)
-
-	return resp, err
+	return api.DescribeTable(c, input)
 }
 
 func main() {

--- a/gov2/dynamodb/ScanItems/ScanItemsv2.go
+++ b/gov2/dynamodb/ScanItems/ScanItemsv2.go
@@ -43,9 +43,7 @@ type Item struct {
 //     If successful, a ScanOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to Scan.
 func GetItems(c context.Context, api DynamoDBScanAPI, input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) {
-	resp, err := api.Scan(c, input)
-
-	return resp, err
+	return api.Scan(c, input)
 }
 
 // Get the items above a minimum rating in a specific year.

--- a/gov2/ec2/CreateImage/CreateImagev2.go
+++ b/gov2/ec2/CreateImage/CreateImagev2.go
@@ -31,9 +31,7 @@ type EC2CreateImageAPI interface {
 //     If success, a CreateImageOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CreateImage.
 func MakeImage(c context.Context, api EC2CreateImageAPI, input *ec2.CreateImageInput) (*ec2.CreateImageOutput, error) {
-    resp, err := api.CreateImage(c, input)
-
-    return resp, err
+    return api.CreateImage(c, input)
 }
 
 func main() {

--- a/gov2/ec2/CreateInstance/CreateInstancev2.go
+++ b/gov2/ec2/CreateInstance/CreateInstancev2.go
@@ -35,9 +35,7 @@ type EC2CreateInstanceAPI interface {
 //     If success, a RunInstancesOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to RunInstances.
 func MakeInstance(c context.Context, api EC2CreateInstanceAPI, input *ec2.RunInstancesInput) (*ec2.RunInstancesOutput, error) {
-    result, err := api.RunInstances(c, input)
-
-    return result, err
+    return api.RunInstances(c, input)
 }
 
 // MakeTags creates tags for an Amazon Elastic Compute Cloud (Amazon EC2) instance.
@@ -49,9 +47,7 @@ func MakeInstance(c context.Context, api EC2CreateInstanceAPI, input *ec2.RunIns
 //     If success, a CreateTagsOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CreateTags.
 func MakeTags(c context.Context, api EC2CreateInstanceAPI, input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
-    result, err := api.CreateTags(c, input)
-
-    return result, err
+    return api.CreateTags(c, input)
 }
 
 func main() {

--- a/gov2/ec2/DescribeInstances/DescribeInstancesv2.go
+++ b/gov2/ec2/DescribeInstances/DescribeInstancesv2.go
@@ -28,9 +28,7 @@ type EC2DescribeInstancesAPI interface {
 //     If success, a DescribeInstancesOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to DescribeInstances.
 func GetInstances(c context.Context, api EC2DescribeInstancesAPI, input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
-    result, err := api.DescribeInstances(c, input)
-
-    return result, err
+    return api.DescribeInstances(c, input)
 }
 
 func main() {

--- a/gov2/ec2/DescribeVpcEndpoints/DescribeVpcEndpointsv2.go
+++ b/gov2/ec2/DescribeVpcEndpoints/DescribeVpcEndpointsv2.go
@@ -32,8 +32,7 @@ type EC2DescribeVpcEndpointConnectionsAPI interface {
 func GetConnectionInfo(c context.Context,
 	api EC2DescribeVpcEndpointConnectionsAPI,
 	input *ec2.DescribeVpcEndpointConnectionsInput) (*ec2.DescribeVpcEndpointConnectionsOutput, error) {
-	resp, err := api.DescribeVpcEndpointConnections(context.Background(), input)
-	return resp, err
+	return api.DescribeVpcEndpointConnections(context.Background(), input)
 }
 
 func main() {

--- a/gov2/iam/AccessKeyLastUsed/AccessKeyLastUsedv2.go
+++ b/gov2/iam/AccessKeyLastUsed/AccessKeyLastUsedv2.go
@@ -29,9 +29,7 @@ type IAMGetAccessKeyLastUsedAPI interface {
 //     If successful, a GetAccessKeyLastUsedOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetAccessKeyLastUsed.
 func WhenWasKeyUsed(c context.Context, api IAMGetAccessKeyLastUsedAPI, input *iam.GetAccessKeyLastUsedInput) (*iam.GetAccessKeyLastUsedOutput, error) {
-	result, err := api.GetAccessKeyLastUsed(c, input)
-
-	return result, err
+	return api.GetAccessKeyLastUsed(c, input)
 }
 
 func main() {

--- a/gov2/iam/AttachUserPolicy/AttachUserPolicyv2.go
+++ b/gov2/iam/AttachUserPolicy/AttachUserPolicyv2.go
@@ -29,9 +29,7 @@ type IAMAttachRolePolicyAPI interface {
 //     If successful, an AttachRolePolicyOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to AttachRolePolicy.
 func AttachDynamoFullPolicy(c context.Context, api IAMAttachRolePolicyAPI, input *iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error) {
-	result, err := api.AttachRolePolicy(c, input)
-
-	return result, err
+	return api.AttachRolePolicy(c, input)
 }
 
 func main() {

--- a/gov2/iam/CreateAccessKey/CreateAccessKeyv2.go
+++ b/gov2/iam/CreateAccessKey/CreateAccessKeyv2.go
@@ -29,9 +29,7 @@ type IAMCreateAccessKeyAPI interface {
 //     If successful, a CreateAccessKeyOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CreateAccessKey.
 func MakeAccessKey(c context.Context, api IAMCreateAccessKeyAPI, input *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
-    result, err := api.CreateAccessKey(c, input)
-
-    return result, err
+    return api.CreateAccessKey(c, input)
 }
 
 func main() {

--- a/gov2/iam/CreateAccountAlias/CreateAccountAliasv2.go
+++ b/gov2/iam/CreateAccountAlias/CreateAccountAliasv2.go
@@ -29,9 +29,7 @@ type IAMCreateAccountAliasAPI interface {
 //     If successful, a CreateAccountAliasOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CreateAccountAlias.
 func MakeAccountAlias(c context.Context, api IAMCreateAccountAliasAPI, input *iam.CreateAccountAliasInput) (*iam.CreateAccountAliasOutput, error) {
-    results, err := api.CreateAccountAlias(c, input)
-
-    return results, err
+    return api.CreateAccountAlias(c, input)
 }
 
 func main() {

--- a/gov2/iam/CreatePolicy/CreatePolicyv2.go
+++ b/gov2/iam/CreatePolicy/CreatePolicyv2.go
@@ -76,9 +76,7 @@ func CreatePolicyDoc() ([]byte, error) {
 //     If successful, a CreatePolicyOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CreatePolicy.
 func MakePolicy(c context.Context, api IAMCreatePolicyAPI, input *iam.CreatePolicyInput) (*iam.CreatePolicyOutput, error) {
-    result, err := api.CreatePolicy(c, input)
-
-    return result, err
+    return api.CreatePolicy(c, input)
 }
 
 func main() {

--- a/gov2/iam/CreateUser/CreateUserv2.go
+++ b/gov2/iam/CreateUser/CreateUserv2.go
@@ -29,9 +29,7 @@ type IAMCreateUserAPI interface {
 //     If successful, a CreateUserOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CreateUser.
 func MakeUser(c context.Context, api IAMCreateUserAPI, input *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
-	results, err := api.CreateUser(c, input)
-
-	return results, err
+	return api.CreateUser(c, input)
 }
 
 func main() {

--- a/gov2/iam/DeleteAccessKey/DeleteAccessKeyv2.go
+++ b/gov2/iam/DeleteAccessKey/DeleteAccessKeyv2.go
@@ -29,9 +29,7 @@ type IAMDeleteAccessKeyAPI interface {
 //     If successful, a DeleteAccessKeyOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to DeleteAccessKey.
 func RemoveAccessKey(c context.Context, api IAMDeleteAccessKeyAPI, input *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
-    results, err := api.DeleteAccessKey(c, input)
-
-    return results, err
+    return api.DeleteAccessKey(c, input)
 }
 
 func main() {

--- a/gov2/iam/DeleteAccountAlias/DeleteAccountAliasv2.go
+++ b/gov2/iam/DeleteAccountAlias/DeleteAccountAliasv2.go
@@ -29,9 +29,7 @@ type IAMDeleteAccountAliasAPI interface {
 //     If successful, a DeleteAccountAliasOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to DeleteAccountAlias.
 func RemoveAccountAlias(c context.Context, api IAMDeleteAccountAliasAPI, input *iam.DeleteAccountAliasInput) (*iam.DeleteAccountAliasOutput, error) {
-	result, err := api.DeleteAccountAlias(c, input)
-
-	return result, err
+	return api.DeleteAccountAlias(c, input)
 }
 
 func main() {

--- a/gov2/iam/DeleteServerCert/DeleteServerCertv2.go
+++ b/gov2/iam/DeleteServerCert/DeleteServerCertv2.go
@@ -29,9 +29,7 @@ type IAMDeleteServerCertificateAPI interface {
 //     If successful, a DeleteServerCertificateOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to DeleteServerCertificate.
 func DeleteServerCert(c context.Context, api IAMDeleteServerCertificateAPI, input *iam.DeleteServerCertificateInput) (*iam.DeleteServerCertificateOutput, error) {
-    result, err := api.DeleteServerCertificate(c, input)
-
-    return result, err
+    return api.DeleteServerCertificate(c, input)
 }
 
 func main() {

--- a/gov2/iam/DeleteUser/DeleteUserv2.go
+++ b/gov2/iam/DeleteUser/DeleteUserv2.go
@@ -29,9 +29,7 @@ type IAMDeleteUserAPI interface {
 //     If successful, a DeleteUserOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to DeleteUser.
 func RemoveUser(c context.Context, api IAMDeleteUserAPI, input *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
-    result, err := api.DeleteUser(c, input)
-
-    return result, err
+    return api.DeleteUser(c, input)
 }
 
 func main() {

--- a/gov2/iam/DetachUserPolicy/DetachUserPolicyv2.go
+++ b/gov2/iam/DetachUserPolicy/DetachUserPolicyv2.go
@@ -29,9 +29,7 @@ type IAMDetachRolePolicyAPI interface {
 //     If successful, a DetachRolePolicyOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to DetachRolePolicy.
 func DetachDynamoFullPolicy(c context.Context, api IAMDetachRolePolicyAPI, input *iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error) {
-    result, err := api.DetachRolePolicy(c, input)
-
-    return result, err
+    return api.DetachRolePolicy(c, input)
 }
 
 func main() {

--- a/gov2/iam/GetPolicy/GetPolicyv2.go
+++ b/gov2/iam/GetPolicy/GetPolicyv2.go
@@ -29,9 +29,7 @@ type IAMGetPolicyAPI interface {
 //     If successful, a GetPolicyOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetPolicy.
 func GetPolicyDescription(c context.Context, api IAMGetPolicyAPI, input *iam.GetPolicyInput) (*iam.GetPolicyOutput, error) {
-	result, err := api.GetPolicy(c, input)
-
-	return result, err
+	return api.GetPolicy(c, input)
 }
 
 func main() {

--- a/gov2/iam/GetServerCert/GetServerCertv2.go
+++ b/gov2/iam/GetServerCert/GetServerCertv2.go
@@ -29,9 +29,7 @@ type IAMGetServerCertificateAPI interface {
 //     If successful, a GetServerCertificateOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetServerCertificate.
 func FindServerCert(c context.Context, api IAMGetServerCertificateAPI, input *iam.GetServerCertificateInput) (*iam.GetServerCertificateOutput, error) {
-	result, err := api.GetServerCertificate(c, input)
-
-	return result, err
+	return api.GetServerCertificate(c, input)
 }
 
 func main() {

--- a/gov2/iam/ListAccessKeys/ListAccessKeysv2.go
+++ b/gov2/iam/ListAccessKeys/ListAccessKeysv2.go
@@ -30,9 +30,7 @@ type IAMListAccessKeysAPI interface {
 //     If successful, a ListAccessKeysOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to ListAccessKeys.
 func GetAccessKeys(c context.Context, api IAMListAccessKeysAPI, input *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
-    result, err := api.ListAccessKeys(c, input)
-
-    return result, err
+    return api.ListAccessKeys(c, input)
 }
 
 func main() {

--- a/gov2/iam/ListAccountAliases/ListAccountAliasesv2.go
+++ b/gov2/iam/ListAccountAliases/ListAccountAliasesv2.go
@@ -30,9 +30,7 @@ type IAMListAccountAliasesAPI interface {
 //     If successful, a ListAccountAliasesOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to ListAccountAliases.
 func GetAccountAliases(c context.Context, api IAMListAccountAliasesAPI, input *iam.ListAccountAliasesInput) (*iam.ListAccountAliasesOutput, error) {
-    result, err := api.ListAccountAliases(c, input)
-
-    return result, err
+    return api.ListAccountAliases(c, input)
 }
 
 func main() {

--- a/gov2/iam/ListServerCerts/ListServerCertsv2.go
+++ b/gov2/iam/ListServerCerts/ListServerCertsv2.go
@@ -29,9 +29,7 @@ type IAMListServerCertificatesAPI interface {
 //     If successful, a ListServerCertificatesOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to ListServerCertificates.
 func GetServerCerts(c context.Context, api IAMListServerCertificatesAPI, input *iam.ListServerCertificatesInput) (*iam.ListServerCertificatesOutput, error) {
-    result, err := api.ListServerCertificates(c, input)
-
-    return result, err
+    return api.ListServerCertificates(c, input)
 }
 
 func main() {

--- a/gov2/iam/ListUsers/ListUsersv2.go
+++ b/gov2/iam/ListUsers/ListUsersv2.go
@@ -30,9 +30,7 @@ type IAMListUsersAPI interface {
 //     If successful, a ListUsersOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to ListUsers.
 func GetUsers(c context.Context, api IAMListUsersAPI, input *iam.ListUsersInput) (*iam.ListUsersOutput, error) {
-	result, err := api.ListUsers(c, input)
-
-	return result, err
+	return api.ListUsers(c, input)
 }
 
 func main() {

--- a/gov2/iam/UpdateAccessKey/UpdateAccessKeyv2.go
+++ b/gov2/iam/UpdateAccessKey/UpdateAccessKeyv2.go
@@ -30,9 +30,7 @@ type IAMUpdateAccessKeyAPI interface {
 //     If successful, a UpdateAccessKeyOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to UpdateAccessKey.
 func ActivateKey(c context.Context, api IAMUpdateAccessKeyAPI, input *iam.UpdateAccessKeyInput) (*iam.UpdateAccessKeyOutput, error) {
-    results, err := api.UpdateAccessKey(c, input)
-
-    return results, err
+    return api.UpdateAccessKey(c, input)
 }
 
 func main() {

--- a/gov2/iam/UpdateServerCert/UpdateServerCertv2.go
+++ b/gov2/iam/UpdateServerCert/UpdateServerCertv2.go
@@ -29,9 +29,7 @@ type IAMUpdateServerCertificateAPI interface {
 //     If successful, a (*iam.UpdateServerCertificateOutput, error)Output object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to (*iam.UpdateServerCertificateOutput, error).
 func RenameServerCert(c context.Context, api IAMUpdateServerCertificateAPI, input *iam.UpdateServerCertificateInput) (*iam.UpdateServerCertificateOutput, error) {
-    result, err := api.UpdateServerCertificate(c, input)
-
-    return result, err
+    return api.UpdateServerCertificate(c, input)
 }
 
 func main() {

--- a/gov2/iam/UpdateUser/UpdateUserv2.go
+++ b/gov2/iam/UpdateUser/UpdateUserv2.go
@@ -29,8 +29,7 @@ type IAMUpdateUserAPI interface {
 //     If successful, a UpdateUserOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to UpdateUser.
 func RenameUser(c context.Context, api IAMUpdateUserAPI, input *iam.UpdateUserInput) (*iam.UpdateUserOutput, error) {
-    result, err := api.UpdateUser(c, input)
-    return result, err
+    return api.UpdateUser(c, input)
 }
 
 func main() {

--- a/gov2/kms/CreateKey/CreateKeyv2.go
+++ b/gov2/kms/CreateKey/CreateKeyv2.go
@@ -28,9 +28,7 @@ type KMSCreateKeyAPI interface {
 //     If success, a CreateKeyOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CreateKey.
 func MakeKey(c context.Context, api KMSCreateKeyAPI, input *kms.CreateKeyInput) (*kms.CreateKeyOutput, error) {
-    result, err := api.CreateKey(c, input)
-
-    return result, err
+    return api.CreateKey(c, input)
 }
 
 func main() {

--- a/gov2/kms/DecryptData/DecryptDatav2.go
+++ b/gov2/kms/DecryptData/DecryptDatav2.go
@@ -30,9 +30,7 @@ type KMSDecryptAPI interface {
 //     If success, a DecryptOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to Decrypt.
 func DecodeData(c context.Context, api KMSDecryptAPI, input *kms.DecryptInput) (*kms.DecryptOutput, error) {
-	result, err := api.Decrypt(c, input)
-
-	return result, err
+	return api.Decrypt(c, input)
 }
 
 func main() {

--- a/gov2/kms/EncryptData/EncryptDatav2.go
+++ b/gov2/kms/EncryptData/EncryptDatav2.go
@@ -30,9 +30,7 @@ type KMSEncryptAPI interface {
 //     If success, an EncryptOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to Encrypt.
 func EncryptText(c context.Context, api KMSEncryptAPI, input *kms.EncryptInput) (*kms.EncryptOutput, error) {
-	result, err := api.Encrypt(c, input)
-
-	return result, err
+	return api.Encrypt(c, input)
 }
 
 func main() {

--- a/gov2/kms/ReEncryptData/ReEncryptDatav2.go
+++ b/gov2/kms/ReEncryptData/ReEncryptDatav2.go
@@ -29,9 +29,7 @@ type KMSReEncryptAPI interface {
 //     If success, a ReEncryptOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to ReEncrypt.
 func ReEncryptText(c context.Context, api KMSReEncryptAPI, input *kms.ReEncryptInput) (*kms.ReEncryptOutput, error) {
-    result, err := api.ReEncrypt(c, input)
-
-    return result, err
+    return api.ReEncrypt(c, input)
 }
 
 func main() {

--- a/gov2/s3/CopyObject/CopyObjectv2.go
+++ b/gov2/s3/CopyObject/CopyObjectv2.go
@@ -31,9 +31,7 @@ type S3CopyObjectAPI interface {
 //     If success, a CopyObjectOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CopyObject.
 func CopyItem(c context.Context, api S3CopyObjectAPI, input *s3.CopyObjectInput) (*s3.CopyObjectOutput, error) {
-	resp, err := api.CopyObject(c, input)
-
-	return resp, err
+	return api.CopyObject(c, input)
 }
 
 func main() {

--- a/gov2/s3/CreateBucket/CreateBucketv2.go
+++ b/gov2/s3/CreateBucket/CreateBucketv2.go
@@ -29,9 +29,7 @@ type S3CreateBucketAPI interface {
 //     If success, a CreateBucketOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CreateBucket.
 func MakeBucket(c context.Context, api S3CreateBucketAPI, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
-	resp, err := api.CreateBucket(c, input)
-
-	return resp, err
+	return api.CreateBucket(c, input)
 }
 
 func main() {

--- a/gov2/s3/DeleteBucket/DeleteBucketv2.go
+++ b/gov2/s3/DeleteBucket/DeleteBucketv2.go
@@ -29,9 +29,7 @@ type S3DeleteBucketAPI interface {
 //     If success, a DeleteBucketOutput object containing the result of the service call and nil
 //     Otherwise, an error from the call to CreateBucket
 func RemoveBucket(c context.Context, api S3DeleteBucketAPI, input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
-	result, err := api.DeleteBucket(c, input)
-
-	return result, err
+	return api.DeleteBucket(c, input)
 }
 
 func main() {

--- a/gov2/s3/DeleteObject/DeleteObjectv2.go
+++ b/gov2/s3/DeleteObject/DeleteObjectv2.go
@@ -29,9 +29,7 @@ type S3DeleteObjectAPI interface {
 //     If success, a DeleteObjectOutput object containing the result of the service call and nil
 //     Otherwise, an error from the call to DeleteObject
 func DeleteItem(c context.Context, api S3DeleteObjectAPI, input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
-	result, err := api.DeleteObject(c, input)
-
-	return result, err
+	return api.DeleteObject(c, input)
 }
 
 func main() {

--- a/gov2/s3/GeneratePresignedURL/GeneratePresignedURLv2.go
+++ b/gov2/s3/GeneratePresignedURL/GeneratePresignedURLv2.go
@@ -31,12 +31,7 @@ type S3PresignGetObjectAPI interface {
 //     If successful, the presigned URL for the object and nil.
 //     Otherwise, nil and an error from the call to PresignGetObject.
 func GetPresignedURL(c context.Context, api S3PresignGetObjectAPI, input *s3.GetObjectInput) (*v4.PresignedHTTPRequest, error) {
-	resp, err := api.PresignGetObject(c, input)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return api.PresignGetObject(c, input)
 }
 
 func main() {

--- a/gov2/s3/GetBucketAcl/GetBucketAclv2.go
+++ b/gov2/s3/GetBucketAcl/GetBucketAclv2.go
@@ -29,9 +29,7 @@ type S3GetBucketAclAPI interface {
 //     If success, a GetBucketAclOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to GetBucketAcl
 func FindBucketAcl(c context.Context, api S3GetBucketAclAPI, input *s3.GetBucketAclInput) (*s3.GetBucketAclOutput, error) {
-	result, err := api.GetBucketAcl(c, input)
-
-	return result, err
+	return api.GetBucketAcl(c, input)
 }
 
 func main() {

--- a/gov2/s3/GetObjectAcl/GetObjectAclv2.go
+++ b/gov2/s3/GetObjectAcl/GetObjectAclv2.go
@@ -29,9 +29,7 @@ type S3GetObjectAclAPI interface {
 //     If success, a GetObjectAclOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to GetObjectAcl
 func FindObjectAcl(c context.Context, api S3GetObjectAclAPI, input *s3.GetObjectAclInput) (*s3.GetObjectAclOutput, error) {
-	result, err := api.GetObjectAcl(c, input)
-
-	return result, err
+	return api.GetObjectAcl(c, input)
 }
 
 func main() {

--- a/gov2/s3/ListBuckets/ListBucketsv2.go
+++ b/gov2/s3/ListBuckets/ListBucketsv2.go
@@ -28,9 +28,7 @@ type S3ListBucketsAPI interface {
 //     If success, a ListBucketsOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to ListBuckets.
 func GetAllBuckets(c context.Context, api S3ListBucketsAPI, input *s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
-	result, err := api.ListBuckets(c, input)
-
-	return result, err
+	return api.ListBuckets(c, input)
 }
 
 func main() {

--- a/gov2/s3/ListObjects/ListObjectsv2.go
+++ b/gov2/s3/ListObjects/ListObjectsv2.go
@@ -29,9 +29,7 @@ type S3ListObjectsAPI interface {
 //     If success, a ListObjectsV2Output object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to ListObjectsV2
 func GetObjects(c context.Context, api S3ListObjectsAPI, input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
-	resp, err := api.ListObjectsV2(c, input)
-
-	return resp, err
+	return api.ListObjectsV2(c, input)
 }
 
 func main() {

--- a/gov2/s3/PutObject/PutObjectv2.go
+++ b/gov2/s3/PutObject/PutObjectv2.go
@@ -30,9 +30,7 @@ type S3PutObjectAPI interface {
 //     If success, a PutObjectOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to PutObject
 func PutFile(c context.Context, api S3PutObjectAPI, input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
-	resp, err := api.PutObject(c, input)
-
-	return resp, err
+	return api.PutObject(c, input)
 }
 
 func main() {

--- a/gov2/sns/CreateTopic/CreateTopicv2.go
+++ b/gov2/sns/CreateTopic/CreateTopicv2.go
@@ -29,9 +29,7 @@ type SNSCreateTopicAPI interface {
 //     If success, a CreateTopicOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CreateTopic.
 func MakeTopic(c context.Context, api SNSCreateTopicAPI, input *sns.CreateTopicInput) (*sns.CreateTopicOutput, error) {
-	results, err := api.CreateTopic(c, input)
-
-	return results, err
+	return api.CreateTopic(c, input)
 }
 
 func main() {

--- a/gov2/sns/ListSubscriptions/ListSubscriptionsv2.go
+++ b/gov2/sns/ListSubscriptions/ListSubscriptionsv2.go
@@ -28,9 +28,7 @@ type SNSListSubscriptionsAPI interface {
 //     If success, a ListSubscriptionsOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to ListSubscriptions.
 func GetSubscriptions(c context.Context, api SNSListSubscriptionsAPI, input *sns.ListSubscriptionsInput) (*sns.ListSubscriptionsOutput, error) {
-	result, err := api.ListSubscriptions(c, input)
-
-	return result, err
+	return api.ListSubscriptions(c, input)
 }
 
 func main() {

--- a/gov2/sns/ListTopics/ListTopicsv2.go
+++ b/gov2/sns/ListTopics/ListTopicsv2.go
@@ -28,9 +28,7 @@ type SNSListTopicsAPI interface {
 //     If success, a ListTopicsOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to ListTopics
 func GetTopics(c context.Context, api SNSListTopicsAPI, input *sns.ListTopicsInput) (*sns.ListTopicsOutput, error) {
-	results, err := api.ListTopics(c, input)
-
-	return results, err
+	return api.ListTopics(c, input)
 }
 
 func main() {

--- a/gov2/sns/Publish/Publishv2.go
+++ b/gov2/sns/Publish/Publishv2.go
@@ -29,9 +29,7 @@ type SNSPublishAPI interface {
 //     If success, a PublishOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to Publish
 func PublishMessage(c context.Context, api SNSPublishAPI, input *sns.PublishInput) (*sns.PublishOutput, error) {
-	result, err := api.Publish(c, input)
-
-	return result, err
+	return api.Publish(c, input)
 }
 
 func main() {

--- a/gov2/sns/Subscribe/Subscribev2.go
+++ b/gov2/sns/Subscribe/Subscribev2.go
@@ -30,9 +30,7 @@ type SNSSubscribeAPI interface {
 //     If success, a SubscribeOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to Subscribe
 func SubscribeTopic(c context.Context, api SNSSubscribeAPI, input *sns.SubscribeInput) (*sns.SubscribeOutput, error) {
-	result, err := api.Subscribe(c, input)
-
-	return result, err
+	return api.Subscribe(c, input)
 }
 
 func main() {

--- a/gov2/sqs/ChangeMsgVisibility/ChangeMsgVisibilityv2.go
+++ b/gov2/sqs/ChangeMsgVisibility/ChangeMsgVisibilityv2.go
@@ -35,9 +35,7 @@ type SQSSetMsgVisibilityAPI interface {
 //     If success, a GetQueueUrlOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetQueueUrl.
 func GetQueueURL(c context.Context, api SQSSetMsgVisibilityAPI, input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
-    result, err := api.GetQueueUrl(c, input)
-
-    return result, err
+    return api.GetQueueUrl(c, input)
 }
 
 // SetMsgVisibility sets the visibility timeout for a message in an Amazon SQS queue.
@@ -49,9 +47,7 @@ func GetQueueURL(c context.Context, api SQSSetMsgVisibilityAPI, input *sqs.GetQu
 //     If success, a ChangeMessageVisibilityOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to ChangeMessageVisibility.
 func SetMsgVisibility(c context.Context, api SQSSetMsgVisibilityAPI, input *sqs.ChangeMessageVisibilityInput) (*sqs.ChangeMessageVisibilityOutput, error) {
-    result, err := api.ChangeMessageVisibility(c, input)
-
-    return result, err
+    return api.ChangeMessageVisibility(c, input)
 }
 
 func main() {

--- a/gov2/sqs/ConfigureLPQueue/ConfigureLPQueuev2.go
+++ b/gov2/sqs/ConfigureLPQueue/ConfigureLPQueuev2.go
@@ -35,9 +35,7 @@ type SQSConfigureLPQueueAPI interface {
 //     If success, a GetQueueUrlOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetQueueUrl.
 func GetQueueURL(c context.Context, api SQSConfigureLPQueueAPI, input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
-    result, err := api.GetQueueUrl(c, input)
-
-    return result, err
+    return api.GetQueueUrl(c, input)
 }
 
 // ConfigureLPQueue configures an Amazon SQS queue to use long polling.
@@ -49,9 +47,7 @@ func GetQueueURL(c context.Context, api SQSConfigureLPQueueAPI, input *sqs.GetQu
 //     If success, a SetQueueAttributesOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to MSetQueueAttributesETHOD.
 func ConfigureLPQueue(c context.Context, api SQSConfigureLPQueueAPI, input *sqs.SetQueueAttributesInput) (*sqs.SetQueueAttributesOutput, error) {
-    results, err := api.SetQueueAttributes(c, input)
-
-    return results, err
+    return api.SetQueueAttributes(c, input)
 }
 
 func main() {

--- a/gov2/sqs/CreateLPQueue/CreateLPQueuev2.go
+++ b/gov2/sqs/CreateLPQueue/CreateLPQueuev2.go
@@ -31,9 +31,7 @@ type SQSCreateQueueAPI interface {
 //     If success, a CreateQueueOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CreateQueue.
 func CreateLPQueue(c context.Context, api SQSCreateQueueAPI, input *sqs.CreateQueueInput) (*sqs.CreateQueueOutput, error) {
-    result, err := api.CreateQueue(c, input)
-
-    return result, err
+    return api.CreateQueue(c, input)
 }
 
 func main() {

--- a/gov2/sqs/CreateQueue/CreateQueuev2.go
+++ b/gov2/sqs/CreateQueue/CreateQueuev2.go
@@ -30,9 +30,7 @@ type SQSCreateQueueAPI interface {
 //     If success, a CreateQueueOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to CreateQueue.
 func CreateQueue(c context.Context, api SQSCreateQueueAPI, input *sqs.CreateQueueInput) (*sqs.CreateQueueOutput, error) {
-	result, err := api.CreateQueue(c, input)
-
-	return result, err
+	return api.CreateQueue(c, input)
 }
 
 func main() {

--- a/gov2/sqs/DeadLetterQueue/DeadLetterQueuev2.go
+++ b/gov2/sqs/DeadLetterQueue/DeadLetterQueuev2.go
@@ -36,9 +36,7 @@ type SQSDeadLetterQueueAPI interface {
 //     If success, a GetQueueUrlOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetQueueUrl.
 func GetQueueURL(c context.Context, api SQSDeadLetterQueueAPI, input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
-	result, err := api.GetQueueUrl(c, input)
-
-	return result, err
+	return api.GetQueueUrl(c, input)
 }
 
 // GetQueueArn gets the ARN of a queue based on its URL
@@ -60,9 +58,7 @@ func GetQueueArn(queueURL *string) *string {
 //     If success, a SetQueueAttributesOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to SetQueueAttributes.
 func ConfigureDeadLetterQueue(c context.Context, api SQSDeadLetterQueueAPI, input *sqs.SetQueueAttributesInput) (*sqs.SetQueueAttributesOutput, error) {
-	result, err := api.SetQueueAttributes(c, input)
-
-	return result, err
+	return api.SetQueueAttributes(c, input)
 }
 
 func main() {

--- a/gov2/sqs/DeleteMessage/DeleteMessagev2.go
+++ b/gov2/sqs/DeleteMessage/DeleteMessagev2.go
@@ -33,9 +33,7 @@ type SQSDeleteMessageAPI interface {
 //     If success, a GetQueueUrlOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetQueueUrl.
 func GetQueueURL(c context.Context, api SQSDeleteMessageAPI, input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
-    result, err := api.GetQueueUrl(c, input)
-
-    return result, err
+    return api.GetQueueUrl(c, input)
 }
 
 // RemoveMessage deletes a message from an Amazon SQS queue.
@@ -47,9 +45,7 @@ func GetQueueURL(c context.Context, api SQSDeleteMessageAPI, input *sqs.GetQueue
 //     If success, a DeleteMessageOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to DeleteMessage.
 func RemoveMessage(c context.Context, api SQSDeleteMessageAPI, input *sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error) {
-    result, err := api.DeleteMessage(c, input)
-
-    return result, err
+    return api.DeleteMessage(c, input)
 }
 
 func main() {

--- a/gov2/sqs/DeleteQueue/DeleteQueuev2.go
+++ b/gov2/sqs/DeleteQueue/DeleteQueuev2.go
@@ -33,9 +33,7 @@ type SQSDeleteQueueAPI interface {
 //     If success, a GetQueueUrlOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetQueueUrl.
 func GetQueueURL(c context.Context, api SQSDeleteQueueAPI, input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
-    result, err := api.GetQueueUrl(c, input)
-
-    return result, err
+    return api.GetQueueUrl(c, input)
 }
 
 // DeleteQueue deletes an Amazon SQS queue.
@@ -47,9 +45,7 @@ func GetQueueURL(c context.Context, api SQSDeleteQueueAPI, input *sqs.GetQueueUr
 //     If success, a DeleteQueueOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to DeleteQueue.
 func DeleteQueue(c context.Context, api SQSDeleteQueueAPI, input *sqs.DeleteQueueInput) (*sqs.DeleteQueueOutput, error) {
-    result, err := api.DeleteQueue(c, input)
-
-    return result, err
+    return api.DeleteQueue(c, input)
 }
 
 func main() {

--- a/gov2/sqs/GetQueueURL/GetQueueURLv2.go
+++ b/gov2/sqs/GetQueueURL/GetQueueURLv2.go
@@ -29,9 +29,7 @@ type SQSGetQueueUrlAPI interface {
 //     If success, a GetQueueUrlOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetQueueUrl.
 func GetQueueURL(c context.Context, api SQSGetQueueUrlAPI, input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
-    result, err := api.GetQueueUrl(c, input)
-
-    return result, err
+    return api.GetQueueUrl(c, input)
 }
 
 func main() {

--- a/gov2/sqs/ListQueues/ListQueuesv2.go
+++ b/gov2/sqs/ListQueues/ListQueuesv2.go
@@ -28,9 +28,7 @@ type SQSListQueuesAPI interface {
 //     If success, a ListQueuesOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to ListQueues.
 func GetQueues(c context.Context, api SQSListQueuesAPI, input *sqs.ListQueuesInput) (*sqs.ListQueuesOutput, error) {
-    result, err := api.ListQueues(c, input)
-
-    return result, err
+    return api.ListQueues(c, input)
 }
 
 func main() {

--- a/gov2/sqs/ReceiveLPMessage/ReceiveLPMessagev2.go
+++ b/gov2/sqs/ReceiveLPMessage/ReceiveLPMessagev2.go
@@ -35,9 +35,7 @@ type SQSGetLPMsgAPI interface {
 //     If success, a GetQueueUrlOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetQueueUrl.
 func GetQueueURL(c context.Context, api SQSGetLPMsgAPI, input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
-    result, err := api.GetQueueUrl(c, input)
-
-    return result, err
+    return api.GetQueueUrl(c, input)
 }
 
 // GetLPMessages gets the messages from an Amazon SQS long polling queue.
@@ -49,9 +47,7 @@ func GetQueueURL(c context.Context, api SQSGetLPMsgAPI, input *sqs.GetQueueUrlIn
 //     If success, a ReceiveMessageOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to ReceiveMessage.
 func GetLPMessages(c context.Context, api SQSGetLPMsgAPI, input *sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error) {
-    result, err := api.ReceiveMessage(c, input)
-
-    return result, err
+    return api.ReceiveMessage(c, input)
 }
 
 func main() {

--- a/gov2/sqs/ReceiveMessage/ReceiveMessagev2.go
+++ b/gov2/sqs/ReceiveMessage/ReceiveMessagev2.go
@@ -35,9 +35,7 @@ type SQSReceiveMessageAPI interface {
 //     If success, a GetQueueUrlOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetQueueUrl.
 func GetQueueURL(c context.Context, api SQSReceiveMessageAPI, input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
-	result, err := api.GetQueueUrl(c, input)
-
-	return result, err
+	return api.GetQueueUrl(c, input)
 }
 
 // GetMessages gets the most recent message from an Amazon SQS queue.
@@ -49,9 +47,7 @@ func GetQueueURL(c context.Context, api SQSReceiveMessageAPI, input *sqs.GetQueu
 //     If success, a ReceiveMessageOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to ReceiveMessage.
 func GetMessages(c context.Context, api SQSReceiveMessageAPI, input *sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error) {
-	result, err := api.ReceiveMessage(c, input)
-
-	return result, err
+	return api.ReceiveMessage(c, input)
 }
 
 func main() {

--- a/gov2/sqs/SendMessage/SendMessagev2.go
+++ b/gov2/sqs/SendMessage/SendMessagev2.go
@@ -37,9 +37,7 @@ type SQSSendMessageAPI interface {
 //     If success, a GetQueueUrlOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to GetQueueUrl.
 func GetQueueURL(c context.Context, api SQSSendMessageAPI, input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
-    result, err := api.GetQueueUrl(c, input)
-
-    return result, err
+    return api.GetQueueUrl(c, input)
 }
 
 // SendMsg sends a message to an Amazon SQS queue.
@@ -51,9 +49,7 @@ func GetQueueURL(c context.Context, api SQSSendMessageAPI, input *sqs.GetQueueUr
 //     If success, a SendMessageOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to SendMessage.
 func SendMsg(c context.Context, api SQSSendMessageAPI, input *sqs.SendMessageInput) (*sqs.SendMessageOutput, error) {
-    result, err := api.SendMessage(c, input)
-
-    return result, err
+    return api.SendMessage(c, input)
 }
 
 func main() {

--- a/gov2/ssm/DeleteParameter/DeleteParameterv2.go
+++ b/gov2/ssm/DeleteParameter/DeleteParameterv2.go
@@ -29,9 +29,7 @@ type SSMDeleteParameterAPI interface {
 //     If success, a DeleteParameterOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to DeleteParameter.
 func RemoveParameter(c context.Context, api SSMDeleteParameterAPI, input *ssm.DeleteParameterInput) (*ssm.DeleteParameterOutput, error) {
-    results, err := api.DeleteParameter(c, input)
-
-    return results, err
+    return api.DeleteParameter(c, input)
 }
 
 func main() {

--- a/gov2/ssm/GetParameter/GetParameterv2.go
+++ b/gov2/ssm/GetParameter/GetParameterv2.go
@@ -29,9 +29,7 @@ type SSMGetParameterAPI interface {
 //     If success, a GetParameterOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to GetParameter
 func FindParameter(c context.Context, api SSMGetParameterAPI, input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
-    results, err := api.GetParameter(c, input)
-
-    return results, err
+    return api.GetParameter(c, input)
 }
 
 func main() {

--- a/gov2/ssm/PutParameter/PutParameterv2.go
+++ b/gov2/ssm/PutParameter/PutParameterv2.go
@@ -30,9 +30,7 @@ type SSMPutParameterAPI interface {
 //     If success, a PutParameterOutput object containing the result of the service call and nil
 //     Otherwise, nil and an error from the call to PutParameter
 func AddStringParameter(c context.Context, api SSMPutParameterAPI, input *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
-    results, err := api.PutParameter(c, input)
-
-    return results, err
+    return api.PutParameter(c, input)
 }
 
 func main() {

--- a/gov2/sts/AssumeRole/AssumeRolev2.go
+++ b/gov2/sts/AssumeRole/AssumeRolev2.go
@@ -29,9 +29,7 @@ type STSAssumeRoleAPI interface {
 //     If successful, an AssumeRoleOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to AssumeRole.
 func TakeRole(c context.Context, api STSAssumeRoleAPI, input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
-	result, err := api.AssumeRole(c, input)
-
-	return result, err
+	return api.AssumeRole(c, input)
 }
 
 func main() {


### PR DESCRIPTION
The call used to look like:

```
resp, err := API(context, inputs)
return resp, err
```

It now looks like:

```
return API(context, inputs)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
