### PR TITLE
Updated MediaLive code examples in Rust to use alpha 0.0.13 bits

### DIFF
--- a/.rust_alpha/medialive/Cargo.toml
+++ b/.rust_alpha/medialive/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-medialive = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.9-alpha", package = "aws-sdk-medialive" }
-
+aws-sdk-medialive = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.13-alpha", package = "aws-sdk-medialive" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.13-alpha", package = "aws-types" }
 tokio = { version = "1", features = ["full"] }
-# used only to enable basic logging:
-env_logger = "0.8.2"
+structopt = { version = "0.3", default-features = false }
+tracing-subscriber = "0.2.18"

--- a/.rust_alpha/medialive/README.md
+++ b/.rust_alpha/medialive/README.md
@@ -16,7 +16,12 @@ You must have an AWS account, and have configured your default credentials and A
 
 This example lists your MediaLive input names and ARNs.
 
-`cargo run --bin medialive-helloworld`
+`cargo run --bin medialive-helloworld [-r REGION] [-v]`
+
+- _REGION_ is the Region in which the client is created.
+  If not supplied, uses the value of the __AWS_REGION__ environment variable.
+  If the environment variable is not set, defaults to __us-west-2__.
+- __-v__ displays additional information.
 
 ### Notes
 

--- a/.rust_alpha/medialive/src/bin/medialive-helloworld.rs
+++ b/.rust_alpha/medialive/src/bin/medialive-helloworld.rs
@@ -3,17 +3,62 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-/// Lists your AWS Elemental MediaLive input names and ARNs.
+use aws_sdk_medialive::{Client, Config, Error, Region, PKG_VERSION};
+use aws_types::region;
+use aws_types::region::ProvideRegion;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The AWS Region.
+    #[structopt(short, long)]
+    region: Option<String>,
+
+    /// Whether to display additional information.
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Lists your AWS Elemental MediaLive input names and ARNs in the Region.
+/// # Arguments
+///
+/// * `[-r REGION]` - The Region in which the client is created.
+///    If not supplied, uses the value of the **AWS_REGION** environment variable.
+///    If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-v]` - Whether to display additional information.
 #[tokio::main]
-async fn main() -> Result<(), medialive::Error> {
-    let client = medialive::Client::from_env();
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+
+    let Opt { region, verbose } = Opt::from_args();
+
+    let region = region::ChainProvider::first_try(region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
+
+    println!();
+
+    if verbose {
+        println!("MediaLive client version: {}", PKG_VERSION);
+        println!(
+            "Region:                   {}",
+            region.region().unwrap().as_ref()
+        );
+        println!();
+    }
+
+    let conf = Config::builder().region(region).build();
+    let client = Client::from_conf(conf);
+
     let input_list = client.list_inputs().send().await?;
 
     for i in input_list.inputs.unwrap_or_default() {
         let input_arn = i.arn.as_deref().unwrap_or_default();
         let input_name = i.name.as_deref().unwrap_or_default();
 
-        println!("Input Name : {}, Input ARN : {}", input_name, input_arn);
+        println!("Input Name : {}", input_name);
+        println!("Input ARN : {}", input_arn);
+        println!();
     }
 
     Ok(())


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

## Existing Example Update

The submitter has:

- [x] Confirmed that the correct copyright is included in all files.
- [x] Major code changes have been reviewed, and the submitter has incorporated review comments.
- [ ] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
