### PR TITLE
Updated Rust code examples to use 0.0.26 Alpha bits

### DIFF
--- a/rust_dev_preview/apigateway/Cargo.toml
+++ b/rust_dev_preview/apigateway/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-apigateway = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-apigateway = "0.0.26-alpha"
+aws-smithy-types-convert = { version = "0.30.0-alpha", features = ["convert-chrono"] }
 tokio = { version = "1", features = ["full"] }
 actix-rt = "*"
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/apigateway/src/bin/get_rest_apis.rs
+++ b/rust_dev_preview/apigateway/src/bin/get_rest_apis.rs
@@ -5,6 +5,7 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_apigateway::{Client, Error, Region, PKG_VERSION};
+use aws_smithy_types_convert::date_time::DateTimeExt;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -26,15 +27,12 @@ async fn show_apis(client: &Client) -> Result<(), Error> {
     for api in resp.items.unwrap_or_default() {
         println!("ID:          {}", api.id().unwrap_or_default());
         println!("Name:        {}", api.name().unwrap_or_default());
+        println!("Description: {}", api.description().unwrap_or_default());
+        println!("Version:     {}", api.version().unwrap_or_default());
         println!(
-            "Description: {}",
-            api.description().unwrap_or_default()
+            "Created:     {}",
+            api.created_date().unwrap().to_chrono_utc()
         );
-        println!(
-            "Version:     {}",
-            api.version().unwrap_or_default()
-        );
-        println!("Created:     {}", api.created_date().unwrap().to_chrono());
         println!();
     }
 

--- a/rust_dev_preview/applicationautoscaling/Cargo.toml
+++ b/rust_dev_preview/applicationautoscaling/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-applicationautoscaling = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-applicationautoscaling = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 actix-rt = "*"
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/autoscaling/Cargo.toml
+++ b/rust_dev_preview/autoscaling/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-autoscaling = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-autoscaling = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/autoscaling/src/bin/list-autoscaling-groups.rs
+++ b/rust_dev_preview/autoscaling/src/bin/list-autoscaling-groups.rs
@@ -28,10 +28,7 @@ async fn list_groups(client: &Client) -> Result<(), Error> {
     let groups = resp.auto_scaling_groups().unwrap_or_default();
 
     for group in groups {
-        println!(
-            "  {}",
-            group.auto_scaling_group_name().unwrap_or_default()
-        );
+        println!("  {}", group.auto_scaling_group_name().unwrap_or_default());
         println!(
             "  ARN:          {}",
             group.auto_scaling_group_arn().unwrap_or_default()

--- a/rust_dev_preview/batch/Cargo.toml
+++ b/rust_dev_preview/batch/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-batch = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-batch = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/batch/src/bin/batch-helloworld.rs
+++ b/rust_dev_preview/batch/src/bin/batch-helloworld.rs
@@ -27,7 +27,7 @@ async fn show_envs(client: &Client) -> Result<(), Error> {
     println!("Found {} compute environments:", compute_envs.len());
     for env in compute_envs {
         let arn = env.compute_environment_arn().unwrap_or_default();
-        let name = env.compute_environment_name().as_deref().unwrap_or_default();
+        let name = env.compute_environment_name().unwrap_or_default();
 
         println!("  Name : {}", name);
         println!("  ARN:   {}", arn);

--- a/rust_dev_preview/cloudformation/Cargo.toml
+++ b/rust_dev_preview/cloudformation/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-cloudformation = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-cloudformation = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/cloudformation/src/bin/describe-stack.rs
+++ b/rust_dev_preview/cloudformation/src/bin/describe-stack.rs
@@ -30,7 +30,12 @@ async fn describe_stack(client: &Client, name: &str) -> Result<(), Error> {
 
     // Otherwise we get an array of stacks that match the stack_name.
     // The array should only have one item, so just access it via first().
-    let status = resp.stacks().unwrap_or_default().first().unwrap().stack_status();
+    let status = resp
+        .stacks()
+        .unwrap_or_default()
+        .first()
+        .unwrap()
+        .stack_status();
 
     println!("Stack status: {}", status.unwrap().as_ref());
 

--- a/rust_dev_preview/cloudformation/src/bin/list-stacks.rs
+++ b/rust_dev_preview/cloudformation/src/bin/list-stacks.rs
@@ -29,7 +29,6 @@ async fn list_stacks(client: &Client) -> Result<(), Error> {
         println!();
     }
 
-
     Ok(())
 }
 // snippet-end:[cloudformation.rust.list-stacks]

--- a/rust_dev_preview/cognitoidentity/Cargo.toml
+++ b/rust_dev_preview/cognitoidentity/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-cognitoidentity = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-cognitoidentity = "0.0.26-alpha"
+aws-smithy-types-convert = { version = "0.30.0-alpha", features = ["convert-chrono"] }
 tokio = { version = "1", features = ["full"] }
 chrono = "0.4"
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/cognitoidentity/src/bin/list-pool-identities.rs
+++ b/rust_dev_preview/cognitoidentity/src/bin/list-pool-identities.rs
@@ -5,6 +5,7 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cognitoidentity::{Client, Error, Region, PKG_VERSION};
+use aws_smithy_types_convert::date_time::DateTimeExt;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -35,9 +36,9 @@ async fn list_identities(client: &Client, pool_id: &str) -> Result<(), Error> {
     if let Some(ids) = response.identities() {
         println!("Identitities:");
         for id in ids {
-            let creation_timestamp = id.creation_date().unwrap().to_chrono();
+            let creation_timestamp = id.creation_date().unwrap().to_chrono_utc();
             let idid = id.identity_id().unwrap_or_default();
-            let mod_timestamp = id.last_modified_date().unwrap().to_chrono();
+            let mod_timestamp = id.last_modified_date().unwrap().to_chrono_utc();
             println!("  Creation date:      {}", creation_timestamp);
             println!("  ID:                 {}", idid);
             println!("  Last modified date: {}", mod_timestamp);

--- a/rust_dev_preview/cognitoidentityprovider/Cargo.toml
+++ b/rust_dev_preview/cognitoidentityprovider/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-cognitoidentityprovider = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-cognitoidentityprovider = "0.0.26-alpha"
+aws-smithy-types-convert = { version = "0.30.0-alpha", features = ["convert-chrono"] }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/cognitoidentityprovider/src/bin/list-user-pools.rs
+++ b/rust_dev_preview/cognitoidentityprovider/src/bin/list-user-pools.rs
@@ -5,6 +5,7 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cognitoidentityprovider::{Client, Error, Region, PKG_VERSION};
+use aws_smithy_types_convert::date_time::DateTimeExt;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -31,11 +32,11 @@ async fn show_pools(client: &Client) -> Result<(), Error> {
             println!("  Lambda Config:   {:?}", pool.lambda_config().unwrap());
             println!(
                 "  Last modified:   {}",
-                pool.last_modified_date().unwrap().to_chrono()
+                pool.last_modified_date().unwrap().to_chrono_utc()
             );
             println!(
                 "  Creation date:   {:?}",
-                pool.creation_date().unwrap().to_chrono()
+                pool.creation_date().unwrap().to_chrono_utc()
             );
             println!();
         }

--- a/rust_dev_preview/cognitosync/Cargo.toml
+++ b/rust_dev_preview/cognitosync/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-cognitosync = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-cognitosync = "0.0.26-alpha"
+aws-smithy-types-convert = { version = "0.30.0-alpha", features = ["convert-chrono"] }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/cognitosync/src/bin/list-identity-pool-usage.rs
+++ b/rust_dev_preview/cognitosync/src/bin/list-identity-pool-usage.rs
@@ -5,6 +5,7 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cognitosync::{Client, Error, Region, PKG_VERSION};
+use aws_smithy_types_convert::date_time::DateTimeExt;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -45,7 +46,7 @@ async fn show_pools(client: &Client) -> Result<(), Error> {
             );
             println!(
                 "  Last modified:       {}",
-                pool.last_modified_date().unwrap().to_chrono()
+                pool.last_modified_date().unwrap().to_chrono_utc()
             );
             println!();
         }

--- a/rust_dev_preview/config/Cargo.toml
+++ b/rust_dev_preview/config/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.25-alpha", package = "aws-config" }
-aws-sdk-config = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.25-alpha", package = "aws-sdk-config" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.26-alpha", package = "aws-config" }
+aws-sdk-config = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.26-alpha", package = "aws-sdk-config" }
 actix-rt = "*"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/config/src/bin/enable-config.rs
+++ b/rust_dev_preview/config/src/bin/enable-config.rs
@@ -72,7 +72,10 @@ async fn enable_config(
         println!("Use delete-configuration-recorder to delete it before you call this again.");
 
         for recorder in recorders {
-            println!("Recorder: {}", recorder.name().as_deref().unwrap_or_default());
+            println!(
+                "Recorder: {}",
+                recorder.name().as_deref().unwrap_or_default()
+            );
         }
 
         process::exit(1);
@@ -90,7 +93,10 @@ async fn enable_config(
         println!("Use delete-delivery-channel to delete it before you call this again.");
 
         for channel in channels {
-            println!("  Channel: {}", channel.name().as_deref().unwrap_or_default());
+            println!(
+                "  Channel: {}",
+                channel.name().as_deref().unwrap_or_default()
+            );
         }
 
         process::exit(1);

--- a/rust_dev_preview/config/src/bin/list-configuration-recorders.rs
+++ b/rust_dev_preview/config/src/bin/list-configuration-recorders.rs
@@ -29,7 +29,10 @@ async fn show_recorders(client: &Client) -> Result<(), Error> {
         println!("You have no configuration recorders")
     } else {
         for recorder in recorders {
-            println!("Recorder: {}", recorder.name().as_deref().unwrap_or_default());
+            println!(
+                "Recorder: {}",
+                recorder.name().as_deref().unwrap_or_default()
+            );
         }
     }
 

--- a/rust_dev_preview/config/src/bin/list-delivery-channels.rs
+++ b/rust_dev_preview/config/src/bin/list-delivery-channels.rs
@@ -31,7 +31,10 @@ async fn show_channels(client: &Client) -> Result<(), Error> {
         println!("You have no delivery channels")
     } else {
         for channel in channels {
-            println!("  Channel: {}", channel.name().as_deref().unwrap_or_default());
+            println!(
+                "  Channel: {}",
+                channel.name().as_deref().unwrap_or_default()
+            );
         }
     }
 

--- a/rust_dev_preview/cross_service/detect_faces/Cargo.toml
+++ b/rust_dev_preview/cross_service/detect_faces/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-rekognition = "0.0.25-alpha"
-aws-sdk-s3 = "0.0.25-alpha"
-aws-types = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-rekognition = "0.0.26-alpha"
+aws-sdk-s3 = "0.0.26-alpha"
+aws-types = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/cross_service/detect_labels/Cargo.toml
+++ b/rust_dev_preview/cross_service/detect_labels/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-dynamodb = "0.0.25-alpha"
-aws-sdk-rekognition = "0.0.25-alpha"
-aws-sdk-s3 = "0.0.25-alpha"
-aws-types = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-dynamodb = "0.0.26-alpha"
+aws-sdk-rekognition = "0.0.26-alpha"
+aws-sdk-s3 = "0.0.26-alpha"
+aws-types = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/cross_service/telephone/Cargo.toml
+++ b/rust_dev_preview/cross_service/telephone/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-polly = "0.0.25-alpha"
-aws-sdk-s3 = "0.0.25-alpha"
-aws-sdk-transcribe = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-polly = "0.0.26-alpha"
+aws-sdk-s3 = "0.0.26-alpha"
+aws-sdk-transcribe = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 async-stream = "0.3"
 bytes = "1"

--- a/rust_dev_preview/custom_retries/Cargo.toml
+++ b/rust_dev_preview/custom_retries/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-s3 = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-s3 = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/dynamodb/Cargo.toml
+++ b/rust_dev_preview/dynamodb/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-dynamodb = "0.0.25-alpha"
-aws-hyper = "0.0.25-alpha"
-aws-http = "0.0.25-alpha"
-aws-smithy-http = "0.28.0-alpha"
-aws-smithy-types = "0.28.0-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-dynamodb = "0.0.26-alpha"
+aws-hyper = "0.0.26-alpha"
+aws-http = "0.0.26-alpha"
+aws-smithy-http = "0.30.0-alpha"
+aws-smithy-types = "0.30.0-alpha"
 rand = "0.8.3"
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }

--- a/rust_dev_preview/ebs/Cargo.toml
+++ b/rust_dev_preview/ebs/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-ebs = "0.0.25-alpha"
-aws-sdk-ec2 = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-ebs = "0.0.26-alpha"
+aws-sdk-ec2 = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"]}
 base64 = "0.13.0"
 sha2 = "0.9.5"

--- a/rust_dev_preview/ec2/Cargo.toml
+++ b/rust_dev_preview/ec2/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-ec2 = "0.0.25-alpha"
-aws-types = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-ec2 = "0.0.26-alpha"
+aws-types = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"]}
 actix-rt = "*"
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/iam/Cargo.toml
+++ b/rust_dev_preview/iam/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 description = "Example usage of the IAM service"
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-iam = "0.0.25-alpha"
-aws-hyper = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-iam = "0.0.26-alpha"
+aws-hyper = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"]}
 serde_json = "1"
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/iot/Cargo.toml
+++ b/rust_dev_preview/iot/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-iot = "0.0.25-alpha"
-aws-types = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-iot = "0.0.26-alpha"
+aws-types = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/kinesis/Cargo.toml
+++ b/rust_dev_preview/kinesis/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-kinesis = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-kinesis = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/rust_dev_preview/kms/Cargo.toml
+++ b/rust_dev_preview/kms/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 description = "Example usage of the KMS service"
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-kms = "0.0.25-alpha"
-aws-hyper = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-kms = "0.0.26-alpha"
+aws-hyper = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"]}
 base64 = "0.13.0"
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/lambda/Cargo.toml
+++ b/rust_dev_preview/lambda/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-ec2 = "0.0.25-alpha"
-aws-sdk-lambda = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-ec2 = "0.0.26-alpha"
+aws-sdk-lambda = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/rust_dev_preview/logging/logger/Cargo.toml
+++ b/rust_dev_preview/logging/logger/Cargo.toml
@@ -8,8 +8,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.24-alpha"
-aws-sdk-dynamodb = "0.0.24-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-dynamodb = "0.0.26-alpha"
 # snippet-start:[logging.rust.logger-cargo.toml-env_logger]
 env_logger = "0.9.0"
 # snippet-end:[logging.rust.logger-cargo.toml-env_logger]

--- a/rust_dev_preview/logging/tracing/Cargo.toml
+++ b/rust_dev_preview/logging/tracing/Cargo.toml
@@ -8,8 +8,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.24-alpha"
-aws-sdk-dynamodb = "0.0.24-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-dynamodb = "0.0.26-alpha"
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
 # snippet-start:[logging.rust.tracing-cargo.toml-tracing_subscriber]

--- a/rust_dev_preview/medialive/Cargo.toml
+++ b/rust_dev_preview/medialive/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-medialive = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-medialive = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/mediapackage/Cargo.toml
+++ b/rust_dev_preview/mediapackage/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-mediapackage = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-mediapackage = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/polly/Cargo.toml
+++ b/rust_dev_preview/polly/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-polly = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-polly = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 bytes = "1"
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/qldb/Cargo.toml
+++ b/rust_dev_preview/qldb/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-qldb = "0.0.25-alpha"
-aws-sdk-qldbsession = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-qldb = "0.0.26-alpha"
+aws-sdk-qldbsession = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/rust_dev_preview/rds/Cargo.toml
+++ b/rust_dev_preview/rds/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-rds = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-rds = "0.0.26-alpha"
 tokio = {version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/rust_dev_preview/rdsdata/Cargo.toml
+++ b/rust_dev_preview/rdsdata/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-rdsdata = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-rdsdata = "0.0.26-alpha"
 tokio = {version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/rust_dev_preview/route53/Cargo.toml
+++ b/rust_dev_preview/route53/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-route53 = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-route53 = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/rust_dev_preview/s3/Cargo.toml
+++ b/rust_dev_preview/s3/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-s3 = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-s3 = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/sagemaker/Cargo.toml
+++ b/rust_dev_preview/sagemaker/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-sagemaker = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-sagemaker = "0.0.26-alpha"
+aws-smithy-types-convert = { version = "0.30.0-alpha", features = ["convert-chrono"] }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/sagemaker/src/bin/list-training-jobs.rs
+++ b/rust_dev_preview/sagemaker/src/bin/list-training-jobs.rs
@@ -5,6 +5,7 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sagemaker::{Client, Error, Region, PKG_VERSION};
+use aws_smithy_types_convert::date_time::DateTimeExt;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -27,8 +28,8 @@ async fn show_jobs(client: &Client) -> Result<(), Error> {
 
     for j in job_details.training_job_summaries.unwrap_or_default() {
         let name = j.training_job_name.as_deref().unwrap_or_default();
-        let creation_time = j.creation_time.unwrap().to_chrono();
-        let training_end_time = j.training_end_time.unwrap().to_chrono();
+        let creation_time = j.creation_time.unwrap().to_chrono_utc();
+        let training_end_time = j.training_end_time.unwrap().to_chrono_utc();
 
         let status = j.training_job_status.unwrap();
         let duration = training_end_time - creation_time;

--- a/rust_dev_preview/secretsmanager/Cargo.toml
+++ b/rust_dev_preview/secretsmanager/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 description = "Example usage of the SecretManager service"
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-secretsmanager = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-secretsmanager = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/rust_dev_preview/ses/Cargo.toml
+++ b/rust_dev_preview/ses/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Russell Cohen <rcoh@amazon.com>", "Doug Schwartz <dougsch@amazon.com
 edition = "2018"
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-sesv2 = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-sesv2 = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/snowball/Cargo.toml
+++ b/rust_dev_preview/snowball/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-snowball = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-snowball = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/sns/Cargo.toml
+++ b/rust_dev_preview/sns/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-sns = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-sns = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/sqs/Cargo.toml
+++ b/rust_dev_preview/sqs/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-sqs = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-sqs = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/rust_dev_preview/ssm/Cargo.toml
+++ b/rust_dev_preview/ssm/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-ssm = "0.0.25-alpha"
+aws-config = "0.0.26-alpha"
+aws-sdk-ssm = "0.0.26-alpha"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/scripts/testRust.sh
+++ b/scripts/testRust.sh
@@ -20,6 +20,22 @@ vetService () {
 	return
     fi
 
+    # Special case for logging
+    if [ $SERVICE == "logging" ]
+    then
+	for d in ./*
+	do
+	    if [ -d "$d" ]; then
+		pushd $d > /dev/null
+         	vetService $from $to
+	        popd > /dev/null
+		echo
+           fi
+        done
+
+	return
+    fi
+
     # Does Cargo.toml have the old version?
     foundOld=`grep "$1" Cargo.toml`
 
@@ -69,7 +85,8 @@ else
     echo The Rust source is found at $root
 fi
 
-# FromVersion is the old version of the Rust SDK crates that we are replacing
+# FromVersion is the old version of the Rust SDK crates that we are replacing,
+# such as 0.0.NN-alpha"
 if [[ -z "${FromVersion}" ]]; then
     echo You must define the environment variable FromVersion
     exit 1
@@ -88,6 +105,8 @@ else
 fi
 
 echo
+echo Started vetting code examples at
+date
 
 for f in $root/*
 do
@@ -100,3 +119,6 @@ do
 done
 
 echo
+echo Finished vetting code examples at
+date
+


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

## Existing Example Update

The submitter has:

- [x] Confirmed that the correct copyright is included in all files.
- [x] Major code changes have been reviewed, and the submitter has incorporated review comments.
- [ ] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.

### Description of Changes

- Changed crate dependencies to 0.0.26-alpha.
- Changed chrono() to chrono_utc()
- Added dependency on aws-smithy-types-convert to support chrono_utc()

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._