### PR TITLE
Editorial feedback on 'for a complete list' blurb.

### DIFF
--- a/.doc_gen/templates/zonbook/service_chapter_bundle_template.xml
+++ b/.doc_gen/templates/zonbook/service_chapter_bundle_template.xml
@@ -18,9 +18,9 @@
     </info>
     <para>The following code examples show how to use {{.BundleOwner.Short}} with an &AWS; software development kit (SDK).
         {{.BundleOwner.Caveat}}</para>
-    <para>For a complete list of &AWS; SDK developer guides and code examples, including help getting started
-        and information about previous versions, see
-        <xref linkend="sdk-general-information-section" endterm="sdk-general-information-section.title"></xref>.</para>
+    <para>For a complete list of &AWS; SDK developer guides and code examples, see
+        <xref linkend="sdk-general-information-section" endterm="sdk-general-information-section.title"></xref>.
+        This topic also includes information about getting started and details about previous SDK versions.</para>
     <para role="contents-abbrev">Code examples</para>
     {{- range $model := .BundledModels}}
     <xi:include href="file://AWSShared/code-samples/docs/{{$model}}_code_examples_section.xml"></xi:include>

--- a/.doc_gen/templates/zonbook/service_chapter_template.xml
+++ b/.doc_gen/templates/zonbook/service_chapter_template.xml
@@ -51,9 +51,9 @@
         </varlistentry>
         {{- end }}
     </variablelist>
-    <para>For a complete list of &AWS; SDK developer guides and code examples, including help getting started
-        and information about previous versions, see
-        <xref linkend="sdk-general-information-section" endterm="sdk-general-information-section.title"></xref>.</para>
+    <para>For a complete list of &AWS; SDK developer guides and code examples, see
+        <xref linkend="sdk-general-information-section" endterm="sdk-general-information-section.title"></xref>.
+        This topic also includes information about getting started and details about previous SDK versions.</para>
     <para role="contents-abbrev">Code examples</para>
     {{- range $category := .CategoryNamesSorted}}
     {{- with $cat_examples := index $.CategorizedExampleSets $category}}
@@ -112,9 +112,9 @@
             <para>For more information, see <ulink {{.GuideTopic.DocType}} url="{{.GuideTopic.Url}}">{{.GuideTopic.Text}}</ulink>.</para>
             {{- end}}
             <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}{{$addSvc}}_tablist.xml"></xi:include>
-            <para>For a complete list of &AWS; SDK developer guides and code examples, including help getting started
-                and information about previous versions, see
-                <xref linkend="sdk-general-information-section" endterm="sdk-general-information-section.title"></xref>.</para>
+            <para>For a complete list of &AWS; SDK developer guides and code examples, see
+                <xref linkend="sdk-general-information-section" endterm="sdk-general-information-section.title"></xref>.
+                This topic also includes information about getting started and details about previous SDK versions.</para>
         </section>
         {{- end}}
     </section>


### PR DESCRIPTION
Update the "For a complete list..." blurb that appears in a few places in the SOS doc output, according to editorial feedback.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
