### PR TITLE
Added s3 rust alpha code examples

### DIFF
--- a/.rust_alpha/.gitignore
+++ b/.rust_alpha/.gitignore
@@ -1,0 +1,3 @@
+target/
+Cargo.lock
+

--- a/.rust_alpha/s3/Cargo.toml
+++ b/.rust_alpha/s3/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "s3-code-examples"
+version = "0.1.0"
+authors = ["Russell Cohen <rcoh@amazon.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+s3 = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-sdk-s3" }
+smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "smithy-http" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-types"}
+
+tokio = { version = "1", features = ["full"] }
+tracing-subscriber = "0.2.18"
+bytes = "1"
+hyper = "0.14.7"
+structopt = { version = "0.3", default-features = false }
+
+[profile.dev]
+split-debuginfo = "unpacked"

--- a/.rust_alpha/s3/Cargo.toml
+++ b/.rust_alpha/s3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s3-code-examples"
 version = "0.1.0"
-authors = ["Russell Cohen <rcoh@amazon.com>"]
+authors = ["Russell Cohen <rcoh@amazon.com>", "Doug Schwartz <dougsch@amazon.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,6 +10,7 @@ edition = "2018"
 s3 = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-sdk-s3" }
 smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "smithy-http" }
 aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-types"}
+smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "smithy-types"}
 
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.2.18"

--- a/.rust_alpha/s3/README.md
+++ b/.rust_alpha/s3/README.md
@@ -1,0 +1,112 @@
+# AWS SDK for Rust code examples for Amazon S3
+
+## Purpose
+
+These examples demonstrate how to perform several Amazon Simple Storage Service (Amazon S3) operations using the alpha version of the AWS SDK for Rust.
+
+## Prerequisites
+
+You must have an AWS account, and have configured your default credentials and AWS Region as described in [https://github.com/awslabs/aws-sdk-rust](https://github.com/awslabs/aws-sdk-rust).
+
+## Running the code
+
+### create-bucket
+
+This example creates an Amazon S3 bucket.
+
+`cargo run --bin create-bucket -- -b BUCKET [-d DEFAULT-REGION] [-v]`
+
+- _BUCKET_ is the name of the bucket to create.
+- _DEFAULT-REGION_ is name of the AWS Region, such as __us-east-1__, where the table is located.
+  If not supplied, uses the value of the __AWS_DEFAULT_REGION__ or __AWS_REGION__ environment variable.
+  If the environment variable is not set, defaults to __us-west-2__.
+- __-v__ displays additional information.
+
+### delete-bucket
+
+This example deletes an Amazon S3 bucket.
+
+`cargo run --bin delete-bucket -- -b BUCKET [-d DEFAULT-REGION] [-v]`
+
+- _BUCKET_ is the name of the bucket to delete.
+- _DEFAULT-REGION_ is name of the AWS Region, such as __us-east-1__, where the table is located.
+  If not supplied, uses the value of the __AWS_DEFAULT_REGION__ or __AWS_REGION__ environment variable.
+  If the environment variable is not set, defaults to __us-west-2__.
+- __-v__ displays additional information.
+
+### delete-object
+
+This example deletes an object from an Amazon S3 bucket.
+
+`cargo run --bin delete-object -- -b BUCKET -k KEY [-d DEFAULT-REGION] [-v]`
+
+- _BUCKET_ is the name of the bucket.
+- _KEY_ is the name of the object to delete.
+- _DEFAULT-REGION_ is name of the AWS Region, such as __us-east-1__, where the table is located.
+  If not supplied, uses the value of the __AWS_DEFAULT_REGION__ or __AWS_REGION__ environment variable.
+  If the environment variable is not set, defaults to __us-west-2__.
+- __-v__ displays additional information.
+
+### hello-world
+
+This example lists your buckets in __us-east-2__, 
+creates the bucket __aws-rust-sdk__ (you might have to change the name if anyone has already run this code example), 
+adds __Cargo.toml__ to the bucket,
+retrieves the object as a string, and displays it.
+
+`cargo run --bin hello-world -- [-d DEFAULT-REGION] [-v]`
+
+- _DEFAULT-REGION_ is name of the AWS Region, such as __us-east-1__, where the table is located.
+  If not supplied, uses the value of the __AWS_DEFAULT_REGION__ or __AWS_REGION__ environment variable.
+  If the environment variable is not set, defaults to __us-west-2__.
+- __-v__ displays additional information.
+
+### list-buckets
+
+This example lists your Amazon S3 buckets.
+
+`cargo run --bin list-buckets -- [-d DEFAULT-REGION] [-v]`
+
+- _DEFAULT-REGION_ is name of the AWS Region, such as __us-east-1__, where the table is located.
+  If not supplied, uses the value of the __AWS_DEFAULT_REGION__ or __AWS_REGION__ environment variable.
+  If the environment variable is not set, defaults to __us-west-2__.
+- __-v__ displays additional information.
+
+### list-objects
+
+This example lists the objects in an Amazon S3 bucket.
+
+`cargo run --bin list-objects -- -b BUCKET [-d DEFAULT-REGION] [-v]`
+
+- _BUCKET_ is the name of the bucket.
+- _DEFAULT-REGION_ is name of the AWS Region, such as __us-east-1__, where the table is located.
+  If not supplied, uses the value of the __AWS_DEFAULT_REGION__ or __AWS_REGION__ environment variable.
+  If the environment variable is not set, defaults to __us-west-2__.
+- __-v__ displays additional information.
+
+### put-object
+
+This example adds an object (file) to an Amazon S3 bucket.
+
+`cargo run --bin put-object -- -b BUCKET -k KEY [-d DEFAULT-REGION] [-v]`
+
+- _BUCKET_ is the name of the bucket.
+- _KEY_ is the name of the object (file).
+- _DEFAULT-REGION_ is name of the AWS Region, such as __us-east-1__, where the table is located.
+  If not supplied, uses the value of the __AWS_DEFAULT_REGION__ or __AWS_REGION__ environment variable.
+  If the environment variable is not set, defaults to __us-west-2__.
+- __-v__ displays additional information.
+
+### Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/.rust_alpha/s3/src/bin/create-bucket.rs
+++ b/.rust_alpha/s3/src/bin/create-bucket.rs
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::process;
+
+use s3::{Client, Config, Region};
+
+use s3::model::{BucketLocationConstraint, CreateBucketConfiguration};
+
+use aws_types::region::ProvideRegion;
+
+use structopt::StructOpt;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::fmt::SubscriberBuilder;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The default region
+    #[structopt(short, long)]
+    default_region: Option<String>,
+
+    /// The name of the bucket
+    #[structopt(short, long)]
+    name: String,
+
+    /// Whether to display additional information
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Creates an Amazon S3 bucket
+/// # Arguments
+///
+/// * `-n NAME` - The name of the bucket.
+/// * `[-d DEFAULT-REGION]` - The region containing the bucket.
+///   If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
+///   If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-v]` - Whether to display additional information.
+#[tokio::main]
+async fn main() {
+    let Opt {
+        default_region,
+        name,
+        verbose,
+    } = Opt::from_args();
+
+    let region = default_region
+        .as_ref()
+        .map(|region| Region::new(region.clone()))
+        .or_else(|| aws_types::region::default_provider().region())
+        .unwrap_or_else(|| Region::new("us-west-2"));
+
+    let r: &str = &region.as_ref();
+
+    if verbose {
+        println!("S3 client version: {}", s3::PKG_VERSION);
+        println!("Region:            {:?}", &region);
+
+        SubscriberBuilder::default()
+            .with_env_filter("info")
+            .with_span_events(FmtSpan::CLOSE)
+            .init();
+    }
+
+    let config = Config::builder().region(&region).build();
+
+    let client = Client::from_conf(config);
+
+    let constraint = BucketLocationConstraint::from(r);
+    let cfg = CreateBucketConfiguration::builder()
+        .location_constraint(constraint)
+        .build();
+
+    match client
+        .create_bucket()
+        .create_bucket_configuration(cfg)
+        .bucket(&name)
+        .send()
+        .await
+    {
+        Ok(_) => {
+            println!("Created bucket {}", name);
+        }
+
+        Err(e) => {
+            println!("Got an error creating bucket:");
+            println!("{}", e);
+            process::exit(1);
+        }
+    };
+}

--- a/.rust_alpha/s3/src/bin/create-bucket.rs
+++ b/.rust_alpha/s3/src/bin/create-bucket.rs
@@ -17,15 +17,15 @@ use tracing_subscriber::fmt::SubscriberBuilder;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// The default region
+    /// The AWS Region.
     #[structopt(short, long)]
     default_region: Option<String>,
 
-    /// The name of the bucket
+    /// The name of the bucket to create.
     #[structopt(short, long)]
-    name: String,
+    bucket: String,
 
-    /// Whether to display additional information
+    /// Whether to display additional information.
     #[structopt(short, long)]
     verbose: bool,
 }
@@ -33,7 +33,7 @@ struct Opt {
 /// Creates an Amazon S3 bucket
 /// # Arguments
 ///
-/// * `-n NAME` - The name of the bucket.
+/// * `-b BUCKET` - The name of the bucket to create.
 /// * `[-d DEFAULT-REGION]` - The region containing the bucket.
 ///   If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
 ///   If the environment variable is not set, defaults to **us-west-2**.
@@ -42,7 +42,7 @@ struct Opt {
 async fn main() {
     let Opt {
         default_region,
-        name,
+        bucket,
         verbose,
     } = Opt::from_args();
 
@@ -56,7 +56,7 @@ async fn main() {
 
     if verbose {
         println!("S3 client version: {}", s3::PKG_VERSION);
-        println!("Region:            {:?}", &region);
+        println!("AWS Region:        {:?}", &region);
 
         SubscriberBuilder::default()
             .with_env_filter("info")
@@ -76,12 +76,12 @@ async fn main() {
     match client
         .create_bucket()
         .create_bucket_configuration(cfg)
-        .bucket(&name)
+        .bucket(&bucket)
         .send()
         .await
     {
         Ok(_) => {
-            println!("Created bucket {}", name);
+            println!("Created bucket {}", bucket);
         }
 
         Err(e) => {

--- a/.rust_alpha/s3/src/bin/delete-bucket.rs
+++ b/.rust_alpha/s3/src/bin/delete-bucket.rs
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::process;
+
+use s3::{Client, Config, Region};
+
+use aws_types::region::ProvideRegion;
+
+use structopt::StructOpt;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::fmt::SubscriberBuilder;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The default region
+    #[structopt(short, long)]
+    default_region: Option<String>,
+
+    /// The name of the bucket
+    #[structopt(short, long)]
+    bucket: String,
+
+    /// Whether to display additional information
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Deletes an Amazon S3 bucket.
+/// The bucket must be empty.
+/// # Arguments
+///
+/// * `-n NAME` - The name of the bucket.
+/// * `[-d DEFAULT-REGION]` - The region containing the bucket.
+///   If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
+///   If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-v]` - Whether to display additional information.
+#[tokio::main]
+async fn main() {
+    let Opt {
+        default_region,
+        bucket,
+        verbose,
+    } = Opt::from_args();
+
+    let region = default_region
+        .as_ref()
+        .map(|region| Region::new(region.clone()))
+        .or_else(|| aws_types::region::default_provider().region())
+        .unwrap_or_else(|| Region::new("us-west-2"));
+
+    if verbose {
+        println!("S3 client version: {}", s3::PKG_VERSION);
+        println!("Region:            {:?}", &region);
+
+        SubscriberBuilder::default()
+            .with_env_filter("info")
+            .with_span_events(FmtSpan::CLOSE)
+            .init();
+    }
+
+    let config = Config::builder().region(&region).build();
+
+    let client = Client::from_conf(config);
+
+    match client.delete_bucket().bucket(&bucket).send().await {
+        Ok(_) => {
+            println!("Deleted bucket {}", bucket);
+        }
+
+        Err(e) => {
+            println!("Got an error deleting bucket:");
+            println!("{}", e);
+            process::exit(1);
+        }
+    };
+}

--- a/.rust_alpha/s3/src/bin/delete-bucket.rs
+++ b/.rust_alpha/s3/src/bin/delete-bucket.rs
@@ -15,15 +15,15 @@ use tracing_subscriber::fmt::SubscriberBuilder;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// The default region
+    /// The AWS Region.
     #[structopt(short, long)]
     default_region: Option<String>,
 
-    /// The name of the bucket
+    /// The name of the bucket to delete.
     #[structopt(short, long)]
     bucket: String,
 
-    /// Whether to display additional information
+    /// Whether to display additional information.
     #[structopt(short, long)]
     verbose: bool,
 }
@@ -32,7 +32,7 @@ struct Opt {
 /// The bucket must be empty.
 /// # Arguments
 ///
-/// * `-n NAME` - The name of the bucket.
+/// * `-b BUCKET` - The name of the bucket to delete.
 /// * `[-d DEFAULT-REGION]` - The region containing the bucket.
 ///   If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
 ///   If the environment variable is not set, defaults to **us-west-2**.
@@ -53,7 +53,7 @@ async fn main() {
 
     if verbose {
         println!("S3 client version: {}", s3::PKG_VERSION);
-        println!("Region:            {:?}", &region);
+        println!("AWS Region:        {:?}", &region);
 
         SubscriberBuilder::default()
             .with_env_filter("info")

--- a/.rust_alpha/s3/src/bin/delete-object.rs
+++ b/.rust_alpha/s3/src/bin/delete-object.rs
@@ -15,19 +15,19 @@ use tracing_subscriber::fmt::SubscriberBuilder;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// The bucket to which the object is added
+    /// The bucket to which the object is added.
     #[structopt(short, long)]
     bucket: String,
 
-    /// The default region
+    /// The AWS Region.
     #[structopt(short, long)]
     default_region: Option<String>,
 
-    /// The name of the object
+    /// The name of the object.
     #[structopt(short, long)]
     key: String,
 
-    /// Whether to display additional information
+    /// Whether to display additional information.
     #[structopt(short, long)]
     verbose: bool,
 }
@@ -58,7 +58,7 @@ async fn main() {
 
     if verbose {
         println!("S3 client version: {}", s3::PKG_VERSION);
-        println!("Region:            {:?}", &region);
+        println!("AWS Region:        {:?}", &region);
 
         SubscriberBuilder::default()
             .with_env_filter("info")

--- a/.rust_alpha/s3/src/bin/delete-object.rs
+++ b/.rust_alpha/s3/src/bin/delete-object.rs
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::process;
+
+use s3::{Client, Config, Region};
+
+use aws_types::region::ProvideRegion;
+
+use structopt::StructOpt;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::fmt::SubscriberBuilder;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The bucket to which the object is added
+    #[structopt(short, long)]
+    bucket: String,
+
+    /// The default region
+    #[structopt(short, long)]
+    default_region: Option<String>,
+
+    /// The name of the object
+    #[structopt(short, long)]
+    key: String,
+
+    /// Whether to display additional information
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Delets an object from an Amazon S3 bucket
+/// # Arguments
+///
+/// * `-b BUCKET` - The name of the bucket.
+/// * `-k KEY` - The name of the object.
+/// * `[-d DEFAULT-REGION]` - The region containing the bucket.
+///   If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
+///   If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-v]` - Whether to display additional information.
+#[tokio::main]
+async fn main() {
+    let Opt {
+        bucket,
+        default_region,
+        key,
+        verbose,
+    } = Opt::from_args();
+
+    let region = default_region
+        .as_ref()
+        .map(|region| Region::new(region.clone()))
+        .or_else(|| aws_types::region::default_provider().region())
+        .unwrap_or_else(|| Region::new("us-west-2"));
+
+    if verbose {
+        println!("S3 client version: {}", s3::PKG_VERSION);
+        println!("Region:            {:?}", &region);
+
+        SubscriberBuilder::default()
+            .with_env_filter("info")
+            .with_span_events(FmtSpan::CLOSE)
+            .init();
+    }
+
+    let config = Config::builder().region(&region).build();
+
+    let client = Client::from_conf(config);
+
+    match client
+        .delete_object()
+        .bucket(&bucket)
+        .key(&key)
+        .send()
+        .await
+    {
+        Ok(_) => {
+            println!("Deleted object {} from bucket {}", key, bucket);
+        }
+
+        Err(e) => {
+            println!("Got an error deleting object from bucket:");
+            println!("{}", e);
+            process::exit(1);
+        }
+    };
+}

--- a/.rust_alpha/s3/src/bin/hello-world.rs
+++ b/.rust_alpha/s3/src/bin/hello-world.rs
@@ -1,0 +1,46 @@
+use s3::Region;
+use smithy_http::body::SdkBody;
+use smithy_http::byte_stream::ByteStream;
+use std::error::Error;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::fmt::SubscriberBuilder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    SubscriberBuilder::default()
+        .with_env_filter("info")
+        .with_span_events(FmtSpan::CLOSE)
+        .init();
+    let conf = s3::Config::builder()
+        .region(Region::new("us-east-2"))
+        .build();
+    let client = s3::Client::from_conf(conf);
+    let resp = client.list_buckets().send().await?;
+    for bucket in resp.buckets.unwrap_or_default() {
+        println!("bucket: {:?}", bucket.name.expect("buckets have names"))
+    }
+    // not the best pattern but fine for now because it reads a file all the way into memory
+    let f = tokio::fs::read("Cargo.toml").await?;
+    let body = ByteStream::new(SdkBody::from(f));
+    let resp = client
+        .put_object()
+        .bucket("aws-rust-sdk")
+        .key("demo")
+        .body(body)
+        .send();
+    let resp = resp.await?;
+    println!("version: {:?}", resp.version_id);
+
+    let downloaded = client
+        .get_object()
+        .bucket("aws-rust-sdk")
+        .key("demo")
+        .send()
+        .await?;
+    let data = downloaded.body.collect().await?;
+    println!(
+        "data: {}",
+        String::from_utf8(data.into_bytes().to_vec()).unwrap()
+    );
+    Ok(())
+}

--- a/.rust_alpha/s3/src/bin/hello-world.rs
+++ b/.rust_alpha/s3/src/bin/hello-world.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     for bucket in resp.buckets.unwrap_or_default() {
         println!("bucket: {:?}", bucket.name.expect("buckets have names"))
     }
-    // not the best pattern but fine for now because it reads a file all the way into memory
+    // Not the best pattern but fine for now because it reads a file all the way into memory.
     let f = tokio::fs::read("Cargo.toml").await?;
     let body = ByteStream::new(SdkBody::from(f));
     let resp = client

--- a/.rust_alpha/s3/src/bin/list-buckets.rs
+++ b/.rust_alpha/s3/src/bin/list-buckets.rs
@@ -1,0 +1,125 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::process;
+
+use s3::{Client, Config, Region};
+
+use aws_types::region::ProvideRegion;
+
+use structopt::StructOpt;
+// use tracing_subscriber::fmt::format::FmtSpan;
+// use tracing_subscriber::fmt::SubscriberBuilder;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The default region
+    #[structopt(short, long)]
+    default_region: Option<String>,
+
+    /// Whether to show all buckets
+    #[structopt(short, long)]
+    global: bool,
+
+    /// Whether to display additional information
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Lists your Amazon S3 buckets
+/// # Arguments
+///
+/// * `[-d DEFAULT-REGION]` - The region containing the buckets.
+///   If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
+///   If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-g]` - Whether to display buckets in all regions.
+/// * `[-v]` - Whether to display additional information.
+#[tokio::main]
+async fn main() {
+    let Opt {
+        default_region,
+        global,
+        verbose,
+    } = Opt::from_args();
+
+    let region = default_region
+        .as_ref()
+        .map(|region| Region::new(region.clone()))
+        .or_else(|| aws_types::region::default_provider().region())
+        .unwrap_or_else(|| Region::new("us-west-2"));
+
+    let r: &str = &region.as_ref();
+
+    if verbose {
+        println!("S3 client version: {}", s3::PKG_VERSION);
+        println!("Region:            {:?}", &region);
+
+        // SubscriberBuilder::default()
+        //    .with_env_filter("info")
+        //    .with_span_events(FmtSpan::CLOSE)
+        //    .init();
+    }
+
+    let config = Config::builder().region(&region).build();
+
+    let client = Client::from_conf(config);
+
+    let mut num_buckets = 0;
+
+    match client.list_buckets().send().await {
+        Ok(resp) => {
+            println!("\nBuckets:\n");
+
+            let buckets = resp.buckets.unwrap_or_default();
+
+            for bucket in &buckets {
+                match &bucket.name {
+                    None => {}
+                    Some(b) => {
+                        if global {
+                            println!("{}", b);
+                            num_buckets += 1;
+                        } else {
+                            match client.get_bucket_location().bucket(b).send().await {
+                                Ok(resp) => match resp.location_constraint {
+                                    None => {
+                                        if verbose {
+                                            println!("Could not get a location for {}", b);
+                                        }
+                                    }
+                                    Some(c) => {
+                                        if verbose {
+                                            println!("Location for {}: {}", b, c.as_str());
+                                        }
+                                        if c.as_str() == r {
+                                            println!("{}", b);
+                                            num_buckets += 1;
+                                        }
+                                    }
+                                },
+                                Err(e) => {
+                                    println!("Got an error listing buckets:");
+                                    println!("{}", e);
+                                    process::exit(1);
+                                }
+                            };
+                        }
+                    }
+                }
+            }
+
+            if global {
+                println!("\nFound {} buckets globally", num_buckets);
+            } else {
+                println!("\nFound {} buckets in {}", num_buckets, r);
+            }
+        }
+        Err(e) => {
+            println!("Got an error listing buckets:");
+            println!("{}", e);
+            process::exit(1);
+        }
+    };
+}

--- a/.rust_alpha/s3/src/bin/list-buckets.rs
+++ b/.rust_alpha/s3/src/bin/list-buckets.rs
@@ -10,8 +10,8 @@ use s3::{Client, Config, Region};
 use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
-// use tracing_subscriber::fmt::format::FmtSpan;
-// use tracing_subscriber::fmt::SubscriberBuilder;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::fmt::SubscriberBuilder;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
@@ -56,10 +56,10 @@ async fn main() {
         println!("S3 client version: {}", s3::PKG_VERSION);
         println!("Region:            {:?}", &region);
 
-        // SubscriberBuilder::default()
-        //    .with_env_filter("info")
-        //    .with_span_events(FmtSpan::CLOSE)
-        //    .init();
+        SubscriberBuilder::default()
+            .with_env_filter("info")
+            .with_span_events(FmtSpan::CLOSE)
+            .init();
     }
 
     let config = Config::builder().region(&region).build();

--- a/.rust_alpha/s3/src/bin/list-buckets.rs
+++ b/.rust_alpha/s3/src/bin/list-buckets.rs
@@ -15,20 +15,20 @@ use tracing_subscriber::fmt::SubscriberBuilder;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// The default region
+    /// The AWS Region.
     #[structopt(short, long)]
     default_region: Option<String>,
 
-    /// Whether to show all buckets
+    /// Whether to show all buckets.
     #[structopt(short, long)]
     global: bool,
 
-    /// Whether to display additional information
+    /// Whether to display additional information.
     #[structopt(short, long)]
     verbose: bool,
 }
 
-/// Lists your Amazon S3 buckets
+/// Lists your Amazon S3 buckets.
 /// # Arguments
 ///
 /// * `[-d DEFAULT-REGION]` - The region containing the buckets.
@@ -54,7 +54,7 @@ async fn main() {
 
     if verbose {
         println!("S3 client version: {}", s3::PKG_VERSION);
-        println!("Region:            {:?}", &region);
+        println!("AWS Region:        {:?}", &region);
 
         SubscriberBuilder::default()
             .with_env_filter("info")

--- a/.rust_alpha/s3/src/bin/list-objects.rs
+++ b/.rust_alpha/s3/src/bin/list-objects.rs
@@ -1,0 +1,103 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::process;
+
+use s3::{Client, Config, Region};
+
+use aws_types::region::ProvideRegion;
+
+use structopt::StructOpt;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::fmt::SubscriberBuilder;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The bucket containing objects to list
+    #[structopt(short, long)]
+    bucket: String,
+
+    /// The default region
+    #[structopt(short, long)]
+    default_region: Option<String>,
+
+    /// Whether to display additional information
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Lists your Amazon S3 bucket objects
+/// # Arguments
+///
+/// * `[-b BUCKET]` - The bucket containing the objects to list.
+/// * `[-d DEFAULT-REGION]` - The region containing the buckets.
+///   If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
+///   If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-g]` - Whether to display buckets in all regions.
+/// * `[-v]` - Whether to display additional information.
+#[tokio::main]
+async fn main() {
+    let Opt {
+        bucket,
+        default_region,
+        verbose,
+    } = Opt::from_args();
+
+    let region = default_region
+        .as_ref()
+        .map(|region| Region::new(region.clone()))
+        .or_else(|| aws_types::region::default_provider().region())
+        .unwrap_or_else(|| Region::new("us-west-2"));
+
+    if verbose {
+        println!("S3 client version: {}", s3::PKG_VERSION);
+        println!("Region:            {:?}", &region);
+
+        SubscriberBuilder::default()
+            .with_env_filter("info")
+            .with_span_events(FmtSpan::CLOSE)
+            .init();
+    }
+
+    let config = Config::builder().region(&region).build();
+
+    let client = Client::from_conf(config);
+
+    let mut num_objects: i32 = 0;
+
+    match client.list_objects().bucket(&bucket).send().await {
+        Ok(resp) => {
+            println!("\nObjects in {}:\n", &bucket);
+
+            let objects = resp.contents.unwrap_or_default();
+
+            for object in &objects {
+                match &object.key {
+                    None => {}
+                    Some(k) => {
+                        println!("Name:          {}", k);
+                        num_objects += 1;
+                    }
+                }
+
+                println!("Size:          {} bytes", &object.size);
+
+                match &object.storage_class {
+                    None => {}
+                    Some(sc) => {
+                        println!("Storage class: {}\n", sc.as_str());
+                    }
+                }
+            }
+
+            println!("\nFound {} object(s) in {}", num_objects, bucket);
+        }
+        Err(e) => {
+            println!("Got an error listing objects:");
+            println!("{}", e);
+            process::exit(1);
+        }
+    };
+}

--- a/.rust_alpha/s3/src/bin/list-objects.rs
+++ b/.rust_alpha/s3/src/bin/list-objects.rs
@@ -15,20 +15,20 @@ use tracing_subscriber::fmt::SubscriberBuilder;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// The bucket containing objects to list
+    /// The bucket containing objects to list.
     #[structopt(short, long)]
     bucket: String,
 
-    /// The default region
+    /// The AWS Region.
     #[structopt(short, long)]
     default_region: Option<String>,
 
-    /// Whether to display additional information
+    /// Whether to display additional information.
     #[structopt(short, long)]
     verbose: bool,
 }
 
-/// Lists your Amazon S3 bucket objects
+/// Lists the objects in an Amazon S3 bucket.
 /// # Arguments
 ///
 /// * `[-b BUCKET]` - The bucket containing the objects to list.
@@ -53,7 +53,7 @@ async fn main() {
 
     if verbose {
         println!("S3 client version: {}", s3::PKG_VERSION);
-        println!("Region:            {:?}", &region);
+        println!("AWS Region:        {:?}", &region);
 
         SubscriberBuilder::default()
             .with_env_filter("info")

--- a/.rust_alpha/s3/src/bin/put-object.rs
+++ b/.rust_alpha/s3/src/bin/put-object.rs
@@ -18,24 +18,24 @@ use tracing_subscriber::fmt::SubscriberBuilder;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// The bucket to which the object is added
+    /// The bucket to which the object is added.
     #[structopt(short, long)]
     bucket: String,
 
-    /// The default region
+    /// The AWS Region.
     #[structopt(short, long)]
     default_region: Option<String>,
 
-    /// The name of the object
+    /// The name of the object.
     #[structopt(short, long)]
     key: String,
 
-    /// Whether to display additional information
+    /// Whether to display additional information.
     #[structopt(short, long)]
     verbose: bool,
 }
 
-/// Adds an object (file) to an Amazon S3 bucket
+/// Adds an object (file) to an Amazon S3 bucket.
 /// # Arguments
 ///
 /// * `-b BUCKET` - The name of the bucket.
@@ -61,7 +61,7 @@ async fn main() {
 
     if verbose {
         println!("S3 client version: {}", s3::PKG_VERSION);
-        println!("Region:            {:?}", &region);
+        println!("AWS Region:        {:?}", &region);
 
         SubscriberBuilder::default()
             .with_env_filter("info")

--- a/.rust_alpha/s3/src/bin/put-object.rs
+++ b/.rust_alpha/s3/src/bin/put-object.rs
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::process;
+
+use s3::{Client, Config, Region};
+
+use aws_types::region::ProvideRegion;
+
+use smithy_http::byte_stream::ByteStream;
+use std::path::Path;
+
+use structopt::StructOpt;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::fmt::SubscriberBuilder;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The bucket to which the object is added
+    #[structopt(short, long)]
+    bucket: String,
+
+    /// The default region
+    #[structopt(short, long)]
+    default_region: Option<String>,
+
+    /// The name of the object
+    #[structopt(short, long)]
+    key: String,
+
+    /// Whether to display additional information
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Adds an object (file) to an Amazon S3 bucket
+/// # Arguments
+///
+/// * `-b BUCKET` - The name of the bucket.
+/// * `-k KEY` - The name of the object (file).
+/// * `[-d DEFAULT-REGION]` - The region containing the bucket.
+///   If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
+///   If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-v]` - Whether to display additional information.
+#[tokio::main]
+async fn main() {
+    let Opt {
+        bucket,
+        default_region,
+        key,
+        verbose,
+    } = Opt::from_args();
+
+    let region = default_region
+        .as_ref()
+        .map(|region| Region::new(region.clone()))
+        .or_else(|| aws_types::region::default_provider().region())
+        .unwrap_or_else(|| Region::new("us-west-2"));
+
+    if verbose {
+        println!("S3 client version: {}", s3::PKG_VERSION);
+        println!("Region:            {:?}", &region);
+
+        SubscriberBuilder::default()
+            .with_env_filter("info")
+            .with_span_events(FmtSpan::CLOSE)
+            .init();
+    }
+
+    let config = Config::builder().region(&region).build();
+
+    let client = Client::from_conf(config);
+
+    // Snarf body of file into bytes
+    let f = Path::new(&key);
+    let bs = ByteStream::from_path(&f).await.expect(&key);
+
+    match client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(bs)
+        .send()
+        .await
+    {
+        Ok(_) => {
+            println!("Added file {} to bucket {}", key, bucket);
+        }
+
+        Err(e) => {
+            println!("Got an error adding object to bucket:");
+            println!("{}", e);
+            process::exit(1);
+        }
+    };
+}


### PR DESCRIPTION
*Issue #, if available:*
There were no S3 code examples for the Rust alpha release.

*Description of changes:*
Added them.

Checklist:

- [x] The submitter has successfully built the package, the service guide package(s), and SDK guide package.
- [x] The submitter has added unit tests for all code paths, run all of them, and they all pass.
- [x] The submitter has run a linter on the code, and all of the submitter's team's minimum rules pass.
- [x] The submitter has added the team's minimum usage documentation to the code.
- [x] The submitter has had the code reviewed, and the submitter has incorporated any and all resulting review comments.
      Not required for legacy code.
- [ ] The submitter has had their Editor edit all comments and strings, and the submitter has incorporated any and all resulting edits.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
