### PR TITLE
Fixed params is not defined

### DIFF
--- a/javascriptv3/example_code/s3/src/s3_get_presignedURL.js
+++ b/javascriptv3/example_code/s3/src/s3_get_presignedURL.js
@@ -47,7 +47,7 @@ const run = async () => {
       new CreateBucketCommand({ Bucket: bucketParams.Bucket })
     );
     return data; // For unit tests.
-    console.log(`Waiting for "${params.Bucket}" bucket creation...\n`);
+    console.log(`Waiting for "${bucketParams.Bucket}" bucket creation...\n`);
   } catch (err) {
     console.log("Error creating bucket", err);
   }


### PR DESCRIPTION
Fixed #1902

https://github.com/awsdocs/aws-doc-sdk-examples/blob/bbf4677910bb6dc9d4efaea27e60f4dbeced5991/javascriptv3/example_code/s3/src/s3_get_presignedURL.js#L50

Should have been `bucketParams`.
