### PR TITLE
Added docs to simplify connections to local DynamoDB.

### DIFF
--- a/go/dynamodb/ListTables/ListTables.go
+++ b/go/dynamodb/ListTables/ListTables.go
@@ -50,6 +50,26 @@ func main() {
     }))
     // snippet-end:[dynamodb.go.list_all_tables.session]
 
+    // Connecting via hard-coded credentials
+    // Hard-Coded Credentials in an Application (Not Recommended)
+    // Do not embed credentials inside an application. 
+    // Use this method only for testing purposes.
+    // Make sure to import "github.com/aws/aws-sdk-go/aws/credentials"
+    // [Endpoint:optional] Mention the endpoint when connecting to local DynamoDB
+    /* 
+	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String("us-west-2"),
+		Endpoint:    aws.String("http://localhost:8000"),
+		Credentials: credentials.NewStaticCredentials("AKID", "SECRET_KEY", "TOKEN"),
+	})
+
+	if err != nil {
+		fmt.Println("Got an error fetching configurations")
+		fmt.Println(err)
+		return
+	}
+    */
+
     tables, err := GetTables(sess, limit)
     if err != nil {
         fmt.Println("Got an error retrieving table names:")


### PR DESCRIPTION
The commented code snippet added would greatly help developers and beginners working with the local DynamoDB setup for testing purposes. 

The local DynamoDB setup usually expects an endpoint specification which was tough to figure out for beginners, which is usually not set while configuring AWS CLI for general use cases.

Please do let me know if any changes / corrections are required to be done.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
