### PR TITLE
Update Python IAM user scenario to create read-write user instead of write-only

### DIFF
--- a/.doc_gen/metadata/iam_metadata.yaml
+++ b/.doc_gen/metadata/iam_metadata.yaml
@@ -1297,9 +1297,9 @@ iam_DetachUserPolicy:
   services:
     iam: {DetachUserPolicy}
 iam_Scenario_UserPolicies:
-  title: Create read-only and write-only &IAM; users using an &AWS; SDK
-  title_abbrev: Create read-only and write-only users
-  synopsis: create two &IAMlong; (&IAM;) users, where one user can only put
+  title: Create read-only and read-write &IAM; users using an &AWS; SDK
+  title_abbrev: Create read-only and read-write users
+  synopsis: create two &IAMlong; (&IAM;) users, where one user can get and put
     objects in an &S3long; (&S3;) bucket and the other can only get objects from
     the bucket. The users' credentials are then used to move objects in and out of
     the bucket.

--- a/python/example_code/iam/iam_basics/README.md
+++ b/python/example_code/iam/iam_basics/README.md
@@ -20,7 +20,7 @@ that control which AWS resources users and applications can access.*
 
 ### Scenario examples
 
-* [Create read-only and write-only users](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/python/example_code/iam/user_wrapper.py)
+* [Create read-only and read-write users](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/python/example_code/iam/user_wrapper.py)
 * [Manage access keys](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/python/example_code/iam/access_key_wrapper.py)
 * [Manage policies](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/python/example_code/iam/policy_wrapper.py)
 * [Manage roles](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/python/example_code/iam/role_wrapper.py)

--- a/python/example_code/iam/iam_basics/user_wrapper.py
+++ b/python/example_code/iam/iam_basics/user_wrapper.py
@@ -135,7 +135,7 @@ def detach_policy(user_name, policy_arn):
 def usage_demo():
     """
     Shows how to manage users, keys, and policies.
-    This demonstration creates two users: one user who can only put objects in an
+    This demonstration creates two users: one user who can put and get objects in an
     Amazon S3 bucket, and another user who can only get objects from the bucket.
     The demo then shows how the users can perform only the actions they are permitted
     to perform.
@@ -154,24 +154,24 @@ def usage_demo():
         }
     )
     print(f"Created an Amazon S3 bucket named {bucket.name}.")
-    user_writer = create_user('demo-iam-writer')
+    user_read_writer = create_user('demo-iam-read-writer')
     user_reader = create_user('demo-iam-reader')
-    print(f"Created two IAM users: {user_writer.name} and {user_reader.name}")
-    update_user(user_writer.name, 'demo-iam-creator')
+    print(f"Created two IAM users: {user_read_writer.name} and {user_reader.name}")
+    update_user(user_read_writer.name, 'demo-iam-creator')
     update_user(user_reader.name, 'demo-iam-getter')
     users = list_users()
-    user_writer = next(user for user in users if user.user_id == user_writer.user_id)
+    user_read_writer = next(user for user in users if user.user_id == user_read_writer.user_id)
     user_reader = next(user for user in users if user.user_id == user_reader.user_id)
-    print(f"Changed the names of the users to {user_writer.name} "
+    print(f"Changed the names of the users to {user_read_writer.name} "
           f"and {user_reader.name}.")
 
-    write_policy = policy_wrapper.create_policy(
-        'demo-iam-write-policy',
-        'Grants rights to create an object in the demo bucket.',
-        's3:PutObject',
+    read_write_policy = policy_wrapper.create_policy(
+        'demo-iam-read-write-policy',
+        'Grants rights to create and get an object in the demo bucket.',
+        ['s3:PutObject', 's3:GetObject'],
         f'arn:aws:s3:::{bucket.name}/*')
-    print(f"Created policy {write_policy.policy_name} with ARN: {write_policy.arn}")
-    print(write_policy.description)
+    print(f"Created policy {read_write_policy.policy_name} with ARN: {read_write_policy.arn}")
+    print(read_write_policy.description)
     read_policy = policy_wrapper.create_policy(
         'demo-iam-read-policy',
         'Grants rights to get an object from the demo bucket.',
@@ -179,25 +179,25 @@ def usage_demo():
         f'arn:aws:s3:::{bucket.name}/*')
     print(f"Created policy {read_policy.policy_name} with ARN: {read_policy.arn}")
     print(read_policy.description)
-    attach_policy(user_writer.name, write_policy.arn)
-    print(f"Attached {write_policy.policy_name} to {user_writer.name}.")
+    attach_policy(user_read_writer.name, read_write_policy.arn)
+    print(f"Attached {read_write_policy.policy_name} to {user_read_writer.name}.")
     attach_policy(user_reader.name, read_policy.arn)
     print(f"Attached {read_policy.policy_name} to {user_reader.name}.")
 
-    user_writer_key = access_key_wrapper.create_key(user_writer.name)
-    print(f"Created access key pair for {user_writer.name}.")
+    user_read_writer_key = access_key_wrapper.create_key(user_read_writer.name)
+    print(f"Created access key pair for {user_read_writer.name}.")
     user_reader_key = access_key_wrapper.create_key(user_reader.name)
     print(f"Created access key pair for {user_reader.name}.")
 
-    s3_writer_resource = boto3.resource(
+    s3_read_writer_resource = boto3.resource(
         's3',
-        aws_access_key_id=user_writer_key.id,
-        aws_secret_access_key=user_writer_key.secret)
+        aws_access_key_id=user_read_writer_key.id,
+        aws_secret_access_key=user_read_writer_key.secret)
     demo_object_key = f'object-{time.time_ns()}'
     demo_object = None
     while demo_object is None:
         try:
-            demo_object = s3_writer_resource.Bucket(bucket.name).put_object(
+            demo_object = s3_read_writer_resource.Bucket(bucket.name).put_object(
                 Key=demo_object_key, Body=b'AWS IAM demo object content!')
         except ClientError as error:
             if error.response['Error']['Code'] == 'InvalidAccessKeyId':
@@ -206,17 +206,14 @@ def usage_demo():
             else:
                 raise
     print(f"Put {demo_object_key} into {bucket.name} using "
-          f"{user_writer.name}'s credentials.")
+          f"{user_read_writer.name}'s credentials.")
 
-    try:
-        s3_writer_resource.Bucket(bucket.name).Object(demo_object_key).get()
-    except ClientError as error:
-        if error.response['Error']['Code'] == 'AccessDenied':
-            print("Tried to get the demo object with the writer user's credentials. "
-                  "Got expected AccessDenied error because the writer is not allowed "
-                  "to get objects.")
-        else:
-            raise
+    read_writer_object = s3_read_writer_resource.Bucket(
+        bucket.name).Object(demo_object_key)
+    read_writer_content = read_writer_object.get()['Body'].read()
+    print(f"Got object {read_writer_object.key} using read-writer user's credentials.")
+    print(f"Object content: {read_writer_content}")
+
     s3_reader_resource = boto3.resource(
         's3',
         aws_access_key_id=user_reader_key.id,
@@ -239,9 +236,11 @@ def usage_demo():
         demo_object.delete()
     except ClientError as error:
         if error.response['Error']['Code'] == 'AccessDenied':
+            print('-'*88)
             print("Tried to delete the object using the reader user's credentials. "
                   "Got expected AccessDenied error because the reader is not "
                   "allowed to delete objects.")
+            print('-'*88)
 
     access_key_wrapper.delete_key(user_reader.name, user_reader_key.id)
     detach_policy(user_reader.name, read_policy.arn)
@@ -249,11 +248,11 @@ def usage_demo():
     delete_user(user_reader.name)
     print(f"Deleted keys, detached and deleted policy, and deleted {user_reader.name}.")
 
-    access_key_wrapper.delete_key(user_writer.name, user_writer_key.id)
-    detach_policy(user_writer.name, write_policy.arn)
-    policy_wrapper.delete_policy(write_policy.arn)
-    delete_user(user_writer.name)
-    print(f"Deleted keys, detached and deleted policy, and deleted {user_writer.name}.")
+    access_key_wrapper.delete_key(user_read_writer.name, user_read_writer_key.id)
+    detach_policy(user_read_writer.name, read_write_policy.arn)
+    policy_wrapper.delete_policy(read_write_policy.arn)
+    delete_user(user_read_writer.name)
+    print(f"Deleted keys, detached and deleted policy, and deleted {user_read_writer.name}.")
 
     bucket.objects.delete()
     bucket.delete()


### PR DESCRIPTION
The existing Python IAM user scenario creates a read-only and a write-only user. Feedback suggests a read-write user is a better practice to demonstrate. This PR updates the scenario to create a read-write user.

- [x] I have tested my changes and created unit tests for new code paths.
- [ ] Changes have been reviewed, and all reviewer comments have been incorporated.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
