### PR TITLE
Fix typo in variable name

### DIFF
--- a/javav2/example_code/cognito/src/main/java/com/example/cognito/CreateUserPool.java
+++ b/javav2/example_code/cognito/src/main/java/com/example/cognito/CreateUserPool.java
@@ -51,12 +51,12 @@ public class CreateUserPool {
     public static String createPool(CognitoIdentityProviderClient cognitoclient,String userPoolName ) {
 
         try {
-            CreateUserPoolResponse repsonse = cognitoclient.createUserPool(
+            CreateUserPoolResponse userPoolResponse = cognitoclient.createUserPool(
                     CreateUserPoolRequest.builder()
                             .poolName(userPoolName)
                             .build()
             );
-            return repsonse.userPool().id();
+            return userPoolResponse.userPool().id();
 
         } catch (CognitoIdentityProviderException e){
             System.err.println(e.awsErrorDetails().errorMessage());


### PR DESCRIPTION
A customer left some feedback that one of the variable names was spelled "repsonse" - renamed this variable and retested Cognito package/tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
