### PR TITLE
Add s3.cpp.put_bucket_policy01.code back

### DIFF
--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -1449,6 +1449,7 @@ s3_PutBucketPolicy:
             - description:
               snippet_tags:
                 - s3.cpp.put_bucket_policy02.code
+                - s3.cpp.put_bucket_policy01.code
     Java:
       versions:
         - sdk_version: 2

--- a/cpp/example_code/s3/put_bucket_policy.cpp
+++ b/cpp/example_code/s3/put_bucket_policy.cpp
@@ -65,6 +65,9 @@ bool AwsDoc::S3::PutBucketPolicy(const Aws::String &bucketName,
     return outcome.IsSuccess();
 }
 
+// snippet-end:[s3.cpp.put_bucket_policy02.code]
+
+// snippet-start:[s3.cpp.put_bucket_policy01.code]
 //! Build a policy JSON string.
 /*!
   \sa GetPolicyString()
@@ -94,7 +97,7 @@ Aws::String GetPolicyString(const Aws::String &userArn,
             "   ]\n"
             "}";
 }
-// snippet-end:[s3.cpp.put_bucket_policy02.code]
+// snippet-end:[s3.cpp.put_bucket_policy01.code]
 
 /*
  *


### PR DESCRIPTION
This snippet is reference in the C++ guide so we can't just remove it. I added it back for the moment to fix the build. We can look into a more permanent update later.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
