### PR TITLE
SOS: Add title_override to metadata validator

### DIFF
--- a/.doc_gen/validation/sdks_schema.yaml
+++ b/.doc_gen/validation/sdks_schema.yaml
@@ -13,11 +13,16 @@ version:
   caveat: str(required=False, upper_start=True, end_punc=True)
   bookmark: str(required=False)
   api_ref: include('api_ref', required=False)
+  title_override: include('title_override', required=False)
 
 api_ref:
   uid: str(check_aws=False)
   name: include('entity_regex')
   link_template: str(required=False, check_aws=False)
+
+title_override:
+  title: str()
+  title_abbrev: str()
 
 syntax_enum: enum('cpp', 'go', 'java', 'javascript', 'kotlin', 'csharp', 'php', 'python', 'ruby', 'rust', 'swift')
 entity_regex: regex('^[&]([\dA-Za-z-_])+[;]$', name='valid entity')


### PR DESCRIPTION
A `title_override` features was added for SDK guides in the latest SOS tool update. This adds that field to the validator so we can actually use it.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
