### PR TITLE
fix js example_code for dynamodb scan ExpressionAttributeValues

### DIFF
--- a/javascript/example_code/dynamodb/ddb_scan.js
+++ b/javascript/example_code/dynamodb/ddb_scan.js
@@ -39,9 +39,9 @@ const params = {
   FilterExpression: "Subtitle = :topic AND Season = :s AND Episode = :e",
   // Define the expression attribute value, which are substitutes for the values you want to compare.
   ExpressionAttributeValues: {
-    ":topic": "SubTitle2",
-    ":s": 1,
-    ":e": 2,
+    ":topic": {S: "SubTitle2"},
+    ":s": {N: 1},
+    ":e": {N: 2},
   },
   // Set the projection expression, which are the attributes that you want.
   ProjectionExpression: "Season, Episode, Title, Subtitle",


### PR DESCRIPTION
When using `dbb.scan`  (`var ddb = new AWS.DynamoDB({ apiVersion: "2012-08-10" });`) 
the `ExpressionAttributeValues` needs to be a structure
https://github.com/awsdocs/aws-doc-sdk-examples/blob/b2536b19987975ca3e685f3ee6f0e5a2c32e249d/javascript/example_code/dynamodb/ddb_scan.js#L42
should be `":topic": {S: "SubTitle2"}` following the same `ExpressionAttributeValues` syntax as in the `dbb.query` example:
https://github.com/awsdocs/aws-doc-sdk-examples/blob/b2536b19987975ca3e685f3ee6f0e5a2c32e249d/javascript/example_code/dynamodb/ddb_query.js#L41

otherwise you will get a: 
`InvalidParameterType: Expected params.ExpressionAttributeValues[':topic'] to be a structure` error

Cheers & thanks for the examples 🍻 