### PR TITLE
Added service caveat and sample guide link to Rekognition service

### DIFF
--- a/.doc_gen/metadata/rekognition_metadata.yaml
+++ b/.doc_gen/metadata/rekognition_metadata.yaml
@@ -336,6 +336,9 @@ rekognition_DetectLabels:
   title_abbrev: Detect labels in an image
   synopsis: detect labels in an image with &REK;.
   category:
+  guide_topic:
+    title: Detecting labels in an image
+    url: rekognition/latest/dg/labels-detect-labels-image.html
   languages:
     Java:
       versions:

--- a/.doc_gen/metadata/services.yaml
+++ b/.doc_gen/metadata/services.yaml
@@ -100,6 +100,8 @@ rekognition:
   short: "&REK;"
   sort: "Rekognition"
   version: rekognition-2016-06-27
+  caveat: The code examples in this chapter are intended to supplement the
+    code examples found throughout the rest of this guide.
 s3:
   long: "&S3long;"
   short: "&S3;"

--- a/.doc_gen/templates/zonbook/service_chapter_template.xml
+++ b/.doc_gen/templates/zonbook/service_chapter_template.xml
@@ -16,7 +16,8 @@
             <para>Code examples that show how to use {{.ServiceEntity.Short}} with an &AWS; SDK.</para>
         </abstract>
     </info>
-    <para>The following code examples show how to use {{.ServiceEntity.Short}} with an &AWS; software development kit (SDK).</para>
+    <para>The following code examples show how to use {{.ServiceEntity.Short}} with an &AWS; software development kit (SDK).
+        {{.ServiceEntity.Caveat}}</para>
     <para>For a complete list of &AWS; SDK developer guides and code examples, including help getting started
         and information about previous versions, see
         <xref linkend="sdk-general-information-section" endterm="sdk-general-information-section.title"></xref>.</para>
@@ -47,6 +48,9 @@
                 </abstract>
             </info>
             <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}_desc.xml"></xi:include>
+            {{- if .GuideTopic.Url}}
+            <para>For more information, see <ulink {{.GuideTopic.DocType}} url="{{.GuideTopic.Url}}">{{.GuideTopic.Text}}</ulink>.</para>
+            {{- end}}
             <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}{{$addSvc}}_tablist.xml"></xi:include>
             <para>For a complete list of &AWS; SDK developer guides and code examples, including help getting started
                 and information about previous versions, see

--- a/.doc_gen/validation/example_schema.yaml
+++ b/.doc_gen/validation/example_schema.yaml
@@ -9,8 +9,13 @@ example:
   synopsis: str(required=False)
   synopsis_list: list(str(), required=False)
   category: str(required=False)
+  guide_topic: include('guide_topic', required=False)
   languages: map(include('language'), key=enum('C++', 'Go', 'Java', 'JavaScript', 'Kotlin', '.NET', 'PHP', 'Python', 'Ruby', 'Rust'))
   services: map(map(key=str(), required=False), key=service_name())
+
+guide_topic:
+  title: str()
+  url: include('doc_url', required=False)
 
 language:
   versions: list(include('version'))
@@ -18,7 +23,7 @@ language:
 version:
   sdk_version: int(min=1)
   github: regex('^(?!http).+', name="relative URL", required=False)
-  sdkguide: regex('^(?!https://docs.aws.amazon.com/).+', name="relative documentation URL", required=False)
+  sdkguide: include('doc_url', required=False)
   excerpts: list(include('excerpt'), required=False)
   block_content: block_content(required=False)
   add_services: map(key=service_name(), required=False)
@@ -28,3 +33,4 @@ excerpt:
   snippet_tags: list(str())
 
 service_slug_regex: regex('^[\da-z-]+$', name='service slug')
+doc_url: regex('^(?!https://docs.aws.amazon.com/).+', name="relative documentation URL")

--- a/.doc_gen/validation/services_schema.yaml
+++ b/.doc_gen/validation/services_schema.yaml
@@ -7,5 +7,6 @@ service:
   short: include('entity_regex')
   sort: regex('^[^&]\w', name='non-entity')
   version: service_version()
+  caveat: str(required=False)
 
 entity_regex: regex('^[&]([\dA-Za-z-_])+[;]$|^&AWS; SDK for Kotlin Developer Guide$', name='valid entity')


### PR DESCRIPTION
Add SOS data for two features for Rekognition:
* service caveat that states the examples are supplemental to others within the guide.
* link from an example to a page in the guide (added a single example of this as a demo).

- [x] I have tested my changes and created unit tests for new code paths.
- [ ] Changes have been reviewed, and all reviewer comments have been incorporated.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
