### PR TITLE
Add snapshot paths to SOS templates

### DIFF
--- a/.doc_gen/templates/zonbook/example_description_template.xml
+++ b/.doc_gen/templates/zonbook/example_description_template.xml
@@ -2,6 +2,10 @@
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "file://zonbook/docbookx.dtd"[
     <!ENTITY % phrases-code-examples SYSTEM "file://AWSShared/code-samples/docs/phrases-code-examples.ent">
     %phrases-code-examples;
+{{- if isSnapshot}}
+    <!ENTITY % phrases-prerelease-examples SYSTEM "phrases-prerelease-examples.ent">
+    %phrases-prerelease-examples;
+{{- end}}
     <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
     %phrases-shared;
 ]>

--- a/.doc_gen/templates/zonbook/example_language_template.xml
+++ b/.doc_gen/templates/zonbook/example_language_template.xml
@@ -4,10 +4,20 @@
     %xinclude;
     <!ENTITY % phrases-code-examples SYSTEM "file://AWSShared/code-samples/docs/phrases-code-examples.ent">
     %phrases-code-examples;
+{{- if isSnapshot}}
+    <!ENTITY % phrases-prerelease-examples SYSTEM "phrases-prerelease-examples.ent">
+    %phrases-prerelease-examples;
+{{- end}}
     <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
     %phrases-shared;
 ]>
 <!-- zexi 0.4.0 -->
+{{- $include_base := "file://AWSShared/"}}
+{{- $include_docs := "file://AWSShared/code-samples/docs/"}}
+{{- if isSnapshot}}
+    {{- $include_base = ""}}
+    {{- $include_docs := ""}}
+{{- end}}
 <variablelist role="termdef">
     {{- range $version := .Versions}}
     <varlistentry>
@@ -17,7 +27,7 @@
             <note><para>{{$version.Caveat}}</para></note>
             {{- end}}
             {{- if $version.BlockContent}}
-            <xi:include href="file://AWSShared/code-samples/docs/{{.BlockContent}}"></xi:include>
+            <xi:include href="{{$include_docs}}{{.BlockContent}}"></xi:include>
             <itemizedlist>
                 <title>Services used in this example</title>
                 {{- range $svc_ent := $version.Services}}
@@ -37,7 +47,7 @@
             <block>
                 <para>{{.Description}}</para>
                 <!-- The following line break must be preserved and left-justified exactly as-is, to keep snippets looking good. -->
-                <programlisting language="{{.Syntax}}">{{range .SnippetTags}}<xi:include parse="text" href="file://AWSShared/snippets/{{.}}.txt"/>
+                <programlisting language="{{.Syntax}}">{{range .SnippetTags}}<xi:include parse="text" href="{{$include_base}}snippets/{{.}}.txt"/>
 {{end}}</programlisting>
             </block>
             {{- end}}

--- a/.doc_gen/templates/zonbook/example_tablist_template.xml
+++ b/.doc_gen/templates/zonbook/example_tablist_template.xml
@@ -3,13 +3,16 @@
     <!ENTITY % xinclude SYSTEM "file://AWSShared/common/xinclude.mod">
     %xinclude;
 ]>
-<!-- zexi 0.2.0 -->
+{{- $include_docs := "file://AWSShared/code-samples/docs/"}}
+{{- if isSnapshot}}
+    {{- $include_docs = ""}}
+{{- end}}
 <tablist>
     {{- range $language, $example_id := .}}
     <tablistentry>
         <tabname>{{$language}}</tabname>
         <tabcontent>
-            <xi:include href="file://AWSShared/code-samples/docs/{{$example_id}}_{{$language}}.xml"></xi:include>
+            <xi:include href="{{$include_docs}}{{$example_id}}_{{$language}}.xml"></xi:include>
         </tabcontent>
     </tablistentry>
     {{- end}}

--- a/.doc_gen/templates/zonbook/library_by_sdk_chapter.xml
+++ b/.doc_gen/templates/zonbook/library_by_sdk_chapter.xml
@@ -4,12 +4,20 @@
     %xinclude;
     <!ENTITY % phrases-code-examples SYSTEM "file://AWSShared/code-samples/docs/phrases-code-examples.ent">
     %phrases-code-examples;
+{{- if isSnapshot}}
+    <!ENTITY % phrases-prerelease-examples SYSTEM "phrases-prerelease-examples.ent">
+    %phrases-prerelease-examples;
+{{- end}}
     <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
     %phrases-shared;
 ]>
 <!-- zexi 0.5.0 -->
 {{- $omitted_sdks := makeSlice "java_1"}}
 {{- $chapter_id := "code_example_library_by_sdk"}}
+{{- $include_docs := "file://AWSShared/code-samples/docs/"}}
+{{- if isSnapshot}}
+    {{- $include_docs = ""}}
+{{- end}}
 <chapter id="{{$chapter_id}}" role="topic">
     <info>
         <title id="{{$chapter_id}}.title">Code examples by SDK using &AWS; SDKs</title>
@@ -110,7 +118,7 @@
                             {{- if .GuideTopic.Url}}
                             <para>For more information, see <ulink {{.GuideTopic.DocType}} url="{{.GuideTopic.Url}}">{{.GuideTopic.Text}}</ulink>.</para>
                             {{- end}}
-                            <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}_{{$sdk_examples.Language}}.xml"></xi:include>
+                            <xi:include href="{{$include_docs}}{{.ExampleId}}_{{$sdk_examples.Language}}.xml"></xi:include>
                         </section>
                         {{- end}}
                     </collapsible>
@@ -142,7 +150,7 @@
                     <title id="{{.ExampleId}}_{{$sdk_ver}}_topic.title">{{.Title}}</title>
                     <titleabbrev id="{{.ExampleId}}_{{$sdk_ver}}_topic.titleabbrev">{{.TitleAbbrev}}</titleabbrev>
                 </info>
-                <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}_{{$sdk_examples.Language}}.xml"></xi:include>
+                <xi:include href="{{$include_docs}}{{.ExampleId}}_{{$sdk_examples.Language}}.xml"></xi:include>
                 {{- if .GuideTopic.Url}}
                 <para>For more information, see <ulink {{.GuideTopic.DocType}} url="{{.GuideTopic.Url}}">{{.GuideTopic.Text}}</ulink>.</para>
                 {{- end}}

--- a/.doc_gen/templates/zonbook/library_by_service_chapter.xml
+++ b/.doc_gen/templates/zonbook/library_by_service_chapter.xml
@@ -4,11 +4,18 @@
     %xinclude;
     <!ENTITY % phrases-code-examples SYSTEM "file://AWSShared/code-samples/docs/phrases-code-examples.ent">
     %phrases-code-examples;
+{{- if isSnapshot}}
+    <!ENTITY % phrases-prerelease-examples SYSTEM "phrases-prerelease-examples.ent">
+    %phrases-prerelease-examples;
+{{- end}}
     <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
     %phrases-shared;
 ]>
-<!-- zexi 0.4.1  -->
 {{- $chapter_id := "code_example_library_by_service"}}
+{{- $include_docs := "file://AWSShared/code-samples/docs/"}}
+{{- if isSnapshot}}
+    {{- $include_docs = ""}}
+{{- end}}
 <chapter id="{{$chapter_id}}" role="topic">
     <info>
         <title id="{{$chapter_id}}.title">Code examples by service using &AWS; SDKs</title>
@@ -73,11 +80,11 @@
                             <keyword>{{.Title}}</keyword>
                         </keywordset>
                     </info>
-                    <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}_desc.xml"></xi:include>
+                    <xi:include href="{{$include_docs}}{{.ExampleId}}_desc.xml"></xi:include>
                     {{- if .GuideTopic.Url}}
                     <para>For more information, see <ulink {{.GuideTopic.DocType}} url="{{.GuideTopic.Url}}">{{.GuideTopic.Text}}</ulink>.</para>
                     {{- end}}
-                    <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}{{$addSvc}}_tablist.xml"></xi:include>
+                    <xi:include href="{{$include_docs}}{{.ExampleId}}{{$addSvc}}_tablist.xml"></xi:include>
                 </section>
                 {{- end}}
             </section>

--- a/.doc_gen/templates/zonbook/library_by_service_tag_chapter.xml
+++ b/.doc_gen/templates/zonbook/library_by_service_tag_chapter.xml
@@ -4,6 +4,10 @@
         %xinclude;
         <!ENTITY % phrases-code-examples SYSTEM "file://AWSShared/code-samples/docs/phrases-code-examples.ent">
         %phrases-code-examples;
+{{- if isSnapshot}}
+    <!ENTITY % phrases-prerelease-examples SYSTEM "phrases-prerelease-examples.ent">
+    %phrases-prerelease-examples;
+{{- end}}
         <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
         %phrases-shared;
         ]>

--- a/.doc_gen/templates/zonbook/sdk_chapter_template.xml
+++ b/.doc_gen/templates/zonbook/sdk_chapter_template.xml
@@ -4,10 +4,13 @@
     %xinclude;
     <!ENTITY % phrases-code-examples SYSTEM "file://AWSShared/code-samples/docs/phrases-code-examples.ent">
     %phrases-code-examples;
+{{- if isSnapshot}}
+    <!ENTITY % phrases-prerelease-examples SYSTEM "phrases-prerelease-examples.ent">
+    %phrases-prerelease-examples;
+{{- end}}
     <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
     %phrases-shared;
 ]>
-<!-- zexi 0.2.0 -->
 {{- $chapter_title := print .SdkEntity.Short " code examples" }}
 {{- $chapter_title_abbrev := "Code examples" }}
 {{- if .TitleOverride.Title }}
@@ -16,6 +19,10 @@
 {{- if .TitleOverride.TitleAbbrev }}
     {{- $chapter_title_abbrev = .TitleOverride.TitleAbbrev }}
 {{- end }}
+{{- $include_docs := "file://AWSShared/code-samples/docs/"}}
+{{- if isSnapshot}}
+    {{- $include_docs = ""}}
+{{- end}}
 {{- if eq .OutputType "section" }}
 <section id="{{.LanguageSlug}}_code_examples" role="topic">
 {{- else }}
@@ -113,7 +120,7 @@
                         {{- if .GuideTopic.Url}}
                         <para>For more information, see <ulink {{.GuideTopic.DocType}} url="{{.GuideTopic.Url}}">{{.GuideTopic.Text}}</ulink>.</para>
                         {{- end}}
-                        <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}_{{$.Language}}.xml"></xi:include>
+                        <xi:include href="{{$include_docs}}{{.ExampleId}}_{{$.Language}}.xml"></xi:include>
                     </section>
                     {{- end}}
                 </collapsible>
@@ -145,7 +152,7 @@
                 <title id="{{.ExampleId}}_{{$.LanguageSlug}}_topic.title">{{.Title}}</title>
                 <titleabbrev id="{{.ExampleId}}_{{$.LanguageSlug}}_topic.titleabbrev">{{.TitleAbbrev}}</titleabbrev>
             </info>
-            <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}_{{$.Language}}.xml"></xi:include>
+            <xi:include href="{{$include_docs}}{{.ExampleId}}_{{$.Language}}.xml"></xi:include>
             {{- if .GuideTopic.Url}}
             <para>For more information, see <ulink {{.GuideTopic.DocType}} url="{{.GuideTopic.Url}}">{{.GuideTopic.Text}}</ulink>.</para>
             {{- end}}

--- a/.doc_gen/templates/zonbook/service_chapter_bundle_template.xml
+++ b/.doc_gen/templates/zonbook/service_chapter_bundle_template.xml
@@ -4,10 +4,17 @@
     %xinclude;
     <!ENTITY % phrases-code-examples SYSTEM "file://AWSShared/code-samples/docs/phrases-code-examples.ent">
     %phrases-code-examples;
+{{- if isSnapshot}}
+    <!ENTITY % phrases-prerelease-examples SYSTEM "phrases-prerelease-examples.ent">
+    %phrases-prerelease-examples;
+{{- end}}
     <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
     %phrases-shared;
 ]>
-<!-- zexi 0.4.3 -->
+{{- $include_docs := "file://AWSShared/code-samples/docs/"}}
+{{- if isSnapshot}}
+    {{- $include_docs = ""}}
+{{- end}}
 <chapter id="service_code_examples" role="topic">
     <info>
         <title id="service_code_examples.title">Code examples for {{.BundleOwner.Short}} using &AWS; SDKs</title>
@@ -23,6 +30,6 @@
         This topic also includes information about getting started and details about previous SDK versions.</para>
     <para role="contents-abbrev">Code examples</para>
     {{- range $model := .BundledModels}}
-    <xi:include href="file://AWSShared/code-samples/docs/{{$model}}_code_examples_section.xml"></xi:include>
+    <xi:include href="{{$include_docs}}{{$model}}_code_examples_section.xml"></xi:include>
     {{- end}}
 </chapter>

--- a/.doc_gen/templates/zonbook/service_chapter_template.xml
+++ b/.doc_gen/templates/zonbook/service_chapter_template.xml
@@ -4,6 +4,10 @@
     %xinclude;
     <!ENTITY % phrases-code-examples SYSTEM "file://AWSShared/code-samples/docs/phrases-code-examples.ent">
     %phrases-code-examples;
+{{- if isSnapshot}}
+    <!ENTITY % phrases-prerelease-examples SYSTEM "phrases-prerelease-examples.ent">
+    %phrases-prerelease-examples;
+{{- end}}
     <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
     %phrases-shared;
 ]>
@@ -13,6 +17,10 @@
 {{- $cross_service := index .CategorizedExampleSets "Cross-service examples"}}
 {{- $scenarios :=  index .CategorizedExampleSets "Scenarios"}}
 {{- $actions := index .CategorizedExampleSets "Actions"}}
+{{- $include_docs := "file://AWSShared/code-samples/docs/"}}
+{{- if isSnapshot}}
+    {{- $include_docs = ""}}
+{{- end}}
 {{- if .Bundle}}
 {{- $doc_id = printf "service_code_examples_%s" .Model }}
 {{- $title_abbrev = printf "%s examples" .ServiceEntity.Short }}
@@ -105,7 +113,7 @@
                     <para>{{.Title}}</para>
                 </abstract>
             </info>
-            <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}_desc.xml"></xi:include>
+            <xi:include href="{{$include_docs}}{{.ExampleId}}_desc.xml"></xi:include>
             <note buildtype="markdown">
                 <para>The source code for these examples is in the
                     <ulink url="https://github.com/awsdocs/aws-doc-sdk-examples">&AWS; Code Examples GitHub repository</ulink>.
@@ -117,7 +125,7 @@
             {{- if .GuideTopic.Url}}
             <para>For more information, see <ulink {{.GuideTopic.DocType}} url="{{.GuideTopic.Url}}">{{.GuideTopic.Text}}</ulink>.</para>
             {{- end}}
-            <xi:include href="file://AWSShared/code-samples/docs/{{.ExampleId}}{{$addSvc}}_tablist.xml"></xi:include>
+            <xi:include href="{{$include_docs}}{{.ExampleId}}{{$addSvc}}_tablist.xml"></xi:include>
             <para>For a complete list of &AWS; SDK developer guides and code examples, see
                 <xref linkend="sdk-general-information-section" endterm="sdk-general-information-section.title"></xref>.
                 This topic also includes information about getting started and details about previous SDK versions.</para>


### PR DESCRIPTION
Add snapshot paths to the SOS templates for making a standalone prerelease snapshot that can be copied into a local document package. In this way, a document package can include code examples without having a dependency on the example source package.

This feature is part of the process for making a prerelease documentation package that includes code examples that demonstrate a future (i.e. not public) feature.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
