### PR TITLE
Add non-maintenance notice to Python signv4 files.

### DIFF
--- a/python/example_code/signv4/v4-signing-get-authheader.py
+++ b/python/example_code/signv4/v4-signing-get-authheader.py
@@ -1,19 +1,17 @@
-# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# This file is licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with the License. A copy of the
-# License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-# OF ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-#
-# ABOUT THIS PYTHON SAMPLE: This sample is part of the AWS General Reference 
-# Signing AWS API Requests top available at
-# https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
-#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Important
+
+The AWS SDKs sign API requests for you using the access key that you specify when you
+configure the SDK. When you use an SDK, you don’t need to learn how to sign API requests.
+We recommend that you use the AWS SDKs to send API requests, instead of writing your own code.
+
+The following example is a reference to help you get started if you have a need to write
+your own code to send and sign requests. The example is for reference only and is not
+maintained as functional code.
+"""
 
 # AWS Version 4 signing example
 
@@ -133,17 +131,3 @@ r = requests.get(request_url, headers=headers)
 print('\nRESPONSE++++++++++++++++++++++++++++++++++++')
 print('Response code: %d\n' % r.status_code)
 print(r.text)
- 
-
-# snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
-# snippet-sourcedescription:[v4-signing-get-authheader.py shows how to make a request using the Amazon DynamoDB query API. The request makes a POST request and passes values to AWS in the body of the request. Authentication information is passed using the Authorization request header.]
-# snippet-keyword:[Python]
-# snippet-sourcesyntax:[python]
-# snippet-sourcesyntax:[python]
-# snippet-keyword:[Code Sample]
-# snippet-keyword:[Amazon DynamoDB]
-# snippet-service:[AWS Signature Version 4 Signing Process]
-# snippet-sourcetype:[full-example]
-# snippet-sourcedate:[2018-09-20]
-# snippet-sourceauthor:[AWS]
-

--- a/python/example_code/signv4/v4-signing-get-post.py
+++ b/python/example_code/signv4/v4-signing-get-post.py
@@ -1,14 +1,17 @@
-# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# This file is licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with the License. A copy of the
-# License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-# OF ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Important
+
+The AWS SDKs sign API requests for you using the access key that you specify when you
+configure the SDK. When you use an SDK, you don’t need to learn how to sign API requests.
+We recommend that you use the AWS SDKs to send API requests, instead of writing your own code.
+
+The following example is a reference to help you get started if you have a need to write
+your own code to send and sign requests. The example is for reference only and is not
+maintained as functional code.
+"""
 
 # AWS Version 4 signing example
 
@@ -141,17 +144,3 @@ r = requests.post(endpoint, data=request_parameters, headers=headers)
 print('\nRESPONSE++++++++++++++++++++++++++++++++++++')
 print('Response code: %d\n' % r.status_code)
 print(r.text)
- 
-
-# snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
-# snippet-sourcedescription:[v4-signing-get-post.py shows how to make a request using the Amazon EC2 query API. The request makes a POST request and passes authentication information to AWS using the Authorization header.]
-# snippet-keyword:[Python]
-# snippet-sourcesyntax:[python]
-# snippet-sourcesyntax:[python]
-# snippet-keyword:[Code Sample]
-# snippet-keyword:[Amazon EC2]
-# snippet-service:[AWS Signature Version 4 Signing Process]
-# snippet-sourcetype:[full-example]
-# snippet-sourcedate:[2018-09-20]
-# snippet-sourceauthor:[AWS]
-

--- a/python/example_code/signv4/v4-signing-get-querystring.py
+++ b/python/example_code/signv4/v4-signing-get-querystring.py
@@ -1,19 +1,17 @@
-# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# This file is licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with the License. A copy of the
-# License is located at
-#
-# http://aws.amazon.com/apache2.0/
-#
-# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-# OF ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-#
-# ABOUT THIS PYTHON SAMPLE: This sample is part of the AWS General Reference 
-# Signing AWS API Requests top available at
-# https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
-#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Important
+
+The AWS SDKs sign API requests for you using the access key that you specify when you
+configure the SDK. When you use an SDK, you don’t need to learn how to sign API requests.
+We recommend that you use the AWS SDKs to send API requests, instead of writing your own code.
+
+The following example is a reference to help you get started if you have a need to write
+your own code to send and sign requests. The example is for reference only and is not
+maintained as functional code.
+"""
 
 # AWS Version 4 signing example
 
@@ -133,17 +131,3 @@ r = requests.get(request_url)
 print('\nRESPONSE++++++++++++++++++++++++++++++++++++')
 print('Response code: %d\n' % r.status_code)
 print(r.text)
- 
-
-# snippet-comment:[These are tags for the AWS doc team's sample catalog. Do not remove.]
-# snippet-sourcedescription:[v4-signing-get-querystring.py shows how to make a request using the IAM query API. The request makes a GET request and passes parameters and signing information using the query string.]
-# snippet-keyword:[Python]
-# snippet-sourcesyntax:[python]
-# snippet-sourcesyntax:[python]
-# snippet-keyword:[Code Sample]
-# snippet-keyword:[Amazon IAM]
-# snippet-service:[AWS Signature Version 4 Signing Process]
-# snippet-sourcetype:[full-example]
-# snippet-sourcedate:[2018-09-20]
-# snippet-sourceauthor:[AWS]
-


### PR DESCRIPTION
Added a notice to Python signv4 examples that they are included for reference only and are not maintained.

I'm doing this instead of deleting them because they are referenced directly in the General Reference guide so we can't just delete them, and I want to make it clear what the intent is.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
