### PR TITLE
Add "swift" to top-level README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,7 @@ Examples for SDKs currently in preview
 --------------------------------------
 
 * **.kotlin_alpha** for the alpha version of the AWS SDK for Kotlin
+* **swift** for the preview release of the AWS SDK for Swift
 * **rust_dev_preview** for the developer preview version of the AWS SDK for Rust
 
 Examples for SDKs that have been deprecated


### PR DESCRIPTION
Swift was missing from the list of preview SDKs. Now it's not.

# aws-doc-sdk-examples Pull Request

## Resolve Issue

Issue # n/a

### Description of Changes

I noticed the Swift SDK wasn't mentioned in this README. I've added it. That's all.

- [x] I have tested my changes and created unit tests for new code paths.
- [ ] Changes have been reviewed, and all reviewer comments have been incorporated.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
