### PR TITLE
SOS: Wrap 'AWS' in an entity in markdown note.

### DIFF
--- a/.doc_gen/templates/zonbook/service_chapter_template.xml
+++ b/.doc_gen/templates/zonbook/service_chapter_template.xml
@@ -102,7 +102,7 @@
             <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}_desc.xml"></xi:include>
             <note buildtype="markdown">
                 <para>The source code for these examples is in the
-                    <ulink url="https://github.com/awsdocs/aws-doc-sdk-examples">AWS Code Examples GitHub repository</ulink>.
+                    <ulink url="https://github.com/awsdocs/aws-doc-sdk-examples">&AWS; Code Examples GitHub repository</ulink>.
                     Have feedback on a code example?
                     <ulink url="https://github.com/awsdocs/aws-doc-sdk-examples/issues/new/choose">Create an Issue</ulink>
                     in the code examples repo.


### PR DESCRIPTION
The markdown note includes the phrase "AWS Code Examples". All uses of "AWS" must be entities or it breaks the doc build, so this fixes the string to "&AWS; Code Examples".

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
