### PR TITLE
Added CloudFormation script template from Go CDK app

### DIFF
--- a/resources/cdk/go_example_lambda/setup.ts
+++ b/resources/cdk/go_example_lambda/setup.ts
@@ -16,7 +16,7 @@ import { StreamViewType } from '@aws-cdk/aws-dynamodb';
 import { EventType } from '@aws-cdk/aws-s3';
 import { CfnOutput } from '@aws-cdk/core';
 
-export class GoLambdaCdkStack extends cdk.Stack {
+export class GoCdkStack extends cdk.Stack {
     constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
       super(scope, id, props);
   
@@ -151,4 +151,4 @@ export class GoLambdaCdkStack extends cdk.Stack {
 }
 
 const app = new cdk.App();
-new GoLambdaCdkStack(app, 'GoLambdaCdkStack');
+new GoCdkStack(app, 'GoCdkStack');

--- a/resources/cdk/go_example_lambda/setup.ts
+++ b/resources/cdk/go_example_lambda/setup.ts
@@ -36,7 +36,7 @@ export class GoCdkStack extends cdk.Stack {
       });
   
       // Create Amazon Simple Queue Service (Amazon SQS) queue
-      const myQueue = new sqs.Queue(this, 'MyQueue');
+      const myQueue = new sqs.Queue(this, 'MyNewQueue');
   
       // Subscribe a queue to the topic:
       const mySubscription = new subs.SqsSubscription(myQueue)
@@ -131,7 +131,7 @@ export class GoCdkStack extends cdk.Stack {
       
       // Display info about the resources.
       // You can see this information at any time by running:
-      //   aws cloudformation describe-stacks --stack-name GoLambdaCdkStack --query Stacks[0].Outputs --output text
+      //   aws cloudformation describe-stacks --stack-name GoCdkStack --query Stacks[0].Outputs --output text
       new CfnOutput(this, 'Bucket name: ', {value: myBucket.bucketName});
       new CfnOutput(this, 'S3 function name: ', {value: myS3Function.functionName});
       new CfnOutput(this, 'S3 function CloudWatch log group: ', {value: myS3Function.logGroup.logGroupName});

--- a/resources/cfn/go_example_lambda/GoCdkStack.template.json
+++ b/resources/cfn/go_example_lambda/GoCdkStack.template.json
@@ -26,7 +26,7 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain",
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyTable/Resource"
+        "aws:cdk:path": "GoCdkStack/MyTable/Resource"
       }
     },
     "MyBucketF68F3FF0": {
@@ -42,7 +42,7 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain",
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyBucket/Resource"
+        "aws:cdk:path": "GoCdkStack/MyBucket/Resource"
       }
     },
     "MyBucketNotifications46AC0CD2": {
@@ -74,13 +74,13 @@
         }
       },
       "DependsOn": [
-        "MyBucketAllowBucketNotificationsToGoLambdaCdkStackMyS3FunctionFD4F511A067D9641"
+        "MyBucketAllowBucketNotificationsToGoCdkStackMyS3Function112EB5684250720A"
       ],
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyBucket/Notifications/Resource"
+        "aws:cdk:path": "GoCdkStack/MyBucket/Notifications/Resource"
       }
     },
-    "MyBucketAllowBucketNotificationsToGoLambdaCdkStackMyS3FunctionFD4F511A067D9641": {
+    "MyBucketAllowBucketNotificationsToGoCdkStackMyS3Function112EB5684250720A": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
@@ -102,7 +102,7 @@
         }
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyBucket/AllowBucketNotificationsToGoLambdaCdkStackMyS3FunctionFD4F511A"
+        "aws:cdk:path": "GoCdkStack/MyBucket/AllowBucketNotificationsToGoCdkStackMyS3Function112EB568"
       }
     },
     "MyTopic86869434": {
@@ -111,13 +111,13 @@
         "DisplayName": "User subscription topic"
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyTopic/Resource"
+        "aws:cdk:path": "GoCdkStack/MyTopic/Resource"
       }
     },
     "MyQueueE6CA6235": {
       "Type": "AWS::SQS::Queue",
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyQueue/Resource"
+        "aws:cdk:path": "GoCdkStack/MyQueue/Resource"
       }
     },
     "MyQueuePolicy6BBEDDAC": {
@@ -155,10 +155,10 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyQueue/Policy/Resource"
+        "aws:cdk:path": "GoCdkStack/MyQueue/Policy/Resource"
       }
     },
-    "MyQueueGoLambdaCdkStackMyTopic0A78A3D9603413A3": {
+    "MyQueueGoCdkStackMyTopicC4A147EE8F169AC2": {
       "Type": "AWS::SNS::Subscription",
       "Properties": {
         "Protocol": "sqs",
@@ -173,7 +173,7 @@
         }
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyQueue/GoLambdaCdkStackMyTopic0A78A3D9/Resource"
+        "aws:cdk:path": "GoCdkStack/MyQueue/GoCdkStackMyTopicC4A147EE/Resource"
       }
     },
     "MyDynamoDBFunctionServiceRole4D295727": {
@@ -207,7 +207,7 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyDynamoDBFunction/ServiceRole/Resource"
+        "aws:cdk:path": "GoCdkStack/MyDynamoDBFunction/ServiceRole/Resource"
       }
     },
     "MyDynamoDBFunctionServiceRoleDefaultPolicy24607661": {
@@ -259,7 +259,7 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyDynamoDBFunction/ServiceRole/DefaultPolicy/Resource"
+        "aws:cdk:path": "GoCdkStack/MyDynamoDBFunction/ServiceRole/DefaultPolicy/Resource"
       }
     },
     "MyDynamoDBFunctionD8356FF8": {
@@ -317,12 +317,12 @@
         "MyDynamoDBFunctionServiceRole4D295727"
       ],
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyDynamoDBFunction/Resource",
+        "aws:cdk:path": "GoCdkStack/MyDynamoDBFunction/Resource",
         "aws:asset:path": "asset.01755609b1034218e373e033b48308c5b55cb7f5da94a7ecfbb72c01ce0958ed",
         "aws:asset:property": "Code"
       }
     },
-    "MyDynamoDBFunctionDynamoDBEventSourceGoLambdaCdkStackMyTable2A76715EDF2C013F": {
+    "MyDynamoDBFunctionDynamoDBEventSourceGoCdkStackMyTable5FC9C1EFB01A57EB": {
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "FunctionName": {
@@ -350,7 +350,7 @@
         "StartingPosition": "TRIM_HORIZON"
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyDynamoDBFunction/DynamoDBEventSource:GoLambdaCdkStackMyTable2A76715E/Resource"
+        "aws:cdk:path": "GoCdkStack/MyDynamoDBFunction/DynamoDBEventSource:GoCdkStackMyTable5FC9C1EF/Resource"
       }
     },
     "MyDynamoDBFunctionLogRetention564CFF77": {
@@ -375,13 +375,13 @@
         }
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyDynamoDBFunction/LogRetention/Resource"
+        "aws:cdk:path": "GoCdkStack/MyDynamoDBFunction/LogRetention/Resource"
       }
     },
     "MyDLQueueFC9F303C": {
       "Type": "AWS::SQS::Queue",
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyDLQueue/Resource"
+        "aws:cdk:path": "GoCdkStack/MyDLQueue/Resource"
       }
     },
     "MyDLQueuePolicy3E3BD7C7": {
@@ -419,7 +419,7 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyDLQueue/Policy/Resource"
+        "aws:cdk:path": "GoCdkStack/MyDLQueue/Policy/Resource"
       }
     },
     "MyS3FunctionServiceRoleC6299E6D": {
@@ -453,7 +453,7 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyS3Function/ServiceRole/Resource"
+        "aws:cdk:path": "GoCdkStack/MyS3Function/ServiceRole/Resource"
       }
     },
     "MyS3Function6C4C4C99": {
@@ -510,7 +510,7 @@
         "MyS3FunctionServiceRoleC6299E6D"
       ],
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyS3Function/Resource",
+        "aws:cdk:path": "GoCdkStack/MyS3Function/Resource",
         "aws:asset:path": "asset.9e615d69f3b6d99d379f69f82382e33b20b238a23dc7dc1edf5902684ef688f9",
         "aws:asset:property": "Code"
       }
@@ -537,7 +537,7 @@
         }
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MyS3Function/LogRetention/Resource"
+        "aws:cdk:path": "GoCdkStack/MyS3Function/LogRetention/Resource"
       }
     },
     "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleB6FB88EC": {
@@ -571,7 +571,7 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/Resource"
+        "aws:cdk:path": "GoCdkStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/Resource"
       }
     },
     "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleDefaultPolicy2CF63D36": {
@@ -595,7 +595,7 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/DefaultPolicy/Resource"
+        "aws:cdk:path": "GoCdkStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/DefaultPolicy/Resource"
       }
     },
     "BucketNotificationsHandler050a0587b7544547bf325f094a3db8347ECC3691": {
@@ -620,7 +620,7 @@
         "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleB6FB88EC"
       ],
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Resource"
+        "aws:cdk:path": "GoCdkStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Resource"
       }
     },
     "MySNSFunctionServiceRole3E4F5D81": {
@@ -654,7 +654,7 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MySNSFunction/ServiceRole/Resource"
+        "aws:cdk:path": "GoCdkStack/MySNSFunction/ServiceRole/Resource"
       }
     },
     "MySNSFunction58612F6D": {
@@ -711,12 +711,12 @@
         "MySNSFunctionServiceRole3E4F5D81"
       ],
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MySNSFunction/Resource",
+        "aws:cdk:path": "GoCdkStack/MySNSFunction/Resource",
         "aws:asset:path": "asset.54b0556f856e94135c3d3497b7c8f523625e542ef4182871083e0b7139c47ccc",
         "aws:asset:property": "Code"
       }
     },
-    "MySNSFunctionAllowInvokeGoLambdaCdkStackMyTopic0A78A3D9172034A2": {
+    "MySNSFunctionAllowInvokeGoCdkStackMyTopicC4A147EE1AC8EF98": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
@@ -732,7 +732,7 @@
         }
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MySNSFunction/AllowInvoke:GoLambdaCdkStackMyTopic0A78A3D9"
+        "aws:cdk:path": "GoCdkStack/MySNSFunction/AllowInvoke:GoCdkStackMyTopicC4A147EE"
       }
     },
     "MySNSFunctionMyTopic197B4C28": {
@@ -764,7 +764,7 @@
         }
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MySNSFunction/MyTopic/Resource"
+        "aws:cdk:path": "GoCdkStack/MySNSFunction/MyTopic/Resource"
       }
     },
     "MySNSFunctionLogRetention9BA80035": {
@@ -789,7 +789,7 @@
         }
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MySNSFunction/LogRetention/Resource"
+        "aws:cdk:path": "GoCdkStack/MySNSFunction/LogRetention/Resource"
       }
     },
     "MySQSFunctionServiceRole5140D4AD": {
@@ -823,7 +823,7 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MySQSFunction/ServiceRole/Resource"
+        "aws:cdk:path": "GoCdkStack/MySQSFunction/ServiceRole/Resource"
       }
     },
     "MySQSFunctionServiceRoleDefaultPolicy322A7FFE": {
@@ -858,7 +858,7 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MySQSFunction/ServiceRole/DefaultPolicy/Resource"
+        "aws:cdk:path": "GoCdkStack/MySQSFunction/ServiceRole/DefaultPolicy/Resource"
       }
     },
     "MySQSFunction2F6CC41A": {
@@ -916,12 +916,12 @@
         "MySQSFunctionServiceRole5140D4AD"
       ],
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MySQSFunction/Resource",
+        "aws:cdk:path": "GoCdkStack/MySQSFunction/Resource",
         "aws:asset:path": "asset.2cc921ad0cd39e60b0db737bd06a977b9a5337f8065481cae7f63ed2a82f1502",
         "aws:asset:property": "Code"
       }
     },
-    "MySQSFunctionSqsEventSourceGoLambdaCdkStackMyQueue2B40B92BE308D5F1": {
+    "MySQSFunctionSqsEventSourceGoCdkStackMyQueue9883952B48BFF52A": {
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "FunctionName": {
@@ -936,7 +936,7 @@
         }
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MySQSFunction/SqsEventSource:GoLambdaCdkStackMyQueue2B40B92B/Resource"
+        "aws:cdk:path": "GoCdkStack/MySQSFunction/SqsEventSource:GoCdkStackMyQueue9883952B/Resource"
       }
     },
     "MySQSFunctionLogRetention1914FA38": {
@@ -961,7 +961,7 @@
         }
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/MySQSFunction/LogRetention/Resource"
+        "aws:cdk:path": "GoCdkStack/MySQSFunction/LogRetention/Resource"
       }
     },
     "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": {
@@ -995,7 +995,7 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/ServiceRole/Resource"
+        "aws:cdk:path": "GoCdkStack/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/ServiceRole/Resource"
       }
     },
     "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": {
@@ -1022,7 +1022,7 @@
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/ServiceRole/DefaultPolicy/Resource"
+        "aws:cdk:path": "GoCdkStack/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/ServiceRole/DefaultPolicy/Resource"
       }
     },
     "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
@@ -1080,7 +1080,7 @@
         "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB"
       ],
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/Resource"
+        "aws:cdk:path": "GoCdkStack/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/Resource"
       }
     },
     "CDKMetadata": {
@@ -1089,7 +1089,7 @@
         "Modules": "aws-cdk=1.87.0,@aws-cdk/assets=1.87.1,@aws-cdk/aws-apigateway=1.87.1,@aws-cdk/aws-applicationautoscaling=1.87.1,@aws-cdk/aws-autoscaling-common=1.87.1,@aws-cdk/aws-cloudwatch=1.87.1,@aws-cdk/aws-codeguruprofiler=1.87.1,@aws-cdk/aws-dynamodb=1.87.1,@aws-cdk/aws-ec2=1.87.1,@aws-cdk/aws-ecr=1.87.1,@aws-cdk/aws-ecr-assets=1.87.1,@aws-cdk/aws-events=1.87.1,@aws-cdk/aws-iam=1.87.1,@aws-cdk/aws-kms=1.87.1,@aws-cdk/aws-lambda=1.87.1,@aws-cdk/aws-lambda-event-sources=1.87.1,@aws-cdk/aws-logs=1.87.1,@aws-cdk/aws-s3=1.87.1,@aws-cdk/aws-s3-assets=1.87.1,@aws-cdk/aws-s3-notifications=1.87.1,@aws-cdk/aws-sns=1.87.1,@aws-cdk/aws-sns-subscriptions=1.87.1,@aws-cdk/aws-sqs=1.87.1,@aws-cdk/aws-ssm=1.87.1,@aws-cdk/cloud-assembly-schema=1.87.1,@aws-cdk/core=1.87.1,@aws-cdk/custom-resources=1.87.1,@aws-cdk/cx-api=1.87.1,@aws-cdk/region-info=1.87.1,jsii-runtime=node.js/v14.15.0"
       },
       "Metadata": {
-        "aws:cdk:path": "GoLambdaCdkStack/CDKMetadata/Default"
+        "aws:cdk:path": "GoCdkStack/CDKMetadata/Default"
       },
       "Condition": "CDKMetadataAvailable"
     }

--- a/resources/cfn/go_example_lambda/GoCdkStack.template.json
+++ b/resources/cfn/go_example_lambda/GoCdkStack.template.json
@@ -114,13 +114,13 @@
         "aws:cdk:path": "GoCdkStack/MyTopic/Resource"
       }
     },
-    "MyQueueE6CA6235": {
+    "MyNewQueue486005E3": {
       "Type": "AWS::SQS::Queue",
       "Metadata": {
-        "aws:cdk:path": "GoCdkStack/MyQueue/Resource"
+        "aws:cdk:path": "GoCdkStack/MyNewQueue/Resource"
       }
     },
-    "MyQueuePolicy6BBEDDAC": {
+    "MyNewQueuePolicy115B53FD": {
       "Type": "AWS::SQS::QueuePolicy",
       "Properties": {
         "PolicyDocument": {
@@ -140,7 +140,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "MyQueueE6CA6235",
+                  "MyNewQueue486005E3",
                   "Arn"
                 ]
               }
@@ -150,15 +150,15 @@
         },
         "Queues": [
           {
-            "Ref": "MyQueueE6CA6235"
+            "Ref": "MyNewQueue486005E3"
           }
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "GoCdkStack/MyQueue/Policy/Resource"
+        "aws:cdk:path": "GoCdkStack/MyNewQueue/Policy/Resource"
       }
     },
-    "MyQueueGoCdkStackMyTopicC4A147EE8F169AC2": {
+    "MyNewQueueGoCdkStackMyTopicC4A147EED2DB26BD": {
       "Type": "AWS::SNS::Subscription",
       "Properties": {
         "Protocol": "sqs",
@@ -167,13 +167,13 @@
         },
         "Endpoint": {
           "Fn::GetAtt": [
-            "MyQueueE6CA6235",
+            "MyNewQueue486005E3",
             "Arn"
           ]
         }
       },
       "Metadata": {
-        "aws:cdk:path": "GoCdkStack/MyQueue/GoCdkStackMyTopicC4A147EE/Resource"
+        "aws:cdk:path": "GoCdkStack/MyNewQueue/GoCdkStackMyTopicC4A147EE/Resource"
       }
     },
     "MyDynamoDBFunctionServiceRole4D295727": {
@@ -842,7 +842,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "MyQueueE6CA6235",
+                  "MyNewQueue486005E3",
                   "Arn"
                 ]
               }
@@ -921,7 +921,7 @@
         "aws:asset:property": "Code"
       }
     },
-    "MySQSFunctionSqsEventSourceGoCdkStackMyQueue9883952B48BFF52A": {
+    "MySQSFunctionSqsEventSourceGoCdkStackMyNewQueueE4FEAF7ED885DDBD": {
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "FunctionName": {
@@ -930,13 +930,13 @@
         "BatchSize": 10,
         "EventSourceArn": {
           "Fn::GetAtt": [
-            "MyQueueE6CA6235",
+            "MyNewQueue486005E3",
             "Arn"
           ]
         }
       },
       "Metadata": {
-        "aws:cdk:path": "GoCdkStack/MySQSFunction/SqsEventSource:GoCdkStackMyQueue9883952B/Resource"
+        "aws:cdk:path": "GoCdkStack/MySQSFunction/SqsEventSource:GoCdkStackMyNewQueueE4FEAF7E/Resource"
       }
     },
     "MySQSFunctionLogRetention1914FA38": {
@@ -1217,7 +1217,7 @@
     "Queuename": {
       "Value": {
         "Fn::GetAtt": [
-          "MyQueueE6CA6235",
+          "MyNewQueue486005E3",
           "QueueName"
         ]
       }

--- a/resources/cfn/go_example_lambda/GoExamplleLambda.json
+++ b/resources/cfn/go_example_lambda/GoExamplleLambda.json
@@ -1,0 +1,1413 @@
+{
+  "Resources": {
+    "MyTable794EDED1": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH"
+          }
+        ],
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S"
+          }
+        ],
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 5,
+          "WriteCapacityUnits": 5
+        },
+        "StreamSpecification": {
+          "StreamViewType": "NEW_IMAGE"
+        }
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain",
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyTable/Resource"
+      }
+    },
+    "MyBucketF68F3FF0": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "NameTag",
+            "Value": "MyBucket"
+          }
+        ]
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain",
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyBucket/Resource"
+      }
+    },
+    "MyBucketNotifications46AC0CD2": {
+      "Type": "Custom::S3BucketNotifications",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "BucketNotificationsHandler050a0587b7544547bf325f094a3db8347ECC3691",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "MyBucketF68F3FF0"
+        },
+        "NotificationConfiguration": {
+          "LambdaFunctionConfigurations": [
+            {
+              "Events": [
+                "s3:ObjectCreated:*"
+              ],
+              "LambdaFunctionArn": {
+                "Fn::GetAtt": [
+                  "MyS3Function6C4C4C99",
+                  "Arn"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "DependsOn": [
+        "MyBucketAllowBucketNotificationsToGoLambdaCdkStackMyS3FunctionFD4F511A067D9641"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyBucket/Notifications/Resource"
+      }
+    },
+    "MyBucketAllowBucketNotificationsToGoLambdaCdkStackMyS3FunctionFD4F511A067D9641": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "MyS3Function6C4C4C99",
+            "Arn"
+          ]
+        },
+        "Principal": "s3.amazonaws.com",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        },
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "MyBucketF68F3FF0",
+            "Arn"
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyBucket/AllowBucketNotificationsToGoLambdaCdkStackMyS3FunctionFD4F511A"
+      }
+    },
+    "MyTopic86869434": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "DisplayName": "User subscription topic"
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyTopic/Resource"
+      }
+    },
+    "MyQueueE6CA6235": {
+      "Type": "AWS::SQS::Queue",
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyQueue/Resource"
+      }
+    },
+    "MyQueuePolicy6BBEDDAC": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "MyTopic86869434"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "sns.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "MyQueueE6CA6235",
+                  "Arn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Queues": [
+          {
+            "Ref": "MyQueueE6CA6235"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyQueue/Policy/Resource"
+      }
+    },
+    "MyQueueGoLambdaCdkStackMyTopic0A78A3D9603413A3": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "MyTopic86869434"
+        },
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "MyQueueE6CA6235",
+            "Arn"
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyQueue/GoLambdaCdkStackMyTopic0A78A3D9/Resource"
+      }
+    },
+    "MyDynamoDBFunctionServiceRole4D295727": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyDynamoDBFunction/ServiceRole/Resource"
+      }
+    },
+    "MyDynamoDBFunctionServiceRoleDefaultPolicy24607661": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "MyDLQueueFC9F303C",
+                  "Arn"
+                ]
+              }
+            },
+            {
+              "Action": "dynamodb:ListStreams",
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {
+              "Action": [
+                "dynamodb:DescribeStream",
+                "dynamodb:GetRecords",
+                "dynamodb:GetShardIterator"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "MyTable794EDED1",
+                  "StreamArn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "MyDynamoDBFunctionServiceRoleDefaultPolicy24607661",
+        "Roles": [
+          {
+            "Ref": "MyDynamoDBFunctionServiceRole4D295727"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyDynamoDBFunction/ServiceRole/DefaultPolicy/Resource"
+      }
+    },
+    "MyDynamoDBFunctionD8356FF8": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParameters01755609b1034218e373e033b48308c5b55cb7f5da94a7ecfbb72c01ce0958edS3BucketC4CCFD8C"
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters01755609b1034218e373e033b48308c5b55cb7f5da94a7ecfbb72c01ce0958edS3VersionKeyE3F5FDFF"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters01755609b1034218e373e033b48308c5b55cb7f5da94a7ecfbb72c01ce0958edS3VersionKeyE3F5FDFF"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            ]
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "MyDynamoDBFunctionServiceRole4D295727",
+            "Arn"
+          ]
+        },
+        "Handler": "main",
+        "Runtime": "go1.x"
+      },
+      "DependsOn": [
+        "MyDynamoDBFunctionServiceRoleDefaultPolicy24607661",
+        "MyDynamoDBFunctionServiceRole4D295727"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyDynamoDBFunction/Resource",
+        "aws:asset:path": "asset.01755609b1034218e373e033b48308c5b55cb7f5da94a7ecfbb72c01ce0958ed",
+        "aws:asset:property": "Code"
+      }
+    },
+    "MyDynamoDBFunctionDynamoDBEventSourceGoLambdaCdkStackMyTable2A76715EDF2C013F": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "MyDynamoDBFunctionD8356FF8"
+        },
+        "BatchSize": 5,
+        "BisectBatchOnFunctionError": true,
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": {
+              "Fn::GetAtt": [
+                "MyDLQueueFC9F303C",
+                "Arn"
+              ]
+            }
+          }
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "MyTable794EDED1",
+            "StreamArn"
+          ]
+        },
+        "MaximumRetryAttempts": 10,
+        "StartingPosition": "TRIM_HORIZON"
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyDynamoDBFunction/DynamoDBEventSource:GoLambdaCdkStackMyTable2A76715E/Resource"
+      }
+    },
+    "MyDynamoDBFunctionLogRetention564CFF77": {
+      "Type": "Custom::LogRetention",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn"
+          ]
+        },
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "MyDynamoDBFunctionD8356FF8"
+              }
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyDynamoDBFunction/LogRetention/Resource"
+      }
+    },
+    "MyDLQueueFC9F303C": {
+      "Type": "AWS::SQS::Queue",
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyDLQueue/Resource"
+      }
+    },
+    "MyDLQueuePolicy3E3BD7C7": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "MyTopic86869434"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "sns.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "MyDLQueueFC9F303C",
+                  "Arn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Queues": [
+          {
+            "Ref": "MyDLQueueFC9F303C"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyDLQueue/Policy/Resource"
+      }
+    },
+    "MyS3FunctionServiceRoleC6299E6D": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyS3Function/ServiceRole/Resource"
+      }
+    },
+    "MyS3Function6C4C4C99": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParameters9e615d69f3b6d99d379f69f82382e33b20b238a23dc7dc1edf5902684ef688f9S3BucketC56C4996"
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters9e615d69f3b6d99d379f69f82382e33b20b238a23dc7dc1edf5902684ef688f9S3VersionKey39A5D412"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters9e615d69f3b6d99d379f69f82382e33b20b238a23dc7dc1edf5902684ef688f9S3VersionKey39A5D412"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            ]
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "MyS3FunctionServiceRoleC6299E6D",
+            "Arn"
+          ]
+        },
+        "Handler": "main",
+        "Runtime": "go1.x"
+      },
+      "DependsOn": [
+        "MyS3FunctionServiceRoleC6299E6D"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyS3Function/Resource",
+        "aws:asset:path": "asset.9e615d69f3b6d99d379f69f82382e33b20b238a23dc7dc1edf5902684ef688f9",
+        "aws:asset:property": "Code"
+      }
+    },
+    "MyS3FunctionLogRetention33B2AE92": {
+      "Type": "Custom::LogRetention",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn"
+          ]
+        },
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "MyS3Function6C4C4C99"
+              }
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MyS3Function/LogRetention/Resource"
+      }
+    },
+    "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleB6FB88EC": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/Resource"
+      }
+    },
+    "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleDefaultPolicy2CF63D36": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:PutBucketNotification",
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleDefaultPolicy2CF63D36",
+        "Roles": [
+          {
+            "Ref": "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleB6FB88EC"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/DefaultPolicy/Resource"
+      }
+    },
+    "BucketNotificationsHandler050a0587b7544547bf325f094a3db8347ECC3691": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Description": "AWS CloudFormation handler for \"Custom::S3BucketNotifications\" resources (@aws-cdk/aws-s3)",
+        "Code": {
+          "ZipFile": "exports.handler = (event, context) => {\n    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies\n    const s3 = new (require('aws-sdk').S3)();\n    // eslint-disable-next-line @typescript-eslint/no-require-imports\n    const https = require('https');\n    // eslint-disable-next-line @typescript-eslint/no-require-imports\n    const url = require('url');\n    log(JSON.stringify(event, undefined, 2));\n    const props = event.ResourceProperties;\n    if (event.RequestType === 'Delete') {\n        props.NotificationConfiguration = {}; // this is how you clean out notifications\n    }\n    const req = {\n        Bucket: props.BucketName,\n        NotificationConfiguration: props.NotificationConfiguration,\n    };\n    return s3.putBucketNotificationConfiguration(req, (err, data) => {\n        log({ err, data });\n        if (err) {\n            return submitResponse('FAILED', err.message + `\\nMore information in CloudWatch Log Stream: ${context.logStreamName}`);\n        }\n        else {\n            return submitResponse('SUCCESS');\n        }\n    });\n    function log(obj) {\n        console.error(event.RequestId, event.StackId, event.LogicalResourceId, obj);\n    }\n    // eslint-disable-next-line max-len\n    // adapted from https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-cfnresponsemodule\n    // to allow sending an error messge as a reason.\n    function submitResponse(responseStatus, reason) {\n        const responseBody = JSON.stringify({\n            Status: responseStatus,\n            Reason: reason || 'See the details in CloudWatch Log Stream: ' + context.logStreamName,\n            PhysicalResourceId: event.PhysicalResourceId || event.LogicalResourceId,\n            StackId: event.StackId,\n            RequestId: event.RequestId,\n            LogicalResourceId: event.LogicalResourceId,\n            NoEcho: false,\n        });\n        log({ responseBody });\n        const parsedUrl = url.parse(event.ResponseURL);\n        const options = {\n            hostname: parsedUrl.hostname,\n            port: 443,\n            path: parsedUrl.path,\n            method: 'PUT',\n            headers: {\n                'content-type': '',\n                'content-length': responseBody.length,\n            },\n        };\n        const request = https.request(options, (r) => {\n            log({ statusCode: r.statusCode, statusMessage: r.statusMessage });\n            context.done();\n        });\n        request.on('error', (error) => {\n            log({ sendError: error });\n            context.done();\n        });\n        request.write(responseBody);\n        request.end();\n    }\n};"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleB6FB88EC",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs10.x",
+        "Timeout": 300
+      },
+      "DependsOn": [
+        "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleDefaultPolicy2CF63D36",
+        "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleB6FB88EC"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Resource"
+      }
+    },
+    "MySNSFunctionServiceRole3E4F5D81": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MySNSFunction/ServiceRole/Resource"
+      }
+    },
+    "MySNSFunction58612F6D": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParameters54b0556f856e94135c3d3497b7c8f523625e542ef4182871083e0b7139c47cccS3Bucket6870E811"
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters54b0556f856e94135c3d3497b7c8f523625e542ef4182871083e0b7139c47cccS3VersionKeyD52FF4F0"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters54b0556f856e94135c3d3497b7c8f523625e542ef4182871083e0b7139c47cccS3VersionKeyD52FF4F0"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            ]
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "MySNSFunctionServiceRole3E4F5D81",
+            "Arn"
+          ]
+        },
+        "Handler": "main",
+        "Runtime": "go1.x"
+      },
+      "DependsOn": [
+        "MySNSFunctionServiceRole3E4F5D81"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MySNSFunction/Resource",
+        "aws:asset:path": "asset.54b0556f856e94135c3d3497b7c8f523625e542ef4182871083e0b7139c47ccc",
+        "aws:asset:property": "Code"
+      }
+    },
+    "MySNSFunctionAllowInvokeGoLambdaCdkStackMyTopic0A78A3D9172034A2": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "MySNSFunction58612F6D",
+            "Arn"
+          ]
+        },
+        "Principal": "sns.amazonaws.com",
+        "SourceArn": {
+          "Ref": "MyTopic86869434"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MySNSFunction/AllowInvoke:GoLambdaCdkStackMyTopic0A78A3D9"
+      }
+    },
+    "MySNSFunctionMyTopic197B4C28": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "Protocol": "lambda",
+        "TopicArn": {
+          "Ref": "MyTopic86869434"
+        },
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "MySNSFunction58612F6D",
+            "Arn"
+          ]
+        },
+        "FilterPolicy": {
+          "Field": [
+            "cat",
+            "dog"
+          ]
+        },
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "MyDLQueueFC9F303C",
+              "Arn"
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MySNSFunction/MyTopic/Resource"
+      }
+    },
+    "MySNSFunctionLogRetention9BA80035": {
+      "Type": "Custom::LogRetention",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn"
+          ]
+        },
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "MySNSFunction58612F6D"
+              }
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MySNSFunction/LogRetention/Resource"
+      }
+    },
+    "MySQSFunctionServiceRole5140D4AD": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MySQSFunction/ServiceRole/Resource"
+      }
+    },
+    "MySQSFunctionServiceRoleDefaultPolicy322A7FFE": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "MyQueueE6CA6235",
+                  "Arn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "MySQSFunctionServiceRoleDefaultPolicy322A7FFE",
+        "Roles": [
+          {
+            "Ref": "MySQSFunctionServiceRole5140D4AD"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MySQSFunction/ServiceRole/DefaultPolicy/Resource"
+      }
+    },
+    "MySQSFunction2F6CC41A": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParameters2cc921ad0cd39e60b0db737bd06a977b9a5337f8065481cae7f63ed2a82f1502S3BucketE2A7FF9F"
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters2cc921ad0cd39e60b0db737bd06a977b9a5337f8065481cae7f63ed2a82f1502S3VersionKeyB0F44375"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters2cc921ad0cd39e60b0db737bd06a977b9a5337f8065481cae7f63ed2a82f1502S3VersionKeyB0F44375"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            ]
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "MySQSFunctionServiceRole5140D4AD",
+            "Arn"
+          ]
+        },
+        "Handler": "main",
+        "Runtime": "go1.x"
+      },
+      "DependsOn": [
+        "MySQSFunctionServiceRoleDefaultPolicy322A7FFE",
+        "MySQSFunctionServiceRole5140D4AD"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MySQSFunction/Resource",
+        "aws:asset:path": "asset.2cc921ad0cd39e60b0db737bd06a977b9a5337f8065481cae7f63ed2a82f1502",
+        "aws:asset:property": "Code"
+      }
+    },
+    "MySQSFunctionSqsEventSourceGoLambdaCdkStackMyQueue2B40B92BE308D5F1": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "MySQSFunction2F6CC41A"
+        },
+        "BatchSize": 10,
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "MyQueueE6CA6235",
+            "Arn"
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MySQSFunction/SqsEventSource:GoLambdaCdkStackMyQueue2B40B92B/Resource"
+      }
+    },
+    "MySQSFunctionLogRetention1914FA38": {
+      "Type": "Custom::LogRetention",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn"
+          ]
+        },
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "MySQSFunction2F6CC41A"
+              }
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/MySQSFunction/LogRetention/Resource"
+      }
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/ServiceRole/Resource"
+      }
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:PutRetentionPolicy",
+                "logs:DeleteRetentionPolicy"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "Roles": [
+          {
+            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/ServiceRole/DefaultPolicy/Resource"
+      }
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Runtime": "nodejs12.x",
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3Bucket4D46ABB5"
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3VersionKeyB0F28861"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3VersionKeyB0F28861"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            ]
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/Resource"
+      }
+    },
+    "CDKMetadata": {
+      "Type": "AWS::CDK::Metadata",
+      "Properties": {
+        "Modules": "aws-cdk=1.87.0,@aws-cdk/assets=1.87.1,@aws-cdk/aws-apigateway=1.87.1,@aws-cdk/aws-applicationautoscaling=1.87.1,@aws-cdk/aws-autoscaling-common=1.87.1,@aws-cdk/aws-cloudwatch=1.87.1,@aws-cdk/aws-codeguruprofiler=1.87.1,@aws-cdk/aws-dynamodb=1.87.1,@aws-cdk/aws-ec2=1.87.1,@aws-cdk/aws-ecr=1.87.1,@aws-cdk/aws-ecr-assets=1.87.1,@aws-cdk/aws-events=1.87.1,@aws-cdk/aws-iam=1.87.1,@aws-cdk/aws-kms=1.87.1,@aws-cdk/aws-lambda=1.87.1,@aws-cdk/aws-lambda-event-sources=1.87.1,@aws-cdk/aws-logs=1.87.1,@aws-cdk/aws-s3=1.87.1,@aws-cdk/aws-s3-assets=1.87.1,@aws-cdk/aws-s3-notifications=1.87.1,@aws-cdk/aws-sns=1.87.1,@aws-cdk/aws-sns-subscriptions=1.87.1,@aws-cdk/aws-sqs=1.87.1,@aws-cdk/aws-ssm=1.87.1,@aws-cdk/cloud-assembly-schema=1.87.1,@aws-cdk/core=1.87.1,@aws-cdk/custom-resources=1.87.1,@aws-cdk/cx-api=1.87.1,@aws-cdk/region-info=1.87.1,jsii-runtime=node.js/v14.15.0"
+      },
+      "Metadata": {
+        "aws:cdk:path": "GoLambdaCdkStack/CDKMetadata/Default"
+      },
+      "Condition": "CDKMetadataAvailable"
+    }
+  },
+  "Parameters": {
+    "AssetParameters01755609b1034218e373e033b48308c5b55cb7f5da94a7ecfbb72c01ce0958edS3BucketC4CCFD8C": {
+      "Type": "String",
+      "Description": "S3 bucket for asset \"01755609b1034218e373e033b48308c5b55cb7f5da94a7ecfbb72c01ce0958ed\""
+    },
+    "AssetParameters01755609b1034218e373e033b48308c5b55cb7f5da94a7ecfbb72c01ce0958edS3VersionKeyE3F5FDFF": {
+      "Type": "String",
+      "Description": "S3 key for asset version \"01755609b1034218e373e033b48308c5b55cb7f5da94a7ecfbb72c01ce0958ed\""
+    },
+    "AssetParameters01755609b1034218e373e033b48308c5b55cb7f5da94a7ecfbb72c01ce0958edArtifactHashCAD51A78": {
+      "Type": "String",
+      "Description": "Artifact hash for asset \"01755609b1034218e373e033b48308c5b55cb7f5da94a7ecfbb72c01ce0958ed\""
+    },
+    "AssetParameters9e615d69f3b6d99d379f69f82382e33b20b238a23dc7dc1edf5902684ef688f9S3BucketC56C4996": {
+      "Type": "String",
+      "Description": "S3 bucket for asset \"9e615d69f3b6d99d379f69f82382e33b20b238a23dc7dc1edf5902684ef688f9\""
+    },
+    "AssetParameters9e615d69f3b6d99d379f69f82382e33b20b238a23dc7dc1edf5902684ef688f9S3VersionKey39A5D412": {
+      "Type": "String",
+      "Description": "S3 key for asset version \"9e615d69f3b6d99d379f69f82382e33b20b238a23dc7dc1edf5902684ef688f9\""
+    },
+    "AssetParameters9e615d69f3b6d99d379f69f82382e33b20b238a23dc7dc1edf5902684ef688f9ArtifactHash21295088": {
+      "Type": "String",
+      "Description": "Artifact hash for asset \"9e615d69f3b6d99d379f69f82382e33b20b238a23dc7dc1edf5902684ef688f9\""
+    },
+    "AssetParameters54b0556f856e94135c3d3497b7c8f523625e542ef4182871083e0b7139c47cccS3Bucket6870E811": {
+      "Type": "String",
+      "Description": "S3 bucket for asset \"54b0556f856e94135c3d3497b7c8f523625e542ef4182871083e0b7139c47ccc\""
+    },
+    "AssetParameters54b0556f856e94135c3d3497b7c8f523625e542ef4182871083e0b7139c47cccS3VersionKeyD52FF4F0": {
+      "Type": "String",
+      "Description": "S3 key for asset version \"54b0556f856e94135c3d3497b7c8f523625e542ef4182871083e0b7139c47ccc\""
+    },
+    "AssetParameters54b0556f856e94135c3d3497b7c8f523625e542ef4182871083e0b7139c47cccArtifactHash0CEA96CB": {
+      "Type": "String",
+      "Description": "Artifact hash for asset \"54b0556f856e94135c3d3497b7c8f523625e542ef4182871083e0b7139c47ccc\""
+    },
+    "AssetParameters2cc921ad0cd39e60b0db737bd06a977b9a5337f8065481cae7f63ed2a82f1502S3BucketE2A7FF9F": {
+      "Type": "String",
+      "Description": "S3 bucket for asset \"2cc921ad0cd39e60b0db737bd06a977b9a5337f8065481cae7f63ed2a82f1502\""
+    },
+    "AssetParameters2cc921ad0cd39e60b0db737bd06a977b9a5337f8065481cae7f63ed2a82f1502S3VersionKeyB0F44375": {
+      "Type": "String",
+      "Description": "S3 key for asset version \"2cc921ad0cd39e60b0db737bd06a977b9a5337f8065481cae7f63ed2a82f1502\""
+    },
+    "AssetParameters2cc921ad0cd39e60b0db737bd06a977b9a5337f8065481cae7f63ed2a82f1502ArtifactHash06513F4E": {
+      "Type": "String",
+      "Description": "Artifact hash for asset \"2cc921ad0cd39e60b0db737bd06a977b9a5337f8065481cae7f63ed2a82f1502\""
+    },
+    "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3Bucket4D46ABB5": {
+      "Type": "String",
+      "Description": "S3 bucket for asset \"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\""
+    },
+    "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3VersionKeyB0F28861": {
+      "Type": "String",
+      "Description": "S3 key for asset version \"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\""
+    },
+    "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": {
+      "Type": "String",
+      "Description": "Artifact hash for asset \"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\""
+    }
+  },
+  "Outputs": {
+    "Bucketname": {
+      "Value": {
+        "Ref": "MyBucketF68F3FF0"
+      }
+    },
+    "S3functionname": {
+      "Value": {
+        "Ref": "MyS3Function6C4C4C99"
+      }
+    },
+    "S3functionCloudWatchloggroup": {
+      "Value": {
+        "Fn::GetAtt": [
+          "MyS3FunctionLogRetention33B2AE92",
+          "LogGroupName"
+        ]
+      }
+    },
+    "Tablename": {
+      "Value": {
+        "Ref": "MyTable794EDED1"
+      }
+    },
+    "DynamoDBfunctionname": {
+      "Value": {
+        "Ref": "MyDynamoDBFunctionD8356FF8"
+      }
+    },
+    "DynamoDBfunctionCloudWatchloggroup": {
+      "Value": {
+        "Fn::GetAtt": [
+          "MyDynamoDBFunctionLogRetention564CFF77",
+          "LogGroupName"
+        ]
+      }
+    },
+    "Topicname": {
+      "Value": {
+        "Fn::GetAtt": [
+          "MyTopic86869434",
+          "TopicName"
+        ]
+      }
+    },
+    "SNSfunctionname": {
+      "Value": {
+        "Ref": "MySNSFunction58612F6D"
+      }
+    },
+    "SNSfunctionCloudWatchloggroup": {
+      "Value": {
+        "Fn::GetAtt": [
+          "MySNSFunctionLogRetention9BA80035",
+          "LogGroupName"
+        ]
+      }
+    },
+    "Queuename": {
+      "Value": {
+        "Fn::GetAtt": [
+          "MyQueueE6CA6235",
+          "QueueName"
+        ]
+      }
+    },
+    "SQSfunctionname": {
+      "Value": {
+        "Ref": "MySQSFunction2F6CC41A"
+      }
+    },
+    "SQSfunctionCloudWatchloggroup": {
+      "Value": {
+        "Fn::GetAtt": [
+          "MySQSFunctionLogRetention1914FA38",
+          "LogGroupName"
+        ]
+      }
+    }
+  },
+  "Conditions": {
+    "CDKMetadataAvailable": {
+      "Fn::Or": [
+        {
+          "Fn::Or": [
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-east-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-northeast-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-northeast-2"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-south-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-southeast-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-southeast-2"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ca-central-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "cn-north-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "cn-northwest-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "eu-central-1"
+              ]
+            }
+          ]
+        },
+        {
+          "Fn::Or": [
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "eu-north-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "eu-west-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "eu-west-2"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "eu-west-3"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "me-south-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "sa-east-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "us-east-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "us-east-2"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "us-west-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "us-west-2"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/resources/cfn/go_example_lambda/README.md
+++ b/resources/cfn/go_example_lambda/README.md
@@ -1,6 +1,6 @@
 # Creating resources to run AWS Lambda functions in Go
 
-The AWS CloudFormation template **GoExamplleLambda.json**  
+The AWS CloudFormation template **GoCdkStack.template.json** 
 contains definitions that you can use to create the following resources:
 
 - An Amazon S3 bucket
@@ -32,7 +32,7 @@ To create these resources from this template:
    where *STACK-NAME* is the name of the CloudFormation stack to create.
    It displays the names of the resources when it finishes:
 
-   `aws cloudformation create-stack --stack-name STACK-NAME --template-body file://GoExamplleLambda.json`
+   `aws cloudformation create-stack --stack-name STACK-NAME --template-body file://GoCdkStack.template.json`
 
 If you forget any of the names of the resources, 
 you can use the AWS CLI to get information about the resources created by

--- a/resources/cfn/go_example_lambda/README.md
+++ b/resources/cfn/go_example_lambda/README.md
@@ -1,0 +1,58 @@
+# Creating resources to run AWS Lambda functions in Go
+
+The AWS CloudFormation template **GoExamplleLambda.json**  
+contains definitions that you can use to create the following resources:
+
+- An Amazon S3 bucket
+- An Amazon DynamoDB table
+- An Amazon SNS topic
+- An Amazon SQS queue
+
+In addition, the template creates AWS Lambda functions,
+in Go, to detect the following events:
+
+- An object uploaded to the Amazon S3 bucket
+- An item added to the Amazon DynamoDB table
+- A message sent to the Amazon SNS topic
+- A message sent to the Amazon SQS queue
+
+## Creating the resources using the AWS CLI
+
+You can use the
+AWS Command Line Interface (AWS CLI)
+to run the CloudFormation template and create the resources.
+You can get the AWS CLI from
+[here](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
+
+To create these resources from this template:
+
+1. Copy the template to your computer.
+
+1. Run the following AWS CLI command to create the resources,
+   where *STACK-NAME* is the name of the CloudFormation stack to create.
+   It displays the names of the resources when it finishes:
+
+   `aws cloudformation create-stack --stack-name STACK-NAME --template-body file://GoExamplleLambda.json`
+
+If you forget any of the names of the resources, 
+you can use the AWS CLI to get information about the resources created by
+the resulting CloudFormation template by running the following command,
+where *STACK-NAME* is the name of the CloudFormation stack to get information from:
+
+`aws cloudformation describe-stacks --stack-name STACK-NAME --query Stacks[0].Outputs --output text`
+
+## Customizing the template
+
+The template was created using the 
+[AWS Cloud Development Kit (AWS CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html) 
+project in
+[go_example_lambda](../../cdk/go_example_lambda).
+If you want to customize the template, use that AWS CDK project.
+See the **README.md** file in that directory for details.
+
+## Testing the notifications
+
+The [go_example_lambda](../../cdk/go_example_lambda) 
+project contains Windows batch and Bash script files that you can use 
+to test the AWS Lambda functions.
+See the **README.md** file in that project for details.


### PR DESCRIPTION
*Issue #, if available:*
If we want to give users the option of creating the resources defined in CDK apps in resources/cdk,
we should provide the CloudFormation template and tell them how to run it.

*Description of changes:*
Added the CloudFormation template created from resources/cdk/go_example_lambda.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
