### PR TITLE
Cleaned up AWS Config examples

### DIFF
--- a/python/example_code/config/README.md
+++ b/python/example_code/config/README.md
@@ -11,10 +11,10 @@ create and manage config rules.
 
 * [Creating an AWS Config rule](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/python/example_code/config/config_rules.py) 
 (`put_config_rule`)
-* [Describing an AWS Config rule](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/python/example_code/config/config_rules.py) 
-(`describe_config_rules`)
 * [Deleting an AWS Config rule](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/python/example_code/config/config_rules.py) 
 (`delete_config_rule`)
+* [Describing an AWS Config rule](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/python/example_code/config/config_rules.py) 
+(`describe_config_rules`)
 
 ## ⚠ Important
 
@@ -47,6 +47,26 @@ a command prompt with the following command.
 ```
 python config_rules.py
 ``` 
+
+### Example structure
+
+The example contains the following file.
+
+**config_rules.py**
+
+Shows how to use AWS Config APIs. The `usage_demo` script creates a rule that prohibits
+making Amazon S3 buckets publicly readable, gets data about the rule, and deletes it.
+
+## Running the tests
+
+The unit tests in this module use the botocore Stubber. This captures requests before 
+they are sent to AWS, and returns a mocked response. To run all of the tests, 
+run the following in your [GitHub root]/python/example_code/config 
+folder.
+
+```    
+python -m pytest
+```
 
 ## Additional information
 

--- a/python/example_code/config/README.md
+++ b/python/example_code/config/README.md
@@ -55,7 +55,8 @@ The example contains the following file.
 **config_rules.py**
 
 Shows how to use AWS Config APIs. The `usage_demo` script creates a rule that prohibits
-making Amazon S3 buckets publicly readable, gets data about the rule, and deletes it.
+making Amazon Simple Storage Service (Amazon S3) buckets publicly readable, gets data 
+about the rule, and deletes it.
 
 ## Running the tests
 

--- a/python/example_code/config/config_rules.py
+++ b/python/example_code/config/config_rules.py
@@ -1,69 +1,121 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# snippet-start:[python.example_code.config.config_rule_imports]
+"""
+Purpose
+
+Shows how to use the AWS SDK for Python (Boto3) with AWS Config to create and
+manage configuration rules.
+"""
+
+import logging
 from pprint import pprint
+
 import boto3
 from botocore.exceptions import ClientError
-# snippet-end:[python.example_code.config.config_rule_imports]
+
+logger = logging.getLogger(__name__)
 
 
-# snippet-start:[python.example_code.config.put_config_rule]
-def put_config_rule(config_client, rule_name):
-    try:
-        response = config_client.put_config_rule(
-            ConfigRule={
-                'ConfigRuleName': rule_name,
-                'Description': 'S3 Public Read Prohibited Bucket Rule',
-                'Scope': {
-                    'ComplianceResourceTypes': [
-                        'AWS::S3::Bucket',
-                    ],
-                },
-                'Source': {
-                    'Owner': 'AWS',
-                    'SourceIdentifier': 'S3_BUCKET_PUBLIC_READ_PROHIBITED',
-                },
-                'InputParameters': '{}',
-                'ConfigRuleState': 'ACTIVE'
-            }
-        )
-        pprint(response)
-    except ClientError as e:
-        print(e)
-# snippet-end:[python.example_code.config.put_config_rule]
+# snippet-start:[python.example_code.config.ConfigWrapper]
+class ConfigWrapper:
+    """
+    Encapsulates AWS Config functions.
+    """
+    def __init__(self, config_client):
+        """
+        :param config_client: A Boto3 AWS Config client.
+        """
+        self.config_client = config_client
 
+# snippet-end:[python.example_code.config.ConfigWrapper]
+# snippet-start:[python.example_code.config.PutConfigRule]
+    def put_config_rule(self, rule_name):
+        """
+        Sets a configuration rule that prohibits making Amazon S3 buckets publicly
+        readable.
 
-# snippet-start:[python.example_code.config.describe_config_rules]
-def describe_config_rule(config_client, rule_name):
-    try:
-        response = config_client.describe_config_rules(ConfigRuleNames=[rule_name])
-        pprint(response)
-    except ClientError as e:
-        print(e)
-# snippet-end:[python.example_code.config.describe_config_rules]
+        :param rule_name: The name to give the rule.
+        """
+        try:
+            self.config_client.put_config_rule(
+                ConfigRule={
+                    'ConfigRuleName': rule_name,
+                    'Description': 'S3 Public Read Prohibited Bucket Rule',
+                    'Scope': {
+                        'ComplianceResourceTypes': [
+                            'AWS::S3::Bucket',
+                        ],
+                    },
+                    'Source': {
+                        'Owner': 'AWS',
+                        'SourceIdentifier': 'S3_BUCKET_PUBLIC_READ_PROHIBITED',
+                    },
+                    'InputParameters': '{}',
+                    'ConfigRuleState': 'ACTIVE'
+                }
+            )
+            logger.info("Created configuration rule %s.", rule_name)
+        except ClientError:
+            logger.exception("Couldn't create configuration rule %s.", rule_name)
+            raise
+# snippet-end:[python.example_code.config.PutConfigRule]
 
+# snippet-start:[python.example_code.config.DescribeConfigRules]
+    def describe_config_rule(self, rule_name):
+        """
+        Gets data for the specified rule.
 
-# snippet-start:[python.example_code.config.delete_config_rule]
-def delete_config_rule(config_client, rule_name):
-    try:
-        response = config_client.delete_config_rule(ConfigRuleName=rule_name)
-        pprint(response)
-    except ClientError as e:
-        print(e)
-# snippet-end:[python.example_code.config.delete_config_rule]
+        :param rule_name: The name of the rule to retrieve.
+        :return: The rule data.
+        """
+        try:
+            response = self.config_client.describe_config_rules(
+                ConfigRuleNames=[rule_name])
+            rule = response['ConfigRules']
+            logger.info("Got data for rule %s.", rule_name)
+        except ClientError:
+            logger.exception("Couldn't get data for rule %s.", rule_name)
+            raise
+        else:
+            return rule
+# snippet-end:[python.example_code.config.DescribeConfigRules]
+
+# snippet-start:[python.example_code.config.DeleteConfigRule]
+    def delete_config_rule(self, rule_name):
+        """
+        Delete the specified rule.
+
+        :param rule_name: The name of the rule to delete.
+        """
+        try:
+            self.config_client.delete_config_rule(ConfigRuleName=rule_name)
+            logger.info("Deleted rule %s.", rule_name)
+        except ClientError:
+            logger.exception("Couldn't delete rule %s.", rule_name)
+            raise
+# snippet-end:[python.example_code.config.DeleteConfigRule]
 
 
 def usage_demo():
-    config_client = boto3.client('config')
-    rule_name = 'S3BucketRule'
-    print(f"Putting AWS Config rule '{rule_name}'...")
-    put_config_rule(config_client, rule_name)
+    print('-'*88)
+    print("Welcome to the AWS Config demo!")
+    print('-'*88)
+
+    logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+    config = ConfigWrapper(boto3.client('config'))
+    rule_name = 'DemoS3BucketRule'
+    print(f"Creating AWS Config rule '{rule_name}'...")
+    config.put_config_rule(rule_name)
     print(f"Describing AWS Config rule '{rule_name}'...")
-    describe_config_rule(config_client, rule_name)
+    rule = config.describe_config_rule(rule_name)
+    pprint(rule)
     print(f"Deleting AWS Config rule '{rule_name}'...")
-    delete_config_rule(config_client, rule_name)
+    config.delete_config_rule(rule_name)
+
     print("Thanks for watching!")
+    print('-'*88)
 
 
 if __name__ == '__main__':

--- a/python/example_code/config/test/conftest.py
+++ b/python/example_code/config/test/conftest.py
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Contains common test fixtures used to run unit tests.
+"""
+
+import sys
+# This is needed so Python can find test_tools on the path.
+sys.path.append('../..')
+from test_tools.fixtures.common import *

--- a/python/example_code/config/test/test_config_rules.py
+++ b/python/example_code/config/test/test_config_rules.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for config_rules.py.
+"""
+
+import boto3
+from botocore.exceptions import ClientError
+import pytest
+
+from config_rules import ConfigWrapper
+
+
+@pytest.mark.parametrize('error_code', [None, 'TestException'])
+def test_put_config_rule(make_stubber, error_code):
+    config_client = boto3.client('config')
+    config_stubber = make_stubber(config_client)
+    config = ConfigWrapper(config_client)
+    rule_name = 'test-rule_name'
+    rule = {
+        'ConfigRuleName': rule_name,
+        'Description': 'S3 Public Read Prohibited Bucket Rule',
+        'Scope': {
+            'ComplianceResourceTypes': [
+                'AWS::S3::Bucket']},
+        'Source': {
+            'Owner': 'AWS',
+            'SourceIdentifier': 'S3_BUCKET_PUBLIC_READ_PROHIBITED'},
+        'InputParameters': '{}',
+        'ConfigRuleState': 'ACTIVE'}
+
+    config_stubber.stub_put_config_rule(rule, error_code=error_code)
+
+    if error_code is None:
+        config.put_config_rule(rule_name)
+    else:
+        with pytest.raises(ClientError) as exc_info:
+            config.put_config_rule(rule_name)
+        assert exc_info.value.response['Error']['Code'] == error_code
+
+
+@pytest.mark.parametrize('error_code', [None, 'TestException'])
+def test_describe_config_rule(make_stubber, error_code):
+    config_client = boto3.client('config')
+    config_stubber = make_stubber(config_client)
+    config = ConfigWrapper(config_client)
+    rule_name = 'test-rule_name'
+    rules = [{'ConfigRuleName': rule_name}]
+
+    config_stubber.stub_describe_config_rules([rule_name], error_code=error_code)
+
+    if error_code is None:
+        got_rule = config.describe_config_rule(rule_name)
+        assert ([gr['ConfigRuleName'] for gr in got_rule] ==
+                [r['ConfigRuleName'] for r in rules])
+    else:
+        with pytest.raises(ClientError) as exc_info:
+            config.describe_config_rule(rule_name)
+        assert exc_info.value.response['Error']['Code'] == error_code
+
+
+@pytest.mark.parametrize('error_code', [None, 'TestException'])
+def test_delete_config_rule(make_stubber, error_code):
+    config_client = boto3.client('config')
+    config_stubber = make_stubber(config_client)
+    config = ConfigWrapper(config_client)
+    rule_name = 'test-rule_name'
+
+    config_stubber.stub_delete_config_rule(rule_name, error_code=error_code)
+
+    if error_code is None:
+        config.delete_config_rule(rule_name)
+    else:
+        with pytest.raises(ClientError) as exc_info:
+            config.delete_config_rule(rule_name)
+        assert exc_info.value.response['Error']['Code'] == error_code

--- a/python/test_tools/config_stubber.py
+++ b/python/test_tools/config_stubber.py
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Stub functions that are used by the AWS Config unit tests.
+"""
+
+from test_tools.example_stubber import ExampleStubber
+
+
+class ConfigStubber(ExampleStubber):
+    """
+    A class that implements stub functions used by AWS Config unit tests.
+
+    The stubbed functions expect certain parameters to be passed to them as
+    part of the tests, and raise errors if the parameters are not as expected.
+    """
+    def __init__(self, client, use_stubs=True):
+        """
+        Initializes the object with a specific client and configures it for
+        stubbing or AWS passthrough.
+
+        :param client: A Boto3 AWS Config client.
+        :param use_stubs: When True, use stubs to intercept requests. Otherwise,
+                          pass requests through to AWS.
+        """
+        super().__init__(client, use_stubs)
+
+    def stub_put_config_rule(self, rule, error_code=None):
+        expected_params = {'ConfigRule': rule}
+        response = {}
+        self._stub_bifurcator(
+            'put_config_rule', expected_params, response, error_code=error_code)
+
+    def stub_describe_config_rules(self, rule_names, error_code=None):
+        expected_params = {'ConfigRuleNames': rule_names}
+        response = {'ConfigRules': [{
+            'ConfigRuleName': name,
+            'Source': {'Owner': 'Test', 'SourceIdentifier': 'TestID'}}
+            for name in rule_names]}
+        self._stub_bifurcator(
+            'describe_config_rules', expected_params, response, error_code=error_code)
+
+    def stub_delete_config_rule(self, rule_name, error_code=None):
+        expected_params = {'ConfigRuleName': rule_name}
+        response = {}
+        self._stub_bifurcator(
+            'delete_config_rule', expected_params, response, error_code=error_code)

--- a/python/test_tools/stubber_factory.py
+++ b/python/test_tools/stubber_factory.py
@@ -15,6 +15,7 @@ from test_tools.apigateway_v2_stubber import ApiGatewayV2Stubber
 from test_tools.cloudwatch_stubber import CloudWatchStubber
 from test_tools.cloudwatch_logs_stubber import CloudWatchLogsStubber
 from test_tools.comprehend_stubber import ComprehendStubber
+from test_tools.config_stubber import ConfigStubber
 from test_tools.dynamodb_stubber import DynamoStubber
 from test_tools.ec2_stubber import Ec2Stubber
 from test_tools.emr_stubber import EmrStubber
@@ -62,6 +63,8 @@ def stubber_factory(service_name):
         return CloudWatchLogsStubber
     elif service_name == 'comprehend':
         return ComprehendStubber
+    elif service_name == 'config':
+        return ConfigStubber
     elif service_name == 'dynamodb':
         return DynamoStubber
     elif service_name == 'ec2':


### PR DESCRIPTION
## SDK Code Example

AWS Config: cleaned up existing code examples, added snippets, unit tests, and documentation.

- [x] Added the default copyright notice to all files.
- [x] Created unit tests for all paths through the code and they all pass.
- [x] Run a linter against all code and implemented the resulting suggestions.
- [x] Added minimum usage documentation as comments in the code.
- [x] Had comments and strings reviewed and incorporated suggested changes.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
