### PR TITLE
Updated SSM code examples in Rust to use alpha 0.0.13 bits

### DIFF
--- a/.rust_alpha/ssm/Cargo.toml
+++ b/.rust_alpha/ssm/Cargo.toml
@@ -7,10 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ssm = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.9-alpha", package = "aws-sdk-ssm" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.9-alpha", package = "aws-types" }
-
+aws-sdk-ssm = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.13-alpha", package = "aws-sdk-ssm" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.13-alpha", package = "aws-types" }
 tokio = { version = "1", features = ["full"] }
-
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/.rust_alpha/ssm/README.md
+++ b/.rust_alpha/ssm/README.md
@@ -14,7 +14,7 @@ You must have an AWS account, and have configured your default credentials and A
 
 ### create-parameter
 
-This example creates a new Systems Manager parameter.
+This example creates a new Systems Manager parameter in the Region.
 
 `cargo run --bin create-parameter -- -n NAME -p PARAMETER-VALUE -d DESCRIPTION [-r REGION] [-v]`
 
@@ -23,21 +23,21 @@ Where:
 - _DESCRIPTION_ is the description of the parameter.
 - _PARAMETER-VALUE_ is the value of the parameter.
 - _NAME_ is the name of the parameter.
-- _REGION_ is name of the AWS Region, such as __us-east-1__, where the parameter is created.
-  If not supplied, uses the value of the __AWS_DEFAULT_REGION__ or __AWS_REGION__ environment variable.
+- _REGION_ is the Region in which the client is created.
+  If not supplied, uses the value of the __AWS_REGION__ environment variable.
   If the environment variable is not set, defaults to __us-west-2__.
 - __-v__ displays additional information.
 
 ### describe-parameters
 
-This example lists the names of your Systems Manager parameters.
+This example lists the names of your Systems Manager parameters in the Region.
 
-`cargo run --bin describe-parameters -- [-d DEFAULT-REGION] [-v]`
+`cargo run --bin describe-parameters -- [-r REGION] [-v]`
 
 Where:
 
-- _DEFAULT-REGION_ is name of the AWS Region, such as __us-east-1__, where the parameters are defined.
-  If not supplied, uses the value of the __AWS_DEFAULT_REGION__ or __AWS_REGION__ environment variable.
+- _REGION_ is the Region in which the client is created.
+  If not supplied, uses the value of the __AWS_REGION__ environment variable.
   If the environment variable is not set, defaults to __us-west-2__.
 - __-v__ displays additional information.
 

--- a/.rust_alpha/ssm/src/bin/create-parameter.rs
+++ b/.rust_alpha/ssm/src/bin/create-parameter.rs
@@ -3,92 +3,88 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use std::process;
-
-use ssm::model::ParameterType;
-use ssm::{Client, Config, Region};
-
-use aws_types::region::{EnvironmentProvider, ProvideRegion};
-
+use aws_sdk_ssm::model::ParameterType;
+use aws_sdk_ssm::{Client, Config, Error, Region, PKG_VERSION};
+use aws_types::region;
+use aws_types::region::ProvideRegion;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// The region
+    /// The AWS Region.
     #[structopt(short, long)]
     region: Option<String>,
 
-    /// The parameter name
+    /// The parameter name.
     #[structopt(short, long)]
     name: String,
 
-    /// The parameter value
+    /// The parameter value.
     #[structopt(short, long)]
     parameter_value: String,
 
-    /// The parameter description
+    /// The parameter title (description).
     #[structopt(short, long)]
-    description: String,
+    title: String,
 
-    /// Whether to display additional information
+    /// Whether to display additional information.
     #[structopt(short, long)]
     verbose: bool,
 }
 
-/// Creates a new AWS Systems Manager parameter.
+/// Creates a new AWS Systems Manager parameter in the Region.
 /// # Arguments
 ///
 /// * `-n NAME` - The name of the parameter.
 /// * `-p PARAMETER_VALUE` - The value of the parameter.
-/// * `-d DESCRIPTION` - The description of the parameter.
-/// * `[-d DEFAULT-REGION]` - The region in which the client is created.
-///    If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
+/// * `-t TITLE` - The description of the parameter.
+/// * `[-r REGION]` - The Region in which the client is created.
+///    If not supplied, uses the value of the **AWS_REGION** environment variable.
 ///    If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
     let Opt {
         name,
         parameter_value,
-        description,
+        title,
         region,
         verbose,
     } = Opt::from_args();
 
-    let region = EnvironmentProvider::new()
-        .region()
-        .or_else(|| region.as_ref().map(|region| Region::new(region.clone())))
-        .unwrap_or_else(|| Region::new("us-west-2"));
+    let region = region::ChainProvider::first_try(region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
+
+    println!();
 
     if verbose {
-        println!("SSM client version:   {}", ssm::PKG_VERSION);
-        println!("Region:               {:?}", &region);
-        println!("Parameter name:       {}", name);
-        println!("Paramter value:       {}", parameter_value);
-        println!("Paramter description: {}", description);
-
-        tracing_subscriber::fmt::init();
+        println!("SQS client version:   {}", PKG_VERSION);
+        println!(
+            "Region:               {}",
+            region.region().unwrap().as_ref()
+        );
+        println!("Parameter name:       {}", &name);
+        println!("Paramter value:       {}", &parameter_value);
+        println!("Paramter description: {}", &title);
+        println!();
     }
 
     let config = Config::builder().region(region).build();
     let client = Client::from_conf(config);
 
-    match client
+    let resp = client
         .put_parameter()
         .overwrite(true)
         .r#type(ParameterType::String)
         .name(name)
         .value(parameter_value)
-        .description(description)
+        .description(title)
         .send()
-        .await
-    {
-        Ok(response) => {
-            println!("Success! Parameter now has version: {}", response.version)
-        }
-        Err(error) => {
-            println!("Got an error putting the parameter: {}", error);
-            process::exit(1);
-        }
-    }
+        .await?;
+
+    println!("Success! Parameter now has version: {}", resp.version);
+
+    Ok(())
 }

--- a/.rust_alpha/ssm/src/bin/describe-parameters.rs
+++ b/.rust_alpha/ssm/src/bin/describe-parameters.rs
@@ -3,46 +3,45 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use std::process;
-
-use ssm::{Client, Config, Region};
-
-use aws_types::region::{EnvironmentProvider, ProvideRegion};
-
+use aws_sdk_ssm::{Client, Config, Error, Region, PKG_VERSION};
+use aws_types::region;
+use aws_types::region::ProvideRegion;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// The region
+    /// The AWS Region.
     #[structopt(short, long)]
     region: Option<String>,
 
-    /// Whether to display additional information
+    /// Whether to display additional information.
     #[structopt(short, long)]
     verbose: bool,
 }
 
-/// Lists the names of your AWS Systems Manager parameters.
+/// Lists the names of your AWS Systems Manager parameters in the Region.
 /// # Arguments
 ///
-/// * `[-d DEFAULT-REGION]` - The region in which the client is created.
-///    If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
+/// * `[-r REGION]` - The Region in which the client is created.
+///    If not supplied, uses the value of the **AWS_REGION** environment variable.
 ///    If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+
     let Opt { region, verbose } = Opt::from_args();
 
-    let region = EnvironmentProvider::new()
-        .region()
-        .or_else(|| region.as_ref().map(|region| Region::new(region.clone())))
-        .unwrap_or_else(|| Region::new("us-west-2"));
+    let region = region::ChainProvider::first_try(region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
+
+    println!();
 
     if verbose {
-        println!("SSM client version:   {}", ssm::PKG_VERSION);
-        println!("Region:               {:?}", &region);
-
-        tracing_subscriber::fmt::init();
+        println!("SQS client version: {}", PKG_VERSION);
+        println!("Region:             {}", region.region().unwrap().as_ref());
+        println!();
     }
 
     let config = Config::builder().region(region).build();
@@ -50,22 +49,11 @@ async fn main() {
 
     println!("Parameter names:");
 
-    match client.describe_parameters().send().await {
-        Ok(response) => {
-            for param in response.parameters.unwrap().iter() {
-                match &param.name {
-                    None => {}
-                    Some(n) => {
-                        println!("  {}", n);
-                    }
-                }
-            }
-        }
-        Err(error) => {
-            println!("Got an error listing the parameter names: {}", error);
-            process::exit(1);
-        }
+    let resp = client.describe_parameters().send().await?;
+
+    for param in resp.parameters.unwrap().iter() {
+        println!("  {}", param.name.as_deref().unwrap_or_default());
     }
 
-    println!();
+    Ok(())
 }


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

## Existing Example Update

The submitter has:

- [x] Confirmed that the correct copyright is included in all files.
- [x] Major code changes have been reviewed, and the submitter has incorporated review comments.
- [ ] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
