### PR TITLE
3263 story update template pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,29 +9,23 @@ Thank you for making a submission to the *aws-doc-sdk-examples* repository. For 
 The submitter has:
 
 - [ ] Added the default copyright notice to all files.
-- [ ] Created unit tests for all paths through the code and they all pass.
+- [ ] Created unit tests for all paths through the code, and confirmed that the all the tests pass.
 - [ ] Run a linter against all code and implemented the resulting suggestions.
 - [ ] Added minimum usage documentation as comments in the code.
-- [ ] Had comments and strings reviewed and incorporated suggested changes.
-- [ ] Had the code reviewed and implemented the reviewer's suggested changes.
 
 ## Existing Example Update
 
+Please describe the changes you have made here.
+
 The submitter has:
 
-- [ ] Confirmed that the correct copyright is included in all files.
-- [ ] Major code changes have been reviewed, and the submitter has incorporated review comments.
-- [ ] Changed or added comments and strings have been reviewed, and the submitter has incorporated any and all suggested edits.
+- [ ] Tested the changed code.
+- [ ] Run a linter against the changed code and implemented the resulting suggestions.
 
 ## Resolve Issue
 
 Issue #
 
-### Description of Changes
-
-Please describe the changes you have made here.
-
-- [ ] I have tested my changes and created unit tests for new code paths.
-- [ ] Changes have been reviewed, and all reviewer comments have been incorporated.
+## License Adherence Confirmation
 
 _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,6 @@ The submitter has:
 
 Issue #
 
-## License Adherence Confirmation
+## Open Source License Adherence
 
 _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # aws-doc-sdk-examples Pull Request
 
-Thank you for making a submission to the *aws-doc-sdk-examples* repository. For more information about submitting pull requests to this repository, see [Guidelines for contributing](/CONTRIBUTING.md).
+Thank you for making a submission to the *aws-doc-sdk-examples* repository. For more information about submitting pull requests to this repository, see [Guidelines for contributing](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/CONTRIBUTING.md).
 
 *NOTE:* This PR template contains three sections. Depending on the reason for your pull request, please fill out the section that applies to you and then remove the other two sections.
 


### PR DESCRIPTION
The PR template is for external users.
Amazon team contributors will mostly do as I am doing now.  Not use the template.

I just included the checks that are the submitters responsibility. I deleted the checks that will be handled by the team member assigned to the PR.

I am very open to suggestions
