### PR TITLE
Added workflow to run Go unit tests if they are in a PR or checkin

### DIFF
--- a/.github/ciTest.yml
+++ b/.github/ciTest.yml
@@ -1,0 +1,37 @@
+# Run bash script on push or pull request
+name: BashPushOrPR
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: checkout repo content
+        uses: actions/checkout@v2 # checkout the repository content to github runner.
+      - name: setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.13.1' # The Go version to download (if necessary) and use.
+      - id: files
+        uses: jitterbit/get-changed-files@v1
+      - run: |
+          # make file runnable, might not be necessary
+          chmod +x scripts/run_go_tests.sh
+
+          # run script
+          scripts/run_go_tests.sh ${{ steps.files.outputs.all }}

--- a/scripts/run_go_tests.sh
+++ b/scripts/run_go_tests.sh
@@ -1,0 +1,29 @@
+TestGoFile () {
+    if [ "$1" == "" ]
+    then
+       return
+    fi
+
+    pushd $1
+
+    declare RESULT=(`go test`)  # (..) = array
+    
+    if [ "${RESULT[0]}" == "PASS" ]
+    then
+      echo 0
+    else
+      echo 1
+    fi
+
+    popd
+}
+
+for f in $@ ; do
+    # Do any end with "_test.go"?
+    path="$(dirname $f)"
+    file="$(basename $f)"
+
+    # If it's a go test file
+    # test it
+    [[ $file =~ ^[a-zA-Z]*_test.go$ ]] && TestGoFile "$path"
+done


### PR DESCRIPTION
*Issue #, if available:*
We had a request (issue #1583 ) to add CI tests for the Go files.

*Description of changes:*
Added the workflow and bash script.

I've tested these on my personal repo. Once this PR is merged, we can enable the workflow from the Actions menu.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
