### PR TITLE
Python Pinpoint templated message examples updates

### DIFF
--- a/.doc_gen/metadata/pinpoint_metadata.yaml
+++ b/.doc_gen/metadata/pinpoint_metadata.yaml
@@ -55,6 +55,26 @@ pinpoint_SendMessages:
                 - pinpoint.javascript.pinpoint_send_sms_message_api.complete
   services:
     pinpoint: {SendMessages}
+pinpoint_SendMessages_Templated:
+  title: Send templated email and text messages with &PIN; using an &AWS; SDK
+  title_abbrev: Send templated email and text messages
+  synopsis: send templated email and text messages with &PIN;.
+  category:
+  languages:
+    Python:
+      versions:
+        - sdk_version: 3
+          github: python/example_code/pinpoint
+          sdkguide:
+          excerpts:
+            - description: Send an email message with an existing email template.
+              snippet_tags:
+                - pinpoint.python.pinpoint_send_templated_email_message.complete
+            - description: Send a text message with an existing SMS template.
+              snippet_tags:
+                - pinpoint.python.pinpoint_send_templated_sms_message.complete
+  services:
+    pinpoint: {SendMessages}
 pinpoint_CreateApp:
   title: Create an &PIN; application
   title_abbrev: Create an application 

--- a/python/example_code/pinpoint/README.md
+++ b/python/example_code/pinpoint/README.md
@@ -12,11 +12,17 @@ messages, and push notifications.*
 
 ### Scenario examples
 
-* [Send a text message with an SMTP server](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/python/example_code/pinpoint/pinpoint_send_email_smtp.py)
+* [Send a text message with an SMTP server](pinpoint_send_email_smtp.py)
 
 ### API examples
 
-* [Send email and text messages](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/python/example_code/pinpoint/pinpoint_send_email_message_api.py)
+* [Send email messages](pinpoint_send_email_message_api.py)
+(`SendMessages`)
+* [Send templated email messages](pinpoint_send_templated_email_message.py)
+(`SendMessages`)
+* [Send templated text messages](pinpoint_send_templated_sms_message.py)
+(`SendMessages`)
+* [Send text messages](pinpoint_send_sms_message_api.py)
 (`SendMessages`)
 
 ## ⚠ Important

--- a/python/example_code/pinpoint/pinpoint_send_templated_email_message.py
+++ b/python/example_code/pinpoint/pinpoint_send_templated_email_message.py
@@ -9,12 +9,12 @@ send email using a message template.
 """
 
 # snippet-start:[pinpoint.python.pinpoint_send_templated_email_message.complete]
-
 import logging
 import boto3
 from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
+
 
 def send_templated_email_message(
         pinpoint_client, project_id, sender, to_addresses, template_name,
@@ -23,14 +23,12 @@ def send_templated_email_message(
     Sends an email message with HTML and plain text versions.
 
     :param pinpoint_client: A Boto3 Pinpoint client.
-    :param project_id: The Amazon Pinpoint project ID to use when you send this
-                       message.
+    :param project_id: The Amazon Pinpoint project ID to use when you send this message.
     :param sender: The "From" address. This address must be verified in
                    Amazon Pinpoint in the AWS Region you're using to send email.
     :param to_addresses: The addresses on the "To" line. If your Amazon Pinpoint
                          account is in the sandbox, these addresses must be verified.
-    :param template_name: The name of the email template to use when sending the
-                          message.
+    :param template_name: The name of the email template to use when sending the message.
     :param template_version: The version number of the message template.
 
     :return: A dict of to_addresses and their message IDs.
@@ -45,7 +43,7 @@ def send_templated_email_message(
                     } for to_address in to_addresses
                 },
                 'MessageConfiguration': {
-                    'EmailMessage': { 'FromAddress': sender }
+                    'EmailMessage': {'FromAddress': sender}
                 },
                 'TemplateConfiguration': {
                     'EmailTemplate': {
@@ -64,6 +62,7 @@ def send_templated_email_message(
             to_address, message in response['MessageResponse']['Result'].items()
         }
 
+
 def main():
     project_id = "296b04b342374fceb661bf494example"
     sender = "sender@example.com"
@@ -76,6 +75,7 @@ def main():
         boto3.client('pinpoint'), project_id, sender, to_addresses, template_name,
         template_version)
     print(f"Message sent! Message IDs: {message_ids}")
+
 
 if __name__ == '__main__':
     main()

--- a/python/example_code/pinpoint/pinpoint_send_templated_sms_message.py
+++ b/python/example_code/pinpoint/pinpoint_send_templated_sms_message.py
@@ -15,6 +15,7 @@ from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
 
+
 def send_templated_sms_message(
         pinpoint_client,
         project_id,
@@ -66,6 +67,7 @@ def send_templated_sms_message(
     else:
         return response['MessageResponse']['Result'][destination_number]['MessageId']
 
+
 def main():
     region = "us-east-1"
     origination_number = "+18555550001"
@@ -75,12 +77,12 @@ def main():
     template_name = "My_SMS_Template"
     template_version = "1"
     message_id = send_templated_sms_message(
-        boto3.client('pinpoint',region_name=region), project_id,
+        boto3.client('pinpoint', region_name=region), project_id,
         destination_number, message_type, origination_number, template_name,
         template_version)
     print(f"Message sent! Message ID: {message_id}.")
 
+
 if __name__ == '__main__':
     main()
-
 # snippet-end:[pinpoint.python.pinpoint_send_templated_sms_message.complete]

--- a/python/test_tools/pinpoint_stubber.py
+++ b/python/test_tools/pinpoint_stubber.py
@@ -111,6 +111,35 @@ class PinpointStubber(ExampleStubber):
         self._stub_bifurcator(
             'send_messages', expected_params, response, error_code=error_code)
 
+    def stub_send_templated_email_messages(
+            self, app_id, sender, to_addresses, template_name, template_version,
+            message_ids, error_code=None):
+        expected_params = {
+            'ApplicationId': app_id,
+            'MessageRequest': {
+                'Addresses': {
+                    to_address: {'ChannelType': 'EMAIL'} for to_address in to_addresses
+                },
+                'MessageConfiguration': {'EmailMessage': {'FromAddress': sender}},
+                'TemplateConfiguration': {
+                    'EmailTemplate': {
+                        'Name': template_name, 'Version': template_version}}}}
+        response = {
+            'MessageResponse': {
+                'ApplicationId': app_id,
+                'Result': {
+                    to_address: {
+                        'MessageId': message_id,
+                        'DeliveryStatus': 'SUCCESSFUL',
+                        'StatusCode': 200
+                    }
+                    for to_address, message_id in zip(to_addresses, message_ids)
+                }
+            }
+        }
+        self._stub_bifurcator(
+            'send_messages', expected_params, response, error_code=error_code)
+
     def stub_send_sms_message(
             self, app_id, origination_number, destination_number, message, message_type,
             message_id, error_code=None):
@@ -123,6 +152,30 @@ class PinpointStubber(ExampleStubber):
                         'Body': message,
                         'MessageType': message_type,
                         'OriginationNumber': origination_number}}}}
+        response = {'MessageResponse': {
+            'ApplicationId': app_id,
+            'Result': {
+                destination_number: {
+                    'DeliveryStatus': 'SUCCESSFUL',
+                    'StatusCode': 200,
+                    'MessageId': message_id}}}}
+        self._stub_bifurcator(
+            'send_messages', expected_params, response, error_code=error_code)
+
+    def stub_send_templated_sms_message(
+            self, app_id, origination_number, destination_number, message_type,
+            template_name, template_version, message_id, error_code=None):
+        expected_params = {
+            'ApplicationId': app_id,
+            'MessageRequest': {
+                'Addresses': {destination_number: {'ChannelType': 'SMS'}},
+                'MessageConfiguration': {
+                    'SMSMessage': {
+                        'MessageType': message_type,
+                        'OriginationNumber': origination_number}},
+                'TemplateConfiguration': {
+                    'SMSTemplate': {
+                        'Name': template_name, 'Version': template_version}}}}
         response = {'MessageResponse': {
             'ApplicationId': app_id,
             'Result': {


### PR DESCRIPTION
Add unit tests, SOS data, and update README for external contribution of examples on how to send templated email and text messages.

- [x] I have tested my changes and created unit tests for new code paths.
- [ ] Changes have been reviewed, and all reviewer comments have been incorporated.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
