### PR TITLE
Fixed file path in jsv3 S3 Photo Example README.md

### DIFF
--- a/javascriptv3/example_code/s3/photoExample/README.md
+++ b/javascriptv3/example_code/s3/photoExample/README.md
@@ -14,7 +14,7 @@ such as *@aws-sdk/client-s3*, *@aws-sdk/client-cognito-identity*, and
 *@aws-sdk/credential-provider-cognito-identity*.
 ```
 npm install ts-node -g # If using JavaScript, enter 'npm install node -g' instead
-cd javascriptv3/example_code/s3/src/photoExample/src
+cd javascriptv3/example_code/s3/photoExample/src
 npm install
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There was an incorrect file path given in the README.md documentation for the javascriptv3 S3 photoExample. This pull request fixes that file path so that `npm install` will work correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
