### PR TITLE
Adding additional languages/tools to auto-labeler 

### DIFF
--- a/.github/label-ruleset.yml
+++ b/.github/label-ruleset.yml
@@ -1,2 +1,36 @@
+lang/cpp:
+  - cpp/**/*
+lang/dotnet-v3:
+  - dotnetv3/**/*
+lang/go-v1:
+  - go/**/*
+lang/go-v2:
+  - gov2/**/*
+lang/java-v1:
+  - java/**/*
+lang/java-v2:
+  - javav2/**/*
+lang/javascript-v2:
+  - javascript/**/*
+lang/javascript-v3:
+  - javascriptv3/**/*
+lang/kotlin:
+  - kotlin/**/*
+lang/php:
+  - php/**/*
+lang/python:
+  - python/**/*
 lang/ruby:
   - ruby/**/*
+lang/rust:
+  - rust_dev_preview/**/*
+lang/swift:
+  - swift/**/*
+lang/typescript:
+  - typescript/**/*
+tool/cli:
+  - aws-cli/**/*
+tool/cdk:
+  - resources/cdk/**/*
+tool/cloudformation:
+  - cloudformation/**/*


### PR DESCRIPTION
# context
Last sprint, I fixed the auto-labeling tool that tags PR's based on the subdirectory where the change was made. 

Per the team's request, I added all of the main languages and tools to the auto-labeler.

---

# what's in this PR
Just a single file change, summarized as follows:
* **Before**, only Ruby stuff got the Ruby label.
* **Now**, most of the languages and tools that have their own top-level directories are auto-labeled.

---

# risks/backout
If our auto-label workflow goes haywire, we can back out this change in a matter of minutes with a code push to main disabling it in the YAML.

# afterword
Yes, auto-label is a word and I invented it.

