### PR TITLE
Fixed a method name in a CloudWatch Java example 

### DIFF
--- a/javav2/example_code/cloudwatch/src/main/java/com/example/cloudwatch/GetLogEvents.java
+++ b/javav2/example_code/cloudwatch/src/main/java/com/example/cloudwatch/GetLogEvents.java
@@ -43,12 +43,12 @@ public class GetLogEvents {
                 .region(region)
                 .build();
 
-        getCWLogEvebts(cloudWatchLogsClient, logGroupName, logStreamName) ;
+        getCWLogEvents(cloudWatchLogsClient, logGroupName, logStreamName) ;
         cloudWatchLogsClient.close();
     }
 
     // snippet-start:[cloudwatch.java2.get_logs.main]
-    public static void getCWLogEvebts(CloudWatchLogsClient cloudWatchLogsClient, String logGroupName, String logStreamName) {
+    public static void getCWLogEvents(CloudWatchLogsClient cloudWatchLogsClient, String logGroupName, String logStreamName) {
 
         try {
 

--- a/javav2/example_code/cloudwatch/src/test/java/CloudWatchTest.java
+++ b/javav2/example_code/cloudwatch/src/test/java/CloudWatchTest.java
@@ -141,7 +141,7 @@ public class CloudWatchTest {
     @Order(8)
     public void GetLogEvents() {
 
-        GetLogEvents.getCWLogEvebts(cloudWatchLogsClient,logGroup,streamName);
+        GetLogEvents.getCWLogEvents(cloudWatchLogsClient,logGroup,streamName);
         System.out.println("\n Test 8 passed");
     }
 

--- a/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/CreateSecret.java
+++ b/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/CreateSecret.java
@@ -21,6 +21,15 @@ import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse
 import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
 //snippet-end:[secretsmanager.java2.create_secret.import]
 
+/**
+ * To run this AWS code example, ensure that you have setup your development environment, including your AWS credentials.
+ *
+ * For information, see this documentation topic:
+ *
+ *https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+
+
 public class CreateSecret {
 
     public static void main(String[] args) {

--- a/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/DeleteSecret.java
+++ b/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/DeleteSecret.java
@@ -20,6 +20,14 @@ import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
 //snippet-end:[secretsmanager.java2.delete_secret.import]
 
+/**
+ * To run this AWS code example, ensure that you have setup your development environment, including your AWS credentials.
+ *
+ * For information, see this documentation topic:
+ *
+ *https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+
 public class DeleteSecret {
 
     public static void main(String[] args) {

--- a/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/DescribeSecret.java
+++ b/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/DescribeSecret.java
@@ -25,6 +25,14 @@ import java.time.format.FormatStyle;
 import java.util.Locale;
 //snippet-end:[secretsmanager.java2.describe_secret.import]
 
+/**
+ * To run this AWS code example, ensure that you have setup your development environment, including your AWS credentials.
+ *
+ * For information, see this documentation topic:
+ *
+ *https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+
 public class DescribeSecret {
 
     public static void main(String[] args) {

--- a/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/GetSecretValue.java
+++ b/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/GetSecretValue.java
@@ -21,6 +21,14 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRespon
 import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
 //snippet-end:[secretsmanager.java2.get_secret.import]
 
+/**
+ * To run this AWS code example, ensure that you have setup your development environment, including your AWS credentials.
+ *
+ * For information, see this documentation topic:
+ *
+ *https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+
 public class GetSecretValue {
 
     public static void main(String[] args) {

--- a/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/ListSecrets.java
+++ b/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/ListSecrets.java
@@ -22,6 +22,14 @@ import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerExcept
 import java.util.List;
 //snippet-end:[secretsmanager.java2.list_secrets.import]
 
+/**
+ * To run this AWS code example, ensure that you have setup your development environment, including your AWS credentials.
+ *
+ * For information, see this documentation topic:
+ *
+ *https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+
 public class ListSecrets {
 
     public static void main(String[] args) {

--- a/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/UpdateSecret.java
+++ b/javav2/example_code/secretsmanager/src/main/java/com/example/secrets/UpdateSecret.java
@@ -20,6 +20,14 @@ import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerExcept
 import software.amazon.awssdk.services.secretsmanager.model.UpdateSecretRequest;
 //snippet-end:[secretsmanager.java2.update_secret.import]
 
+/**
+ * To run this AWS code example, ensure that you have setup your development environment, including your AWS credentials.
+ *
+ * For information, see this documentation topic:
+ *
+ *https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+
 public class UpdateSecret {
 
     public static void main(String[] args) {

--- a/javav2/usecases/video_analyzer_application/Readme.md
+++ b/javav2/usecases/video_analyzer_application/Readme.md
@@ -1121,8 +1121,8 @@ The following Java code represents the **WriteExcel** class.
                 count++;
         }
         return count;
+      }
      }
-    }
 
 ## Create the HTML files
 
@@ -1424,6 +1424,17 @@ The following JavaScript represents the **message.js** file. The **ProcessImages
     }
 
 **Note:** There are other CSS files located in the GitHub repository that you must add to your project. Ensure all of the files under the **resources** folder are included in your project.   
+
+## Set Timeout value for Elastic Beanstalk
+
+When a request is made by the application to analyze a video, it may take longer then the default timeout value. You can increase the timeout setting for Elastic Beanstalk by placing a .config file in a **.ebextensions** folder in the root of your project. The following file can be used to increase the timeout value.
+
+      option_settings:
+        - namespace: aws:elasticbeanstalk:command
+          option_name: Timeout
+          value: 1800
+
+For more information, see  [Advanced environment customization with configuration files](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/ebextensions.html).
 
 ## Package the project
 

--- a/javav2/usecases/video_analyzer_application/Readme.md
+++ b/javav2/usecases/video_analyzer_application/Readme.md
@@ -1425,7 +1425,7 @@ The following JavaScript represents the **message.js** file. The **ProcessImages
 
 **Note:** There are other CSS files located in the GitHub repository that you must add to your project. Ensure all of the files under the **resources** folder are included in your project.   
 
-## Set Timeout value for Elastic Beanstalk
+## Increase the timeout value for Elastic Beanstalk
 
 When a request is made by the application to analyze a video, it may take longer then the default timeout value. You can increase the timeout setting for Elastic Beanstalk by placing a .config file in a **.ebextensions** folder in the root of your project. The following file can be used to increase the timeout value.
 


### PR DESCRIPTION
Fixed the name of a custom method. New method name is getCWLogEvents. 