### PR TITLE
Restore Rust DynamoDB paginator examples

### DIFF
--- a/rust_dev_preview/dynamodb/Cargo.toml
+++ b/rust_dev_preview/dynamodb/Cargo.toml
@@ -18,5 +18,5 @@ rand = "0.8.3"
 serde_json = "1"
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
-#tokio-stream = "0.1.8"
+tokio-stream = "0.1.8"
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }


### PR DESCRIPTION
## Existing Example Update

The submitter has:

- [x] Confirmed that the correct copyright is included in all files.
- [x] Major code changes have been reviewed, and the submitter has incorporated review comments.
- [x] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.

### Description of Changes

A couple of DynamoDB paginator examples from [awslabs/smithy-rs](https://github.com/awslabs/smithy-rs) were lost in https://github.com/awsdocs/aws-doc-sdk-examples/pull/2726. This PR restores them.

- [x] I have tested my changes ~~and created unit tests for new code paths.~~
- [x] Changes have been reviewed, and all reviewer comments have been incorporated.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
