### PR TITLE
Updates npm run script to correctly build main.js

### DIFF
--- a/javascriptv3/example_code/polly/package.json
+++ b/javascriptv3/example_code/polly/package.json
@@ -6,7 +6,7 @@
   "author": "Brian Murray <brmur@amazon.com>, Alex Forsyth <alex-git@amazon.com>",
   "license": "Apache 2.0",
   "scripts": {
-    "run":"webpack polly.js --mode development --libraryTarget commonjs2 --target web --devtool false -o main.js"
+    "run":"webpack src/polly.js --mode development --libraryTarget commonjs2 --target web --devtool false -o src/dist/main.js"
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity": "^3.32.0",


### PR DESCRIPTION
Old version of npm's run script does not correctly specify the entry point for webpack, resulting in error while building main.js.
Additionally, since polly.html specifies the source of main.js to be "./dist/main.js", we modify the script's output file path to match this specification.

## Existing Example Update

The submitter has:

- [x] Confirmed that the correct copyright is included in all files.
- [x] Major code changes have been reviewed, and the submitter has incorporated review comments.
- [x] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
