### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ main.zip
 node_modules/
 cdk.out/
 package-lock.json
+*.class


### PR DESCRIPTION
*Issue #, if available:*
We were not blocking checkins of binary Java .class files.

*Description of changes:*
Added "*.class" to .gitignore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
