### PR TITLE
Fix typo in Python S3 example.

### DIFF
--- a/python/example_code/s3/s3_basics/object_wrapper.py
+++ b/python/example_code/s3/s3_basics/object_wrapper.py
@@ -118,12 +118,12 @@ class ObjectWrapper:
             dest_object.wait_until_exists()
             logger.info(
                 "Copied object from %s:%s to %s:%s.",
-                self.object.key, self.object.bucket_name,
+                self.object.bucket_name, self.object.key,
                 dest_object.bucket_name, dest_object.key)
         except ClientError:
             logger.exception(
                 "Couldn't copy object from %s/%s to %s/%s.",
-                self.object.key, self.object.bucket_name,
+                self.object.bucket_name, self.object.key,
                 dest_object.bucket_name, dest_object.key)
             raise
 # snippet-end:[python.example_code.s3.CopyObject]


### PR DESCRIPTION
A customer noted that the bucket and key were out of order in this example. This PR fixes it.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
