### PR TITLE
Added SoS metadata for Rust

### DIFF
--- a/.doc_gen/metadata/rds-data_metadata.yaml
+++ b/.doc_gen/metadata/rds-data_metadata.yaml
@@ -1,5 +1,5 @@
 # zexi 0.4.0
-Srds-data_ExecuteStatement:
+rds-data_ExecuteStatement:
   title: Run an SQL statement against a database using an &AWS; SDK
   title_abbrev: Run an SQL statement
   synopsis: run an SQL statement.
@@ -12,6 +12,6 @@ Srds-data_ExecuteStatement:
           excerpts:
             - description:
               snippet_tags:
-                -
+                - rdsdata.rust.rdsdata-helloworld
   services:
-    SERVICE-LC: { ExecuteStatement }
+    rds-data: { ExecuteStatement }

--- a/.doc_gen/metadata/rds-data_metadata.yaml
+++ b/.doc_gen/metadata/rds-data_metadata.yaml
@@ -1,6 +1,6 @@
 # zexi 0.4.0
 rds-data_ExecuteStatement:
-  title: Run an SQL statement against a database using an &AWS; SDK
+  title: Run an SQL statement using an &AWS; SDK
   title_abbrev: Run an SQL statement
   synopsis: run an SQL statement.
   category:

--- a/.doc_gen/metadata/rds-data_metadata.yaml
+++ b/.doc_gen/metadata/rds-data_metadata.yaml
@@ -1,0 +1,17 @@
+# zexi 0.4.0
+Srds-data_ExecuteStatement:
+  title: Run an SQL statement against a database using an &AWS; SDK
+  title_abbrev: Run an SQL statement
+  synopsis: run an SQL statement.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/rdsdata
+          excerpts:
+            - description:
+              snippet_tags:
+                -
+  services:
+    SERVICE-LC: { ExecuteStatement }

--- a/.doc_gen/metadata/sagemaker_metadata.yaml
+++ b/.doc_gen/metadata/sagemaker_metadata.yaml
@@ -1,0 +1,33 @@
+# zexi 0.4.0
+sagemaker_ListNotebookInstances:
+  title: List the &SM; notebook instances using an &AWS; SDK
+  title_abbrev: List notebook instances
+  synopsis: list &SM; notebook instances.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/sagemaker
+          excerpts:
+            - description:
+              snippet_tags:
+                - sagemaker.rust.sagemaker-helloworld
+  services:
+    sagemaker: { ListNotebookInstances }
+sagemaker_ListTrainingJobs:
+  title: List &SM; training jobs using an &AWS; SDK
+  title_abbrev: List training jobs
+  synopsis: list &SM; training jobs.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/sagemaker
+          excerpts:
+            - description:
+              snippet_tags:
+                - sagemaker.rust.list-training-jobs
+  services:
+    sagemaker: { ListTrainingJobs }

--- a/.doc_gen/metadata/sesv2_metadata.yaml
+++ b/.doc_gen/metadata/sesv2_metadata.yaml
@@ -1,8 +1,8 @@
 # zexi 0.4.0
 sesv2_CreateContactList:
-  title: Create a &SESv2; contact list using an &AWS; SDK
+  title: Create an &SESv2; contact list using an &AWS; SDK
   title_abbrev: Create a contact list
-  synopsis: create a &SESv2; contact list.
+  synopsis: create an &SESv2; contact list.
   category:
   languages:
     Rust:
@@ -16,9 +16,9 @@ sesv2_CreateContactList:
   services:
     sesv2: { CreateContactList }
 sesv2_CreateContact:
-  title: Create a &SESv2; contact in a contact list using an &AWS; SDK
+  title: Create an &SESv2; contact in a contact list using an &AWS; SDK
   title_abbrev: Create a contact in a contact list
-  synopsis: create a &SESv2; contact in a contact list.
+  synopsis: create an &SESv2; contact in a contact list.
   category:
   languages:
     Rust:
@@ -32,7 +32,7 @@ sesv2_CreateContact:
   services:
     sesv2: { CreateContact }
 sesv2_GetEmailIdentity:
-  title: Get information about a &SESv2; identity using an &AWS; SDK
+  title: Get information about an &SESv2; identity using an &AWS; SDK
   title_abbrev: Get identity information
   synopsis: get &SESv2; identity information.
   category:
@@ -64,9 +64,9 @@ sesv2_ListContactLists:
   services:
     sesv2: { ListContactLists }
 sesv2_ListContacts:
-  title: List the contacts in a &SESv2; contact list using an &AWS; SDK
+  title: List the contacts in an &SESv2; contact list using an &AWS; SDK
   title_abbrev: List the contacts in a contact list
-  synopsis: list the contacts in a &SESv2; contact list.
+  synopsis: list the contacts in an &SESv2; contact list.
   category:
   languages:
     Rust:
@@ -80,9 +80,9 @@ sesv2_ListContacts:
   services:
     sesv2: { ListContacts }
 sesv2_SendEmail:
-  title: Send a &SESv2; email using an &AWS; SDK
+  title: Send an &SESv2; email using an &AWS; SDK
   title_abbrev: Send an email
-  synopsis: send an email.
+  synopsis: send an &SESv2; email.
   category:
   languages:
     Rust:

--- a/.doc_gen/metadata/sesv2_metadata.yaml
+++ b/.doc_gen/metadata/sesv2_metadata.yaml
@@ -1,0 +1,97 @@
+# zexi 0.4.0
+sesv2_CreateContactList:
+  title: Create a &SESv2; contact list using an &AWS; SDK
+  title_abbrev: Create a contact list
+  synopsis: create a &SESv2; contact list.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/ses
+          excerpts:
+            - description:
+              snippet_tags:
+                - ses.rust.create-contact-list
+  services:
+    sesv2: { CreateContactList }
+sesv2_CreateContact:
+  title: Create a &SESv2; contact in a contact list using an &AWS; SDK
+  title_abbrev: Create a contact in a contact list
+  synopsis: create a &SESv2; contact in a contact list.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/ses
+          excerpts:
+            - description:
+              snippet_tags:
+                - ses.rust.create-contact
+  services:
+    sesv2: { CreateContact }
+sesv2_GetEmailIdentity:
+  title: Get information about a &SESv2; identity using an &AWS; SDK
+  title_abbrev: Get identity information
+  synopsis: get &SESv2; identity information.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/ses
+          excerpts:
+            - description: Determines whether an email address has been verified.
+              snippet_tags:
+                - ses.rust.is-email-verified
+  services:
+    sesv2: { GetEmailIdentity }
+sesv2_ListContactLists:
+  title: List the &SESv2; contact lists using an &AWS; SDK
+  title_abbrev: List the contact lists
+  synopsis: list the &SESv2; contact lists.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/ses
+          excerpts:
+            - description:
+              snippet_tags:
+                - ses.rust.list-contact-lists
+  services:
+    sesv2: { ListContactLists }
+sesv2_ListContacts:
+  title: List the contacts in a &SESv2; contact list using an &AWS; SDK
+  title_abbrev: List the contacts in a contact list
+  synopsis: list the contacts in a &SESv2; contact list.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/ses
+          excerpts:
+            - description:
+              snippet_tags:
+                - ses.rust.list-contacts
+  services:
+    sesv2: { ListContacts }
+sesv2_SendEmail:
+  title: Send a &SESv2; email using an &AWS; SDK
+  title_abbrev: Send an email
+  synopsis: send an email.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/ses
+          excerpts:
+            - description: Sends a message to all members of the contact list.
+              snippet_tags:
+                - ses.rust.send-email
+  services:
+    sesv2: { SendEmail }

--- a/.doc_gen/metadata/ssm_metadata.yaml
+++ b/.doc_gen/metadata/ssm_metadata.yaml
@@ -1,0 +1,33 @@
+# zexi 0.4.0
+ssm_PutParameter:
+  title: Add a &SYS; parameter using an &AWS; SDK
+  title_abbrev: Add a parameter
+  synopsis: add a &SYS; parameter.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/ssm
+          excerpts:
+            - description:
+              snippet_tags:
+                - ssm.rust.create-parameter
+  services:
+    ssm: { PutParameter }
+ssm-DescribeParameters:
+  title: Get information about &SYS; parameters using an &AWS; SDK
+  title_abbrev: Get parameters information
+  synopsis: get &SYS; parameters information.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/ssm
+          excerpts:
+            - description:
+              snippet_tags:
+                - ssm.rust.describe-parameters
+  services:
+    ssm: { DescribeParameters }

--- a/.doc_gen/metadata/ssm_metadata.yaml
+++ b/.doc_gen/metadata/ssm_metadata.yaml
@@ -1,4 +1,20 @@
 # zexi 0.4.0
+ssm_DescribeParameters:
+  title: Get information about &SYS; parameters using an &AWS; SDK
+  title_abbrev: Get parameters information
+  synopsis: get &SYS; parameters information.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: .rust_alpha/ssm
+          excerpts:
+            - description:
+              snippet_tags:
+                - ssm.rust.describe-parameters
+  services:
+    ssm: { DescribeParameters }
 ssm_PutParameter:
   title: Add a &SYS; parameter using an &AWS; SDK
   title_abbrev: Add a parameter
@@ -15,19 +31,3 @@ ssm_PutParameter:
                 - ssm.rust.create-parameter
   services:
     ssm: { PutParameter }
-ssm-DescribeParameters:
-  title: Get information about &SYS; parameters using an &AWS; SDK
-  title_abbrev: Get parameters information
-  synopsis: get &SYS; parameters information.
-  category:
-  languages:
-    Rust:
-      versions:
-        - sdk_version: 1
-          github: .rust_alpha/ssm
-          excerpts:
-            - description:
-              snippet_tags:
-                - ssm.rust.describe-parameters
-  services:
-    ssm: { DescribeParameters }

--- a/.rust_alpha/ses/src/bin/is-email-verified.rs
+++ b/.rust_alpha/ses/src/bin/is-email-verified.rs
@@ -23,7 +23,7 @@ struct Opt {
 }
 
 // Is email address has been verified?
-// snippet-start:[ses.rust.is-email-verfied]
+// snippet-start:[ses.rust.is-email-verified]
 async fn is_verified(client: &Client, email: &str) -> Result<(), Error> {
     let resp = client
         .get_email_identity()
@@ -39,7 +39,7 @@ async fn is_verified(client: &Client, email: &str) -> Result<(), Error> {
 
     Ok(())
 }
-// snippet-end:[ses.rust.is-email-verfied]
+// snippet-end:[ses.rust.is-email-verified]
 
 /// Determines whether the email address has been verified.
 /// # Arguments


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

### Description of Changes

- The shared entity file had no entries for QLDB Session service, so I've added them.
- Added RDS Data Service metadata file, with entries for Rust.
- Added SES v2 metadata file, with entries for Rust.
- Fixed typo in SES Rust code example filename.
- Added Systems Manager metadata file, with entries for Rust.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
