### PR TITLE
Updated Route53 data code examples in Rust to use alpha 0.0.13 bits

### DIFF
--- a/.rust_alpha/route53/Cargo.toml
+++ b/.rust_alpha/route53/Cargo.toml
@@ -7,11 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-route53 = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.9-alpha", package = "aws-sdk-route53" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.9-alpha", package = "aws-types" }
-
+aws-sdk-route53 = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.13-alpha", package = "aws-sdk-route53" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.13-alpha", package = "aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
-# used only to enable basic logging:
-env_logger = "0.8.2"

--- a/.rust_alpha/route53/README.md
+++ b/.rust_alpha/route53/README.md
@@ -14,12 +14,13 @@ You must have an AWS account, and have configured your default credentials and A
 
 ### route53-helloworld
 
-This example displays the IDs and names of the hosted zones in the region..
+This example displays the IDs and names of the hosted zones in the Region.
 
-`cargo run --bin route53-helloworld -- [-d DEFAULT-REGION] [-v]`
+`cargo run --bin route53-helloworld -- [-r REGION] [-v]`
 
-- _DEFAULT-REGION_ is optional name of a region, such as __us-east-1__.
-  If this value is not supplied, the region defaults to __us-west-2__.
+- _REGION_ is the Region in which the client is created.
+  If not supplied, uses the value of the __AWS_REGION__ environment variable.
+  If the environment variable is not set, defaults to __us-west-2__.
 - __-v__ displays additional information.
 
 ### Notes

--- a/.rust_alpha/route53/src/bin/route53-helloworld.rs
+++ b/.rust_alpha/route53/src/bin/route53-helloworld.rs
@@ -3,71 +3,71 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use route53::{Client, Config, Region};
-
+use aws_sdk_route53::{Client, Config, Error, Region, PKG_VERSION};
+use aws_types::region;
 use aws_types::region::ProvideRegion;
-
 use structopt::StructOpt;
-use tracing_subscriber::fmt::format::FmtSpan;
-use tracing_subscriber::fmt::SubscriberBuilder;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// The region. Overrides environment variable AWS_DEFAULT_REGION.
+    /// The AWS Region.
     #[structopt(short, long)]
-    default_region: Option<String>,
+    region: Option<String>,
 
-    /// Whether to display additional runtime information
+    /// Whether to display additional runtime information.
     #[structopt(short, long)]
     verbose: bool,
 }
 
-/// Displays the IDs and names of the hosted zones in the region.
+/// Displays the IDs and names of the hosted zones in the Region.
 /// # Arguments
 ///
-/// * `[-d DEFAULT-REGION]` - The region in which the client is created.
-///    If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
+/// * `[-r REGION]` - The Region in which the client is created.
+///    If not supplied, uses the value of the **AWS_REGION** environment variable.
 ///    If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
-async fn main() -> Result<(), route53::Error> {
-    let Opt {
-        default_region,
-        verbose,
-    } = Opt::from_args();
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
 
-    let region = default_region
-        .as_ref()
-        .map(|region| Region::new(region.clone()))
-        .or_else(|| aws_types::region::default_provider().region())
-        .unwrap_or_else(|| Region::new("us-west-2"));
+    let Opt { region, verbose } = Opt::from_args();
+
+    let region = region::ChainProvider::first_try(region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
+
+    println!();
 
     if verbose {
-        println!("Route53 client version: {}\n", route53::PKG_VERSION);
-        println!("Region:                 {:?}", &region);
-
-        SubscriberBuilder::default()
-            .with_env_filter("info")
-            .with_span_events(FmtSpan::CLOSE)
-            .init();
+        println!("Route53 client version: {}", PKG_VERSION);
+        println!(
+            "Region:                 {}",
+            region.region().unwrap().as_ref()
+        );
+        println!();
     }
 
     let conf = Config::builder().region(region).build();
     let client = Client::from_conf(conf);
+
     let hosted_zone_count = client.get_hosted_zone_count().send().await?;
 
     println!(
-        "\nNumber of hosted zones in region : {}",
+        "Number of hosted zones in region : {}",
         hosted_zone_count.hosted_zone_count.unwrap_or_default(),
     );
 
     let hosted_zones = client.list_hosted_zones().send().await?;
 
+    println!("Zones:");
+
     for hz in hosted_zones.hosted_zones.unwrap_or_default() {
         let zone_name = hz.name.as_deref().unwrap_or_default();
         let zone_id = hz.id.as_deref().unwrap_or_default();
 
-        println!("Zone ID : {}, Zone Name : {}", zone_id, zone_name);
+        println!("  ID :   {}", zone_id);
+        println!("  Name : {}", zone_name);
+        println!();
     }
 
     Ok(())


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

## Existing Example Update

The submitter has:

- [x] Confirmed that the correct copyright is included in all files.
- [x] Major code changes have been reviewed, and the submitter has incorporated review comments.
- [ ] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
