### PR TITLE
Fix validator bug: index out of range on explicit empty string.

### DIFF
--- a/.doc_gen/validation/validate_doc_metadata.py
+++ b/.doc_gen/validation/validate_doc_metadata.py
@@ -91,6 +91,8 @@ class StringExtension(String):
         return self.last_err
 
     def _is_valid(self, value):
+        if value == '':
+            return True
         valid = True
         if self.check_aws:
             # All occurrences of AWS must be entities or within a word.


### PR DESCRIPTION
Fix to metadata validator bug. On a field with an explicitly set empty string, the validator attempted to index into the string, resulting in an index out of range error. The fix is to pass empty strings as valid because the metadata ingestion tool treats them the same as unspecified or missing string fields.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
