### PR TITLE
Simplify waiting logic in Rust DynamoDB examples

### DIFF
--- a/rust_dev_preview/dynamodb/src/bin/crud.rs
+++ b/rust_dev_preview/dynamodb/src/bin/crud.rs
@@ -4,23 +4,13 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_http::retry::AwsErrorRetryPolicy;
-use aws_sdk_dynamodb::error::DescribeTableError;
-use aws_sdk_dynamodb::input::DescribeTableInput;
-use aws_sdk_dynamodb::middleware::DefaultMiddleware;
 use aws_sdk_dynamodb::model::{
     AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ProvisionedThroughput,
     ScalarAttributeType, Select, TableStatus,
 };
-use aws_sdk_dynamodb::operation::DescribeTable;
-use aws_sdk_dynamodb::output::DescribeTableOutput;
-use aws_sdk_dynamodb::{Client, Config, Error, Region, PKG_VERSION};
-use aws_smithy_client::erase::DynConnector;
-use aws_smithy_http::result::{SdkError, SdkSuccess};
+use aws_sdk_dynamodb::{Client, Error, Region, PKG_VERSION};
+use aws_smithy_http::result::SdkError;
 
-use aws_smithy_http::operation::Operation;
-use aws_smithy_http::retry::ClassifyResponse;
-use aws_smithy_types::retry::RetryKind;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::io::{stdin, Read};
@@ -195,46 +185,6 @@ async fn remove_table(client: &Client, table: &str) -> Result<(), Error> {
 }
 // snippet-end:[dynamodb.rust.crud-remove_table]
 
-/// Hand-written waiter to retry every second until the table is out of `Creating` state
-#[derive(Clone)]
-struct WaitForReadyTable<R> {
-    inner: R,
-}
-
-impl<R> ClassifyResponse<SdkSuccess<DescribeTableOutput>, SdkError<DescribeTableError>>
-    for WaitForReadyTable<R>
-where
-    R: ClassifyResponse<SdkSuccess<DescribeTableOutput>, SdkError<DescribeTableError>>,
-{
-    fn classify(
-        &self,
-        response: Result<&SdkSuccess<DescribeTableOutput>, &SdkError<DescribeTableError>>,
-    ) -> RetryKind {
-        match self.inner.classify(response) {
-            RetryKind::UnretryableFailure | RetryKind::Unnecessary => (),
-            other => return other,
-        };
-        match response {
-            Ok(SdkSuccess { parsed, .. }) => {
-                if parsed
-                    .table
-                    .as_ref()
-                    .unwrap()
-                    .table_status
-                    .as_ref()
-                    .unwrap()
-                    == &TableStatus::Creating
-                {
-                    RetryKind::Explicit(Duration::from_secs(1))
-                } else {
-                    RetryKind::Unnecessary
-                }
-            }
-            _ => RetryKind::UnretryableFailure,
-        }
-    }
-}
-
 /// Wait for the user to press Enter.
 fn pause() {
     println!("Press Enter to continue.");
@@ -317,12 +267,7 @@ async fn main() -> Result<(), Error> {
 
     println!("Waiting for table to be ready.");
 
-    let raw_client = aws_smithy_client::Client::<DynConnector, DefaultMiddleware>::dyn_https();
-
-    raw_client
-        .call(wait_for_ready_table(&table, client.conf()).await)
-        .await
-        .expect("table should become ready.");
+    wait_for_ready_table(&client, &table).await?;
 
     println!("Table is now ready to use.");
 
@@ -387,21 +332,21 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-/// Construct a `DescribeTable` request with a policy to retry every second until the table
-/// is ready
-async fn wait_for_ready_table(
-    table_name: &str,
-    conf: &Config,
-) -> Operation<DescribeTable, WaitForReadyTable<AwsErrorRetryPolicy>> {
-    let operation = DescribeTableInput::builder()
-        .table_name(table_name)
-        .build()
-        .expect("valid input")
-        .make_operation(conf)
-        .await
-        .expect("valid operation");
-    let waiting_policy = WaitForReadyTable {
-        inner: operation.retry_policy().clone(),
-    };
-    operation.with_retry_policy(waiting_policy)
+/// Poll the DescribeTable operation once per second until the table exists.
+async fn wait_for_ready_table(client: &Client, table_name: &str) -> Result<(), Error> {
+    loop {
+        if let Some(table) = client
+            .describe_table()
+            .table_name(table_name)
+            .send()
+            .await?
+            .table()
+        {
+            if !matches!(table.table_status, Some(TableStatus::Creating)) {
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    Ok(())
 }


### PR DESCRIPTION
I'm making some breaking changes to retry in the AWS SDK for Rust in https://github.com/awslabs/smithy-rs/pull/1717 that cause the DynamoDB examples to fail to compile. These examples were using a complicated retry policy override mechanism to wait for table creation. Rather than preserve that, I rewrote the waiting logic to be a simple to follow function. In the future when the SDK supports waiters, this can be simplified further.

- [x] Test the changed code
- [x] Run a linter against the changed code and implement the resulting suggestions

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
