### PR TITLE
Change capitalization of DynamoDB to dynamodb

### DIFF
--- a/.doc_gen/metadata/dynamodb_metadata.yaml
+++ b/.doc_gen/metadata/dynamodb_metadata.yaml
@@ -8,7 +8,7 @@ dynamodb_CreateTable:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description:
               snippet_tags:
@@ -114,7 +114,7 @@ dynamodb_BatchGetItem:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description:
               snippet_tags:
@@ -230,7 +230,7 @@ dynamodb_BatchWriteItem:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description: Writes a batch of items to the movie table.
               snippet_tags:
@@ -311,7 +311,7 @@ dynamodb_DeleteTable:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description:
               snippet_tags:
@@ -415,7 +415,7 @@ dynamodb_PutItem:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description:
               snippet_tags:
@@ -633,7 +633,7 @@ dynamodb_UpdateItem:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description:
               snippet_tags:
@@ -741,7 +741,7 @@ dynamodb_DeleteItem:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description:
               snippet_tags:
@@ -947,7 +947,7 @@ dynamodb_Query:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description:
               snippet_tags:
@@ -1072,7 +1072,7 @@ dynamodb_Scan:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description:
               snippet_tags:
@@ -1180,7 +1180,7 @@ dynamodb_ExecuteStatement:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description: Use an INSERT statement to add an item.
               snippet_tags:
@@ -1262,7 +1262,7 @@ dynamodb_BatchExecuteStatement:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description: Use batches of INSERT statements to add items.
               snippet_tags:
@@ -1381,7 +1381,7 @@ dynamodb_Scenario_GettingStartedMovies:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description:
               snippet_tags:
@@ -1544,7 +1544,7 @@ dynamodb_Scenario_PartiQLSingle:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description:
               snippet_tags:
@@ -1629,7 +1629,7 @@ dynamodb_Scenario_PartiQLBatch:
     .NET:
       versions:
         - sdk_version: 3
-          github: dotnetv3/DynamoDB
+          github: dotnetv3/dynamodb
           excerpts:
             - description:
               snippet_tags:


### PR DESCRIPTION
This is a minor fix to correct the capitalization of the folder in the SoS links.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
