### PR TITLE
Added SoS metadata for Route53 code example in Rust

### DIFF
--- a/.doc_gen/metadata/route53_metadata.yaml
+++ b/.doc_gen/metadata/route53_metadata.yaml
@@ -1,6 +1,6 @@
 # zexi 0.4.3
 route-53_GetHostedZoneCount:
-  title: Get the number of hosted zones that are associated with the current AWS account using an &AWS; SDK
+  title: Get the number of hosted zones that are associated with the current &AWS; account using an &AWS; SDK
   title_abbrev: Get the number of hosted zones
   synopsis: get the number of hosted zones.
   category:
@@ -17,7 +17,7 @@ route-53_GetHostedZoneCount:
   services:
     route-53: {GetHostedZoneCount}
 route-53_ListHostedZones:
-  title: Get a list of the public and private hosted zones associated with the current AWS account using an &AWS; SDK
+  title: Get a list of the public and private hosted zones associated with the current &AWS; account using an &AWS; SDK
   title_abbrev: Get a list of the public and private hosted zones
   synopsis: get a list of the public and private hosted zones.
   category:

--- a/.doc_gen/metadata/route53_metadata.yaml
+++ b/.doc_gen/metadata/route53_metadata.yaml
@@ -1,0 +1,35 @@
+# zexi 0.4.3
+route53_GetHostedZoneCount:
+  title: Get the number of hosted zones that are associated with the current AWS account using an &AWS; SDK
+  title_abbrev: Get the number of hosted zones
+  synopsis: get the number of hosted zones.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rust_dev_preview/route53
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - route53.rust.route53-helloworld
+  services:
+    route53: {GetHostedZoneCount}
+route53_ListHostedZones:
+  title: Get a list of the public and private hosted zones associated with the current AWS account using an &AWS; SDK
+  title_abbrev: Get a list of the public and private hosted zones
+  synopsis: get a list of the public and private hosted zones.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rust_dev_preview/route53
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - route53.rust.route53-helloworld
+  services:
+    route53: {ListHostedZones}

--- a/.doc_gen/metadata/route53_metadata.yaml
+++ b/.doc_gen/metadata/route53_metadata.yaml
@@ -1,23 +1,6 @@
 # zexi 0.4.3
-route-53_GetHostedZoneCount:
-  title: Get the number of hosted zones that are associated with the current &AWS; account using an &AWS; SDK
-  title_abbrev: Get the number of hosted zones
-  synopsis: get the number of hosted zones.
-  category:
-  languages:
-    Rust:
-      versions:
-        - sdk_version: 1
-          github: rust_dev_preview/route53
-          sdkguide:
-          excerpts:
-            - description:
-              snippet_tags:
-                - route53.rust.route53-helloworld
-  services:
-    route-53: {GetHostedZoneCount}
 route-53_ListHostedZones:
-  title: Get a list of the public and private hosted zones associated with the current &AWS; account using an &AWS; SDK
+  title: Get a list of the public and private &R53; hosted zones using an &AWS; SDK
   title_abbrev: Get a list of the public and private hosted zones
   synopsis: get a list of the public and private hosted zones.
   category:

--- a/.doc_gen/metadata/route53_metadata.yaml
+++ b/.doc_gen/metadata/route53_metadata.yaml
@@ -1,5 +1,5 @@
 # zexi 0.4.3
-route53_GetHostedZoneCount:
+route-53_GetHostedZoneCount:
   title: Get the number of hosted zones that are associated with the current AWS account using an &AWS; SDK
   title_abbrev: Get the number of hosted zones
   synopsis: get the number of hosted zones.
@@ -15,8 +15,8 @@ route53_GetHostedZoneCount:
               snippet_tags:
                 - route53.rust.route53-helloworld
   services:
-    route53: {GetHostedZoneCount}
-route53_ListHostedZones:
+    route-53: {GetHostedZoneCount}
+route-53_ListHostedZones:
   title: Get a list of the public and private hosted zones associated with the current AWS account using an &AWS; SDK
   title_abbrev: Get a list of the public and private hosted zones
   synopsis: get a list of the public and private hosted zones.
@@ -32,4 +32,4 @@ route53_ListHostedZones:
               snippet_tags:
                 - route53.rust.route53-helloworld
   services:
-    route53: {ListHostedZones}
+    route-53: {ListHostedZones}

--- a/rust_dev_preview/route53/src/bin/route53-helloworld.rs
+++ b/rust_dev_preview/route53/src/bin/route53-helloworld.rs
@@ -18,6 +18,33 @@ struct Opt {
     verbose: bool,
 }
 
+// Show IDs and names of hosted zones.
+// snippet-start:[route53.rust.route53-helloworld]
+async fn show_zones(client: &aws_sdk_route53::Client) -> Result<(), aws_sdk_route53::Error> {
+    let hosted_zone_count = client.get_hosted_zone_count().send().await?;
+
+    println!(
+        "Number of hosted zones in region : {}",
+        hosted_zone_count.hosted_zone_count.unwrap_or_default(),
+    );
+
+    let hosted_zones = client.list_hosted_zones().send().await?;
+
+    println!("Zones:");
+
+    for hz in hosted_zones.hosted_zones.unwrap_or_default() {
+        let zone_name = hz.name.as_deref().unwrap_or_default();
+        let zone_id = hz.id.as_deref().unwrap_or_default();
+
+        println!("  ID :   {}", zone_id);
+        println!("  Name : {}", zone_name);
+        println!();
+    }
+
+    Ok(())
+}
+// snippet-end:[route53.rust.route53-helloworld]
+
 /// Displays the IDs and names of the hosted zones in the Region.
 /// # Arguments
 ///
@@ -49,25 +76,5 @@ async fn main() -> Result<(), Error> {
     let shared_config = aws_config::from_env().region(region_provider).load().await;
     let client = Client::new(&shared_config);
 
-    let hosted_zone_count = client.get_hosted_zone_count().send().await?;
-
-    println!(
-        "Number of hosted zones in region : {}",
-        hosted_zone_count.hosted_zone_count.unwrap_or_default(),
-    );
-
-    let hosted_zones = client.list_hosted_zones().send().await?;
-
-    println!("Zones:");
-
-    for hz in hosted_zones.hosted_zones.unwrap_or_default() {
-        let zone_name = hz.name.as_deref().unwrap_or_default();
-        let zone_id = hz.id.as_deref().unwrap_or_default();
-
-        println!("  ID :   {}", zone_id);
-        println!("  Name : {}", zone_name);
-        println!();
-    }
-
-    Ok(())
+    show_zones(&client).await
 }


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

## Resolve Issue

Issue #2630 

### Description of Changes

- Added SoS metadata file for Route53 with two Rust entries.

- [ ] Changes have been reviewed, and all reviewer comments have been incorporated.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
