### PR TITLE
Added Java v1 snippets extracted from SNS guide

### DIFF
--- a/java/example_code/sns/CreateMobileEndpoint.java
+++ b/java/example_code/sns/CreateMobileEndpoint.java
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// snippet-start:[sns.java.create_mobile_endpoint]
+class RegistrationExample {
+
+  AmazonSNSClient client = new AmazonSNSClient(); //provide credentials here
+  String arnStorage = null;
+
+  public void registerWithSNS() {
+
+    String endpointArn = retrieveEndpointArn();
+    String token = "Retrieved from the mobile operating system";
+
+    boolean updateNeeded = false;
+    boolean createNeeded = (null == endpointArn);
+
+    if (createNeeded) {
+      // No platform endpoint ARN is stored; need to call createEndpoint.
+      endpointArn = createEndpoint();
+      createNeeded = false;
+    }
+
+    System.out.println("Retrieving platform endpoint data...");
+    // Look up the platform endpoint and make sure the data in it is current, even if
+    // it was just created.
+    try {
+      GetEndpointAttributesRequest geaReq =
+          new GetEndpointAttributesRequest()
+        .withEndpointArn(endpointArn);
+      GetEndpointAttributesResult geaRes =
+        client.getEndpointAttributes(geaReq);
+
+      updateNeeded = !geaRes.getAttributes().get("Token").equals(token)
+        || !geaRes.getAttributes().get("Enabled").equalsIgnoreCase("true");
+
+    } catch (NotFoundException nfe) {
+      // We had a stored ARN, but the platform endpoint associated with it
+      // disappeared. Recreate it.
+        createNeeded = true;
+    }
+
+    if (createNeeded) {
+      createEndpoint(token);
+    }
+
+    System.out.println("updateNeeded = " + updateNeeded);
+
+    if (updateNeeded) {
+      // The platform endpoint is out of sync with the current data;
+      // update the token and enable it.
+      System.out.println("Updating platform endpoint " + endpointArn);
+      Map attribs = new HashMap();
+      attribs.put("Token", token);
+      attribs.put("Enabled", "true");
+      SetEndpointAttributesRequest saeReq =
+          new SetEndpointAttributesRequest()
+        .withEndpointArn(endpointArn)
+        .withAttributes(attribs);
+      client.setEndpointAttributes(saeReq);
+    }
+  }
+
+  /**
+  * @return never null
+  * */
+  private String createEndpoint(String token) {
+
+    String endpointArn = null;
+    try {
+      System.out.println("Creating platform endpoint with token " + token);
+      CreatePlatformEndpointRequest cpeReq =
+          new CreatePlatformEndpointRequest()
+        .withPlatformApplicationArn(applicationArn)
+        .withToken(token);
+      CreatePlatformEndpointResult cpeRes = client
+        .createPlatformEndpoint(cpeReq);
+      endpointArn = cpeRes.getEndpointArn();
+    } catch (InvalidParameterException ipe) {
+      String message = ipe.getErrorMessage();
+      System.out.println("Exception message: " + message);
+      Pattern p = Pattern
+        .compile(".*Endpoint (arn:aws:sns[^ ]+) already exists " +
+                 "with the same [Tt]oken.*");
+      Matcher m = p.matcher(message);
+      if (m.matches()) {
+        // The platform endpoint already exists for this token, but with additional
+        // custom data that createEndpoint doesn't want to overwrite. Use the
+        // existing platform endpoint.
+        endpointArn = m.group(1);
+      } else {
+        // Rethrow the exception, because the input is actually bad.
+        throw ipe;
+      }
+    }
+    storeEndpointArn(endpointArn);
+    return endpointArn;
+  }
+
+  /**
+  * @return the ARN the app was registered under previously, or null if no
+  *         platform endpoint ARN is stored.
+  */
+  private String retrieveEndpointArn() {
+    // Retrieve the platform endpoint ARN from permanent storage,
+    // or return null if null is stored.
+    return arnStorage;
+  }
+
+  /**
+  * Stores the platform endpoint ARN in permanent storage for lookup next time.
+  * */
+  private void storeEndpointArn(String endpointArn) {
+    // Write the platform endpoint ARN to permanent storage.
+    arnStorage = endpointArn;
+  }
+}
+// snippet-end:[sns.java.create_mobile_endpoint]

--- a/java/example_code/sns/FifoTopics.java
+++ b/java/example_code/sns/FifoTopics.java
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+// snippet-start:[sns.java.fifo_topics.create_topic]
+// Create API clients
+
+AWSCredentialsProvider credentials = getCredentials();
+
+AmazonSNS sns = new AmazonSNSClient(credentials);
+AmazonSQS sqs = new AmazonSQSClient(credentials);
+
+// Create FIFO topic
+
+Map<String, String> topicAttributes = new HashMap<String, String>();
+
+topicAttributes.put("FifoTopic", "true");
+topicAttributes.put("ContentBasedDeduplication", "false");
+
+String topicArn = sns.createTopic(
+    new CreateTopicRequest()
+        .withName("PriceUpdatesTopic.fifo")
+        .withAttributes(topicAttributes)
+).getTopicArn();
+
+// Create FIFO queues
+
+Map<String, String> queueAttributes = new HashMap<String, String>();
+
+queueAttributes.put("FifoQueue", "true");
+
+// Disable content-based deduplication because messages published with the same body
+// might carry different attributes that must be processed independently.
+// The price management system uses the message attributes to define whether a given
+// price update applies to the wholesale application or to the retail application.
+queueAttributes.put("ContentBasedDeduplication", "false");
+
+String wholesaleQueueUrl = sqs.createQueue(
+    new CreateQueueRequest()
+        .withName("WholesaleQueue.fifo")
+        .withAttributes(queueAttributes)
+).getQueueUrl();
+
+String retailQueueUrl = sqs.createQueue(
+    new CreateQueueRequest()
+        .withName("RetailQueue.fifo")
+        .withAttributes(queueAttributes)
+).getQueueUrl();
+
+// Subscribe FIFO queues to FIFO topic, setting required permissions
+
+String wholesaleSubscriptionArn =
+    Topics.subscribeQueue(sns, sqs, topicArn, wholesaleQueueUrl);
+
+String retailSubscriptionArn =
+    Topics.subscribeQueue(sns, sqs, topicArn, retailQueueUrl);
+// snippet-end:[sns.java.fifo_topics.create_topic]
+
+// snippet-start:[sns.java.fifo_topics.filter_policy]
+// Set the Amazon SNS subscription filter policies
+
+SNSMessageFilterPolicy wholesalePolicy = new SNSMessageFilterPolicy();
+wholesalePolicy.addAttribute("business", "wholesale");
+wholesalePolicy.apply(sns, wholesaleSubscriptionArn);
+
+SNSMessageFilterPolicy retailPolicy = new SNSMessageFilterPolicy();
+retailPolicy.addAttribute("business", "retail");
+retailPolicy.apply(sns, retailSubscriptionArn);
+// snippet-end:[sns.java.fifo_topics.filter_policy]
+
+// snippet-start:[sns.java.fifo_topics.publish]
+// Publish message to FIFO topic
+
+String subject = "Price Update";
+String payload = "{\"product\": 214, \"price\": 79.99}";
+String groupId = "PID-214";
+String dedupId = UUID.randomUUID().toString();
+String attributeName = "business";
+String attributeValue = "wholesale";
+
+Map<String, MessageAttributeValue> attributes = new HashMap<>();
+
+attributes.put(
+    attributeName,
+    new MessageAttributeValue()
+        .withDataType("String")
+        .withStringValue(attributeValue));
+
+sns.publish(
+    new PublishRequest()
+        .withTopicArn(topicArn)
+        .withSubject(subject)
+        .withMessage(payload)
+        .withMessageGroupId(groupId);
+        .withMessageDeduplicationId(dedupId)
+        .withMessageAttributes(attributes);
+// snippet-end:[sns.java.fifo_topics.publish]
+

--- a/java/example_code/sns/PublishLargeFile.java
+++ b/java/example_code/sns/PublishLargeFile.java
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+// snippet-start:[sns.java.publish_large_file]
+import com.amazon.sqs.javamessaging.AmazonSQSExtendedClient;
+import com.amazon.sqs.javamessaging.ExtendedClientConfiguration;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import com.amazonaws.services.sns.model.CreateTopicRequest;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.SetSubscriptionAttributesRequest;
+import com.amazonaws.services.sns.util.Topics;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import software.amazon.sns.AmazonSNSExtendedClient;
+import software.amazon.sns.SNSExtendedClientConfiguration;
+
+public class Example {
+
+    public static void main(String[] args) {
+        final String BUCKET_NAME = "extended-client-bucket";
+        final String TOPIC_NAME = "extended-client-topic";
+        final String QUEUE_NAME = "extended-client-queue";
+        final Regions region = Regions.DEFAULT_REGION;
+
+        //Message threshold controls the maximum message size that will be allowed to be published
+        //through SNS using the extended client. Payload of messages exceeding this value will be stored in
+        //S3. The default value of this parameter is 256 KB which is the maximum message size in SNS (and SQS).
+        final int EXTENDED_STORAGE_MESSAGE_SIZE_THRESHOLD = 32;
+
+        //Initialize SNS, SQS and S3 clients
+        final AmazonSNS snsClient = AmazonSNSClientBuilder.standard().withRegion(region).build();
+        final AmazonSQS sqsClient = AmazonSQSClientBuilder.standard().withRegion(region).build();
+        final AmazonS3 s3Client = AmazonS3ClientBuilder.standard().withRegion(region).build();
+
+        //Create bucket, topic, queue and subscription
+        s3Client.createBucket(BUCKET_NAME);
+        final String topicArn = snsClient.createTopic(
+                new CreateTopicRequest().withName(TOPIC_NAME)
+        ).getTopicArn();
+        final String queueUrl = sqsClient.createQueue(
+                new CreateQueueRequest().withQueueName(QUEUE_NAME)
+        ).getQueueUrl();
+        final String subscriptionArn = Topics.subscribeQueue(
+                snsClient, sqsClient, topicArn, queueUrl
+        );
+
+        //To read message content stored in S3 transparently through SQS extended client,
+        //set the RawMessageDelivery subscription attribute to TRUE
+        final SetSubscriptionAttributesRequest subscriptionAttributesRequest = new SetSubscriptionAttributesRequest();
+        subscriptionAttributesRequest.setSubscriptionArn(subscriptionArn);
+        subscriptionAttributesRequest.setAttributeName("RawMessageDelivery");
+        subscriptionAttributesRequest.setAttributeValue("TRUE");
+        snsClient.setSubscriptionAttributes(subscriptionAttributesRequest);
+
+        //Initialize SNS extended client
+        //PayloadSizeThreshold triggers message content storage in S3 when the threshold is exceeded
+        //To store all messages content in S3, use AlwaysThroughS3 flag
+        final SNSExtendedClientConfiguration snsExtendedClientConfiguration = new SNSExtendedClientConfiguration()
+                .withPayloadSupportEnabled(s3Client, BUCKET_NAME)
+                .withPayloadSizeThreshold(EXTENDED_STORAGE_MESSAGE_SIZE_THRESHOLD);
+        final AmazonSNSExtendedClient snsExtendedClient = new AmazonSNSExtendedClient(snsClient, snsExtendedClientConfiguration);
+
+        //Publish message via SNS with storage in S3
+        final String message = "This message is stored in S3 as it exceeds the threshold of 32 bytes set above.";
+        snsExtendedClient.publish(topicArn, message);
+
+        //Initialize SQS extended client
+        final ExtendedClientConfiguration sqsExtendedClientConfiguration = new ExtendedClientConfiguration()
+                .withPayloadSupportEnabled(s3Client, BUCKET_NAME);
+        final AmazonSQSExtendedClient sqsExtendedClient =
+                new AmazonSQSExtendedClient(sqsClient, sqsExtendedClientConfiguration);
+
+        //Read the message from the queue
+        final ReceiveMessageResult result = sqsExtendedClient.receiveMessage(queueUrl);
+        System.out.println("Received message is " + result.getMessages().get(0).getBody());
+    }
+}
+// snippet-end:[sns.java.publish_large_file]

--- a/java/example_code/sns/PublishSmsToTopic.java
+++ b/java/example_code/sns/PublishSmsToTopic.java
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+// snippet-start:[sns.java.publish_sms_to_topic.main]
+public static void main(String[] args) {
+    AmazonSNSClient snsClient = new AmazonSNSClient();
+
+    String topicArn = createSNSTopic(snsClient);
+    String phoneNumber = "+1XXX5550100";
+    // Specify a protocol of "sms" when subscribing a phone number.
+    subscribeToTopic(snsClient, topicArn, "sms", phoneNumber);
+
+    String message = "My SMS message";
+    Map<String, MessageAttributeValue> smsAttributes =
+        new HashMap<String, MessageAttributeValue>();
+    addMessageAttributes(smsAttributes)
+    sendSMSMessageToTopic(snsClient, topicArn, message, smsAttributes);
+}
+// snippet-end:[sns.java.publish_sms_to_topic.main]
+
+// snippet-start:[sns.java.publish_sms_to_topic.create_topic]
+public static String createSNSTopic(AmazonSNSClient snsClient) {
+    CreateTopicRequest createTopic = new CreateTopicRequest("mySNSTopic");
+    CreateTopicResult result = snsClient.createTopic(createTopic);
+    System.out.println("Create topic request: " +
+        snsClient.getCachedResponseMetadata(createTopic));
+    System.out.println("Create topic result: " + result);
+    return result.getTopicArn();
+}
+// snippet-end:[sns.java.publish_sms_to_topic.create_topic]
+
+// snippet-start:[sns.java.publish_sms_to_topic.subscribe]
+public static void subscribeToTopic(AmazonSNSClient snsClient, String topicArn,
+        String protocol, String endpoint) {
+    SubscribeRequest subscribe = new SubscribeRequest(topicArn, protocol, endpoint);
+    SubscribeResult subscribeResult = snsClient.subscribe(subscribe);
+    System.out.println("Subscribe request: " +
+        snsClient.getCachedResponseMetadata(subscribe));
+    System.out.println("Subscribe result: " + subscribeResult);
+}
+// snippet-end:[sns.java.publish_sms_to_topic.subscribe]
+
+// snippet-start:[sns.java.publish_sms_to_topic.set_message_attributes]
+public static void addMessageAttributes(Map<String, MessageAttributeValue> smsAttributes) {
+    smsAttributes.put("AWS.SNS.SMS.SenderID", new MessageAttributeValue()
+        .withStringValue("mySenderID") //The sender ID shown on the device.
+        .withDataType("String"));
+    smsAttributes.put("AWS.SNS.SMS.MaxPrice", new MessageAttributeValue()
+        .withStringValue("0.50") //Sets the max price to 0.50 USD.
+        .withDataType("Number"));
+    smsAttributes.put("AWS.SNS.SMS.SMSType", new MessageAttributeValue()
+        .withStringValue("Promotional") //Sets the type to promotional.
+        .withDataType("String"));
+}
+// snippet-end:[sns.java.publish_sms_to_topic.set_message_attributes]
+
+// snippet-start:[sns.java.publish_sms_to_topic.publish]
+public static void sendSMSMessageToTopic(AmazonSNSClient snsClient, String topicArn,
+        String message, Map<String, MessageAttributeValue> smsAttributes) {
+    PublishResult result = snsClient.publish(new PublishRequest()
+        .withTopicArn(topicArn)
+        .withMessage(message)
+        .withMessageAttributes(smsAttributes));
+    System.out.println(result);
+}
+// snippet-end:[sns.java.publish_sms_to_topic.publish]

--- a/java/example_code/sns/README.md
+++ b/java/example_code/sns/README.md
@@ -1,0 +1,47 @@
+# Amazon Simple Notification Service examples
+
+## Purpose
+
+Shows how to use the AWS SDK for Java with Amazon Simple Notification Service
+(Amazon SNS).
+
+*Amazon SNS enables applications, end-users, and devices to instantly send and 
+receive notifications from the cloud.*
+
+## Code examples
+
+* [Create a platform endpoint for push notifications](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/java/example_code/sns/CreateMobileEndpoint.java)
+* [Create and publish to a FIFO topic](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/java/example_code/sns/FifoTopics.java)
+* [Publish a large message](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/java/example_code/sns/PublishLargeFile.java)
+* [Set a dead-letter queue for a subscription](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/java/sns/example_code/RedrivePolicy.java)
+* [Publish SMS messages to a topic](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/java/example_code/sns/PublishSmsToTopic.java)
+
+## ⚠ Important
+
+- As an AWS best practice, grant this code least privilege, or only the 
+  permissions required to perform a task. For more information, see 
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege) 
+  in the *AWS Identity and Access Management 
+  User Guide*.
+- This code has not been tested in all AWS Regions. Some AWS services are 
+  available only in specific Regions. For more information, see the 
+  [AWS Region Table](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/)
+  on the AWS website.
+- Running this code might result in charges to your AWS account.
+
+## Running the code
+
+### Prerequisites
+
+- You must have an AWS account, and have your default credentials and AWS Region
+  configured as described in the [AWS Tools and SDKs Shared Configuration and
+  Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
+
+## Additional information
+
+- [Amazon Simple Notification Service documentation](https://docs.aws.amazon.com/sns/index.html)
+
+---
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0

--- a/java/example_code/sns/RedrivePolicy.java
+++ b/java/example_code/sns/RedrivePolicy.java
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+// snippet-start:[sns.java.redrive_policy]
+// Specify the ARN of the Amazon SNS subscription.
+String subscriptionArn =
+    "arn:aws:sns:us-east-2:123456789012:MyEndpoint:1234a567-bc89-012d-3e45-6fg7h890123i";
+
+// Specify the ARN of the Amazon SQS queue to use as a dead-letter queue.
+String redrivePolicy =
+    "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-2:123456789012:MyDeadLetterQueue\"}";
+
+// Set the specified Amazon SQS queue as a dead-letter queue
+// of the specified Amazon SNS subscription by setting the RedrivePolicy attribute.
+SetSubscriptionAttributesRequest request = new SetSubscriptionAttributesRequest()
+    .withSubscriptionArn(subscriptionArn)
+    .withAttributeName("RedrivePolicy")
+    .withAttributeValue(redrivePolicy);
+sns.setSubscriptionAttributes(request);
+// snippet-end:[sns.java.redrive_policy]


### PR DESCRIPTION
This update is to move inline code examples out of the SNS user guide into this repo. Because these are legacy (Java v1) examples, they won't have unit tests nor be guaranteed to be runnable.

- [x] Added the default copyright notice to all files.
- [x] Added minimum usage documentation as comments in the code.
- [ ] Had comments and strings reviewed and incorporated suggested changes.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
