### PR TITLE
awsdocs_general.sh: Interpret "\n" in iecho and errecho

### DIFF
--- a/aws-cli/bash-linux/ec2/change-ec2-instance-type/awsdocs_general.sh
+++ b/aws-cli/bash-linux/ec2/change-ec2-instance-type/awsdocs_general.sh
@@ -90,7 +90,7 @@ function test_failed {
 # This function outputs everything sent to it to STDERR (standard error output).
 ###############################################################################
 function errecho {
-    printf "%s\n" "$*" 2>&1
+    printf "%b\n" "$*" 2>&1
 }
 
 ###############################################################################
@@ -101,7 +101,7 @@ function errecho {
 ###############################################################################
 function iecho {
     if [[ $VERBOSE == true ]]; then
-        echo "$@"
+        echo -e "$@"
     fi
 }
 


### PR DESCRIPTION
`\n` are used in some of the `iecho` and `errecho` and were displayed literally as `\n` to the screen instead of adding a newline.

## Existing Example Update

The submitter has:

- [x] Confirmed that the correct copyright is included in all files.
- [ ] [N/A] Major code changes have been reviewed, and the submitter has incorporated review comments.
- [ ] [N/A] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
