### PR TITLE
[BUG] Fix label-linter.yml

### DIFF
--- a/.github/workflows/label-linter.yml
+++ b/.github/workflows/label-linter.yml
@@ -1,6 +1,6 @@
 name: "Lint Labels"
 
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   label-linter:
@@ -18,12 +18,12 @@ jobs:
       #
       # For more information, see:
       # https://github.com/actions/labeler
-      #-
-      #  name: Add Labels
-      #  uses: actions/labeler@v4
-      #  with:
-      #    repo-token: "${{ secrets.GITHUB_TOKEN }}"
-      #    configuration-path: .github/label-ruleset.yml
+      -
+       name: Add Labels
+       uses: actions/labeler@v4
+       with:
+         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+         configuration-path: .github/label-ruleset.yml
 
       # The Audit Labels workflow creates, renames, updates
       # or deletes labels based on a list of allowed labels.

--- a/.github/workflows/label-linter.yml
+++ b/.github/workflows/label-linter.yml
@@ -4,6 +4,9 @@ on: [pull_request_target]
 
 jobs:
   label-linter:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
# context
Yesterday, I merged in a change that put into heavy use a new `Auto-Labeler` GitHub Action that we believed fit nicely with our PR process. That evening, Jason noticed that the "Auto-Labeling" action was failing when executed from forks.

# research
I discovered that this is a well-known bug which no published workaround; however, I was able to discover a new trigger called `pull_request_target`, which behaves in an almost identical way to the `pull_request` event, except instead of running against the workflow and code _from the merge commit_, it runs against the workflow and code _from the base of the pull request_.

This makes it so the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. This event can be used in combination with the private repository settings as well.