### PR TITLE
Add comments to clarify when Boto3 high-level resources are used.

### DIFF
--- a/python/example_code/s3/s3_basics/bucket_wrapper.py
+++ b/python/example_code/s3/s3_basics/bucket_wrapper.py
@@ -20,7 +20,12 @@ logger = logging.getLogger(__name__)
 
 # snippet-start:[python.example_code.s3.helper.BucketWrapper]
 class BucketWrapper:
+    """Encapsulates S3 bucket actions."""
     def __init__(self, bucket):
+        """
+        :param bucket: A Boto3 Bucket resource. This is a high-level resource in Boto3
+                       that wraps bucket actions in a class-like structure.
+        """
         self.bucket = bucket
         self.name = bucket.name
 # snippet-end:[python.example_code.s3.helper.BucketWrapper]
@@ -78,6 +83,9 @@ class BucketWrapper:
         """
         Get the buckets in all Regions for the current account.
 
+        :param s3_resource: A Boto3 S3 resource. This is a high-level resource in Boto3
+                            that contains collections and factory methods to create
+                            other high-level S3 sub-resources.
         :return: The list of buckets.
         """
         try:

--- a/python/example_code/s3/s3_basics/object_wrapper.py
+++ b/python/example_code/s3/s3_basics/object_wrapper.py
@@ -20,7 +20,12 @@ logger = logging.getLogger(__name__)
 
 # snippet-start:[python.example_code.s3.helper.ObjectWrapper]
 class ObjectWrapper:
+    """Encapsulates S3 object actions."""
     def __init__(self, s3_object):
+        """
+        :param s3_object: A Boto3 Object resource. This is a high-level resource in Boto3
+                          that wraps object actions in a class-like structure.
+        """
         self.object = s3_object
         self.key = self.object.key
 # snippet-end:[python.example_code.s3.helper.ObjectWrapper]
@@ -85,7 +90,7 @@ class ObjectWrapper:
         """
         Lists the objects in a bucket, optionally filtered by a prefix.
 
-        :param bucket: The bucket to query.
+        :param bucket: The bucket to query. This is a Boto3 Bucket resource.
         :param prefix: When specified, only objects that start with this prefix are listed.
         :return: The list of objects.
         """
@@ -109,6 +114,7 @@ class ObjectWrapper:
         Copies the object to another bucket.
 
         :param dest_object: The destination object initialized with a bucket and key.
+                            This is a Boto3 Object resource.
         """
         try:
             dest_object.copy_from(CopySource={
@@ -153,7 +159,8 @@ class ObjectWrapper:
         Removes a list of objects from a bucket.
         This operation is done as a batch in a single request.
 
-        :param bucket: The bucket that contains the objects.
+        :param bucket: The bucket that contains the objects. This is a Boto3 Bucket
+                       resource.
         :param object_keys: The list of keys that identify the objects to remove.
         :return: The response that contains data about which objects were deleted
                  and any that could not be deleted.
@@ -181,14 +188,13 @@ class ObjectWrapper:
             return response
 # snippet-end:[python.example_code.s3.DeleteObjects_Keys]
 
-
 # snippet-start:[python.example_code.s3.DeleteObjects_All]
     @staticmethod
     def empty_bucket(bucket):
         """
         Remove all objects from a bucket.
 
-        :param bucket: The bucket to empty.
+        :param bucket: The bucket to empty. This is a Boto3 Bucket resource.
         """
         try:
             bucket.objects.delete()


### PR DESCRIPTION
From customer feedback on single-action code examples. Because these are published separately, it was sometimes not clear what type some of the parameters were. This PR adds clarifying comments.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
