### PR TITLE
Update S3 CopyObject example to use sourceBucket & sourceKey parameters

### DIFF
--- a/javav2/example_code/s3/pom.xml
+++ b/javav2/example_code/s3/pom.xml
@@ -14,7 +14,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.16.29</version>
+                <version>2.17.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/javav2/example_code/s3/src/main/java/com/example/s3/CopyObject.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/CopyObject.java
@@ -19,9 +19,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 // snippet-end:[s3.java2.copy_object.import]
 
 /**
@@ -68,14 +65,9 @@ public class CopyObject {
     // snippet-start:[s3.java2.copy_object.main]
     public static String copyBucketObject (S3Client s3, String fromBucket, String objectKey, String toBucket) {
 
-        String encodedUrl = null;
-        try {
-            encodedUrl = URLEncoder.encode(fromBucket + "/" + objectKey, StandardCharsets.UTF_8.toString());
-        } catch (UnsupportedEncodingException e) {
-            System.out.println("URL could not be encoded: " + e.getMessage());
-        }
         CopyObjectRequest copyReq = CopyObjectRequest.builder()
-                .copySource(encodedUrl)
+                .sourceBucket(fromBucket)
+                .sourceKey(objectKey)
                 .destinationBucket(toBucket)
                 .destinationKey(objectKey)
                 .build();


### PR DESCRIPTION
A recent update to the AWS SDK for Java v2 (https://github.com/aws/aws-sdk-java-v2/pull/2612) enabled support for
more user-friendly parameters for specifying the source bucket, key, and version ID for the S3 CopyObject operation. These new parameters are also automatically URL-encoded by the SDK, as most users would expect.

This commit updates the dependency to the latest version for the S3 module and takes advantage of the new parameters, simplifying the example code to no longer need to URL encode.

Related:
https://github.com/awsdocs/aws-doc-sdk-examples/issues/740
https://github.com/awsdocs/aws-doc-sdk-examples/pull/759

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
