### PR TITLE
Use log.Fatalf for simpler and shorter handling of failures

### DIFF
--- a/go/example_code/dynamodb/DynamoDBCreateItem.go
+++ b/go/example_code/dynamodb/DynamoDBCreateItem.go
@@ -33,7 +33,7 @@ import (
     "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 
     "fmt"
-    "os"
+    "log"
     "strconv"
 )
 // snippet-end:[dynamodb.go.create_item.imports]
@@ -71,9 +71,7 @@ func main() {
 
     av, err := dynamodbattribute.MarshalMap(item)
     if err != nil {
-        fmt.Println("Got error marshalling new movie item:")
-        fmt.Println(err.Error())
-        os.Exit(1)
+        log.Fatalf("Got error marshalling new movie item: %s", err)
     }
     // snippet-end:[dynamodb.go.create_item.assign_struct]
 
@@ -88,9 +86,7 @@ func main() {
 
     _, err = svc.PutItem(input)
     if err != nil {
-        fmt.Println("Got error calling PutItem:")
-        fmt.Println(err.Error())
-        os.Exit(1)
+        log.Fatalf("Got error calling PutItem: %s", err)
     }
 
     year := strconv.Itoa(item.Year)

--- a/go/example_code/dynamodb/DynamoDBCreateTable.go
+++ b/go/example_code/dynamodb/DynamoDBCreateTable.go
@@ -32,7 +32,7 @@ import (
     "github.com/aws/aws-sdk-go/service/dynamodb"
 
     "fmt"
-    "os"
+    "log"
 )
 // snippet-end:[dynamodb.go.create_table.imports]
 
@@ -83,9 +83,7 @@ func main() {
 
     _, err := svc.CreateTable(input)
     if err != nil {
-        fmt.Println("Got error calling CreateTable:")
-        fmt.Println(err.Error())
-        os.Exit(1)
+        log.Fatalf("Got error calling CreateTable: %s", err)
     }
 
     fmt.Println("Created the table", tableName)

--- a/go/example_code/dynamodb/DynamoDBDeleteItem.go
+++ b/go/example_code/dynamodb/DynamoDBDeleteItem.go
@@ -32,6 +32,7 @@ import (
     "github.com/aws/aws-sdk-go/service/dynamodb"
 
     "fmt"
+    "log"
 )
 // snippet-end:[dynamodb.go.delete_item.imports]
 
@@ -67,9 +68,7 @@ func main() {
 
     _, err := svc.DeleteItem(input)
     if err != nil {
-        fmt.Println("Got error calling DeleteItem")
-        fmt.Println(err.Error())
-        return
+        log.Fatalf("Got error calling DeleteItem: %s", err)
     }
 
     fmt.Println("Deleted '" + movieName + "' (" + movieYear + ") from table " + tableName)

--- a/go/example_code/dynamodb/DynamoDBLoadItems.go
+++ b/go/example_code/dynamodb/DynamoDBLoadItems.go
@@ -34,8 +34,8 @@ import (
 
     "encoding/json"
     "fmt"
+    "log"
     "io/ioutil"
-    "os"
     "strconv"
 )
 // snippet-end:[dynamodb.go.load_items.imports]
@@ -55,8 +55,7 @@ type Item struct {
 func getItems() []Item {
     raw, err := ioutil.ReadFile("./.movie_data.json")
     if err != nil {
-        fmt.Println(err.Error())
-        os.Exit(1)
+        log.Fatalf("Got error reading file: %s", err)
     }
 
     var items []Item
@@ -88,9 +87,7 @@ func main() {
     for _, item := range items {
         av, err := dynamodbattribute.MarshalMap(item)
         if err != nil {
-            fmt.Println("Got error marshalling map:")
-            fmt.Println(err.Error())
-            os.Exit(1)
+            log.Fatalf("Got error marshalling map: %s", err)
         }
 
         // Create item in table Movies
@@ -101,9 +98,7 @@ func main() {
 
         _, err = svc.PutItem(input)
         if err != nil {
-            fmt.Println("Got error calling PutItem:")
-            fmt.Println(err.Error())
-            os.Exit(1)
+            log.Fatalf("Got error calling PutItem: %s", err)
         }
 
         year := strconv.Itoa(item.Year)

--- a/go/example_code/dynamodb/DynamoDBReadItem.go
+++ b/go/example_code/dynamodb/DynamoDBReadItem.go
@@ -33,6 +33,7 @@ import (
     "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 
     "fmt"
+    "log"
 )
 // snippet-end:[dynamodb.go.read_item.imports]
 
@@ -76,8 +77,7 @@ func main() {
         },
     })
     if err != nil {
-        fmt.Println(err.Error())
-        return
+        log.Fatalf("Got error calling GetItem: %s", err)
     }
     // snippet-end:[dynamodb.go.read_item.call]
 

--- a/go/example_code/dynamodb/DynamoDBScanItems.go
+++ b/go/example_code/dynamodb/DynamoDBScanItems.go
@@ -35,7 +35,7 @@ import (
     "github.com/aws/aws-sdk-go/service/dynamodb/expression"
 
     "fmt"
-    "os"
+    "log"
 )
 // snippet-end:[dynamodb.go.scan_items.imports]
 
@@ -82,9 +82,7 @@ func main() {
 
     expr, err := expression.NewBuilder().WithFilter(filt).WithProjection(proj).Build()
     if err != nil {
-        fmt.Println("Got error building expression:")
-        fmt.Println(err.Error())
-        os.Exit(1)
+        log.Fatalf("Got error building expression: %s", err)
     }
     // snippet-end:[dynamodb.go.scan_items.expr]
 
@@ -101,9 +99,7 @@ func main() {
     // Make the DynamoDB Query API call
     result, err := svc.Scan(params)
     if err != nil {
-        fmt.Println("Query API call failed:")
-        fmt.Println((err.Error()))
-        os.Exit(1)
+        log.Fatalf("Query API call failed: %s", err)
     }
     // snippet-end:[dynamodb.go.scan_items.call]
 
@@ -116,9 +112,7 @@ func main() {
         err = dynamodbattribute.UnmarshalMap(i, &item)
 
         if err != nil {
-            fmt.Println("Got error unmarshalling:")
-            fmt.Println(err.Error())
-            os.Exit(1)
+            log.Fatalf("Got error unmarshalling: %s", err)
         }
 
         // Which ones had a higher rating than minimum?

--- a/go/example_code/dynamodb/DynamoDBUpdateItem.go
+++ b/go/example_code/dynamodb/DynamoDBUpdateItem.go
@@ -32,6 +32,7 @@ import (
     "github.com/aws/aws-sdk-go/service/dynamodb"
 
     "fmt"
+    "log"
 )
 // snippet-end:[dynamodb.go.update_item.imports]
 
@@ -76,8 +77,7 @@ func main() {
 
     _, err := svc.UpdateItem(input)
     if err != nil {
-        fmt.Println(err.Error())
-        return
+        log.Fatalf("Got error calling UpdateItem: %s", err)
     }
 
     fmt.Println("Successfully updated '" + movieName + "' (" + movieYear + ") rating to " + movieRating)

--- a/go/example_code/dynamodb/load_items.go
+++ b/go/example_code/dynamodb/load_items.go
@@ -29,7 +29,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -71,9 +71,7 @@ func main() {
 	)
 
 	if err != nil {
-		fmt.Println("Error creating session:")
-		fmt.Println(err.Error())
-		os.Exit(1)
+		log.Fatalf("Error creating session: %s", err)
 	}
 
 	// Create DynamoDB client
@@ -87,9 +85,7 @@ func main() {
 		av, err := dynamodbattribute.MarshalMap(item)
 
 		if err != nil {
-			fmt.Println("Got error marshalling map:")
-			fmt.Println(err.Error())
-			os.Exit(1)
+			log.Fatalf("Got error marshalling map: %s", err)
 		}
 
 		// Create item in table Movies
@@ -101,9 +97,7 @@ func main() {
 		_, err = svc.PutItem(input)
 
 		if err != nil {
-			fmt.Println("Got error calling PutItem:")
-			fmt.Println(err.Error())
-			os.Exit(1)
+			log.Fatalf("Got error calling PutItem: %s", err)
 		}
 
 		fmt.Println("Successfully added '", item.Title, "' (", item.Year, ") to Movies table")

--- a/go/example_code/dynamodb/read_item.go
+++ b/go/example_code/dynamodb/read_item.go
@@ -27,6 +27,7 @@ package main
 
 import (
     "fmt"
+    "log"
 
     "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
@@ -69,8 +70,7 @@ func main() {
     })
 
     if err != nil {
-        fmt.Println(err.Error())
-        return
+        log.Fatalf("Got error calling GetItem: %s", err)
     }
 
     item := Item{}

--- a/go/example_code/dynamodb/scan_items.go
+++ b/go/example_code/dynamodb/scan_items.go
@@ -28,7 +28,7 @@ package main
 
 import (
     "fmt"
-    "os"
+    "log"
 
     "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
@@ -61,9 +61,7 @@ func main() {
     )
 
     if err != nil {
-        fmt.Println("Got error creating session:")
-        fmt.Println(err.Error())
-        os.Exit(1)
+        log.Fatalf("Got error creating session: %s", err)
     }
 
     // Create DynamoDB client
@@ -82,9 +80,7 @@ func main() {
     expr, err := expression.NewBuilder().WithFilter(filt).WithProjection(proj).Build()
 
     if err != nil {
-        fmt.Println("Got error building expression:")
-        fmt.Println(err.Error())
-        os.Exit(1)
+        log.Fatalf("Got error building expression: %s", err)
     }
 
     // Build the query input parameters
@@ -100,9 +96,7 @@ func main() {
     result, err := svc.Scan(params)
 
     if err != nil {
-        fmt.Println("Query API call failed:")
-        fmt.Println((err.Error()))
-        os.Exit(1)
+        log.Fatalf("Query API call failed: %s", err)
     }
 
     num_items := 0
@@ -113,9 +107,7 @@ func main() {
         err = dynamodbattribute.UnmarshalMap(i, &item)
 
         if err != nil {
-            fmt.Println("Got error unmarshalling:")
-            fmt.Println(err.Error())
-            os.Exit(1)
+            log.Fatalf("Got error unmarshalling: %s", err)
         }
 
         // Which ones had a higher rating?

--- a/go/example_code/dynamodb/update_item.go
+++ b/go/example_code/dynamodb/update_item.go
@@ -30,9 +30,9 @@ import (
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/dynamodb"
     "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
-    
+
     "fmt"
-    "os"
+    "log"
 )
 
 // ItemInfo holds info to update
@@ -67,16 +67,12 @@ func main() {
 
     expr, err := dynamodbattribute.MarshalMap(info)
     if err != nil {
-        fmt.Println("Got error marshalling info:")
-        fmt.Println(err.Error())
-        os.Exit(1)
+        log.Fatalf("Got error marshalling info: %s", err)
     }
 
     key, err := dynamodbattribute.MarshalMap(item)
     if err != nil {
-        fmt.Println("Got error marshalling item:")
-        fmt.Println(err.Error())
-        os.Exit(1)
+        log.Fatalf("Got error marshalling item: %s", err)
     }
 
     // Update item in table Movies
@@ -90,8 +86,7 @@ func main() {
 
     _, err = svc.UpdateItem(input)
     if err != nil {
-        fmt.Println(err.Error())
-        return
+        log.Fatalf("Got error calling UpdateItem: %s", err)
     }
 
     fmt.Println("Successfully updated 'The Big New Movie' (2015) rating to 0.5")


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

Print the error message and exiting the process with exit status 1 using `log.Fatalf` in 1 line rather than 3. Also in a few places I've changed the wording to be similar to the rest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
