### PR TITLE
Fix typos in comments, variables and strings in Go V2 SDK

### DIFF
--- a/gov2/cross_service/wordfreq/wordfreq.go
+++ b/gov2/cross_service/wordfreq/wordfreq.go
@@ -37,7 +37,7 @@ func NewWordfreqStack(scope constructs.Construct, id string, props *WordfreqStac
 		- a service to process the data
 			- read/delete items in the bucket
 			- consume items from the input queue
-			- add items to the ouput queue
+			- add items to the output queue
 		- a role to submit data and collect results.
 
 		The bucket needs to self-expire contents.

--- a/gov2/cross_service/wordfreq/wordfreq/shared/s3/parser_test.go
+++ b/gov2/cross_service/wordfreq/wordfreq/shared/s3/parser_test.go
@@ -67,7 +67,7 @@ func TestParseFullMessage(t *testing.T) {
 		t.Fatal("Event identiy principal was not parsed")
 	}
 
-	// make sure the source address is appropariately parsed out.
+	// make sure the source address is appropriately parsed out.
 	if record.SourceAddress == nil {
 		t.Fatal("source address was not parsed")
 	}

--- a/gov2/ec2/common/CreateImagev2.go
+++ b/gov2/ec2/common/CreateImagev2.go
@@ -75,7 +75,7 @@ func CreateImageCmd() {
 
 	resp, err := MakeImage(context.TODO(), client, input)
 	if err != nil {
-		fmt.Println("Got an error createing image:")
+		fmt.Println("Got an error creating image:")
 		fmt.Println(err)
 		return
 	}

--- a/gov2/ec2/common/CreateImagev2_test.go
+++ b/gov2/ec2/common/CreateImagev2_test.go
@@ -45,7 +45,7 @@ func TestCreateImage(t *testing.T) {
 
 	resp, err := MakeImage(context.Background(), api, input)
 	if err != nil {
-		fmt.Println("Got an error createing image:")
+		fmt.Println("Got an error creating image:")
 		fmt.Println(err)
 		return
 	}

--- a/gov2/ec2/common/MonitorInstancesv2_test.go
+++ b/gov2/ec2/common/MonitorInstancesv2_test.go
@@ -52,7 +52,7 @@ func TestMonitorInstances(t *testing.T) {
 
 		result, err := DisableMonitoring(context.Background(), api, input)
 		if err != nil {
-			fmt.Println("Got an error disablying monitoring for instance:")
+			fmt.Println("Got an error disabling monitoring for instance:")
 			fmt.Println(err)
 			return
 		}

--- a/gov2/iam/AttachUserPolicy/AttachUserPolicyv2_test.go
+++ b/gov2/iam/AttachUserPolicy/AttachUserPolicyv2_test.go
@@ -20,7 +20,7 @@ func (dt IAMAttachRolePolicyImpl) AttachRolePolicy(ctx context.Context,
 	// PolicyArn
 	// RoleName
 	if nil == params.PolicyArn || *params.PolicyArn == "" || nil == params.RoleName || *params.RoleName == "" {
-		args := "POlicyArn or RoleName is nil or an empty string"
+		args := "PolicyArn or RoleName is nil or an empty string"
 		return nil, errors.New(args)
 	}
 

--- a/gov2/iam/common/examples.go
+++ b/gov2/iam/common/examples.go
@@ -263,7 +263,7 @@ func examples(cfg aws.Config) ExampleCreatedResources {
 	})
 
 	if err != nil {
-		panic("Could't create policy!" + err.Error())
+		panic("Couldn't create policy!" + err.Error())
 	}
 
 	fmt.Print("Created a new policy: " + *createPolicyResult.Policy.Arn)

--- a/gov2/rekognition/DetectLabels/DetectLabels.go
+++ b/gov2/rekognition/DetectLabels/DetectLabels.go
@@ -192,13 +192,13 @@ type RekognitionDetectLabelsAPI interface {
 		optFns ...func(*rekognition.Options)) (*rekognition.DetectLabelsOutput, error)
 }
 
-// GetLabels retrieves the lables in a jpg or png image.
+// GetLabels retrieves the labels in a jpg or png image.
 // Inputs:
 //     c is the context of the method call, which includes the AWS Region.
 //     api is the interface that defines the method call.
 //     input defines the input arguments to the service call.
 // Output:
-//     If successful, a DetectLablesOutput object containing the result of the service call and nil.
+//     If successful, a DetectLabelsOutput object containing the result of the service call and nil.
 //     Otherwise, nil and an error from the call to DetectLabels.
 func GetLabels(c context.Context, api RekognitionDetectLabelsAPI, input *rekognition.DetectLabelsInput) (*rekognition.DetectLabelsOutput, error) {
 	resp, err := api.DetectLabels(c, input)

--- a/gov2/sqs/CreateQueue/CreateQueuev2_test.go
+++ b/gov2/sqs/CreateQueue/CreateQueuev2_test.go
@@ -22,7 +22,7 @@ func (dt SQSCreateQueueImpl) CreateQueue(ctx context.Context,
 	optFns ...func(*sqs.Options)) (*sqs.CreateQueueOutput, error) {
 
 	output := &sqs.CreateQueueOutput{
-		QueueUrl: aws.String("aws-docs-example-qaueue-url"),
+		QueueUrl: aws.String("aws-docs-example-queue-url"),
 	}
 
 	return output, nil


### PR DESCRIPTION
### Description of Changes

- [x] Fixed typos in comments, variables, and other strings in Go V2 SDK.
- [x] Changes have been reviewed, and all reviewer comments have been incorporated.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
