### PR TITLE
Python Route 53 recovery: update code and title per feedback

### DIFF
--- a/.doc_gen/metadata/route53-recovery-cluster_metadata.yaml
+++ b/.doc_gen/metadata/route53-recovery-cluster_metadata.yaml
@@ -54,10 +54,9 @@ route53-recovery-cluster_UpdateRoutingControlState:
   services:
     route53-recovery-cluster: {UpdateRoutingControlState}
 route53-recovery-cluster_UpdateRoutingControlStates:
-  title: Update the state of a list of &R53ARC; routing controls using an &AWS; SDK
-  title_abbrev: Update the state of a list of routing controls
-  synopsis: update the state of a list of &R53ARC; routing controls for a list of
-    cluster endpoints.
+  title: Update the states of multiple &R53ARC; routing controls using an &AWS; SDK
+  title_abbrev: Update the states of multiple routing controls
+  synopsis: update the states of multiple &R53ARC; routing controls for a cluster.
   category:
   languages:
     Java:

--- a/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/GetRoutingControlState.java
+++ b/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/GetRoutingControlState.java
@@ -50,7 +50,6 @@ public class GetRoutingControlState {
         System.out.println("GetRoutingControlStateResponse: " + response);
     }
 
-    //snippet-start:[route53_rec.java2.get_routing.main]
     private static List<ClusterEndpoint> getClusterEndpoints(final String endpointsFile) {
         try {
             ClusterEndpoints endpoints =
@@ -65,6 +64,7 @@ public class GetRoutingControlState {
         }
     }
 
+    //snippet-start:[route53_rec.java2.get_routing.main]
     public static GetRoutingControlStateResponse getRoutingControlState(List<ClusterEndpoint> clusterEndpoints,
                                                                         String routingControlArn) {
         for (ClusterEndpoint clusterEndpoint : clusterEndpoints) {

--- a/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/UpdateRoutingControlState.java
+++ b/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/UpdateRoutingControlState.java
@@ -53,7 +53,6 @@ public class UpdateRoutingControlState {
         System.out.println("UpdateRoutingControlStateResponse: " + response);
     }
 
-    //snippet-start:[route53_rec.java2.update_routing_state.main]
     private static List<ClusterEndpoint> getClusterEndpoints(final String endpointsFile) {
         try {
             ClusterEndpoints endpoints =
@@ -68,6 +67,7 @@ public class UpdateRoutingControlState {
         }
     }
 
+    //snippet-start:[route53_rec.java2.update_routing_state.main]
     public static UpdateRoutingControlStateResponse updateRoutingControlState(List<ClusterEndpoint> clusterEndpoints,
                                                                               String routingControlArn,
                                                                               String routingControlState) {

--- a/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/UpdateRoutingControlStates.java
+++ b/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/UpdateRoutingControlStates.java
@@ -55,7 +55,6 @@ public class UpdateRoutingControlStates {
         System.out.println("UpdateRoutingControlStatesResponse: " + response);
     }
 
-    //snippet-start:[route53_rec.java2.update_routing_states.main]
     private static List<UpdateRoutingControlStateEntry> getUpdateRoutingControlEntries(
             final String routingControlStatesFile) {
         try {
@@ -86,6 +85,7 @@ public class UpdateRoutingControlStates {
         }
     }
 
+    //snippet-start:[route53_rec.java2.update_routing_states.main]
     public static UpdateRoutingControlStatesResponse updateRoutingControlStates(List<ClusterEndpoint> clusterEndpoints,
                                                                                 Collection<UpdateRoutingControlStateEntry> updateRoutingControlStateEntries) {
         for (ClusterEndpoint clusterEndpoint : clusterEndpoints) {

--- a/python/example_code/route53-recovery-cluster/README.md
+++ b/python/example_code/route53-recovery-cluster/README.md
@@ -13,7 +13,7 @@ Recovery Controller to manage routing control settings.
 
 * [Get the state of a routing control](routing_control_states.py)
 (`GetRoutingControlState`)
-* [Update the state of a list of routing controls](routing_control_states.py)
+* [Update the state of multiple routing controls](routing_control_states.py)
 (`UpdateRoutingControlStates`)
 * [Update the state of a routing control](routing_control_states.py)
 (`UpdateRoutingControlState`)


### PR DESCRIPTION
Python Route 53 application recovery examples: update code per service dev feedback; update example title per writer feedback.

- [x] I have tested my changes and created unit tests for new code paths.
- [x] Changes have been reviewed, and all reviewer comments have been incorporated.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
