### PR TITLE
Update s3_list1000plusobjects.ts

### DIFF
--- a/javascriptv3/example_code/s3/src/s3_list1000plusobjects.ts
+++ b/javascriptv3/example_code/s3/src/s3_list1000plusobjects.ts
@@ -41,7 +41,7 @@ async function run() {
       // If 'truncated' is true, assign the key of the final element in the response to our variable 'pageMarker'
       if (truncated) {
         pageMarker = response.Contents.slice(-1)[0].Key;
-        // Assigns value of pageMarker to bucketParams so that the next iteration will start from the new pageMarker.
+        // Assign value of pageMarker to bucketParams so that the next iteration will start from the new pageMarker.
         bucketParams.Marker = pageMarker;
       }
       // At end of the list, response.truncated is false and our function exits the while loop.

--- a/javascriptv3/example_code/s3/src/s3_list1000plusobjects.ts
+++ b/javascriptv3/example_code/s3/src/s3_list1000plusobjects.ts
@@ -41,6 +41,7 @@ async function run() {
       // If 'truncated' is true, assign the key of the final element in the response to our variable 'pageMarker'
       if (truncated) {
         pageMarker = response.Contents.slice(-1)[0].Key;
+        bucketParams.Marker = pageMarker;
       }
       // At end of the list, response.truncated is false and our function exits the while loop.
     } catch (err) {

--- a/javascriptv3/example_code/s3/src/s3_list1000plusobjects.ts
+++ b/javascriptv3/example_code/s3/src/s3_list1000plusobjects.ts
@@ -41,6 +41,7 @@ async function run() {
       // If 'truncated' is true, assign the key of the final element in the response to our variable 'pageMarker'
       if (truncated) {
         pageMarker = response.Contents.slice(-1)[0].Key;
+        // Assigns value of pageMarker to bucketParams so that the next iteration will start from the new pageMarker.
         bucketParams.Marker = pageMarker;
       }
       // At end of the list, response.truncated is false and our function exits the while loop.


### PR DESCRIPTION
Fixes infinite loop created by never adding pageMarker to the ListObjectsCommand input params

*Issue #, if available:*
n/a

*Description of changes:*
Assigns value of pageMarker to bucketParams so that the next iteration will start from the new pageMarker instead of proceeding into an infinite loop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
