### PR TITLE
Fixed duplicate snippet tag

### DIFF
--- a/javav2/example_code/s3/src/main/java/com/example/s3/S3BucketDeletion.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/S3BucketDeletion.java
@@ -50,7 +50,7 @@ public class S3BucketDeletion {
         s3.close();
     }
 
-    // snippet-start:[s3.java2.s3_bucket_ops.delete_bucket]
+    // snippet-start:[s3.java2.s3_bucket_ops.delete_bucketobjects]
     public static void listAllObjects(S3Client s3, String bucket) {
 
         try {
@@ -72,7 +72,7 @@ public class S3BucketDeletion {
                         .build();
 
             } while(listObjectsV2Response.isTruncated());
-            // snippet-end:[s3.java2.s3_bucket_ops.delete_bucket]
+            // snippet-end:[s3.java2.s3_bucket_ops.delete_bucketobjects]
 
             DeleteBucketRequest deleteBucketRequest = DeleteBucketRequest.builder().bucket(bucket).build();
             s3.deleteBucket(deleteBucketRequest);


### PR DESCRIPTION
The same code snippet tag ID is used in two different java classes, and the wrong one is showing in the java v2 dev guide. Renaming one of the tag sets to avoid the duplication.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
