### PR TITLE
Reapply .NET auto scale examples with TerminateInstance APIs.

### DIFF
--- a/.doc_gen/metadata/autoscaling_metadata.yaml
+++ b/.doc_gen/metadata/autoscaling_metadata.yaml
@@ -161,6 +161,15 @@ auto-scaling_TerminateInstanceInAutoScalingGroup:
   synopsis: terminate an instance in an &AS; group.
   category:
   languages:
+    .NET:
+      versions:
+        - sdk_version: 3
+          github: dotnetv3/AutoScaling
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - AutoScale.dotnetv3.AutoScale_Basics.TerminateInstanceInAutoScalingGroup
     Python:
       versions:
         - sdk_version: 3
@@ -324,6 +333,22 @@ auto-scaling_Scenario_GroupsAndInstances:
     - Stop collecting metrics, terminate all instances, and delete the group.
   category: Scenarios
   languages:
+    .NET:
+      versions:
+        - sdk_version: 3
+          github: dotnetv3/AutoScaling
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - AutoScale.dotnetv3.AutoScale_Basics.global-usings
+                - AutoScale.dotnetv3.AutoScale_Basics.main
+            - description: Define functions that are called by the scenario to
+                manage launch templates and metrics. These functions wrap
+                &EC2; and &CW; actions.
+              snippet_tags:
+                - AutoScale.dotnetv3.AutoScale_Basics.EC2Methods
+                - AutoScale.dotnetv3.AutoScale_Basics.CloudWatchMethods
     Kotlin:
       versions:
         - sdk_version: 1


### PR DESCRIPTION
Add the .NET EC2 Auto Scaling examples back to the metadata. These were temporarily removed because of a deny list error caused by some API names.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
