### PR TITLE
Fixed final duplicate Go snippet tag

### DIFF
--- a/go/sqs/SendReceiveLongPolling/SendReceiveLongPolling.go
+++ b/go/sqs/SendReceiveLongPolling/SendReceiveLongPolling.go
@@ -97,7 +97,7 @@ func GetLPMessages(sess *session.Session, queueURL *string, waitTime *int64) (*s
     // Create an SQS service client
     svc := sqs.New(sess)
 
-    // snippet-start:[sqs.go.receive_lp_message.call]
+    // snippet-start:[sqs.go.send_receive_long_polling.call]
     results, err := svc.ReceiveMessage(&sqs.ReceiveMessageInput{
         QueueUrl: queueURL,
         AttributeNames: aws.StringSlice([]string{
@@ -109,7 +109,7 @@ func GetLPMessages(sess *session.Session, queueURL *string, waitTime *int64) (*s
         }),
         WaitTimeSeconds: waitTime,
     })
-    // snippet-end:[sqs.go.receive_lp_message.call]
+    // snippet-end:[sqs.go.send_receive_long_polling.call]
     if err != nil {
         return nil, err
     }

--- a/go/sqs/SendReceiveLongPolling/SendReceiveLongPolling.go
+++ b/go/sqs/SendReceiveLongPolling/SendReceiveLongPolling.go
@@ -97,7 +97,7 @@ func GetLPMessages(sess *session.Session, queueURL *string, waitTime *int64) (*s
     // Create an SQS service client
     svc := sqs.New(sess)
 
-    // snippet-start:[sqs.go.send_receive_long_polling.call]
+    // snippet-start:[sqs.go.send_receive_long_polling.call2]
     results, err := svc.ReceiveMessage(&sqs.ReceiveMessageInput{
         QueueUrl: queueURL,
         AttributeNames: aws.StringSlice([]string{
@@ -109,7 +109,7 @@ func GetLPMessages(sess *session.Session, queueURL *string, waitTime *int64) (*s
         }),
         WaitTimeSeconds: waitTime,
     })
-    // snippet-end:[sqs.go.send_receive_long_polling.call]
+    // snippet-end:[sqs.go.send_receive_long_polling.call2]
     if err != nil {
         return nil, err
     }


### PR DESCRIPTION
The snippet tag sqs.go.receive_lp_message.call was used in both go/sqs/SendReceiveLongPolling/SendReceiveLongPolling.go and go/sqs/ReceiveLPMessage/ReceiveLPMessage.go.

I replaced the one in the former with sqs.go.send_receive_long_polling.call.