### PR TITLE
Change deprecated copySource method

### DIFF
--- a/javav2/example_code/s3/src/main/java/com/example/s3/CopyObject.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/CopyObject.java
@@ -73,7 +73,7 @@ public class CopyObject {
         }
         
         CopyObjectRequest copyReq = CopyObjectRequest.builder()
-            .copySource(encodedUrl)
+            .copySourceIfMatch(encodedUrl)
             .destinationBucket(toBucket)
             .destinationKey(objectKey)
             .build();


### PR DESCRIPTION
This is forJava2.

The `copySource` is deprecated. So I updated it since I'll be using this snippet.

# aws-doc-sdk-examples Pull Request

Thank you for making a submission to the *aws-doc-sdk-examples* repository. For more information about submitting pull requests to this repository, see [Guidelines for contributing](/CONTRIBUTING.md).

*NOTE:* This PR template contains three sections. Depending on the reason for your pull request, please fill out the section that applies to you and then remove the other two sections.

## New SDK Code Example

The submitter has:

- [ ] Added the default copyright notice to all files.
- [ ] Created unit tests for all paths through the code and they all pass.
- [ ] Run a linter against all code and implemented the resulting suggestions.
- [ ] Added minimum usage documentation as comments in the code.
- [ ] Had comments and strings reviewed and incorporated suggested changes.
- [ ] Had the code reviewed and implemented the reviewer's suggested changes.

## Existing Example Update

The submitter has:

- [ ] Confirmed that the correct copyright is included in all files.
- [ ] Major code changes have been reviewed, and the submitter has incorporated review comments.
- [ ] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.

## Resolve Issue

Issue #

### Description of Changes

Please describe the changes you have made here.

- [ ] I have tested my changes and created unit tests for new code paths.
- [ ] Changes have been reviewed, and all reviewer comments have been incorporated.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
