### PR TITLE
Do not run Go code in module mode

### DIFF
--- a/.github/workflows/ciTest.yml
+++ b/.github/workflows/ciTest.yml
@@ -36,4 +36,7 @@ jobs:
           # make file runnable, might not be necessary
           chmod +x scripts/run_go_tests.sh
 
+          # Do not run in module mode
+	  set GO111MODULE=off
+
           scripts/run_go_tests.sh ${{ steps.files.outputs.all }}


### PR DESCRIPTION
*Issue #, if available:*
Go CI/CD was producing errors like:

go: cannot find main module, but ...

*Description of changes:*
Added to CITest.yaml:

```set GO111MODULE=off```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
