### PR TITLE
Updated CloudFormation create-stack example in Rust

### DIFF
--- a/.rust_alpha/cloudformation/Cargo.toml
+++ b/.rust_alpha/cloudformation/Cargo.toml
@@ -9,9 +9,7 @@ edition = "2018"
 [dependencies]
 cloudformation = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.9-alpha", package = "aws-sdk-cloudformation" }
 aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.9-alpha", package = "aws-types" }
-
 tokio = { version = "1", features = ["full"] }
-
 env_logger = "0.8.2"
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/.rust_alpha/cloudformation/src/bin/create-stack.rs
+++ b/.rust_alpha/cloudformation/src/bin/create-stack.rs
@@ -81,7 +81,9 @@ async fn main() -> Result<(), cloudformation::Error> {
         .send()
         .await?;
 
-    println!("Stack created");
+    println!("Stack created.");
+    println!("Use describe-stacks with your stack name to see the status of your stack.");
+    println!("You cannot use/deploy the stack until the status is 'CreateComplete'.");
     println!();
 
     Ok(())


### PR DESCRIPTION
Removed extra line breaks in Cargo.toml file and orphaned comments in create-stack example.

## Existing Example Update

The submitter has:

- [x] Confirmed that the correct copyright is included in all files.
- [x] Major code changes have been reviewed, and the submitter has incorporated review comments.
- [ ] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
