### PR TITLE
Fix snippet tag typo in Kotlin Lamba file

### DIFF
--- a/.kotlin_alpha/services/lambda/src/main/kotlin/com/kotlin/lambda/DeleteFunction.kt
+++ b/.kotlin_alpha/services/lambda/src/main/kotlin/com/kotlin/lambda/DeleteFunction.kt
@@ -66,4 +66,4 @@ suspend fun delLambdaFunction(awsLambda: LambdaClient, myFunctionName: String) {
             exitProcess(1)
         }
  }
-// snippet-start:[lambda.kotlin.delete.main]
+// snippet-end:[lambda.kotlin.delete.main]


### PR DESCRIPTION
A snippet-end tag in kotlin/lambda/DeleteFunction.kt was accidentally typed as snippet-start (which breaks the doc build). This fixes that.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
