### PR TITLE
Removed aws- prefix from text parameter file

### DIFF
--- a/gov2/kms/CreateKey/config.json
+++ b/gov2/kms/CreateKey/config.json
@@ -1,4 +1,4 @@
 {
-  "Key": "aws-docs-example-kmskey-key",
-  "Value": "aws-docs-example-kmskey-value"
+  "Key": "docs-example-kmskey-key",
+  "Value": "docs-example-kmskey-value"
 }


### PR DESCRIPTION
*Issue #, if available:*
config.json file has "aws-" prefix. This can be a problem in China.

*Description of changes:*
Removed the prefixes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
