### PR TITLE
Fix C++ S3 create bucket example

### DIFF
--- a/cpp/example_code/s3/create_bucket.cpp
+++ b/cpp/example_code/s3/create_bucket.cpp
@@ -26,7 +26,12 @@
 bool AwsDoc::S3::CreateBucket(const Aws::String& bucketName, 
     const Aws::S3::Model::BucketLocationConstraint& region)
 {
+    Aws::Client::ClientConfiguration config;
+
     Aws::S3::S3Client s3_client(config);
+
+    Aws::S3::Model::CreateBucketRequest request;
+    request.SetBucket(bucketName);
 
     // You only need to set the AWS Region for the bucket if it is 
     // other than US East (N. Virginia) us-east-1.


### PR DESCRIPTION

*Description of changes:* Fixes [#1605](https://github.com/awsdocs/aws-doc-sdk-examples/issues/1605)
Add clientConfiguration
Add createbucketRequest and set bucketName to create


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
