### PR TITLE
Python ticket fixes

### DIFF
--- a/python/example_code/s3/s3_basics/presigned_url.py
+++ b/python/example_code/s3/s3_basics/presigned_url.py
@@ -53,7 +53,9 @@ def usage_demo():
 
     parser = argparse.ArgumentParser()
     parser.add_argument('bucket', help="The name of the bucket.")
-    parser.add_argument('key', help="The key of the object.")
+    parser.add_argument(
+        'key', help="For a GET operation, the key of the object in Amazon S3. For a "
+                    "PUT operation, the name of a file to upload.")
     parser.add_argument(
         'action', choices=('get', 'put'), help="The action to perform.")
     args = parser.parse_args()
@@ -69,13 +71,18 @@ def usage_demo():
         response = requests.get(url)
     elif args.action == 'put':
         print("Putting data to the URL.")
-        with open(args.key, 'r') as object_file:
-            object_text = object_file.read()
-        response = requests.put(url, data=object_text)
+        try:
+            with open(args.key, 'r') as object_file:
+                object_text = object_file.read()
+            response = requests.put(url, data=object_text)
+        except FileNotFoundError:
+            print(f"Couldn't find {args.key}. For a PUT operation, the key must be the "
+                  f"name of a file that exists on your computer.")
 
-    print("Got response:")
-    print(f"Status: {response.status_code}")
-    print(response.text)
+    if response is not None:
+        print("Got response:")
+        print(f"Status: {response.status_code}")
+        print(response.text)
 
     print('-'*88)
 

--- a/python/example_code/signv4/v4-signing-get-querystring.py
+++ b/python/example_code/signv4/v4-signing-get-querystring.py
@@ -22,7 +22,7 @@
 # See: http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
 # This version makes a GET request and passes request parameters
 # and authorization information in the query string
-import sys, os, base64, datetime, hashlib, hmac, urllib
+import sys, os, datetime, hashlib, hmac, urllib.parse
 import requests # pip install requests
 
 # ************* REQUEST VALUES *************
@@ -88,10 +88,9 @@ credential_scope = datestamp + '/' + region + '/' + service + '/' + 'aws4_reques
 # Step 4: Create the canonical query string. In this example, request
 # parameters are in the query string. Query string values must
 # be URL-encoded (space=%20). The parameters must be sorted by name.
-# use urllib.parse.quote_plus() if using Python 3
 canonical_querystring = 'Action=CreateUser&UserName=NewUser&Version=2010-05-08'
 canonical_querystring += '&X-Amz-Algorithm=AWS4-HMAC-SHA256'
-canonical_querystring += '&X-Amz-Credential=' + urllib.quote_plus(access_key + '/' + credential_scope)
+canonical_querystring += '&X-Amz-Credential=' + urllib.parse.quote_plus(access_key + '/' + credential_scope)
 canonical_querystring += '&X-Amz-Date=' + amz_date
 canonical_querystring += '&X-Amz-Expires=30'
 canonical_querystring += '&X-Amz-SignedHeaders=' + signed_headers


### PR DESCRIPTION
Resolve two customer issues:

* presigned_url.py was unclear about the meaning of 'key' when performing a PUT operation. The example is updated with better instructions and a better error message.
* The  signv4 get query string example used an old version of urllib. Updated to use the latest version.

- [x] I have tested my changes.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
