### PR TITLE
Snippet extractor: select reports; dry run now only prints issues.

### DIFF
--- a/.github/extract-snippets/README.md
+++ b/.github/extract-snippets/README.md
@@ -1,7 +1,7 @@
 # Extract Snippets for GitHub Actions
 
 Jerry Kindall, Amazon Web Services  
-Last updated 4-Jun-2021
+Last updated 24-Jun-2021
 
 ## What it is
 
@@ -14,18 +14,19 @@ next build.
 There are two separate workflows: 
 
 * Extract Snippets (`extract-snippets.yaml`): Extracts snippets from all source
-  files in the repo.  Runs on a commit to the main or master branch; can also
-  be run manually.
+  files in the repo.  Runs on a commit to the main or master branch; can also be
+  run manually.
 
 * Extract Snippets Dry Run (`extract-snippets-dryrun.yml`): Extracts snippets
   from all source files in a pull request but does not check in any snippets;
-  meant to validate PRs.  Can also be run manually.
+  meant to validate PRs.  Displays only the issue report (problems found in the
+  extraction process).  Can also be run manually.
 
-To prevent the introduction of errors in the snippets (e.g. duplicate snippet
-filenames with different content), all files in the repo are always processed.
-This is not noticeably slower than e.g. processing only the files in a given
-commit; the overhead of the action setup and Git commands overshadows the run
-time of the actual snippet extraction.
+To prevent the introduction of consistency problems in the snippets (e.g.
+duplicate snippet filenames with different content), all files in the repo are
+always processed.  This is not noticeably slower than e.g. processing only the
+files in a given commit; the overhead of the action setup and Git commands
+overshadows the run time of the actual snippet extraction.
 
 ## Compared to other snippet extraction tools
 
@@ -50,12 +51,12 @@ It does not have the following features of the AWS Docs tool:
 
 Snippet tags are special single-line comments in source files.  They must not
 follow any code on their line and must begin with the language's single-line
-comment marker (`//` in many languages, `#` in some others).  If a language
-does not have a single-line comment marker, the block comment delimiter may be
-used, but should be closed on the same line following the snippet tag.  The
-snippet tag is followed by the snippet directive, a colon, and an argument in
-square brackets.  Whitespace is permitted (but optional) between the comment
-marker and the snippet directive. For example:
+comment marker (`//` in many languages, `#` in some others).  If a language does
+not have a single-line comment marker, the block comment delimiter may be used,
+but should be closed on the same line following the snippet tag.  The snippet
+tag is followed by the snippet directive, a colon, and an argument in square
+brackets.  Whitespace is permitted (but optional) between the comment marker and
+the snippet directive. For example:
 
 <tt>// snippet&#45;start:[cdk.typescript.widget_service]</tt>
 
@@ -68,8 +69,8 @@ name) in the same source file.  Multiple snippets may be extracted from one
 source file, and may overlap.  The snippet tags do not appear in the extracted
 snippets.
 
-The following two tags are unique to this extractor (they are not supported by
-the snippet extractor used by the AWS Docs team).
+The following tags are unique to this extractor (they are not supported by the
+snippet extractor used by the AWS Docs team).
 
 * `snippet-append`: Extracts additional source code to a snippet file that has
   already been created by a previous `snippet-start` directive, stopping at
@@ -77,8 +78,8 @@ the snippet extractor used by the AWS Docs team).
 
 * `snippet-echo`: Writes the argument literally to the snippet(s) currently
   being extracted.  Useful for adding closing braces etc. when extracting a
-  partial code block.  Whitespace is stripped from the right of the argument
-  but not the left, so you can match indentation.
+  partial code block.  Whitespace is stripped from the right of the argument but
+  not the left, so you can match indentation.
 
 Also unique to this extractor, `snippet-start` supports an optional number
 following the closing bracket.  
@@ -108,18 +109,18 @@ metadata about each snippet.
 ## extract-snippets.sh
 
 This `bash` script calls the Python script (described next) to extract the
-snippets, then checks the results in to the `snippets` branch of the repo. 
-If the script is passed any argument (value is irrelevant), it exits after
+snippets, then checks the results in to the `snippets` branch of the repo. If
+the script is passed any argument (value is irrelevant), it exits after
 extracting the snippets without adding them to the repo ("dry run" mode).
 
 ## extract-snippets.py
 
 This script reads from standard input the paths of the files containing the
-snippets to be extracted.  It ignores non-source files, hidden files, and
-files in hidden directories (it is not necessary to filter out such files
-beforehand). The script's required argument is the directory that the snippets
-should be extracted into.  This directory must not contain any files named
-the same as a snippet being extracted.
+snippets to be extracted.  It ignores non-source files, hidden files, and files
+in hidden directories (it is not necessary to filter out such files beforehand).
+The script's required argument is the directory that the snippets should be
+extracted into.  This directory must not contain any files named the same as a
+snippet being extracted.
 
 For example, the following command runs the script on source files in the
 current directory, extracting snippets also into the current directory.
@@ -128,14 +129,14 @@ current directory, extracting snippets also into the current directory.
 ls | python3 extract-snippets.py .
 ```
 
-Both Windows and Linux-style paths are supported so you can test the script
-on Windows during development.
+Both Windows and Linux-style paths are supported so you can test the script on
+Windows during development.
 
 The supported source file formats are stored in `snippet-extensions.yml` or
 another file specified as the second command-line argument. This file is a YAML
-map of filename extensions to comment markers.  If a language supports more
-than one line comment marker, you can provide them separated by whitespace in
-a single string:
+map of filename extensions to comment markers.  If a language supports more than
+one line comment marker, you can provide them separated by whitespace in a
+single string:
 
 ```
 .php: "# //"
@@ -161,8 +162,8 @@ You may pass a different YAML (or JSON) file as the script's second argument --
 for example, the provided `snippet-extensions-more.yml`, which contains a more
 extensive map of source formats.  Note that if you specify only a filename, the
 file of that name *in the same directory as the script* (not in the working
-directory!) is used.  To specify a file in the current directory, use `./`,
-e.g. `./my-snippet-extensions.yml`.
+directory!) is used.  To specify a file in the current directory, use `./`, e.g.
+`./my-snippet-extensions.yml`.
 
 The keys in `snippet-extensions.yml` are matched case-sensitively at the end of
 file paths, and can be used to match more than extensions.  If you wanted to
@@ -186,9 +187,9 @@ shouldn't do this, but you *can.*  It might be useful as a catch-all in a repo
 where you want to process all files and most languages in the repo use the same
 comment marker.  It should go last in the extensions file.
 
-To exclude a file or files from being processed, specify the end of its path
-and an empty string as the comment marker.  Such items should appear earlier
-in the file than others that might match, since the first match wins.
+To exclude a file or files from being processed, specify the end of its path and
+an empty string as the comment marker.  Such items should appear earlier in the
+file than others that might match, since the first match wins.
 
 ```
 "/lambda/widgets.js": ""
@@ -200,14 +201,14 @@ any, notated with EXTRACT.  APPEND operations, errors, and warnings are also
 flagged in similar fashion under the source file.  
 
 At the end of the run, a summary line displays the number of unique snippets
-extracted and the number of source files examined.  This is followed by a
-report of all files with issues, and an index that maps snippets back to the
-files that contain them.
+extracted and the number of source files examined.  This is followed by a report
+of all files with issues, and an index that maps snippets back to the files that
+contain them.
 
 ## Errors
 
-The following situations are considered problematic to varying degrees.  To
-the extent possible, errors do not stop processing.
+The following situations are considered problematic to varying degrees.  To the
+extent possible, errors do not stop processing.
 
 * Unrecognized snippet tag (see earlier section for supported tags).
 
@@ -228,20 +229,20 @@ the extent possible, errors do not stop processing.
   If a file cannot be read, processing continues with the next file, if any.
 
 * `snippet-start` for a snippet file that has already been extracted, *unless*
-  the source file has the same filename and contains exactly the same code.
-  This behavior supports multiple examples that contain the same source code
-  for an incorporated Lambda function or other asset, where that code contains
+  the source file has the same filename and contains exactly the same code. This
+  behavior supports multiple examples that contain the same source code for an
+  incorporated Lambda function or other asset, where that code contains
   snippets. The former situation is an error, the latter a warning.
 
-* `snippet-end` with no corresponding `snippet-start` or `snippet-append` in
-  the same source file.
+* `snippet-end` with no corresponding `snippet-start` or `snippet-append` in the
+  same source file.
 
 * Missing `snippet-end` corresponding to a `snippet-start` or `snippet-append`.
 
-* `snippet-append` with no corresponding `snippet-start` in the same source
-  file (you can't append to snippets created in a different source file since
-  there's no guarantee the files will be processed in any particular order, or
-  that all files will even be processed, leading to consistency issues).
+* `snippet-append` with no corresponding `snippet-start` in the same source file
+  (you can't append to snippets created in a different source file since there's
+  no guarantee the files will be processed in any particular order, or that all
+  files will even be processed, leading to consistency issues).
 
 * `snippet-echo` outside of a snippet.
 
@@ -261,9 +262,11 @@ provide information that users of the snippets should know.
 
 # Version history
 
-* v1.0.0 - Initial public release for CDK Examples repo.
+* v1.0.0 - Initial pull request against the CDK Examples repo.
 * v1.1.0 - Test against SDK team's examples repo and fix the problems found.
            Continue processing after errors instead of stopping at the first.
            Generate report of files with issues.
            Generate index of files containing each snippet.
            Other fixes and tweaks.
+* v1.2.0 - Allow log, issue report, and index to be selectively enabled.
+           Don't try to call non-method attributes to handle snippet tags.

--- a/.github/extract-snippets/extract-snippets.py
+++ b/.github/extract-snippets/extract-snippets.py
@@ -277,9 +277,9 @@ if __name__ == "__main__":
                 err_exit("key, value must both be strings; got %s, %s (%s, %s)" % 
                     (k, v, type(k).__name__, type(v).__name__))
 
-    print("extracting snippets in source files", 
-        " ".join(ex for ex in MAP_EXT_MARKER if MAP_EXT_MARKER[ex]), "\n")
-    print("Reports:", reports)
+    print("==== extracting snippets in source files", 
+        " ".join(ex for ex in MAP_EXT_MARKER if ex and MAP_EXT_MARKER[ex]), "\n")
+    print("reports:", " ".join(reports).upper(), end="\n\n")
 
     # initialize snipper instance and our counters
     with Snipper(snippetdir) as snipper:
@@ -306,28 +306,38 @@ if __name__ == "__main__":
                 snipper(path, markers)
                 processed += 1
     
-    # print log
-    if "log" in reports:
-        print(snipper.log.getvalue())
-
-    # print summary
-    print("\n====", snipper.count, "snippet(s) extracted from", processed, 
-        "source file(s) processed of", seen, "candidate(s) with", snipper.errors, 
-        "error(s) in", len(snipper.issues), "file(s)\n")
-
     # files with issues report (files with most issues first)
-    if "issues" in reports and snipper.issues:
-        print("----", len(snipper.issues), "file(s) with issues:", end="\n\n")
-        for issue, details in sorted(snipper.issues.items(), key=lambda item: -len(item[1])):
-            print(issue, end="\n     ")
-            print(*sorted(details), sep="\n     ", end="\n\n")
+    if "issues" in reports:
+        if snipper.issues:
+            print("====", len(snipper.issues), "file(s) with issues:", end="\n\n")
+            for issue, details in sorted(snipper.issues.items(), key=lambda item: -len(item[1])):
+                print(issue, end="\n     ")
+                print(*sorted(details), sep="\n     ", end="\n\n")
+        else:
+            print("---- no issues found\n")
 
     # snippet index report (snippets that appear in the most files first)
-    if "index" in reports and snipper.index:
-        print("----", len(snipper.index), "snippet(s) extracted from", processed, "files:", end="\n\n")
-        for snippet, files in sorted(snipper.index.items(), key=lambda item: -len(item[1])):
-            print(snippet, "declared in:", end="\n     ")
-            print(*sorted(files), sep="\n     ", end="\n\n")
+    if "index" in reports:
+        if snipper.index:
+            print("====", len(snipper.index), "snippet(s) extracted from", processed, "files:", end="\n\n")
+            for snippet, files in sorted(snipper.index.items(), key=lambda item: -len(item[1])):
+                print(snippet, "declared in:", end="\n     ")
+                print(*sorted(files), sep="\n     ", end="\n\n")
+        else:
+            print("--- no snippets were extracted\n")
+
+    # print log
+    if "log" in reports:
+        print("==== Complete processing log\n")
+        if processed:
+            print(snipper.log.getvalue(), end="\n\n")
+        else:
+            print("No files were processed\n")
+
+    # print summary
+    print("====", snipper.count, "snippet(s) extracted from", processed, 
+        "source file(s) processed of", seen, "candidate(s) with", snipper.errors, 
+        "error(s) in", len(snipper.issues), "file(s)\n")
 
     # exit with nonzero status if we found any errors, so caller won't commit the snippets
     sys.exit(snipper.errors > 0)

--- a/.github/extract-snippets/extract-snippets.py
+++ b/.github/extract-snippets/extract-snippets.py
@@ -279,6 +279,7 @@ if __name__ == "__main__":
 
     print("extracting snippets in source files", 
         " ".join(ex for ex in MAP_EXT_MARKER if MAP_EXT_MARKER[ex]), "\n")
+    print("Reports:", reports)
 
     # initialize snipper instance and our counters
     with Snipper(snippetdir) as snipper:

--- a/.github/extract-snippets/extract-snippets.py
+++ b/.github/extract-snippets/extract-snippets.py
@@ -92,6 +92,7 @@ class Snipper:
     def __enter__(self):
         global print
         print = functools.partial(__builtins__.print, file=self.log)
+        return self
 
     def __exit__(self, *args):
         global print 

--- a/.github/workflows/extract-snippets-dryrun.yml
+++ b/.github/workflows/extract-snippets-dryrun.yml
@@ -8,6 +8,8 @@ jobs:
   extract-snippets-dryrun:
     if: github.repository_owner == 'aws' || github.repository_owner == 'awsdocs' || github.repository_owner == 'aws-samples' || github.repository_owner == 'jerry-aws'
     runs-on: ubuntu-latest
+    env:
+      REPORTS: issues
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Also fix a small bug where if a source file contains a snippet tag that was the same as the name of an attribute on the Snipper class, it would try to call it. Now it correctly tells you the tag is invalid.

Update and rewrap README.md.