### PR TITLE
Update mod files for testtools to point to GitHub sources instead of local folders

### DIFF
--- a/gov2/dynamodb/go.mod
+++ b/gov2/dynamodb/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.8.4
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.4.5
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.15.3
-	github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-00010101000000-000000000000
-	github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools v0.0.0-00010101000000-000000000000
+	github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20220706224858-5c7f475624dc
+	github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools v0.0.0-20220706224858-5c7f475624dc
 )
 
 require (
@@ -28,7 +28,3 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )
-
-replace github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools => ../demotools
-
-replace github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools => ../testtools

--- a/gov2/dynamodb/go.sum
+++ b/gov2/dynamodb/go.sum
@@ -32,6 +32,10 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.3 h1:cJGRyzCSVwZC7zZZ1xbx9m32UnrK
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.3/go.mod h1:bfBj0iVmsUyUg4weDB4NxktD9rDGeKSVWnjTnwbx9b8=
 github.com/aws/smithy-go v1.11.2 h1:eG/N+CcUMAvsdffgMvjMKwfyDzIkjM6pfxMJ8Mzc6mE=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
+github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20220706224858-5c7f475624dc h1:GXIhJ+DrwX3Jy97Tvr0RsMSWa71jkZMHEJA906F/dMs=
+github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20220706224858-5c7f475624dc/go.mod h1:0r22nlw0YYkUMowQkNluzs2dc8kf6s2bg9Oema9TzlE=
+github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools v0.0.0-20220706224858-5c7f475624dc h1:so4oHlm/tkXyJLgrGNny31jqppmezivsObRCmHwMCLU=
+github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools v0.0.0-20220706224858-5c7f475624dc/go.mod h1:eYo61vnozsPsxLFPmQOkdDAvn0K6EX1wDrf+3IZM514=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/gov2/testtools/go.mod
+++ b/gov2/testtools/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.16.2
 	github.com/aws/aws-sdk-go-v2/config v1.15.3
 	github.com/aws/smithy-go v1.11.2
-	github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-00010101000000-000000000000
+	github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20220706224858-5c7f475624dc
 )
 
 require (
@@ -19,5 +19,3 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.3 // indirect
 )
-
-replace github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools => ../demotools

--- a/gov2/testtools/go.sum
+++ b/gov2/testtools/go.sum
@@ -20,6 +20,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.3 h1:cJGRyzCSVwZC7zZZ1xbx9m32UnrK
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.3/go.mod h1:bfBj0iVmsUyUg4weDB4NxktD9rDGeKSVWnjTnwbx9b8=
 github.com/aws/smithy-go v1.11.2 h1:eG/N+CcUMAvsdffgMvjMKwfyDzIkjM6pfxMJ8Mzc6mE=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
+github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20220706224858-5c7f475624dc h1:GXIhJ+DrwX3Jy97Tvr0RsMSWa71jkZMHEJA906F/dMs=
+github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20220706224858-5c7f475624dc/go.mod h1:0r22nlw0YYkUMowQkNluzs2dc8kf6s2bg9Oema9TzlE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=


### PR DESCRIPTION
Now that demotools and testools are live on GH, the mod files can point to the source on GitHub instead of local relative folders.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
