### PR TITLE
Fix spelling 'setRentionPeriod' to 'setRetentionPeriod'

### DIFF
--- a/javav2/example_code/s3/src/main/java/com/example/s3/PutObjectRetention.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/PutObjectRetention.java
@@ -55,12 +55,12 @@ public class PutObjectRetention {
             .credentialsProvider(credentialsProvider)
             .build();
 
-        setRentionPeriod(s3, key, bucketName) ;
+        setRetentionPeriod(s3, key, bucketName) ;
         s3.close();
     }
 
     // snippet-start:[s3.java2.retention_object.main]
-    public static void setRentionPeriod(S3Client s3, String key, String bucket) {
+    public static void setRetentionPeriod(S3Client s3, String key, String bucket) {
 
         try{
             LocalDate localDate = LocalDate.parse("2020-07-17");


### PR DESCRIPTION
A customer noticed this misspelling.


# aws-doc-sdk-examples Pull Request

Thank you for making a submission to the *aws-doc-sdk-examples* repository. For more information about submitting pull requests to this repository, see [Guidelines for contributing](/CONTRIBUTING.md).

*NOTE:* This PR template contains three sections. Depending on the reason for your pull request, please fill out the section that applies to you and then remove the other two sections.

## New SDK Code Example

The submitter has:

- [ ] Added the default copyright notice to all files.
- [ ] Created unit tests for all paths through the code and they all pass.
- [ ] Run a linter against all code and implemented the resulting suggestions.
- [ ] Added minimum usage documentation as comments in the code.
- [ ] Had comments and strings reviewed and incorporated suggested changes.
- [ ] Had the code reviewed and implemented the reviewer's suggested changes.

## Existing Example Update

The submitter has:

- [ ] Confirmed that the correct copyright is included in all files.
- [ ] Major code changes have been reviewed, and the submitter has incorporated review comments.
- [ ] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.

## Resolve Issue

Issue #

### Description of Changes

Please describe the changes you have made here.

- [ ] I have tested my changes and created unit tests for new code paths.
- [ ] Changes have been reviewed, and all reviewer comments have been incorporated.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
