### PR TITLE
Added readmes for IAM code examples in Go v2

### DIFF
--- a/gov2/iam/AccessKeyLastUsed/README.md
+++ b/gov2/iam/AccessKeyLastUsed/README.md
@@ -1,0 +1,49 @@
+# AccessKeyLastUsedv2.go
+
+This example retrieves when an IAM access key was last used, 
+including the AWS Region and with which service.
+
+`go run AccessKeyLastUsedv2.go -k KeyID`
+
+- _KeyID_ is the ID of the access key.
+
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/AttachUserPolicy/README.md
+++ b/gov2/iam/AttachUserPolicy/README.md
@@ -1,0 +1,36 @@
+# AttachUserPolicyv2.go
+
+This example attaches an Amazon DynamoDB full-access policy to an IAM role.
+
+`go run AttachUserPolicyv2.go -n ROLE-NAME`
+
+- _ROLE-NAME_ is the name of the role to which the policy is attached.
+
+The unit test accepts a similar value in _config.json_.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/CreateAccessKey/README.md
+++ b/gov2/iam/CreateAccessKey/README.md
@@ -1,0 +1,46 @@
+# CreateAccessKeyv2.go
+
+This example creates a new IAM access key for a user.
+
+`go run CreateAccessKeyv2.go -u USER-NAME`
+
+- _USER-NAME_ is the name of the user for whom the new key is created.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/CreateAccountAlias/README.md
+++ b/gov2/iam/CreateAccountAlias/README.md
@@ -1,0 +1,48 @@
+# CreateAccountAliasv2.go
+
+This example creates an alias for your IAM account.
+
+`go run CreateAccountAliasv2.go -a ALIAS`
+
+- _ALIAS_ is the alias created for your account.
+
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/CreatePolicy/README.md
+++ b/gov2/iam/CreatePolicy/README.md
@@ -1,0 +1,48 @@
+# CreatePolicyv2.go
+
+This example creates an IAM policy.
+
+`go run CreatePolicyv2.go -n POLICY-NAME`
+
+- _POLICY-NAME_ is the name of the policy to create.
+
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/CreateUser/README.md
+++ b/gov2/iam/CreateUser/README.md
@@ -1,0 +1,48 @@
+# CreateUserv2.go
+
+This example creates an IAM user. 
+
+`go run CreateUserv2.go -u USER-NAME`
+
+- _USER-NAME_ is the name of the user to create.
+
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/DeleteAccessKey/README.md
+++ b/gov2/iam/DeleteAccessKey/README.md
@@ -1,0 +1,49 @@
+# DeleteAccessKeyv2.go
+
+This example deletes an IAM access key.
+
+`go run DeleteAccessKeyv2.go -k KeyID -u USER-NAME`
+
+- _KEYID_ is the access key to delete.
+- _USER-NAME_ is the name of the user deleting the key.
+
+The unit test accepts similar values in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/DeleteAccountAlias/README.md
+++ b/gov2/iam/DeleteAccountAlias/README.md
@@ -1,0 +1,48 @@
+# DeleteAccountAliasv2.go
+
+This example deletes an alias for your IAM account.
+
+`go run DeleteAccountAliasv2.go -a ALIAS`
+
+- _ALIAS_ is the account alias to delete.
+
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/DeleteServerCert/README.md
+++ b/gov2/iam/DeleteServerCert/README.md
@@ -1,0 +1,48 @@
+# DeleteServerCertv2.go
+
+This example deletes an IAM server certificate.
+
+`go run DeleteServerCertv2.go -c CERTIFICATE-NAME`
+
+- _CERTIFICATE-NAME_ is the name of the server certificate to delete.
+
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/DeleteUser/README.md
+++ b/gov2/iam/DeleteUser/README.md
@@ -1,0 +1,48 @@
+# DeleteUserv2.go
+
+This example deletes an IAM user.
+
+`go run DeleteUserv2.go -u USER-NAME`
+
+- _USER-NAME_ is the name of the user to delete.
+
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/DetachUserPolicy/README.md
+++ b/gov2/iam/DetachUserPolicy/README.md
@@ -1,0 +1,48 @@
+# DetachUserPolicyv2.go
+
+This example detaches an Amazon DynamoDB full-access policy from an IAM role.
+
+`go run DetachUserPolicyv2.go -r ROLE-NAME`
+
+- _ROLE-NAME_ is the name of the role from which the policy is detached.
+
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/GetPolicy/README.md
+++ b/gov2/iam/GetPolicy/README.md
@@ -1,0 +1,48 @@
+# GetPolicyv2.go
+
+This example retrieves the description of the IAM policy with the specified ARN.
+
+`go run GetPolicyv2.go -p POLICY-ARN`
+
+- _POLICY-ARN_ is the ARN of the policy.
+
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/GetServerCert/README.md
+++ b/gov2/iam/GetServerCert/README.md
@@ -1,0 +1,48 @@
+# GetServerCertv2.go
+
+This example retrieves an IAM server certificate.
+
+`go run GetServerCertv2.go -c CERTIFICATE`
+
+- _CERTIFICATE_ is the name of the server certificate.
+
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/ListAccessKeys/README.md
+++ b/gov2/iam/ListAccessKeys/README.md
@@ -1,0 +1,50 @@
+# ListAccessKeysv2.go
+
+This example retrieves the access keys for your IAM account.
+
+`go run ListAccessKeysv2.go -u USER-NAME -m MAX-KEYS`
+
+- _USER-NAME_ is the name of the user for which the keys are listed.
+- _MAX-KEYS_ is the maximum number of keys to display.
+  If this value is negative, the code example sets it to 10. 
+
+The unit test accepts similar values in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/ListAccountAliases/README.md
+++ b/gov2/iam/ListAccountAliases/README.md
@@ -1,0 +1,49 @@
+# ListAccountAliasesv2.go
+
+This example retrieves the aliases for your IAM account.
+
+`go run ListAccountAliasesv2.go [-m MAX-ITEMS]`
+
+- _MAX-ITEMS_ is the maximum number of aliases to show.
+  If this value is less than zero, the code example sets it to 10.
+  
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/ListAdmins/README.md
+++ b/gov2/iam/ListAdmins/README.md
@@ -1,0 +1,48 @@
+# ListAdminsv2.go
+
+This example lists the number IAM users and those who have administrative privileges.
+
+`go run ListAdminsv2.go [-d]`
+
+- **-d** to list the user and administrator names.
+
+The unit test accepts a similar value in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/ListServerCerts/README.md
+++ b/gov2/iam/ListServerCerts/README.md
@@ -1,0 +1,44 @@
+# ListServerCertsv2.go
+
+This example retrieves the server certificates.
+
+`go run ListServerCertsv2.go`
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/ListUsers/README.md
+++ b/gov2/iam/ListUsers/README.md
@@ -1,0 +1,48 @@
+# ListUsersv2.go
+
+This example retrieves a list of your IAM users.
+
+`go run ListUsersv2.go [-m MAX-USERS]`
+
+- _MAX-USERS_ is the maximum number of users to list.
+  The code example restricts this to the range of 0 to 100.
+  The default value is 10.
+  
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/UpdateAccessKey/README.md
+++ b/gov2/iam/UpdateAccessKey/README.md
@@ -1,0 +1,49 @@
+# UpdateAccessKeyv2.go
+
+This example sets the status of an IAM access key to active.
+
+`go run UpdateAccessKeyv2.go -k KeyID -u USER-NAME`
+
+- _KEYID_ is the access key to activate.
+- _USER-NAME_ is the name of the user activating the key.
+
+The unit test accepts similar values in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/UpdateServerCert/README.md
+++ b/gov2/iam/UpdateServerCert/README.md
@@ -1,0 +1,49 @@
+# UpdateServerCertv2.go
+
+This example renames an IAM server certificate.
+
+`go run UpdateServerCert/UpdateServerCertv2.go -c CERTIFICATE-NAME -n NEW-NAME`
+
+- _CERTIFICATE-NAME_ is the original name of the server certificate.
+- _NEW-NAME_ is the new name of the server certificate.
+
+The unit test accepts similar values in _config.json_.
+  
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/gov2/iam/UpdateUser/README.md
+++ b/gov2/iam/UpdateUser/README.md
@@ -1,0 +1,49 @@
+# UpdateUserv2.go
+
+This example changes the name of the user.
+
+`go run UpdateUserv2.go -u USER-NAME -n NEW-NAME`
+
+- _USER-NAME_ is the name of the user to change.
+- _NEW-NAME_ is the new name of the user.
+
+The unit test accepts similar values in _config.json_.
+
+## Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+## Running the unit tests
+
+Unit tests should delete any resources they create.
+However, they might result in charges to your
+AWS account.
+
+To run a unit test, enter:
+
+`go test`
+
+You should see something like the following,
+where PATH is the path to the folder containing the Go files:
+
+```sh
+PASS
+ok      PATH 6.593s
+```
+
+If you want to see any log messages, enter:
+
+`go test -v`
+
+You should see some additional log messages.
+The last two lines should be similar to the previous output shown.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
*Issue #, if available:*
The IAM code examples in Go v2 did not have individual README.md files.

*Description of changes:*
Added README.md files to each IAM code example in Go v2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
