### PR TITLE
Added snippet tag accidentally removed in previous IAM MVP commit

### DIFF
--- a/python/example_code/iam/iam_basics/scenario_create_user_assume_role.py
+++ b/python/example_code/iam/iam_basics/scenario_create_user_assume_role.py
@@ -140,6 +140,7 @@ def show_access_denied_without_role(user_key):
             raise
 
 
+# snippet-start:[iam.python.assume_role.complete]
 def list_buckets_from_assumed_role(user_key, assume_role_arn, session_name):
     """
     Assumes a role that grants permission to list the Amazon S3 buckets in the account.
@@ -177,6 +178,7 @@ def list_buckets_from_assumed_role(user_key, assume_role_arn, session_name):
         print(f"Couldn't list buckets for the account. Here's why: "
               f"{error.response['Error']['Message']}")
         raise
+# snippet-end:[iam.python.assume_role.complete]
 
 
 def teardown(user, role):


### PR DESCRIPTION
A service guide relies on the `iam.python.assume_role.complete` tag, which got dropped when I moved a file in the IAM MVP commit. This adds it back in.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
