### PR TITLE
Updated Rust code examples to alpha 0.0.7

### DIFF
--- a/.rust_alpha/README.md
+++ b/.rust_alpha/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-These examples demonstrate how to perform several operations using the alpha 0.0.4 version of the AWS SDK for Rust.
+These examples demonstrate how to perform several operations using the alpha 0.0.7 version of the AWS SDK for Rust.
 
 ## Prerequisites
 

--- a/.rust_alpha/dynamodb/Cargo.toml
+++ b/.rust_alpha/dynamodb/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 
 [dependencies]
 
-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-sdk-dynamodb" }
-aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-http"}
-aws-hyper = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-hyper"}
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-types" }
-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "smithy-http" }
-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "smithy-types" }
+dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-sdk-dynamodb" }
+aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-http"}
+aws-hyper = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-hyper"}
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-types" }
+smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "smithy-http" }
+smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "smithy-types" }
 
 async-std = "1.9.0"
 rand = "0.8.3"

--- a/.rust_alpha/dynamodb/src/bin/add-item.rs
+++ b/.rust_alpha/dynamodb/src/bin/add-item.rs
@@ -8,7 +8,7 @@ use std::process;
 use dynamodb::model::AttributeValue;
 use dynamodb::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -86,7 +86,7 @@ async fn main() {
         .as_ref()
         .map(|region| Region::new(region.clone()))
         .or_else(|| aws_types::region::default_provider().region())
-        .unwrap_or_else(|| Region::new("us-west-2"));    
+        .unwrap_or_else(|| Region::new("us-west-2"));
 
     if verbose {
         println!("DynamoDB client version: {}\n", dynamodb::PKG_VERSION);

--- a/.rust_alpha/dynamodb/src/bin/create-table.rs
+++ b/.rust_alpha/dynamodb/src/bin/create-table.rs
@@ -10,7 +10,7 @@ use dynamodb::model::{
 };
 use dynamodb::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;

--- a/.rust_alpha/dynamodb/src/bin/delete-item.rs
+++ b/.rust_alpha/dynamodb/src/bin/delete-item.rs
@@ -8,7 +8,7 @@ use std::process;
 use dynamodb::model::AttributeValue;
 use dynamodb::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;

--- a/.rust_alpha/dynamodb/src/bin/delete-table.rs
+++ b/.rust_alpha/dynamodb/src/bin/delete-table.rs
@@ -7,7 +7,7 @@ use std::process;
 
 use dynamodb::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;

--- a/.rust_alpha/dynamodb/src/bin/list-items.rs
+++ b/.rust_alpha/dynamodb/src/bin/list-items.rs
@@ -7,7 +7,7 @@ use std::process;
 
 use dynamodb::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;

--- a/.rust_alpha/dynamodb/src/bin/list-tables.rs
+++ b/.rust_alpha/dynamodb/src/bin/list-tables.rs
@@ -7,7 +7,7 @@ use std::process;
 
 use dynamodb::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -33,7 +33,10 @@ struct Opt {
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
 async fn main() {
-    let Opt { default_region, verbose } = Opt::from_args();
+    let Opt {
+        default_region,
+        verbose,
+    } = Opt::from_args();
 
     let region = default_region
         .as_ref()

--- a/.rust_alpha/dynamodb/src/bin/movies.rs
+++ b/.rust_alpha/dynamodb/src/bin/movies.rs
@@ -22,7 +22,7 @@ use smithy_types::retry::RetryKind;
 use std::collections::HashMap;
 use std::time::Duration;
 
-/// A partial reimplementation of 
+/// A partial reimplementation of
 /// https://docs.amazonaws.cn/en_us/amazondynamodb/latest/developerguide/GettingStarted.Ruby.html
 /// in Rust.
 ///

--- a/.rust_alpha/kinesis/Cargo.toml
+++ b/.rust_alpha/kinesis/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kinesis = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-sdk-kinesis" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-types" }
+kinesis = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-sdk-kinesis" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/.rust_alpha/kinesis/src/bin/create-stream.rs
+++ b/.rust_alpha/kinesis/src/bin/create-stream.rs
@@ -7,7 +7,7 @@ use std::process;
 
 use kinesis::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;

--- a/.rust_alpha/kinesis/src/bin/delete-stream.rs
+++ b/.rust_alpha/kinesis/src/bin/delete-stream.rs
@@ -7,7 +7,7 @@ use std::process;
 
 use kinesis::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;

--- a/.rust_alpha/kinesis/src/bin/describe-stream.rs
+++ b/.rust_alpha/kinesis/src/bin/describe-stream.rs
@@ -6,7 +6,7 @@ use std::process;
 
 use kinesis::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;

--- a/.rust_alpha/kinesis/src/bin/list-streams.rs
+++ b/.rust_alpha/kinesis/src/bin/list-streams.rs
@@ -7,7 +7,7 @@ use std::process;
 
 use kinesis::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -33,7 +33,10 @@ struct Opt {
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
 async fn main() {
-    let Opt { default_region, verbose } = Opt::from_args();
+    let Opt {
+        default_region,
+        verbose,
+    } = Opt::from_args();
 
     let region = default_region
         .as_ref()

--- a/.rust_alpha/kinesis/src/bin/put-record.rs
+++ b/.rust_alpha/kinesis/src/bin/put-record.rs
@@ -7,7 +7,7 @@ use std::process;
 
 use kinesis::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;

--- a/.rust_alpha/kms/Cargo.toml
+++ b/.rust_alpha/kms/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Russell Cohen <rcoh@amazon.com>", "Doug Schwartz <dougsch@amazon.com
 edition = "2018"
 
 [dependencies]
-kms = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-sdk-kms" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-types" }
-aws-hyper = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-hyper"}
+kms = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-sdk-kms" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-types" }
+aws-hyper = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-hyper"}
 
 tokio = { version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }

--- a/.rust_alpha/kms/src/bin/decrypt.rs
+++ b/.rust_alpha/kms/src/bin/decrypt.rs
@@ -16,7 +16,7 @@ use tracing_subscriber::fmt::SubscriberBuilder;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// The AWS Region. 
+    /// The AWS Region.
     #[structopt(short, long)]
     default_region: Option<String>,
 

--- a/.rust_alpha/kms/src/bin/reencrypt-data.rs
+++ b/.rust_alpha/kms/src/bin/reencrypt-data.rs
@@ -25,19 +25,19 @@ struct Opt {
     /// The original encryption key.
     #[structopt(short, long)]
     first_key: String,
-    
+
     /// The new encryption key.
     #[structopt(short, long)]
     new_key: String,
-    
+
     /// The name of the input file containing the text to reencrypt.
     #[structopt(short, long)]
     input_file: String,
-    
+
     /// The name of the output file containing the reencrypted text.
     #[structopt(short, long)]
     output_file: String,
-    
+
     /// Whether to display additonal information.
     #[structopt(short, long)]
     verbose: bool,
@@ -119,7 +119,9 @@ async fn main() {
     let o = &output_file;
 
     let mut ofile = File::create(o).expect("Unable to create file.");
-    ofile.write_all(s.as_bytes()).expect("Unable to write to file.");
+    ofile
+        .write_all(s.as_bytes())
+        .expect("Unable to write to file.");
 
     if verbose {
         println!("Wrote the following to {}:", output_file);

--- a/.rust_alpha/polly/Cargo.toml
+++ b/.rust_alpha/polly/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-polly = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-sdk-polly" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-types" }
+polly = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-sdk-polly" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-types" }
 
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }

--- a/.rust_alpha/polly/src/bin/describe-voices.rs
+++ b/.rust_alpha/polly/src/bin/describe-voices.rs
@@ -7,7 +7,7 @@ use std::process;
 
 use polly::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -33,7 +33,10 @@ struct Opt {
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
 async fn main() {
-    let Opt { default_region, verbose } = Opt::from_args();
+    let Opt {
+        default_region,
+        verbose,
+    } = Opt::from_args();
 
     let region = default_region
         .as_ref()
@@ -67,7 +70,7 @@ async fn main() {
                     "  Language: {}",
                     voice.language_name.as_deref().unwrap_or("No language!")
                 );
-		println!();
+                println!();
             }
 
             println!("\nFound {} voices.\n", voices.len());

--- a/.rust_alpha/polly/src/bin/list-lexicons.rs
+++ b/.rust_alpha/polly/src/bin/list-lexicons.rs
@@ -7,7 +7,7 @@ use std::process;
 
 use polly::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -33,7 +33,10 @@ struct Opt {
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
 async fn main() {
-    let Opt { default_region, verbose } = Opt::from_args();
+    let Opt {
+        default_region,
+        verbose,
+    } = Opt::from_args();
 
     let region = default_region
         .as_ref()

--- a/.rust_alpha/polly/src/bin/put-lexicon.rs
+++ b/.rust_alpha/polly/src/bin/put-lexicon.rs
@@ -7,7 +7,7 @@ use std::process;
 
 use polly::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 use tracing_subscriber::fmt::format::FmtSpan;

--- a/.rust_alpha/polly/src/bin/synthesize-speech.rs
+++ b/.rust_alpha/polly/src/bin/synthesize-speech.rs
@@ -8,7 +8,7 @@ use std::process;
 use polly::model::{OutputFormat, VoiceId};
 use polly::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use bytes::Buf;
 use structopt::StructOpt;

--- a/.rust_alpha/s3/Cargo.toml
+++ b/.rust_alpha/s3/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-sdk-s3" }
-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "smithy-http" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-types"}
-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "smithy-types"}
+s3 = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-sdk-s3" }
+smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "smithy-http" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-types"}
+smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "smithy-types"}
 
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.2.18"

--- a/.rust_alpha/secretsmanager/Cargo.toml
+++ b/.rust_alpha/secretsmanager/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 description = "Example usage of the SecretManager service"
 
 [dependencies]
-secretsmanager = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-sdk-secretsmanager" }
-aws-hyper = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-hyper" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.5-alpha", package = "aws-types" }
+secretsmanager = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-sdk-secretsmanager" }
+aws-hyper = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-hyper" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.7-alpha", package = "aws-types" }
 
 tokio = { version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }

--- a/.rust_alpha/secretsmanager/src/bin/create-secret.rs
+++ b/.rust_alpha/secretsmanager/src/bin/create-secret.rs
@@ -5,7 +5,7 @@
 
 use secretsmanager::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 
@@ -25,7 +25,7 @@ struct Opt {
     /// The content of the secret.
     #[structopt(short, long)]
     content: String,
-    
+
     /// Whether to display additonal information.
     #[structopt(short, long)]
     verbose: bool,

--- a/.rust_alpha/secretsmanager/src/bin/get-secret-value.rs
+++ b/.rust_alpha/secretsmanager/src/bin/get-secret-value.rs
@@ -6,7 +6,7 @@ use std::process;
 
 use secretsmanager::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 
@@ -22,7 +22,7 @@ struct Opt {
     /// The name of the secret.
     #[structopt(short, long)]
     name: String,
-    
+
     /// Whether to display additonal information.
     #[structopt(short, long)]
     verbose: bool,

--- a/.rust_alpha/secretsmanager/src/bin/list-secrets.rs
+++ b/.rust_alpha/secretsmanager/src/bin/list-secrets.rs
@@ -6,7 +6,7 @@ use std::process;
 
 use secretsmanager::{Client, Config, Region};
 
-use aws_types::region::{ProvideRegion};
+use aws_types::region::ProvideRegion;
 
 use structopt::StructOpt;
 
@@ -33,7 +33,10 @@ struct Opt {
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
 async fn main() {
-    let Opt { default_region, verbose } = Opt::from_args();
+    let Opt {
+        default_region,
+        verbose,
+    } = Opt::from_args();
 
     let region = default_region
         .as_ref()


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

## Existing Example Update

### Description of Changes

- Changed Rust SDK package version to 0.0.7.
- Ran ```cargo fmt``` to format all code examples.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
