### PR TITLE
Added var to env for Go ci/cd

### DIFF
--- a/.github/workflows/ciTest.yml
+++ b/.github/workflows/ciTest.yml
@@ -29,14 +29,14 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '^1.13.1' # The Go version to download (if necessary) and use.
+      - name: set env var
+        run: |
+            echo "GO111MODULE=off" >> $GITHUB_ENV # Do not run in module mode
       - uses: jitterbit/get-changed-files@v1
         id: files
         continue-on-error: true
       - run: |
           # make file runnable, might not be necessary
           chmod +x scripts/run_go_tests.sh
-
-          # Do not run in module mode
-	  set GO111MODULE=off
 
           scripts/run_go_tests.sh ${{ steps.files.outputs.all }}


### PR DESCRIPTION
*Issue #, if available:*
You cannot set an environment variable directly in a workflow.

*Description of changes:*
See https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
