### PR TITLE
Updated .gitignore to ignore emacs backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vendor/
 *.exe
 .idea
 venv
+.*~


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

Emacs creates backup files with a tilde appended to the filename, so myFile.xyz's backup would be myFIle.xyz~. This commit ignores those files.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
