### PR TITLE
Removed duplicate snippet tags from example.

### DIFF
--- a/dotnet/example_code_legacy/ACM/DescribeCertificate/DescribeCertificate.cs
+++ b/dotnet/example_code_legacy/ACM/DescribeCertificate/DescribeCertificate.cs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. 
 // SPDX-License-Identifier: MIT-0
-// snippet-start:[acm.dotNET.DescribeCertificate]
+
 using System;
 using Amazon;
 using Amazon.CertificateManager;
@@ -42,4 +42,3 @@ namespace DescribeCertificateExample
         }
     }
 }
-// snippet-end:[acm.dotNET.DescribeCertificate]

--- a/dotnet/example_code_legacy/ACM/ListCertificates/ListCertificates.cs
+++ b/dotnet/example_code_legacy/ACM/ListCertificates/ListCertificates.cs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. 
 // SPDX-License-Identifier: MIT-0
-// snippet-start:[acm.dotNET.ListCertificates]
+
 using System;
 using Amazon;
 using Amazon.CertificateManager;
@@ -37,4 +37,3 @@ namespace ListCertificatesExample
         }
     }
 }
-// snippet-end:[acm.dotNET.ListCertificates]


### PR DESCRIPTION
This pull request fixes a problem with duplicate snippet tags in the ACM examples. I have removed the tags from the old version of the examples and left them fin the examples in dotnetv3/ACM.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
