### PR TITLE
Fix incorrect example account ID.

### DIFF
--- a/gov2/iam/common/examples.go
+++ b/gov2/iam/common/examples.go
@@ -250,8 +250,8 @@ func examples(cfg aws.Config) ExampleCreatedResources {
 					"dynamodb:UpdateItem"
 				],
 				"Resource": [
-					"arn:aws:dynamodb:us-west-2:111222333444:table/mytable",
-					"arn:aws:dynamodb:us-west-2:111222333444:table/mytable/*"
+					"arn:aws:dynamodb:us-west-2:123456789012:table/mytable",
+					"arn:aws:dynamodb:us-west-2:123456789012:table/mytable/*"
 				]
 			}
 		]
@@ -288,7 +288,7 @@ func examples(cfg aws.Config) ExampleCreatedResources {
 
 	//snippet-end:[iam.go-v2.ListPolicies]
 	fmt.Println("✅ GetPolicy " + *policyArn)
-	//snippet-start:[iam.go-v2.Getpolicy]
+	//snippet-start:[iam.go-v2.GetPolicy]
 	// GetPolicy
 
 	getPolicyResponse, err := service.GetPolicy(context.Background(), &iam.GetPolicyInput{
@@ -303,7 +303,7 @@ func examples(cfg aws.Config) ExampleCreatedResources {
 		*getPolicyResponse.Policy.Arn,
 		*getPolicyResponse.Policy.PolicyName)
 
-	//snippet-end:[iam.go-v2.Getpolicy]
+	//snippet-end:[iam.go-v2.GetPolicy]
 
 	fmt.Println("🏘 ListGroups")
 	//snippet-start:[iam.go-v2.ListGroups]


### PR DESCRIPTION
Fixes a miscapitalized snippet tag and an example account ID.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
