### PR TITLE
Fix javascript sdk v3 ses send mail example

### DIFF
--- a/javascriptv3/example_code/ses/src/ses_sendemail.js
+++ b/javascriptv3/example_code/ses/src/ses_sendemail.js
@@ -15,8 +15,8 @@ Inputs (replace in code):
 Running the code:
 node ses_sendemail.js
 
-// snippet-start:[ses.JavaScript.email.sendEmailV3]
 */
+// snippet-start:[ses.JavaScript.email.sendEmailV3]
 // Create the promise and SES service object
 
 // Import required AWS SDK clients and commands for Node.js


### PR DESCRIPTION
The syntax highlighting for [an example](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/ses-examples-sending-email.html#ses-examples-sendmail) for sedning ses email using javascript sdk v3 is off as can be seen on the screenshot below:

![Screenshot from 2021-09-09 20-53-21](https://user-images.githubusercontent.com/25728391/132747690-8de63308-4917-4998-9396-6087a4aaf871.png)

This is caused by `*/` at the beginning of the code sample which seems to be there due to misplaced `snippet-start:[ses.JavaScript.email.sendEmailV3]`. It is included as the last line inside a multiline comment meaning that it is immediately followed by `*/` which appears at the beginning of the code sample. Moving the statement into a separate single-line comment and regenerating the docs should fix the problem.

---

## Existing Example Update

The submitter has:

- [ ] Confirmed that the correct copyright is included in all files.
- [ ] Major code changes have been reviewed, and the submitter has incorporated review comments.
- [ ] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.

### Description of Changes

Please describe the changes you have made here.

- [ ] I have tested my changes and created unit tests for new code paths.
- [ ] Changes have been reviewed, and all reviewer comments have been incorporated.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
