### PR TITLE
zexi 0.4.0: update metadata to use service:{action} map

### DIFF
--- a/.doc_gen/metadata/acm_metadata.yaml
+++ b/.doc_gen/metadata/acm_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 acm_DescribeCertificate:
   title: Describe an &ACM; certificate using an &AWS; SDK
   title_abbrev: Describe a certificate
@@ -15,7 +15,7 @@ acm_DescribeCertificate:
                 - python.example_code.acm.AcmCertificate
                 - python.example_code.acm.DescribeCertificate
   services:
-    - acm
+    acm: {DescribeCertificate}
 acm_GetCertificate:
   title: Get an &ACM; certificate using an &AWS; SDK
   title_abbrev: Get a certificate
@@ -32,7 +32,7 @@ acm_GetCertificate:
                 - python.example_code.acm.AcmCertificate
                 - python.example_code.acm.GetCertificate
   services:
-    - acm
+    acm: {GetCertificate}
 acm_ListCertificates:
   title: List &ACM; certificates using an &AWS; SDK
   title_abbrev: List certificates
@@ -49,7 +49,7 @@ acm_ListCertificates:
                 - python.example_code.acm.AcmCertificate
                 - python.example_code.acm.ListCertificates
   services:
-    - acm
+    acm: {ListCertificates}
 acm_ImportCertificate:
   title: Import an &ACM; certificate using an &AWS; SDK
   title_abbrev: Import certificates
@@ -66,7 +66,7 @@ acm_ImportCertificate:
                 - python.example_code.acm.AcmCertificate
                 - python.example_code.acm.ImportCertificate
   services:
-    - acm
+    acm: {ImportCertificate}
 acm_DeleteCertificate:
   title: Delete an &ACM; certificate using an &AWS; SDK
   title_abbrev: Delete a certificate
@@ -83,7 +83,7 @@ acm_DeleteCertificate:
                 - python.example_code.acm.AcmCertificate
                 - python.example_code.acm.DeleteCertificate
   services:
-    - acm
+    acm: {DeleteCertificate}
 acm_AddTagsToCertificate:
   title: Add tags to an &ACM; certificate using an &AWS; SDK
   title_abbrev: Add tags to a certificate
@@ -100,7 +100,7 @@ acm_AddTagsToCertificate:
                 - python.example_code.acm.AcmCertificate
                 - python.example_code.acm.AddTagsToCertificate
   services:
-    - acm
+    acm: {AddTagsToCertificate}
 acm_ListTagsForCertificate:
   title: List tags for an &ACM; certificate using an &AWS; SDK
   title_abbrev: List tags for a certificate
@@ -117,7 +117,7 @@ acm_ListTagsForCertificate:
                 - python.example_code.acm.AcmCertificate
                 - python.example_code.acm.ListTagsForCertificate
   services:
-    - acm
+    acm: {ListTagsForCertificate}
 acm_RemoveTagsFromCertificate:
   title: Remove tags from an &ACM; certificate using an &AWS; SDK
   title_abbrev: Remove tags from a certificate
@@ -134,7 +134,7 @@ acm_RemoveTagsFromCertificate:
                 - python.example_code.acm.AcmCertificate
                 - python.example_code.acm.RemoveTagsFromCertificate
   services:
-    - acm
+    acm: {RemoveTagsFromCertificate}
 acm_RequestCertificate:
   title: Request validation of an &ACM; certificate using an &AWS; SDK
   title_abbrev: Request validation of a certificate
@@ -151,7 +151,7 @@ acm_RequestCertificate:
                 - python.example_code.acm.AcmCertificate
                 - python.example_code.acm.RequestCertificate
   services:
-    - acm
+    acm: {RequestCertificate}
 acm_ResendValidationEmail:
   title: Resend validation email for an &ACM; certificate using an &AWS; SDK
   title_abbrev: Resend validation email for a certificate
@@ -168,7 +168,7 @@ acm_ResendValidationEmail:
                 - python.example_code.acm.AcmCertificate
                 - python.example_code.acm.ResendValidationEmail
   services:
-    - acm
+    acm: {ResendValidationEmail}
 acm_Usage_ImportListRemove:
   title: Manage &ACM; certificates using an &AWS; SDK
   title_abbrev: Manage certificates
@@ -202,4 +202,4 @@ acm_Usage_ImportListRemove:
               snippet_tags:
                 - python.example_code.acm.Usage_ImportListRemove
   services:
-    - acm
+    acm: {}

--- a/.doc_gen/metadata/api-gateway_metadata.yaml
+++ b/.doc_gen/metadata/api-gateway_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 api-gateway_CreateRestApi:
   title: Create an &ABP; REST API using an &AWS; SDK
   title_abbrev: Create a REST API
@@ -16,7 +16,7 @@ api-gateway_CreateRestApi:
                 - python.example_code.api-gateway.ApiGatewayToService.class
                 - python.example_code.api-gateway.CreateRestApi
   services:
-    - api-gateway
+    api-gateway: {CreateRestApi}
 api-gateway_GetResources:
   title: Get &ABP; REST resources using an &AWS; SDK
   title_abbrev: Get REST resources
@@ -34,7 +34,7 @@ api-gateway_GetResources:
                 - python.example_code.api-gateway.ApiGatewayToService.class
                 - python.example_code.api-gateway.CreateRestApi
   services:
-    - api-gateway
+    api-gateway: {GetResources}
 api-gateway_CreateResource:
   title: Create an &ABP; REST resource using an &AWS; SDK
   title_abbrev: Create a REST resource
@@ -52,7 +52,7 @@ api-gateway_CreateResource:
                 - python.example_code.api-gateway.ApiGatewayToService.class
                 - python.example_code.api-gateway.CreateResource
   services:
-    - api-gateway
+    api-gateway: {CreateResource}
 api-gateway_PutMethod:
   title: Add an HTTP method to an &ABP; REST resource using an &AWS; SDK
   title_abbrev: Add an HTTP method to a REST resource
@@ -70,7 +70,7 @@ api-gateway_PutMethod:
                 - python.example_code.api-gateway.ApiGatewayToService.class
                 - python.example_code.api-gateway.PutIntegration
   services:
-    - api-gateway
+    api-gateway: {PutMethod}
 api-gateway_PutMethodResponse:
   title: Add an HTTP response to an &ABP; REST resource using an &AWS; SDK
   title_abbrev: Add an HTTP response to a REST resource
@@ -88,7 +88,7 @@ api-gateway_PutMethodResponse:
                 - python.example_code.api-gateway.ApiGatewayToService.class
                 - python.example_code.api-gateway.PutIntegration
   services:
-    - api-gateway
+    api-gateway: {PutMethodResponse}
 api-gateway_PutIntegration:
   title: Integrate an &ABP; method with an &AWS; service using an &AWS; SDK
   title_abbrev: Integrate a method with an &AWS; service
@@ -106,7 +106,7 @@ api-gateway_PutIntegration:
                 - python.example_code.api-gateway.ApiGatewayToService.class
                 - python.example_code.api-gateway.PutIntegration
   services:
-    - api-gateway
+    api-gateway: {PutIntegration}
 api-gateway_PutIntegrationResponse:
   title: Add a response from an &AWS; service integrated with an &ABP; method using an &AWS; SDK
   title_abbrev: Add a response from an &AWS; service integrated with a method
@@ -124,7 +124,7 @@ api-gateway_PutIntegrationResponse:
                 - python.example_code.api-gateway.ApiGatewayToService.class
                 - python.example_code.api-gateway.PutIntegration
   services:
-    - api-gateway
+    api-gateway: {PutIntegrationResponse}
 api-gateway_CreateDeployment:
   title: Deploy an &ABP; REST API using an &AWS; SDK
   title_abbrev: Deploy a REST API
@@ -143,7 +143,7 @@ api-gateway_CreateDeployment:
                 - python.example_code.api-gateway.CreateDeployment
                 - python.example_code.api-gateway.Helper.ApiUrl
   services:
-    - api-gateway
+    api-gateway: {CreateDeployment}
 api-gateway_GetRestApis:
   title: List &ABP; REST APIs using an &AWS; SDK
   title_abbrev: List REST APIs
@@ -161,7 +161,7 @@ api-gateway_GetRestApis:
                 - python.example_code.api-gateway.ApiGatewayToService.class
                 - python.example_code.api-gateway.GetRestApis
   services:
-    - api-gateway
+    api-gateway: {GetRestApis}
 api-gateway_DeleteRestApi:
   title: Delete an &ABP; REST API using an &AWS; SDK
   title_abbrev: Delete a REST API
@@ -179,7 +179,7 @@ api-gateway_DeleteRestApi:
                 - python.example_code.api-gateway.ApiGatewayToService.class
                 - python.example_code.api-gateway.DeleteRestApi
   services:
-    - api-gateway
+    api-gateway: {DeleteRestApi}
 api-gateway_Usage_CreateDeployRest:
   title: Create and deploy a REST API using an &AWS; SDK
   title_abbrev: Create and deploy a REST API
@@ -205,4 +205,4 @@ api-gateway_Usage_CreateDeployRest:
               snippet_tags:
                 - python.example_code.api-gateway.Usage_CreateDeployRest
   services:
-    - api-gateway
+    api-gateway: {}

--- a/.doc_gen/metadata/cloudfront_metadata.yaml
+++ b/.doc_gen/metadata/cloudfront_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 cloudfront_ListDistributions:
   title: List &CF; distributions using an &AWS; SDK
   title_abbrev: List distributions
@@ -16,7 +16,7 @@ cloudfront_ListDistributions:
                 - python.example_code.cloudfront.CloudFrontWrapper
                 - python.example_code.cloudfront.ListDistributions
   services:
-    - cloudfront
+    cloudfront: {ListDistributions}
 cloudfront_GetDistributionConfig:
   title: Get &CF; distribution configuration using an &AWS; SDK
   title_abbrev: Get distribution configuration
@@ -34,7 +34,7 @@ cloudfront_GetDistributionConfig:
                 - python.example_code.cloudfront.CloudFrontWrapper
                 - python.example_code.cloudfront.UpdateDistribution
   services:
-    - cloudfront
+    cloudfront: {GetDistributionConfig}
 cloudfront_CreateFunction:
   title: Create a &CF; function using an &AWS; SDK
   title_abbrev: Create a function
@@ -51,7 +51,7 @@ cloudfront_CreateFunction:
               snippet_tags:
                 - cloudfront.java2.function.main
   services:
-    - cloudfront
+    cloudfront: {CreateFunction}
 cloudfront_UpdateDistribution:
   title: Update a &CF; distribution using an &AWS; SDK
   title_abbrev: Update a distribution
@@ -78,4 +78,4 @@ cloudfront_UpdateDistribution:
                 - python.example_code.cloudfront.CloudFrontWrapper
                 - python.example_code.cloudfront.UpdateDistribution
   services:
-    - cloudfront
+    cloudfront: {UpdateDistribution}

--- a/.doc_gen/metadata/cloudwatch-events_metadata.yaml
+++ b/.doc_gen/metadata/cloudwatch-events_metadata.yaml
@@ -1,82 +1,82 @@
-# zexi 0.2.0
+# zexi 0.4.0
 cloudwatch-events_PutRule:
-    title: Create a &CWE; scheduled rule using an &AWS; SDK
-    title_abbrev: Create a scheduled rule
-    synopsis: create an &CWElong; scheduled rule.
-    category:
-    languages:
-        JavaScript:
-            versions:
-                - sdk_version: 3
-                  github: javascriptv3/example_code/cloudwatch-events
-                  sdkguide: sdk-for-javascript/v3/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-rules
-                  excerpts:
-                      - description: Create the client in a separate module and export it.
-                        snippet_tags:
-                            - cloudwatch.JavaScript.events.createclientv3
-                      - description: Import the SDK and client modules and call the API.
-                        snippet_tags:
-                            - cwEvents.JavaScript.cwe.putRuleV3
-                - sdk_version: 2
-                  github: javascript/example_code/cloudwatch
-                  sdkguide: sdk-for-javascript/v2/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-rules
-                  excerpts:
-                      - description:
-                        snippet_tags:
-                            - cwEvents.JavaScript.cwe.putRule
-    services:
-        - cloudwatch-events
+  title: Create a &CWE; scheduled rule using an &AWS; SDK
+  title_abbrev: Create a scheduled rule
+  synopsis: create an &CWElong; scheduled rule.
+  category:
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 3
+          github: javascriptv3/example_code/cloudwatch-events
+          sdkguide: sdk-for-javascript/v3/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-rules
+          excerpts:
+            - description: Create the client in a separate module and export it.
+              snippet_tags:
+                - cloudwatch.JavaScript.events.createclientv3
+            - description: Import the SDK and client modules and call the API.
+              snippet_tags:
+                - cwEvents.JavaScript.cwe.putRuleV3
+        - sdk_version: 2
+          github: javascript/example_code/cloudwatch
+          sdkguide: sdk-for-javascript/v2/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-rules
+          excerpts:
+            - description:
+              snippet_tags:
+                - cwEvents.JavaScript.cwe.putRule
+  services:
+    cloudwatch-events: {PutRule}
 cloudwatch-events_PutEvents:
-    title: Send &CWE; events using an &AWS; SDK
-    title_abbrev: Send events
-    synopsis: send &CWElong; events.
-    category:
-    languages:
-        JavaScript:
-            versions:
-                - sdk_version: 3
-                  github: javascriptv3/example_code/cloudwatch-events
-                  sdkguide: sdk-for-javascript/v3/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-putevents
-                  excerpts:
-                      - description: Create the client in a separate module and export it.
-                        snippet_tags:
-                            - cloudwatch.JavaScript.events.createclientv3
-                      - description: Import the SDK and client modules and call the API.
-                        snippet_tags:
-                            - cwEvents.JavaScript.cwe.putEventsV3
-                - sdk_version: 2
-                  github: javascript/example_code/cloudwatch
-                  sdkguide: sdk-for-javascript/v2/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-putevents
-                  excerpts:
-                      - description:
-                        snippet_tags:
-                            - cwEvents.JavaScript.cwe.putEvents
-    services:
-        - cloudwatch-events
+  title: Send &CWE; events using an &AWS; SDK
+  title_abbrev: Send events
+  synopsis: send &CWElong; events.
+  category:
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 3
+          github: javascriptv3/example_code/cloudwatch-events
+          sdkguide: sdk-for-javascript/v3/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-putevents
+          excerpts:
+            - description: Create the client in a separate module and export it.
+              snippet_tags:
+                - cloudwatch.JavaScript.events.createclientv3
+            - description: Import the SDK and client modules and call the API.
+              snippet_tags:
+                - cwEvents.JavaScript.cwe.putEventsV3
+        - sdk_version: 2
+          github: javascript/example_code/cloudwatch
+          sdkguide: sdk-for-javascript/v2/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-putevents
+          excerpts:
+            - description:
+              snippet_tags:
+                - cwEvents.JavaScript.cwe.putEvents
+  services:
+    cloudwatch-events: {PutEvents}
 cloudwatch-events_PutTargets:
-    title: Add a &LAM; function target using an &AWS; SDK
-    title_abbrev: Adding a &LAM; function target
-    synopsis: add an &LAMlong; function target to an &CWElong; event.
-    category:
-    languages:
-        JavaScript:
-            versions:
-                - sdk_version: 3
-                  github: javascriptv3/example_code/cloudwatch-events
-                  sdkguide: sdk-for-javascript/v3/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-targets
-                  excerpts:
-                      - description: Create the client in a separate module and export it.
-                        snippet_tags:
-                            - cloudwatch.JavaScript.events.createclientv3
-                      - description: Import the SDK and client modules and call the API.
-                        snippet_tags:
-                            - cwEvents.JavaScript.cwe.putTargetsV3
-                - sdk_version: 2
-                  github: javascript/example_code/cloudwatch
-                  sdkguide: sdk-for-javascript/v2/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-targets
-                  excerpts:
-                      - description:
-                        snippet_tags:
-                            - cwEvents.JavaScript.cwe.putTargets
-    services:
-        - cloudwatch-events
+  title: Add a &LAM; function target using an &AWS; SDK
+  title_abbrev: Adding a &LAM; function target
+  synopsis: add an &LAMlong; function target to an &CWElong; event.
+  category:
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 3
+          github: javascriptv3/example_code/cloudwatch-events
+          sdkguide: sdk-for-javascript/v3/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-targets
+          excerpts:
+            - description: Create the client in a separate module and export it.
+              snippet_tags:
+                - cloudwatch.JavaScript.events.createclientv3
+            - description: Import the SDK and client modules and call the API.
+              snippet_tags:
+                - cwEvents.JavaScript.cwe.putTargetsV3
+        - sdk_version: 2
+          github: javascript/example_code/cloudwatch
+          sdkguide: sdk-for-javascript/v2/developer-guide/cloudwatch-examples-sending-events.html#cloudwatch-examples-sending-events-targets
+          excerpts:
+            - description:
+              snippet_tags:
+                - cwEvents.JavaScript.cwe.putTargets
+  services:
+    cloudwatch-events: {PutTargets}

--- a/.doc_gen/metadata/cloudwatch-logs_metadata.yaml
+++ b/.doc_gen/metadata/cloudwatch-logs_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 cloudwatch-logs_DescribeSubscriptionFilters:
   title: Describe &CWL; subscription filters using an &AWS; SDK
   title_abbrev: Describe existing subscription filters
@@ -25,7 +25,7 @@ cloudwatch-logs_DescribeSubscriptionFilters:
               snippet_tags:
                 - cwLogs.JavaScript.cwl.describeSubscriptionFilters
   services:
-    - cloudwatch-logs
+    cloudwatch-logs: {DescribeSubscriptionFilters}
 cloudwatch-logs_DeleteSubscriptionFilter:
   title: Delete a &CWL; subscription filter using an &AWS; SDK
   title_abbrev: Delete a subscription filter
@@ -52,7 +52,7 @@ cloudwatch-logs_DeleteSubscriptionFilter:
               snippet_tags:
                 - cwLogs.JavaScript.cwl.deleteSubscriptionFilter
   services:
-    - cloudwatch-logs
+    cloudwatch-logs: {DeleteSubscriptionFilter}
 cloudwatch-logs_PutSubscriptionFilter:
   title: Create a &CWL; subscription filter using an &AWS; SDK
   title_abbrev: Create a subscription filter
@@ -79,4 +79,4 @@ cloudwatch-logs_PutSubscriptionFilter:
               snippet_tags:
                 - cwLogs.JavaScript.cwl.putSubscriptionFilter
   services:
-    - cloudwatch-logs
+    cloudwatch-logs: {PutSubscriptionFilter}

--- a/.doc_gen/metadata/cloudwatch_metadata.yaml
+++ b/.doc_gen/metadata/cloudwatch_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 cloudwatch_ListMetrics:
   title: List &CW; metrics using an &AWS; SDK
   title_abbrev: List metrics
@@ -35,7 +35,7 @@ cloudwatch_ListMetrics:
               snippet_tags:
                 - cw.JavaScript.metrics.listMetrics
   services:
-    - cloudwatch
+    cloudwatch: {ListMetrics}
 cloudwatch_PutMetricData:
   title: Put data into a &CW; metric using an &AWS; SDK
   title_abbrev: Put data into a metric
@@ -72,7 +72,7 @@ cloudwatch_PutMetricData:
               snippet_tags:
                 - cw.JavaScript.metrics.putMetricData
   services:
-    - cloudwatch
+    cloudwatch: {PutMetricData}
 cloudwatch_PutMetricData_DataSet:
   title: Put a set of data into a &CW; metric using an &AWS; SDK
   title_abbrev: Put a set of data into a metric
@@ -90,7 +90,7 @@ cloudwatch_PutMetricData_DataSet:
                 - python.example_code.cloudwatch.CloudWatchWrapper
                 - python.example_code.cloudwatch.PutMetricData_DataSet
   services:
-    - cloudwatch
+    cloudwatch: {PutMetricData}
 cloudwatch_GetMetricStatistics:
   title: Get &CW; metric statistics using an &AWS; SDK
   title_abbrev: Get metric statistics
@@ -108,7 +108,7 @@ cloudwatch_GetMetricStatistics:
                 - python.example_code.cloudwatch.CloudWatchWrapper
                 - python.example_code.cloudwatch.GetMetricStatistics
   services:
-    - cloudwatch
+    cloudwatch: {GetMetricStatistics}
 cloudwatch_PutMetricAlarm:
   title: Create a &CW; alarm that watches a metric using an &AWS; SDK
   title_abbrev: Create an alarm that watches a metric
@@ -145,7 +145,7 @@ cloudwatch_PutMetricAlarm:
               snippet_tags:
                 - cw.JavaScript.alarms.putMetricAlarm
   services:
-    - cloudwatch
+    cloudwatch: {PutMetricAlarm}
 cloudwatch_DescribeAlarmsForMetric:
   title: Describe &CW; alarms for a metric using an &AWS; SDK
   title_abbrev: Describe alarms for a metric
@@ -182,7 +182,7 @@ cloudwatch_DescribeAlarmsForMetric:
               snippet_tags:
                 - cw.JavaScript.alarms.describeAlarms
   services:
-    - cloudwatch
+    cloudwatch: {DescribeAlarmsForMetric}
 cloudwatch_EnableAlarmActions:
   title: Enable &CW; alarm actions using an &AWS; SDK
   title_abbrev: Enable alarm actions
@@ -219,7 +219,7 @@ cloudwatch_EnableAlarmActions:
               snippet_tags:
                 - cw.JavaScript.alarms.enableAlarmActions
   services:
-    - cloudwatch
+    cloudwatch: {EnableAlarmActions}
 cloudwatch_DisableAlarmActions:
   title: Disable &CW; alarm actions using an &AWS; SDK
   title_abbrev: Disable alarm actions
@@ -256,7 +256,7 @@ cloudwatch_DisableAlarmActions:
               snippet_tags:
                 - cw.JavaScript.alarms.disableAlarmActions
   services:
-    - cloudwatch
+    cloudwatch: {DisableAlarmActions}
 cloudwatch_DeleteAlarms:
   title: Delete &CW; alarms using an &AWS; SDK
   title_abbrev: Delete alarms
@@ -293,7 +293,7 @@ cloudwatch_DeleteAlarms:
               snippet_tags:
                 - cw.JavaScript.alarms.deleteAlarms
   services:
-    - cloudwatch
+    cloudwatch: {DeleteAlarms}
 cloudwatch_Usage_MetricsAlarms:
   title: Manage &CW; metrics and alarms using an &AWS; SDK
   title_abbrev: Manage &CWlong; metrics and alarms
@@ -325,4 +325,4 @@ cloudwatch_Usage_MetricsAlarms:
               snippet_tags:
                 - python.example_code.cloudwatch.Usage_MetricsAlarms
   services:
-    - cloudwatch
+    cloudwatch: {}

--- a/.doc_gen/metadata/comprehend_metadata.yaml
+++ b/.doc_gen/metadata/comprehend_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 comprehend_CreateDocumentClassifier:
   title: Create an &CMP; document classifier using an &AWS; SDK
   title_abbrev: Create a document classifier
@@ -25,7 +25,7 @@ comprehend_CreateDocumentClassifier:
                 - python.example_code.comprehend.ComprehendClassifier
                 - python.example_code.comprehend.CreateDocumentClassifier
   services:
-    - comprehend
+    comprehend: {CreateDocumentClassifier}
 comprehend_DescribeDocumentClassifier:
   title: Describe an &CMP; document classifier using an &AWS; SDK
   title_abbrev: Describe a document classifier
@@ -43,7 +43,7 @@ comprehend_DescribeDocumentClassifier:
                 - python.example_code.comprehend.ComprehendClassifier
                 - python.example_code.comprehend.DescribeDocumentClassifier
   services:
-    - comprehend
+    comprehend: {DescribeDocumentClassifier}
 comprehend_ListDocumentClassifiers:
   title: List &CMP; document classifiers using an &AWS; SDK
   title_abbrev: List document classifiers
@@ -61,7 +61,7 @@ comprehend_ListDocumentClassifiers:
                 - python.example_code.comprehend.ComprehendClassifier
                 - python.example_code.comprehend.ListDocumentClassifiers
   services:
-    - comprehend
+    comprehend: {ListDocumentClassifiers}
 comprehend_DeleteDocumentClassifier:
   title: Delete an &CMP; document classifier using an &AWS; SDK
   title_abbrev: Delete a document classifier
@@ -79,7 +79,7 @@ comprehend_DeleteDocumentClassifier:
                 - python.example_code.comprehend.ComprehendClassifier
                 - python.example_code.comprehend.DeleteDocumentClassifier
   services:
-    - comprehend
+    comprehend: {DeleteDocumentClassifier}
 comprehend_StartDocumentClassificationJob:
   title: Start an &CMP; document classification job using an &AWS; SDK
   title_abbrev: Start a document classification job
@@ -97,7 +97,7 @@ comprehend_StartDocumentClassificationJob:
                 - python.example_code.comprehend.ComprehendClassifier
                 - python.example_code.comprehend.StartDocumentClassificationJob
   services:
-    - comprehend
+    comprehend: {StartDocumentClassificationJob}
 comprehend_DescribeDocumentClassificationJob:
   title: Describe an &CMP; document classification job using an &AWS; SDK
   title_abbrev: Describe a document classification job
@@ -115,7 +115,7 @@ comprehend_DescribeDocumentClassificationJob:
                 - python.example_code.comprehend.ComprehendClassifier
                 - python.example_code.comprehend.DescribeDocumentClassificationJob
   services:
-    - comprehend
+    comprehend: {DescribeDocumentClassificationJob}
 comprehend_ListDocumentClassificationJobs:
   title: List &CMP; document classification jobs using an &AWS; SDK
   title_abbrev: List document classification jobs
@@ -133,7 +133,7 @@ comprehend_ListDocumentClassificationJobs:
                 - python.example_code.comprehend.ComprehendClassifier
                 - python.example_code.comprehend.ListDocumentClassificationJobs
   services:
-    - comprehend
+    comprehend: {ListDocumentClassificationJobs}
 comprehend_Usage_ComprehendClassifier:
   title: Train a custom &CMP; classifier and classify documents using an &AWS; SDK
   title_abbrev: Train a custom classifier and classify documents
@@ -145,7 +145,7 @@ comprehend_Usage_ComprehendClassifier:
         - sdk_version: 3
           block_content: usage_ComprehendClassifier_Python_block.xml
   services:
-    - comprehend
+    comprehend: {}
 comprehend_DetectDominantLanguage:
   title: Detect the dominant language in a document with &CMP; using an &AWS; SDK
   title_abbrev: Detect the dominant language in a document
@@ -172,7 +172,7 @@ comprehend_DetectDominantLanguage:
                 - python.example_code.comprehend.ComprehendDetect
                 - python.example_code.comprehend.DetectDominantLanguage
   services:
-    - comprehend
+    comprehend: {DetectDominantLanguage}
 comprehend_DetectEntities:
   title: Detect entities in a document with &CMP; using an &AWS; SDK
   title_abbrev: Detect entities in a document
@@ -199,7 +199,7 @@ comprehend_DetectEntities:
                 - python.example_code.comprehend.ComprehendDetect
                 - python.example_code.comprehend.DetectEntities
   services:
-    - comprehend
+    comprehend: {DetectEntities}
 comprehend_DetectKeyPhrases:
   title: Detect key phrases in a document with &CMP; using an &AWS; SDK
   title_abbrev: Detect key phrases in a document
@@ -226,7 +226,7 @@ comprehend_DetectKeyPhrases:
                 - python.example_code.comprehend.ComprehendDetect
                 - python.example_code.comprehend.DetectKeyPhrases
   services:
-    - comprehend
+    comprehend: {DetectKeyPhrases}
 comprehend_DetectPiiEntities:
   title: Detect personally identifiable information in a document with &CMP; using an &AWS; SDK
   title_abbrev: Detect personally identifiable information in a document
@@ -244,7 +244,7 @@ comprehend_DetectPiiEntities:
                 - python.example_code.comprehend.ComprehendDetect
                 - python.example_code.comprehend.DetectPiiEntities
   services:
-    - comprehend
+    comprehend: {DetectPiiEntities}
 comprehend_DetectSentiment:
   title: Detect the sentiment of a document with &CMP; using an &AWS; SDK
   title_abbrev: Detect the sentiment of a document
@@ -271,7 +271,7 @@ comprehend_DetectSentiment:
                 - python.example_code.comprehend.ComprehendDetect
                 - python.example_code.comprehend.DetectSentiment
   services:
-    - comprehend
+    comprehend: {DetectSentiment}
 comprehend_DetectSyntax:
   title: Detect syntactial elements of a document with &CMP; using an &AWS; SDK
   title_abbrev: Detect syntactical elements of a document
@@ -298,7 +298,7 @@ comprehend_DetectSyntax:
                 - python.example_code.comprehend.ComprehendDetect
                 - python.example_code.comprehend.DetectSyntax
   services:
-    - comprehend
+    comprehend: {DetectSyntax}
 comprehend_Usage_DetectApis:
   title: Use &CMP; detection APIs with an &AWS; SDK
   title_abbrev: Use detection APIs with a document
@@ -326,7 +326,7 @@ comprehend_Usage_DetectApis:
               snippet_tags:
                 - python.example_code.comprehend.Usage_DetectApis
   services:
-    - comprehend
+    comprehend: {}
 comprehend_StartTopicsDetectionJob:
   title: Start an &CMP; topic modeling job using an &AWS; SDK
   title_abbrev: Start a topic modeling job
@@ -344,7 +344,7 @@ comprehend_StartTopicsDetectionJob:
                 - python.example_code.comprehend.ComprehendTopicModeler
                 - python.example_code.comprehend.StartTopicsDetectionJob
   services:
-    - comprehend
+    comprehend: {StartTopicsDetectionJob}
 comprehend_DescribeTopicsDetectionJob:
   title: Describe an &CMP; topic modeling job using an &AWS; SDK
   title_abbrev: Describe a topic modeling job
@@ -362,7 +362,7 @@ comprehend_DescribeTopicsDetectionJob:
                 - python.example_code.comprehend.ComprehendTopicModeler
                 - python.example_code.comprehend.DescribeTopicsDetectionJob
   services:
-    - comprehend
+    comprehend: {DescribeTopicsDetectionJob}
 comprehend_ListTopicsDetectionJobs:
   title: List &CMP; topic modeling jobs using an &AWS; SDK
   title_abbrev: List topic modeling jobs
@@ -380,7 +380,7 @@ comprehend_ListTopicsDetectionJobs:
                 - python.example_code.comprehend.ComprehendTopicModeler
                 - python.example_code.comprehend.ListTopicsDetectionJobs
   services:
-    - comprehend
+    comprehend: {ListTopicsDetectionJobs}
 comprehend_Usage_TopicModeler:
   title: Run an &CMP; topic modeling job on sample data using an &AWS; SDK
   title_abbrev: Run a topic modeling job on sample data
@@ -392,4 +392,4 @@ comprehend_Usage_TopicModeler:
         - sdk_version: 3
           block_content: usage_ComprehendTopicModeler_Python_block.xml
   services:
-    - comprehend
+    comprehend: {}

--- a/.doc_gen/metadata/config-service_metadata.yaml
+++ b/.doc_gen/metadata/config-service_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 config-service_PutConfigRule:
   title: Put an &CC; rule using an &AWS; SDK
   title_abbrev: Put a rule
@@ -16,7 +16,7 @@ config-service_PutConfigRule:
                 - python.example_code.config-service.ConfigWrapper
                 - python.example_code.config-service.PutConfigRule
   services:
-    - config-service
+    config-service: {PutConfigRule}
 config-service_DescribeConfigRules:
   title: Describe &CC; rules using an &AWS; SDK
   title_abbrev: Describe rules
@@ -34,7 +34,7 @@ config-service_DescribeConfigRules:
                 - python.example_code.config-service.ConfigWrapper
                 - python.example_code.config-service.DescribeConfigRules
   services:
-    - config-service
+    config-service: {DescribeConfigRules}
 config-service_DeleteConfigRule:
   title: Delete an &CC; rule using an &AWS; SDK
   title_abbrev: Delete a rule
@@ -52,4 +52,4 @@ config-service_DeleteConfigRule:
                 - python.example_code.config-service.ConfigWrapper
                 - python.example_code.config-service.DeleteConfigRule
   services:
-    - config-service
+    config-service: {DeleteConfigRule}

--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 cross_RDSDataTracker:
   title: Create an &RDSlong; item tracker
   title_abbrev: Create a web application to track &RDS; data
@@ -9,8 +9,8 @@ cross_RDSDataTracker:
         - sdk_version: 2
           block_content: cross_RDSDataTracker_Java_block.xml
   services:
-    - rds
-    - ses
+    rds:
+    ses:
 cross_SnsPublishSubscription:
   title: Build a publish and subscription web application that translates messages
   title_abbrev: Building an &SNS; web application 
@@ -21,8 +21,8 @@ cross_SnsPublishSubscription:
         - sdk_version: 2
           block_content: cross_SNSSubPub_Java_block.xml
   services:
-    - sns
-    - translate
+    sns:
+    translate:
 cross_LexChatbotLanguages:
   title: Create an &LEX2; Chatbot within a web application to engage your web site visitors
   title_abbrev: Building an &LEX2; Chatbot 
@@ -33,9 +33,9 @@ cross_LexChatbotLanguages:
         - sdk_version: 2
           block_content: cross_Lex_Java_block.xml
   services:
-    - lex
-    - translate
-    - comprehend
+    lex:
+    translate:
+    comprehend:
 cross_DynamoDBDataTracker:
   title: Create a dynamic web application to track &DDB; data
   title_abbrev: Create a web application to track &DDB; data
@@ -46,8 +46,8 @@ cross_DynamoDBDataTracker:
         - sdk_version: 2
           block_content: cross_DynamoDBDataTracker_Java_block.xml
   services:
-    - dynamodb
-    - ses
+    dynamodb:
+    ses:
 cross_ApiGatewayDataTracker:
   title: Create an &ABP; REST API to track COVID-19 data
   title_abbrev: Create a REST API to track COVID-19 data
@@ -59,10 +59,10 @@ cross_ApiGatewayDataTracker:
         - sdk_version: 3
           block_content: cross_ApiGatewayDataTracker_Python_block.xml
   services:
-    - api-gateway
-    - cloudformation
-    - dynamodb
-    - lambda
+    api-gateway:
+    cloudformation:
+    dynamodb:
+    lambda:
 cross_ApiGatewayWebsocketChat:
   title: Create a websocket chat application with &ABP;
   title_abbrev: Create a websocket chat application
@@ -73,9 +73,9 @@ cross_ApiGatewayWebsocketChat:
         - sdk_version: 3
           block_content: cross_ApiGatewayWebsocketChat_Python_block.xml
   services:
-    - api-gateway
-    - dynamodb
-    - lambda
+    api-gateway:
+    dynamodb:
+    lambda:
 cross_AuroraRestLendingLibrary:
   title: Create a lending library REST API
   title_abbrev: Create a lending library REST API
@@ -87,10 +87,10 @@ cross_AuroraRestLendingLibrary:
         - sdk_version: 3
           block_content: cross_AuroraRestLendingLibrary_Python_block.xml
   services:
-    - api-gateway
-    - lambda
-    - rds
-    - secrets-manager
+    api-gateway:
+    lambda:
+    rds:
+    secrets-manager:
 cross_StepFunctionsMessenger:
   title: Create a messenger application with &SFN;
   title_abbrev: Create a messenger application
@@ -101,10 +101,10 @@ cross_StepFunctionsMessenger:
         - sdk_version: 3
           block_content: cross_StepFunctionsMessenger_Python_block.xml
   services:
-    - dynamodb
-    - lambda
-    - sqs
-    - sfn
+    dynamodb:
+    lambda:
+    sqs:
+    sfn:
 cross_TextractExplorer:
   title: Create an &TEXTRACT; explorer application
   title_abbrev: Create an &TEXTRACT; explorer application
@@ -115,16 +115,16 @@ cross_TextractExplorer:
         - sdk_version: 3
           block_content: cross_TextractExplorer_JavaScript_block.xml
           add_services:
-            - cognito-identity
+            cognito-identity:
     Python:
       versions:
         - sdk_version: 3
           block_content: cross_TextractExplorer_Python_block.xml
   services:
-    - s3
-    - sns
-    - sqs
-    - textract
+    s3:
+    sns:
+    sqs:
+    textract:
 cross_SubmitDataApp:
   title: Build an app to submit data to an &DDB; table
   title_abbrev: Build an app to submit data to an &DDB; table
@@ -136,8 +136,8 @@ cross_SubmitDataApp:
         - sdk_version: 3
           block_content: cross_SubmitDataApp_JavaScript_block.xml
   services:
-    - dynamodb
-    - sns
+    dynamodb:
+    sns:
 cross_LambdaAPIGateway:
   title: Use &ABP; to invoke a &LAM; function
   title_abbrev: Use &ABP; to invoke a &LAM; function
@@ -152,10 +152,10 @@ cross_LambdaAPIGateway:
         - sdk_version: 3
           block_content: cross_LambdaAPIGateway_JavaScript_block.xml
   services:
-    - api-gateway
-    - lambda
-    - dynamodb
-    - sns
+    api-gateway:
+    lambda:
+    dynamodb:
+    sns:
 cross_LambdaScheduledEvents:
   title: Use scheduled events to invoke a &LAM; function
   title_abbrev: Use scheduled events to invoke a &LAM; function
@@ -171,10 +171,10 @@ cross_LambdaScheduledEvents:
         - sdk_version: 3
           block_content: cross_LambdaScheduledEvents_JavaScript_block.xml
   services:
-    - dynamodb
-    - eventbridge
-    - lambda
-    - sns
+    dynamodb:
+    eventbridge:
+    lambda:
+    sns:
 cross_ServerlessWorkflows:
   title: Use &SFN; to invoke &LAM; functions
   title_abbrev: Use &SFN; to invoke &LAM; functions
@@ -189,10 +189,10 @@ cross_ServerlessWorkflows:
         - sdk_version: 3
           block_content: cross_ServerlessWorkflows_JavaScript_block.xml
   services:
-    - dynamodb
-    - lambda
-    - ses
-    - sfn
+    dynamodb:
+    lambda:
+    ses:
+    sfn:
 cross_TranscriptionApp:
   title: Build an &TSC; app
   title_abbrev: Build an &TSC; app
@@ -203,9 +203,9 @@ cross_TranscriptionApp:
         - sdk_version: 3
           block_content: cross_TranscriptionApp_JavaScript_block.xml
   services:
-    - cognito-identity
-    - s3
-    - transcribe
+    cognito-identity:
+    s3:
+    transcribe:
 cross_TranscriptionStreamingApp:
   title: Build an &TSC; streaming app
   title_abbrev: Build an &TSC; streaming app
@@ -217,10 +217,10 @@ cross_TranscriptionStreamingApp:
         - sdk_version: 3
           block_content: cross_TranscriptionStreamingApp_JavaScript_block.xml
   services:
-    - translate
-    - comprehend
-    - transcribe
-    - ses
+    translate:
+    comprehend:
+    transcribe:
+    ses:
 cross_RekognitionPhotoAnalyzerPPE:
   title: Detect PPE in images with &REK; using an &AWS; SDK
   title_abbrev: Detect PPE in images
@@ -235,10 +235,10 @@ cross_RekognitionPhotoAnalyzerPPE:
         - sdk_version: 3
           block_content: cross_RekognitionPhotoAnalyzerPPE_JavaScript_block.xml
   services:
-    - rekognition
-    - s3
-    - dynamodb
-    - ses
+    rekognition:
+    s3:
+    dynamodb:
+    ses:
 cross_RekognitionPhotoAnalyzer:
   title: Detect objects in images with &REK; using an &AWS; SDK
   title_abbrev: Detect objects in images
@@ -253,9 +253,9 @@ cross_RekognitionPhotoAnalyzer:
         - sdk_version: 3
           block_content: cross_RekognitionPhotoAnalyzer_JavaScript_block.xml
   services:
-    - rekognition
-    - s3
-    - ses
+    rekognition:
+    s3:
+    ses:
 cross_RekognitionVideoDetection:
   title: Detect people and objects in a video with &REK; using an &AWS; SDK
   title_abbrev: Detect people and objects in a video
@@ -267,21 +267,21 @@ cross_RekognitionVideoDetection:
         - sdk_version: 2
           block_content: cross_RekognitionVideoAnalyzer_Java_block.xml
           add_services:
-            - s3
-            - ses
+            s3:
+            ses:
     JavaScript:
       versions:
         - sdk_version: 3
           block_content: cross_RekognitionVideoAnalyzer_JavaScript_block.xml
           add_services:
-            - s3
-            - ses
+            s3:
+            ses:
     Python:
       versions:
         - sdk_version: 3
           block_content: cross_RekognitionVideoDetection_Python_block.xml
           add_services:
-            - sns
-            - sqs
+            sns:
+            sqs:
   services:
-    - rekognition
+    rekognition:

--- a/.doc_gen/metadata/dynamodb_metadata.yaml
+++ b/.doc_gen/metadata/dynamodb_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 dynamodb_CreateTable:
   title: Create a &DDB; table using an &AWS; SDK
   title_abbrev: Create a table
@@ -27,7 +27,7 @@ dynamodb_CreateTable:
               snippet_tags:
                 - dynamodb.python.codeexample.MoviesCreateTable
   services:
-    - dynamodb
+    dynamodb: {CreateTable}
 dynamodb_BatchGetItem:
   title: Get a batch of &DDB; items using an &AWS; SDK
   title_abbrev: Get a batch of items.
@@ -45,7 +45,7 @@ dynamodb_BatchGetItem:
                 - python.example_code.dynamodb.Batching_imports
                 - python.example_code.dynamodb.BatchGetItem
   services:
-    - dynamodb
+    dynamodb: {BatchGetItem}
 dynamodb_BatchWriteItem:
   title: Write a batch of &DDB; items using an &AWS; SDK
   title_abbrev: Write a batch of items
@@ -71,7 +71,7 @@ dynamodb_BatchWriteItem:
               snippet_tags:
                 - python.example_code.dynamodb.PutItem_BatchWriter
   services:
-    - dynamodb
+    dynamodb: {BatchWriteItem}
 dynamodb_Usage_BatchGetWriteDelete:
   title: Get, write, and delete batches of &DDB; items using an &AWS; SDK
   title_abbrev: Get, write, and delete batches of items
@@ -99,7 +99,7 @@ dynamodb_Usage_BatchGetWriteDelete:
               snippet_tags:
                 - python.example_code.dynamodb.Usage_BatchFunctions
   services:
-    - dynamodb
+    dynamodb: {}
 dynamodb_DeleteTable:
   title: Delete a &DDB; table using an &AWS; SDK
   title_abbrev: Delete a table
@@ -125,7 +125,7 @@ dynamodb_DeleteTable:
               snippet_tags:
                 - dynamodb.python.codeexample.MoviesDeleteTable
   services:
-    - dynamodb
+    dynamodb: {DeleteTable}
 dynamodb_PutItem:
   title: Put an item in a &DDB; table using an &AWS; SDK
   title_abbrev: Put an item in a table
@@ -154,7 +154,7 @@ dynamodb_PutItem:
               snippet_tags:
                 - dynamodb.python.codeexample.MoviesLoadData
   services:
-    - dynamodb
+    dynamodb: {PutItem}
 dynamodb_GetItem:
   title: Get an item from a &DDB; table using an &AWS; SDK
   title_abbrev: Get an item from a table
@@ -180,7 +180,7 @@ dynamodb_GetItem:
               snippet_tags:
                 - dynamodb.python.codeexample.MoviesItemOps02
   services:
-    - dynamodb
+    dynamodb: {GetItem}
 dynamodb_UpdateItem:
   title: Update an item in a &DDB; table using an &AWS; SDK
   title_abbrev: Update an item in a table
@@ -215,7 +215,7 @@ dynamodb_UpdateItem:
               snippet_tags:
                 - dynamodb.python.codeexample.MoviesItemOps05
   services:
-    - dynamodb
+    dynamodb: {UpdateItem}
 dynamodb_DeleteItem:
   title: Delete an item from a &DDB; table using an &AWS; SDK
   title_abbrev: Delete an item from a table
@@ -241,7 +241,7 @@ dynamodb_DeleteItem:
               snippet_tags:
                 - dynamodb.python.codeexample.MoviesItemOps06
   services:
-    - dynamodb
+    dynamodb: {DeleteItem}
 dynamodb_ListTables:
   title: List &DDB; tables using an &AWS; SDK
   title_abbrev: List tables
@@ -267,7 +267,7 @@ dynamodb_ListTables:
               snippet_tags:
                 - dynamodb.python.codeexample.MoviesListTables
   services:
-    - dynamodb
+    dynamodb: {ListTables}
 dynamodb_Query:
   title: Query a &DDB; table using an &AWS; SDK
   title_abbrev: Query a table
@@ -296,7 +296,7 @@ dynamodb_Query:
               snippet_tags:
                 - dynamodb.python.codeexample.MoviesQuery02
   services:
-    - dynamodb
+    dynamodb: {Query}
 dynamodb_Scan:
   title: Scan a &DDB; table using an &AWS; SDK
   title_abbrev: Scan a table
@@ -322,7 +322,7 @@ dynamodb_Scan:
               snippet_tags:
                 - dynamodb.python.codeexample.MoviesScan
   services:
-    - dynamodb
+    dynamodb: {Scan}
 dynamodb_Usage_DaxDemo:
   title: Accelerate &DDB; reads with &DAX; using an &AWS; SDK
   title_abbrev: Accelerate reads with &DAX;
@@ -357,4 +357,4 @@ dynamodb_Usage_DaxDemo:
               snippet_tags:
                 - dynamodb.Python.TryDax.06-delete-table
   services:
-    - dynamodb
+    dynamodb: {}

--- a/.doc_gen/metadata/ec2_metadata.yaml
+++ b/.doc_gen/metadata/ec2_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 ec2_CreateKeyPair:
   title: Create a security key pair for &EC2; using an &AWS; SDK
   title_abbrev: Create a security key pair
@@ -24,7 +24,7 @@ ec2_CreateKeyPair:
               snippet_tags:
                 - python.example_code.ec2.CreateKeyPair
   services:
-    - ec2
+    ec2: {CreateKeyPair}
 ec2_CreateSecurityGroup:
   title: Create an &EC2; security group using an &AWS; SDK
   title_abbrev: Create a security group
@@ -50,7 +50,7 @@ ec2_CreateSecurityGroup:
               snippet_tags:
                 - python.example_code.ec2.CreateSecurityGroup_AuthorizeIngress
   services:
-    - ec2
+    ec2: {CreateSecurityGroup}
 ec2_RunInstances:
   title: Create and run an &EC2; instance using an &AWS; SDK
   title_abbrev: Create and run an instance
@@ -67,7 +67,7 @@ ec2_RunInstances:
               snippet_tags:
                 - python.example_code.ec2.RunInstances
   services:
-    - ec2
+    ec2: {RunInstances}
 ec2_StartInstances:
   title: Start an &EC2; instance using an &AWS; SDK
   title_abbrev: Start an instance
@@ -93,7 +93,7 @@ ec2_StartInstances:
               snippet_tags:
                 - python.example_code.ec2.StartInstances
   services:
-    - ec2
+    ec2: {StartInstances}
 ec2_StopInstances:
   title: Stop an &EC2; instance using an &AWS; SDK
   title_abbrev: Stop an instance
@@ -119,7 +119,7 @@ ec2_StopInstances:
               snippet_tags:
                 - python.example_code.ec2.StopInstances
   services:
-    - ec2
+    ec2: {StopInstances}
 ec2_AllocateAddress:
   title: Allocate an Elastic IP address for &EC2; using an &AWS; SDK
   title_abbrev: Allocate an Elastic IP address
@@ -145,7 +145,7 @@ ec2_AllocateAddress:
               snippet_tags:
                 - python.example_code.ec2.AllocateAddress
   services:
-    - ec2
+    ec2: {AllocateAddress}
 ec2_AssociateAddress:
   title: Associate an Elastic IP address with an &EC2; instance using an &AWS; SDK
   title_abbrev: Associate an Elastic IP address with an instance
@@ -162,7 +162,7 @@ ec2_AssociateAddress:
               snippet_tags:
                 - python.example_code.ec2.AssociateAddress
   services:
-    - ec2
+    ec2: {AssociateAddress}
 ec2_DisassociateAddress:
   title: Disassociate an Elastic IP address from an &EC2; instance using an &AWS; SDK
   title_abbrev: Disassociate an Elastic IP address from an instance
@@ -179,7 +179,7 @@ ec2_DisassociateAddress:
               snippet_tags:
                 - python.example_code.ec2.DisassociateAddress
   services:
-    - ec2
+    ec2: {DisassociateAddress}
 ec2_ReleaseAddress:
   title: Release an Elastic IP address using an &AWS; SDK
   title_abbrev: Release an Elastic IP address
@@ -205,7 +205,7 @@ ec2_ReleaseAddress:
               snippet_tags:
                 - python.example_code.ec2.ReleaseAddress
   services:
-    - ec2
+    ec2: {ReleaseAddress}
 ec2_GetConsoleOutput:
   title: Get the console output of an &EC2; instance using an &AWS; SDK
   title_abbrev: Get the console output of an instance
@@ -222,7 +222,7 @@ ec2_GetConsoleOutput:
               snippet_tags:
                 - python.example_code.ec2.GetConsoleOutput
   services:
-    - ec2
+    ec2: {GetConsoleOutput}
 ec2_ModifyNetworkInterfaceAttribute:
   title: Change the security group of an &EC2; instance using an &AWS; SDK
   title_abbrev: Change the security group on an instance
@@ -239,7 +239,7 @@ ec2_ModifyNetworkInterfaceAttribute:
               snippet_tags:
                 - python.example_code.ec2.ModifyNetworkInterfaceAttribute
   services:
-    - ec2
+    ec2: {ModifyNetworkInterfaceAttribute}
 ec2_AuthorizeSecurityGroupIngress:
   title: Set inbound rules for an &EC2; security group using an &AWS; SDK
   title_abbrev: Set inbound rules for a security group
@@ -261,7 +261,7 @@ ec2_AuthorizeSecurityGroupIngress:
               snippet_tags:
                 - python.example_code.ec2.AuthorizeSecurityGroupIngress
   services:
-    - ec2
+    ec2: {AuthorizeSecurityGroupIngress}
 ec2_DeleteKeyPair:
   title: Delete an &EC2; security key pair using an &AWS; SDK
   title_abbrev: Delete a security key pair
@@ -287,7 +287,7 @@ ec2_DeleteKeyPair:
               snippet_tags:
                 - python.example_code.ec2.DeleteKeyPair
   services:
-    - ec2
+    ec2: {DeleteKeyPair}
 ec2_DeleteSecurityGroup:
   title: Delete an &EC2; security group using an &AWS; SDK
   title_abbrev: Delete a security group
@@ -313,7 +313,7 @@ ec2_DeleteSecurityGroup:
               snippet_tags:
                 - python.example_code.ec2.DeleteSecurityGroup
   services:
-    - ec2
+    ec2: {DeleteSecurityGroup}
 ec2_TerminateInstances:
   title: Terminate an &EC2; instance using an &AWS; SDK
   title_abbrev: Terminate an instance
@@ -339,7 +339,7 @@ ec2_TerminateInstances:
               snippet_tags:
                 - python.example_code.ec2.TerminateInstances
   services:
-    - ec2
+    ec2: {TerminateInstances}
 ec2_Usage_InstanceCreationAndManagement:
   title: Create and manage &EC2; instances using an &AWS; SDK
   title_abbrev: Create and manage instances
@@ -360,4 +360,4 @@ ec2_Usage_InstanceCreationAndManagement:
         - sdk_version: 3
           block_content: usage_EC2InstanceManagement_Python_block.xml
   services:
-    - ec2
+    ec2: {}

--- a/.doc_gen/metadata/emr_metadata.yaml
+++ b/.doc_gen/metadata/emr_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.1
+# zexi 0.4.0
 emr_RunJobFlow:
   title: Run an &EMR; job flow using an &AWS; SDK
   title_abbrev: Run a job flow
@@ -15,7 +15,7 @@ emr_RunJobFlow:
               snippet_tags:
                 - python.example_code.emr.RunJobFlow
   services:
-    - emr
+    emr: {RunJobFlow}
 emr_DescribeCluster:
   title: Describe an &EMR; cluster using an &AWS; SDK
   title_abbrev: Describe a cluster
@@ -32,7 +32,7 @@ emr_DescribeCluster:
               snippet_tags:
                 - python.example_code.emr.DescribeCluster
   services:
-    - emr
+    emr: {DescribeCluster}
 emr_TerminateJobFlows:
   title: Terminate &EMR; job flows using an &AWS; SDK
   title_abbrev: Terminate job flows
@@ -49,7 +49,7 @@ emr_TerminateJobFlows:
               snippet_tags:
                 - python.example_code.emr.TerminateJobFlows
   services:
-    - emr
+    emr: {TerminateJobFlows}
 emr_AddJobFlowSteps:
   title: Add steps to an &EMR; job flow using an &AWS; SDK
   title_abbrev: Add steps to a job flow
@@ -66,7 +66,7 @@ emr_AddJobFlowSteps:
               snippet_tags:
                 - python.example_code.emr.AddJobFlowSteps
   services:
-    - emr
+    emr: {AddJobFlowSteps}
 emr_ListSteps:
   title: List steps for an &EMR; cluster using an &AWS; SDK
   title_abbrev: List steps for a cluster
@@ -83,7 +83,7 @@ emr_ListSteps:
               snippet_tags:
                 - python.example_code.emr.ListSteps
   services:
-    - emr
+    emr: {ListSteps}
 emr_DescribeStep:
   title: Describe a step on an &EMR; cluster using an &AWS; SDK
   title_abbrev: Describe a step
@@ -100,7 +100,7 @@ emr_DescribeStep:
               snippet_tags:
                 - python.example_code.emr.DescribeStep
   services:
-    - emr
+    emr: {DescribeStep}
 emr_Usage_RunEmrfsCommand:
   title: Run an &EMR; file system command on a cluster using an &AWS; SDK
   title_abbrev: Run an EMRFS command on a cluster
@@ -119,7 +119,7 @@ emr_Usage_RunEmrfsCommand:
               snippet_tags:
                 - emr.python.addstep.emrfs
   services:
-    - emr
+    emr: {}
 emr_Usage_InstallLibrariesWithSsm:
   title: Run a shell script to install libraries on &EMR; instances using an &AWS; SDK
   title_abbrev: Run a shell script to install libraries on instances
@@ -138,7 +138,7 @@ emr_Usage_InstallLibrariesWithSsm:
               snippet_tags:
                 - emr.python.jupyterhub.installlibraries
   services:
-    - emr
+    emr: {}
 emr_Usage_ShortLivedCluster:
   title: Create an &EMR; short-lived cluster and run a step using an &AWS; SDK
   title_abbrev: Create a short-lived cluster and run a step
@@ -151,7 +151,7 @@ emr_Usage_ShortLivedCluster:
         - sdk_version: 3
           block_content: usage_EmrShortLivedCluster_Python_block.xml
   services:
-    - emr
+    emr: {}
 emr_Usage_LongLivedCluster:
   title: Create an &EMR; long-lived cluster and run several steps using an &AWS; SDK
   title_abbrev: Create a long-lived cluster and run several steps
@@ -163,4 +163,4 @@ emr_Usage_LongLivedCluster:
         - sdk_version: 3
           block_content: usage_EmrLongLivedCluster_Python_block.xml
   services:
-    - emr
+    emr: {}

--- a/.doc_gen/metadata/glacier_metadata.yaml
+++ b/.doc_gen/metadata/glacier_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 glacier_CreateVault:
   title: Create an &GLlong; vault using an &AWS; SDK
   title_abbrev: Create a vault
@@ -24,7 +24,7 @@ glacier_CreateVault:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.CreateVault
   services:
-    - glacier
+    glacier: {CreateVault}
 glacier_ListVaults:
   title: List &GLlong; vaults using an &AWS; SDK
   title_abbrev: List vaults
@@ -50,7 +50,7 @@ glacier_ListVaults:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.ListVaults
   services:
-    - glacier
+    glacier: {ListVaults}
 glacier_UploadArchive:
   title: Upload an archive to an &GLlong; vault using an &AWS; SDK
   title_abbrev: Upload an archive to a vault
@@ -76,7 +76,7 @@ glacier_UploadArchive:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.UploadArchive
   services:
-    - glacier
+    glacier: {UploadArchive}
 glacier_InitiateJob_InventoryRetrieval:
   title: Retrieve an &GLlong; vault inventory using an &AWS; SDK
   title_abbrev: Retrieve a vault inventory
@@ -102,7 +102,7 @@ glacier_InitiateJob_InventoryRetrieval:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.InitiateJob.InventoryRetrieval
   services:
-    - glacier
+    glacier: {InitiateJob}
 glacier_ListJobs:
   title: List &GLlong; jobs using an &AWS; SDK
   title_abbrev: List jobs
@@ -119,7 +119,7 @@ glacier_ListJobs:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.ListJobs
   services:
-    - glacier
+    glacier: {ListJobs}
 glacier_DeleteVault:
   title: Delete an &GLlong; vault using an &AWS; SDK
   title_abbrev: Delete a vault
@@ -145,7 +145,7 @@ glacier_DeleteVault:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.DeleteVault
   services:
-    - glacier
+    glacier: {DeleteVault}
 glacier_InitiateJob_ArchiveRetrieval:
   title: Retrieve an archive from an &GLlong; vault using an &AWS; SDK
   title_abbrev: Retrieve an archive from a vault
@@ -162,7 +162,7 @@ glacier_InitiateJob_ArchiveRetrieval:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.InitiateJob.ArchiveRetrieval
   services:
-    - glacier
+    glacier: {InitiateJob}
 glacier_DeleteArchive:
   title: Delete an &GLlong; archive using an &AWS; SDK
   title_abbrev: Delete an archive
@@ -188,7 +188,7 @@ glacier_DeleteArchive:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.DeleteArchive
   services:
-    - glacier
+    glacier: {DeleteArchive}
 glacier_DescribeJob:
   title: Describe an &GLlong; job using an &AWS; SDK
   title_abbrev: Describe a job
@@ -205,7 +205,7 @@ glacier_DescribeJob:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.DescribeJob
   services:
-    - glacier
+    glacier: {DescribeJob}
 glacier_GetJobOutput:
   title: Get &GLlong; job output using an &AWS; SDK
   title_abbrev: Get job output
@@ -222,7 +222,7 @@ glacier_GetJobOutput:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.GetJobOutput
   services:
-    - glacier
+    glacier: {GetJobOutput}
 glacier_SetVaultNotifications:
   title: Set &GLlong; vault notifications using an &AWS; SDK
   title_abbrev: Set vault notifications
@@ -239,7 +239,7 @@ glacier_SetVaultNotifications:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.SetVaultNotifications
   services:
-    - glacier
+    glacier: {SetVaultNotifications}
 glacier_GetVaultNotifications:
   title: Get &GLlong; vault notification configuration using an &AWS; SDK
   title_abbrev: Get vault notification configuration
@@ -256,7 +256,7 @@ glacier_GetVaultNotifications:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.GetVaultNotifications
   services:
-    - glacier
+    glacier: {GetVaultNotifications}
 glacier_DeleteVaultNotifications:
   title: Delete &GLlong; vault notifications using an &AWS; SDK
   title_abbrev: Delete vault notifications
@@ -273,7 +273,7 @@ glacier_DeleteVaultNotifications:
                 - python.example_code.glacier.GlacierWrapper
                 - python.example_code.glacier.DeleteVaultNotifications
   services:
-    - glacier
+    glacier: {DeleteVaultNotifications}
 glacier_Usage_UploadNotifyInitiate:
   category: Usage
   title: Archive a file to &GLlong;, get notifications, and initiate a job using an &AWS; SDK
@@ -306,7 +306,7 @@ glacier_Usage_UploadNotifyInitiate:
               snippet_tags:
                 - python.example_code.glacier.usage.upload_demo
   services:
-    - glacier
+    glacier: {}
 glacier_Usage_RetrieveDelete:
   category: Usage
   title: |-
@@ -337,4 +337,4 @@ glacier_Usage_RetrieveDelete:
               snippet_tags:
                 - python.example_code.glacier.usage.retrieve_demo
   services:
-    - glacier
+    glacier: {}

--- a/.doc_gen/metadata/rekognition_metadata.yaml
+++ b/.doc_gen/metadata/rekognition_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 rekognition_DescribeCollection:
   title: Describe an &REK; collection using an &AWS; SDK
   title_abbrev: Describe a collection
@@ -25,7 +25,7 @@ rekognition_DescribeCollection:
                 - python.example_code.rekognition.RekognitionCollection
                 - python.example_code.rekognition.DescribeCollection
   services:
-    - rekognition
+    rekognition: {DescribeCollection}
 rekognition_DeleteCollection:
   title: Delete an &REK; collection using an &AWS; SDK
   title_abbrev: Delete a collection
@@ -52,7 +52,7 @@ rekognition_DeleteCollection:
                 - python.example_code.rekognition.RekognitionCollection
                 - python.example_code.rekognition.DeleteCollection
   services:
-    - rekognition
+    rekognition: {DeleteCollection}
 rekognition_IndexFaces:
   title: Index faces to an &REK; collection using an &AWS; SDK
   title_abbrev: Index faces to a collection
@@ -79,7 +79,7 @@ rekognition_IndexFaces:
                 - python.example_code.rekognition.RekognitionCollection
                 - python.example_code.rekognition.IndexFaces
   services:
-    - rekognition
+    rekognition: {IndexFaces}
 rekognition_ListFaces:
   title: List faces in an &REK; collection using an &AWS; SDK
   title_abbrev: List faces in a collection
@@ -106,7 +106,7 @@ rekognition_ListFaces:
                 - python.example_code.rekognition.RekognitionCollection
                 - python.example_code.rekognition.ListFaces
   services:
-    - rekognition
+    rekognition: {ListFaces}
 rekognition_SearchFacesByImage:
   title: Search for faces in an &REK; collection compared to a reference image using an &AWS; SDK
   title_abbrev: Search for faces in a collection compared to a reference image
@@ -133,7 +133,7 @@ rekognition_SearchFacesByImage:
                 - python.example_code.rekognition.RekognitionCollection
                 - python.example_code.rekognition.SearchFacesByImage
   services:
-    - rekognition
+    rekognition: {SearchFacesByImage}
 rekognition_SearchFaces:
   title: Search for faces in an &REK; collection using an &AWS; SDK
   title_abbrev: Search for faces in a collection
@@ -160,7 +160,7 @@ rekognition_SearchFaces:
                 - python.example_code.rekognition.RekognitionCollection
                 - python.example_code.rekognition.SearchFaces
   services:
-    - rekognition
+    rekognition: {SearchFaces}
 rekognition_DeleteFaces:
   title: Delete faces from an &REK; collection using an &AWS; SDK
   title_abbrev: Delete faces from a collection
@@ -187,7 +187,7 @@ rekognition_DeleteFaces:
                 - python.example_code.rekognition.RekognitionCollection
                 - python.example_code.rekognition.DeleteFaces
   services:
-    - rekognition
+    rekognition: {DeleteFaces}
 rekognition_CreateCollection:
   title: Create an &REK; collection using an &AWS; SDK
   title_abbrev: Create a collection
@@ -214,7 +214,7 @@ rekognition_CreateCollection:
                 - python.example_code.rekognition.RekognitionCollectionManager
                 - python.example_code.rekognition.CreateCollection
   services:
-    - rekognition
+    rekognition: {CreateCollection}
 rekognition_ListCollections:
   title: List &REK; collections using an &AWS; SDK
   title_abbrev: List collections
@@ -241,7 +241,7 @@ rekognition_ListCollections:
                 - python.example_code.rekognition.RekognitionCollectionManager
                 - python.example_code.rekognition.ListCollections
   services:
-    - rekognition
+    rekognition: {ListCollections}
 rekognition_Usage_FindFacesInCollection:
   title: Build an &REK; collection and find faces in it using an &AWS; SDK
   title_abbrev: Build a collection and find faces in it
@@ -276,7 +276,7 @@ rekognition_Usage_FindFacesInCollection:
               snippet_tags:
                 - python.example_code.rekognition.Usage_FindFacesInCollection
   services:
-    - rekognition
+    rekognition: {}
 rekognition_DetectFaces:
   title: Detect faces in an image with &REK; using an &AWS; SDK
   title_abbrev: Detect faces in an image
@@ -303,7 +303,7 @@ rekognition_DetectFaces:
                 - python.example_code.rekognition.RekognitionImage
                 - python.example_code.rekognition.DetectFaces
   services:
-    - rekognition
+    rekognition: {DetectFaces}
 rekognition_CompareFaces:
   title: Compare faces in an image against a reference image with &REK; using an &AWS; SDK
   title_abbrev: Compare faces in an image against a reference image
@@ -330,7 +330,7 @@ rekognition_CompareFaces:
                 - python.example_code.rekognition.RekognitionImage
                 - python.example_code.rekognition.CompareFaces
   services:
-    - rekognition
+    rekognition: {CompareFaces}
 rekognition_DetectLabels:
   title: Detect labels in an image with &REK; using an &AWS; SDK
   title_abbrev: Detect labels in an image
@@ -357,7 +357,7 @@ rekognition_DetectLabels:
                 - python.example_code.rekognition.RekognitionImage
                 - python.example_code.rekognition.DetectLabels
   services:
-    - rekognition
+    rekognition: {DetectLabels}
 rekognition_DetectModerationLabels:
   title: Detect moderation labels in an image with &REK; using an &AWS; SDK
   title_abbrev: Detect moderation labels in an image
@@ -385,7 +385,7 @@ rekognition_DetectModerationLabels:
                 - python.example_code.rekognition.RekognitionImage
                 - python.example_code.rekognition.DetectModerationLabels
   services:
-    - rekognition
+    rekognition: {DetectModerationLabels}
 rekognition_DetectText:
   title: Detect text in an image with &REK; using an &AWS; SDK
   title_abbrev: Detect text in an image
@@ -412,7 +412,7 @@ rekognition_DetectText:
                 - python.example_code.rekognition.RekognitionImage
                 - python.example_code.rekognition.DetectText
   services:
-    - rekognition
+    rekognition: {DetectText}
 rekognition_RecognizeCelebrities:
   title: Recognize celebrities in an image with &REK; using an &AWS; SDK
   title_abbrev: Recognize celebrities in an image
@@ -439,7 +439,7 @@ rekognition_RecognizeCelebrities:
                 - python.example_code.rekognition.RekognitionImage
                 - python.example_code.rekognition.RecognizeCelebrities
   services:
-    - rekognition
+    rekognition: {RecognizeCelebrities}
 rekognition_Usage_DetectAndDisplayImage:
   title: Detect and display elements in images with &REK; using an &AWS; SDK
   title_abbrev: Detect and display elements in images
@@ -483,4 +483,4 @@ rekognition_Usage_DetectAndDisplayImage:
               snippet_tags:
                 - python.example_code.rekognition.Usage_ImageDetection
   services:
-    - rekognition
+    rekognition: {}

--- a/.doc_gen/metadata/sdks.yaml
+++ b/.doc_gen/metadata/sdks.yaml
@@ -1,5 +1,4 @@
-# zexi 0.2.0
-# SDK data
+# zexi 0.4.0
 C++:
   property: cpp
   sdk:
@@ -25,7 +24,7 @@ Go:
       api_ref:
         uid: "SdkForGoV2"
         name: "&guide-go-api;"
-        link_template: "https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/{{.Service}}#Client.{{.Operation}}"
+        link_template: "https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/{{.Service}}#Client.{{.Action}}"
   guide: "&guide-go-dev;"
 Java:
   property: java
@@ -55,7 +54,7 @@ JavaScript:
       api_ref:
         uid: "AWSJavaScriptSDKV3"
         name: "&guide-jsb-api;"
-        link_template: "AWSJavaScriptSDK/v3/latest/clients/client-{{.Service}}/classes/{{.OperationLower}}command.html"
+        link_template: "AWSJavaScriptSDK/v3/latest/clients/client-{{.Service}}/classes/{{.ActionLower}}command.html"
   guide: "&guide-jsb-dev;"
 Kotlin:
   property: kotlin

--- a/.doc_gen/metadata/services.yaml
+++ b/.doc_gen/metadata/services.yaml
@@ -1,5 +1,4 @@
-# zexi 0.2.0
-  # AWS service data
+# zexi 0.4.0
 # The sort key of a service is the short display name (the expanded version of the short entity) without the AWS/Amazon prefix.
 acm:
   long: "&ACMlong;"

--- a/.doc_gen/metadata/sns_metadata.yaml
+++ b/.doc_gen/metadata/sns_metadata.yaml
@@ -1,4 +1,4 @@
-# zexi 0.2.0
+# zexi 0.4.0
 sns_GetTopicAttributes:
   title: Get the properties of an &SNS; topic using an &AWS; SDK
   title_abbrev: Get the properties of a topic
@@ -55,7 +55,7 @@ sns_GetTopicAttributes:
               snippet_tags:
                 - sns.JavaScript.topics.getTopicAttributes
   services:
-    - sns
+    sns: {GetTopicAttributes}
 sns_ListSubscriptions:
   title: List the subscribers of an &SNS; topic using an &AWS; SDK
   title_abbrev: List the subscribers of a topic
@@ -125,7 +125,7 @@ sns_ListSubscriptions:
             - snippet_tags:
                 - sns.Ruby.showSubscription
   services:
-    - sns
+    sns: {ListSubscriptions}
 sns_ListTopics:
   title: List &SNS; topics using an &AWS; SDK
   title_abbrev: List topics
@@ -195,7 +195,7 @@ sns_ListTopics:
             - snippet_tags:
                 - sns.Ruby.showTopics
   services:
-    - sns
+    sns: {ListTopics}
 sns_Subscribe_App:
   title: Subscribe a mobile application to an &SNS; topic using an &AWS; SDK
   title_abbrev: Subscribe a mobile application to a topic
@@ -222,7 +222,7 @@ sns_Subscribe_App:
               snippet_tags:
                 - sns.JavaScript.subscriptions.subscribeAppV3
   services:
-    - sns
+    sns: {Subscribe}
 sns_Subscribe_HTTP:
   title: Subscribe an HTTP endpoint to an &SNS; topic using an &AWS; SDK
   title_abbrev: Subscribe an HTTP endpoint to a topic
@@ -246,7 +246,7 @@ sns_Subscribe_HTTP:
             - snippet_tags:
                 - sns.java2.SubscribeHTTPS.main
   services:
-    - sns
+    sns: {Subscribe}
 sns_Subscribe_Lambda:
   title: Subscribe a &LAM; function to receive notifications from an &SNS; topic using an &AWS; SDK
   title_abbrev: Subscribe a &LAM; function to a topic
@@ -281,7 +281,7 @@ sns_Subscribe_Lambda:
               snippet_tags:
                 - sns.JavaScript.subscriptions.subscribeLambdaV3
   services:
-    - sns
+    sns: {Subscribe}
 
 sns_GetSMSAttributes:
   title: Get the settings for sending &SNS; SMS messages using an &AWS; SDK
@@ -325,7 +325,7 @@ sns_GetSMSAttributes:
               snippet_tags:
                 - sns.JavaScript.SMS.getSMSAttributesV3
   services:
-    - sns
+    sns: {GetSMSAttributes}
 sns_PublishTextSMS:
   title: Publish an &SNS; SMS text message using an &AWS; SDK
   title_abbrev: Publish an SMS text message
@@ -364,7 +364,7 @@ sns_PublishTextSMS:
                 - python.example_code.sns.SnsWrapper
                 - python.example_code.sns.Publish_TextMessage
   services:
-    - sns
+    sns: {Publish}
 sns_ConfirmSubscription:
   title: Confirm an endpoint owner wants to receive &SNS; messages using an &AWS; SDK
   title_abbrev: Confirm an endpoint owner wants to receive messages
@@ -400,7 +400,7 @@ sns_ConfirmSubscription:
               snippet_tags:
                 - sns.JavaScript.subscriptions.confirmSubscriptionV3
   services:
-    - sns
+    sns: {ConfirmSubscription}
 sns_CheckIfPhoneNumberIsOptedOut:
   title: Check whether a phone number is opted out of &SNS; using an &AWS; SDK
   title_abbrev: Check whether a phone number is opted out
@@ -444,7 +444,7 @@ sns_CheckIfPhoneNumberIsOptedOut:
               snippet_tags:
                 - sns.JavaScript.SMS.checkIfPhoneNumberIsOptedOutV3
   services:
-    - sns
+    sns: {CheckIfPhoneNumberIsOptedOut}
 sns_TagResource:
   title: Add tags to an &SNS; topic using an &AWS; SDK
   title_abbrev: Add tags to a topic
@@ -459,7 +459,7 @@ sns_TagResource:
             - snippet_tags:
                 - sns.java2.add_tags.main
   services:
-    - sns
+    sns: {TagResource}
 sns_CreateTopic:
   title: Create an &SNS; topic using an &AWS; SDK
   title_abbrev: Create a topic
@@ -529,7 +529,7 @@ sns_CreateTopic:
             - snippet_tags:
                 - sns.Ruby.createTopic
   services:
-    - sns
+    sns: {CreateTopic}
 sns_DeleteTopic:
   title: Delete an &SNS; topic using an &AWS; SDK
   title_abbrev: Delete a topic
@@ -587,7 +587,7 @@ sns_DeleteTopic:
                 - python.example_code.sns.SnsWrapper
                 - python.example_code.sns.DeleteTopic
   services:
-    - sns
+    sns: {DeleteTopic}
 sns_ListPhoneNumbersOptedOut:
   title: List phone numbers opted out of &SNS; using an &AWS; SDK
   title_abbrev: List opted out phone numbers
@@ -611,7 +611,7 @@ sns_ListPhoneNumbersOptedOut:
             - snippet_tags:
                 - sns.php.list_optout.complete
   services:
-    - sns
+    sns: {ListPhoneNumbersOptedOut}
 sns_Publish:
   title: Publish to an &SNS; topic using an &AWS; SDK
   title_abbrev: Publish to a topic
@@ -683,7 +683,7 @@ sns_Publish:
             - snippet_tags:
                 - sns.Ruby.sendMessage
   services:
-    - sns
+    sns: {Publish}
 sns_SetSmsAttributes:
   title: Set the default settings for sending &SNS; SMS messages using an &AWS; SDK
   title_abbrev: Set the default settings for sending SMS messages
@@ -727,7 +727,7 @@ sns_SetSmsAttributes:
             - snippet_tags:
                 - sns.php.set_sms_attributes.main
   services:
-    - sns
+    sns: {SetSmsAttributes}
 sns_SetSubscriptionAttributes:
   title: Set an &SNS; filter policy using an &AWS; SDK
   title_abbrev: Set a filter policy
@@ -751,7 +751,7 @@ sns_SetSubscriptionAttributes:
                 - python.example_code.sns.SnsWrapper
                 - python.example_code.sns.SetSubscriptionAttributes
   services:
-    - sns
+    sns: {SetSubscriptionAttributes}
 sns_SetTopicAttributes:
   title: Set &SNS; topic attributes using an &AWS; SDK
   title_abbrev: Set topic attributes
@@ -795,7 +795,7 @@ sns_SetTopicAttributes:
             - snippet_tags:
                 - sns.Ruby.enableResource
   services:
-    - sns
+    sns: {SetTopicAttributes}
 sns_Subscribe:
   title: Subscribe an email address to an &SNS; topic using an &AWS; SDK
   title_abbrev: Subscribe an email address to a topic
@@ -858,7 +858,7 @@ sns_Subscribe:
             - snippet_tags:
                 - sns.Ruby.createSubscription
   services:
-    - sns
+    sns: {Subscribe}
 sns_Unsubscribe:
   title: Delete an &SNS; subscription using an &AWS; SDK
   title_abbrev: Delete a subscription
@@ -909,7 +909,7 @@ sns_Unsubscribe:
                 - python.example_code.sns.SnsWrapper
                 - python.example_code.sns.Unsubscribe
   services:
-    - sns
+    sns: {Unsubscribe}
 sns_PublishFifoTopic:
   title: Create and publish to a FIFO &SNS; topic using an &AWS; SDK
   title_abbrev: Create and publish to a FIFO topic
@@ -934,7 +934,7 @@ sns_PublishFifoTopic:
               snippet_tags:
                 - sns.java.fifo_topics.publish
   services:
-    - sns
+    sns: {}
 sns_PublishLargeMessage:
   title: Publish a large message to &SNS; with &S3; using an &AWS; SDK
   title_abbrev: Publish a large message
@@ -952,7 +952,7 @@ sns_PublishLargeMessage:
               snippet_tags:
                 - sns.java.publish_large_file
   services:
-    - sns
+    sns: {}
 sns_SetSubscriptionAttributesRedrivePolicy:
   title: Set a dead-letter queue for an &SNS; subscription using an &AWS; SDK
   title_abbrev: Set a dead-letter queue for a subscription
@@ -968,7 +968,7 @@ sns_SetSubscriptionAttributesRedrivePolicy:
             - snippet_tags:
                 - sns.java.redrive_policy
   services:
-    - sns
+    sns: {SetSubscriptionAttributesRedrivePolicy}
 sns_CreatePlatformEndpoint:
   title: Create a platform endpoint for &SNS; push notifications using an &AWS; SDK
   title_abbrev: Create a platform endpoint for push notifications
@@ -985,7 +985,7 @@ sns_CreatePlatformEndpoint:
               snippet_tags:
                 - sns.java.create_mobile_endpoint
   services:
-    - sns
+    sns: {}
 sns_UsageSmsTopic:
   title: Publish SMS messages to an &SNS; topic using an &AWS; SDK
   title_abbrev: Publish SMS messages to a topic
@@ -1021,5 +1021,4 @@ sns_UsageSmsTopic:
               snippet_tags:
                 - sns.java.publish_sms_to_topic.main
   services:
-    - sns
-
+    sns: {}

--- a/.doc_gen/templates/zonbook/example_language_template.xml
+++ b/.doc_gen/templates/zonbook/example_language_template.xml
@@ -5,7 +5,7 @@
     <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
     %phrases-shared;
 ]>
-<!-- zexi 0.2.1 -->
+<!-- zexi 0.4.0 -->
 <variablelist role="termdef">
     {{- range $version := .Versions}}
     <varlistentry>
@@ -43,12 +43,24 @@
                     </para>
                 </listitem>
                 {{- end}}
-                {{- if $version.ApiRefLink.Url}}
+                {{- if gt (len $version.ApiRefLinks) 0 }}
                 <listitem>
+                    {{- if eq (len $version.ApiRefLinks) 1 }}
                     <para>
-                        For API details, see <ulink {{$version.ApiRefLink.DocType}} url="{{$version.ApiRefLink.Url}}">{{$version.ApiRefLink.Text}}</ulink>
+                        For API details, see
+                        {{- range $actionLink := $version.ApiRefLinks}}
+                        <ulink {{$actionLink.DocType}} url="{{$actionLink.Url}}">{{$actionLink.Text}}</ulink>
+                        {{- end}}
                         in <emphasis>{{$version.ApiRefName}}</emphasis>.
                     </para>
+                    {{- else }}
+                    <para>For API details, see the following topics in <emphasis>{{$version.ApiRefName}}</emphasis>.</para>
+                    <itemizedlist>
+                        {{- range $actionLink := $version.ApiRefLinks}}
+                        <listitem><para><ulink {{$actionLink.DocType}} url="{{$actionLink.Url}}">{{$actionLink.Text}}</ulink></para></listitem>
+                        {{- end }}
+                    </itemizedlist>
+                    {{- end }}
                 </listitem>
                 {{- end}}
             </itemizedlist>

--- a/.doc_gen/templates/zonbook/example_language_template.xml
+++ b/.doc_gen/templates/zonbook/example_language_template.xml
@@ -32,7 +32,7 @@
                 {{- if $version.GitHubUrl}}
                 <listitem>
                     <para>
-                        Find instructions and more code on <ulink url="https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/{{$version.GitHubUrl}}">GitHub</ulink>.
+                        Find instructions and more code on <ulink url="https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/{{$version.GitHubUrl}}">GitHub</ulink>.
                     </para>
                 </listitem>
                 {{- end}}

--- a/.doc_gen/validation/example_schema.yaml
+++ b/.doc_gen/validation/example_schema.yaml
@@ -10,7 +10,7 @@ example:
   synopsis_list: list(str(), required=False)
   category: str(required=False)
   languages: map(include('language'), key=enum('C++', 'Go', 'Java', 'JavaScript', 'Kotlin', '.NET', 'PHP', 'Python', 'Ruby', 'Rust'))
-  services: list(service_name())
+  services: map(map(key=str(), required=False), key=service_name())
 
 language:
   versions: list(include('version'))
@@ -21,7 +21,7 @@ version:
   sdkguide: regex('^(?!https://docs.aws.amazon.com/).+', name="relative documentation URL", required=False)
   excerpts: list(include('excerpt'), required=False)
   block_content: block_content(required=False)
-  add_services: list(include('service_slug_regex'), required=False)
+  add_services: map(key=service_name(), required=False)
 
 excerpt:
   description: str(required=False)


### PR DESCRIPTION
Update SOS metadata to use service:{action} map instead of list of services.
Also update the validator to support the new format.

This is for the zexi 0.4.0 update to decouple example IDs from API ref data. This means example IDs are no longer used as data to render API reference links, which allows us to change underlying data like service actions without changing the example IDs. Changing IDs is problematic because they are used in consuming guides to include inline content, and if we change the source ID, it breaks that reference.

This update also lets us list multiple actions in an example (such as sns: {CreateTopic, DeleteTopic}) and will render API reference links for all of them.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
