### PR TITLE
Add categories to zonbook templates.

### DIFF
--- a/.doc_gen/metadata/acm_metadata.yaml
+++ b/.doc_gen/metadata/acm_metadata.yaml
@@ -1,3 +1,4 @@
+# zexi 0.1.0
 acm_DescribeCertificate:
   title: Describe an &ACM; certificate using an &AWS; SDK
   title_abbrev: Describe a certificate

--- a/.doc_gen/metadata/apigateway_metadata.yaml
+++ b/.doc_gen/metadata/apigateway_metadata.yaml
@@ -1,3 +1,4 @@
+# zexi 0.1.0
 apigateway_CreateRestApi:
   title: Create an &ABP; REST API using an &AWS; SDK
   title_abbrev: Create a REST API

--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -1,3 +1,4 @@
+# zexi 0.1.0
 cross_DynamoDBDataTracker:
   title: Create a dynamic web application to track &DDB; data
   title_abbrev: Create a web application to track &DDB; data

--- a/.doc_gen/metadata/sns_metadata.yaml
+++ b/.doc_gen/metadata/sns_metadata.yaml
@@ -1,3 +1,4 @@
+# zexi 0.1.0
 sns_GetTopicAttributes:
   title: Get the properties of an &SNS; topic using an &AWS; SDK
   title_abbrev: Get the properties of a topic

--- a/.doc_gen/templates/zonbook/example_description_template.xml
+++ b/.doc_gen/templates/zonbook/example_description_template.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--zexi 0.1.0-->
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "file://zonbook/docbookx.dtd"[
     <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
     %phrases-shared;

--- a/.doc_gen/templates/zonbook/example_language_template.xml
+++ b/.doc_gen/templates/zonbook/example_language_template.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--zexi 0.1.0-->
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "file://zonbook/docbookx.dtd"[
     <!ENTITY % xinclude SYSTEM "file://AWSShared/common/xinclude.mod">
     %xinclude;

--- a/.doc_gen/templates/zonbook/example_tablist_template.xml
+++ b/.doc_gen/templates/zonbook/example_tablist_template.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--zexi 0.1.0-->
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "file://zonbook/docbookx.dtd"[
     <!ENTITY % xinclude SYSTEM "file://AWSShared/common/xinclude.mod">
     %xinclude;

--- a/.doc_gen/templates/zonbook/sdk_chapter_template.xml
+++ b/.doc_gen/templates/zonbook/sdk_chapter_template.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--zexi 0.1.0-->
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "file://zonbook/docbookx.dtd"[
     <!ENTITY % xinclude SYSTEM "file://AWSShared/common/xinclude.mod">
     %xinclude;
@@ -38,21 +39,21 @@
             <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}_{{$.Language}}.xml"></xi:include>
         </section>
         {{end}}
-        {{if .CrossServiceExamples}}
+    {{if .CrossServiceExamples}}
     </section>
     {{end}}
     {{if .ApiExamples}}
-    <section id="{{.LanguageSlug}}_code_examples_API" role="topic">
+    <section id="{{$.LanguageSlug}}_code_examples_categorized" role="topic">
         <info>
-            <title id="{{.LanguageSlug}}_code_examples_API.title">API examples using {{.SdkEntity.Short}}</title>
-            <titleabbrev id="{{.LanguageSlug}}_code_examples_API.titleabbrev">API examples</titleabbrev>
+            <title id="{{$.LanguageSlug}}_code_examples_categorized.title">Examples using {{$.SdkEntity.Short}}</title>
+            <titleabbrev id="{{$.LanguageSlug}}_code_examples_categorized.titleabbrev">Examples</titleabbrev>
             <abstract>
-                <para>The following code examples show how to use {{.SdkEntity.Short}} to perform &AWS; service operations.</para>
+                <para>The following code examples show how to use {{$.SdkEntity.Short}} with &AWS; services.</para>
             </abstract>
         </info>
-        <para>The following code examples show how to use {{.SdkEntity.Short}} to perform &AWS; service operations.</para>
+        <para>The following code examples show how to use {{$.SdkEntity.Short}} with &AWS; services.</para>
         <para role="topiclist-abbrev">Examples</para>
-        {{end}}
+    {{end}}
         {{range $service, $svc_examples := .ApiExamples}}
         <section id="{{$.LanguageSlug}}_{{$svc_examples.ServiceSlug}}_code_examples" role="topic">
             <info>
@@ -62,9 +63,11 @@
                     <para>Code examples that show how to use {{$.SdkEntity.Long}} with {{$svc_examples.ServiceEntity.Short}}.</para>
                 </abstract>
             </info>
-            <para>Code examples that show how to use {{$.SdkEntity.Long}} with {{$svc_examples.ServiceEntity.Short}}.</para>
+            {{range $category := $svc_examples.CategoryNamesSorted}}
+            {{with $cat_examples := index $svc_examples.CategorizedExampleSets $category}}
+            <para><emphasis role="bold">{{$cat_examples.CategoryName}} examples</emphasis></para>
             <collapsible expand-section="_collapse_all_">
-                {{range $svc_examples.Examples}}
+                {{range $cat_examples.Examples}}
                 <section id="{{.ExampleId}}_{{$.LanguageSlug}}_topic" role="topic">
                     <info>
                         <title id="{{.ExampleId}}_{{$.LanguageSlug}}_topic.titleabbrev">{{.TitleAbbrev}}</title>
@@ -75,9 +78,11 @@
                 </section>
                 {{end}}
             </collapsible>
+            {{end}}
+            {{end}}
         </section>
         {{end}}
-        {{if .ApiExamples}}
+    {{if .ApiExamples}}
     </section>
     {{end}}
 </chapter>

--- a/.doc_gen/templates/zonbook/service_chapter_template.xml
+++ b/.doc_gen/templates/zonbook/service_chapter_template.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--zexi 0.1.0-->
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "file://zonbook/docbookx.dtd"[
-    <!ENTITY % xinclude SYSTEM "file://AWSShared/common/xinclude.mod">
-    %xinclude;
-    <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
-    %phrases-shared;
-]>
+        <!ENTITY % xinclude SYSTEM "file://AWSShared/common/xinclude.mod">
+        %xinclude;
+        <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
+        %phrases-shared;
+        ]>
 <chapter id="service_code_examples" role="topic">
     <info>
         <title id="service_code_examples.title">Code examples for {{.ServiceEntity.Short}}</title>
@@ -18,21 +19,19 @@
         and information about previous versions, see
         <xref linkend="sdk-general-information-section" endterm="sdk-general-information-section.title"></xref>.</para>
     <para role="contents-abbrev">Code examples</para>
-    {{if .CrossServiceExamples}}
-    <section id="service_code_examples_cross_service" role="topic">
+    {{range $category := .CategoryNamesSorted}}
+    {{with $cat_examples := index $.CategorizedExampleSets $category}}
+    <section id="service_code_examples_{{$cat_examples.CategoryIdSuffix}}" role="topic">
         <info>
-            <title id="service_code_examples_cross_service.title">Cross-service examples for {{.ServiceEntity.Short}}</title>
-            <titleabbrev id="service_code_examples_cross_service.titleabbrev">Cross-service examples</titleabbrev>
+            <title id="service_code_examples_{{$cat_examples.CategoryIdSuffix}}.title">{{$cat_examples.CategoryName}} examples for {{$.ServiceEntity.Short}}</title>
+            <titleabbrev id="service_code_examples_{{$cat_examples.CategoryIdSuffix}}.titleabbrev">{{$cat_examples.CategoryName}} examples</titleabbrev>
             <abstract>
-                <para>The following code examples show how to use &AWS; software development kits (SDKs) to combine
-                    multiple services, including {{.ServiceEntity.Short}}.</para>
+                <para>The following code examples show how to use {{$.ServiceEntity.Short}} with &AWS; SDKs.</para>
             </abstract>
         </info>
-        <para>The following code examples show how to use &AWS; software development kits (SDKs) to combine
-            multiple services, including {{.ServiceEntity.Short}}.</para>
+        <para>The following code examples show how to use {{$.ServiceEntity.Short}} with &AWS; SDKs.</para>
         <para role="topiclist-abbrev">Examples</para>
-        {{end}}
-        {{range .CrossServiceExamples}}
+        {{range $cat_examples.Examples}}
         <section id="example_{{.ExampleId}}_section" role="topic">
             <info>
                 <title id="example_{{.ExampleId}}_section.title">{{.Title}}</title>
@@ -48,40 +47,7 @@
                 <xref linkend="sdk-general-information-section" endterm="sdk-general-information-section.title"></xref>.</para>
         </section>
         {{end}}
-    {{if .CrossServiceExamples}}
     </section>
     {{end}}
-    {{if .ApiExamples}}
-    <section id="service_code_examples_this_service" role="topic">
-        <info>
-            <title id="service_code_examples_this_service.title">API examples for {{.ServiceEntity.Short}}</title>
-            <titleabbrev id="service_code_examples_this_service.titleabbrev">API examples</titleabbrev>
-            <abstract>
-                <para>The following code examples show how to use &AWS; software development kits (SDKs)
-                    to perform {{.ServiceEntity.Short}} operations.</para>
-            </abstract>
-        </info>
-        <para>The following code examples show how to use &AWS; software development kits (SDKs) to perform
-            {{.ServiceEntity.Short}} operations.</para>
-        <para role="topiclist-abbrev">Examples</para>
-        {{end}}
-        {{range .ApiExamples}}
-        <section id="example_{{.ExampleId}}_section" role="topic">
-            <info>
-                <title id="example_{{.ExampleId}}_section.title">{{.Title}}</title>
-                <titleabbrev id="example_{{.ExampleId}}_section.titleabbrev">{{.TitleAbbrev}}</titleabbrev>
-                <abstract>
-                    <para>{{.Title}}</para>
-                </abstract>
-            </info>
-            <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}_desc.xml"></xi:include>
-            <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}_tablist.xml"></xi:include>
-            <para>For a complete list of &AWS; SDK developer guides and code examples, including help getting started
-                and information about previous versions, see
-                <xref linkend="sdk-general-information-section" endterm="sdk-general-information-section.title"></xref>.</para>
-        </section>
-        {{end}}
-    {{if .ApiExamples}}
-    </section>
     {{end}}
 </chapter>


### PR DESCRIPTION
Use zexi categories in zonbook output templates. Categories are optional, but offer a more flexible way of segmenting examples in the output. If a category is defined in the metadata, it is used to collect all examples in that service under that category. If no category is specified, examples are categorized as "Cross-service" (having more than one service) or "API" (having only one service).

Also add a comment to the top of metadata and templates that specifies the compatible zexi version.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
