### PR TITLE
php example is missing fclose function

### DIFF
--- a/php/example_code/s3/ObjectUploader.php
+++ b/php/example_code/s3/ObjectUploader.php
@@ -63,6 +63,8 @@ do {
     }
 } while (!isset($result));
 
+fclose($source);
+
 // snippet-end:[s3.php.objectuploader.main]
 // snippet-end:[s3.php.objectuploader.complete]
 // snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]


### PR DESCRIPTION
If you keep uploading a large number of files without doing this fclose(), the FD (File Descriptor) may be exceeded and the php process may die.

Actually I copied and used this example to run it. However, I constantly see the 'too many open files' error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
