### PR TITLE
Lint all of the Ruby code, once and for all!

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -2,15 +2,15 @@ source "https://rubygems.org"
 ruby "3.1.2"
 
 gem "aws-sdk"
-gem "rspec"
-gem "rubyzip"
-gem "rake"
-gem "rubocop"
-gem "rubocop-rake"
-gem "rubocop-github"
-gem 'json'
-gem 'pp'
+gem "cli-ui"
+gem "json"
+gem "openssl"
 gem "open-uri"
+gem "pp"
+gem "rake"
+gem "rspec"
+gem "rubocop"
+gem "rubocop-github"
+gem "rubocop-rake"
+gem "rubyzip"
 gem "zip"
-gem 'openssl'
-gem 'cli-ui'

--- a/ruby/example_code/cloudwatch/cw-ruby-example-alarm-actions.rb
+++ b/ruby/example_code/cloudwatch/cw-ruby-example-alarm-actions.rb
@@ -6,7 +6,7 @@
 # 2. Disable all actions for an alarm.
 
 # snippet-start:[cloudwatch.Ruby.createAnAlarm]
-require 'aws-sdk-cloudwatch'
+require "aws-sdk-cloudwatch"
 
 # Creates or updates an alarm in Amazon CloudWatch.
 
@@ -116,31 +116,31 @@ end
 
 # Full example call:
 def run_me
-  alarm_name = 'ObjectsInBucket'
-  alarm_description = 'Objects exist in this bucket for more than 1 day.'
-  metric_name = 'NumberOfObjects'
+  alarm_name = "ObjectsInBucket"
+  alarm_description = "Objects exist in this bucket for more than 1 day."
+  metric_name = "NumberOfObjects"
   # Notify this Amazon Simple Notification Service (Amazon SNS) topic when
   # the alarm transitions to the ALARM state.
-  alarm_actions = ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic']
-  namespace = 'AWS/S3'
-  statistic = 'Average'
+  alarm_actions = ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"]
+  namespace = "AWS/S3"
+  statistic = "Average"
   dimensions = [
     {
-      name: 'BucketName',
-      value: 'doc-example-bucket'
+      name: "BucketName",
+      value: "doc-example-bucket"
     },
     {
-      name: 'StorageType',
-      value: 'AllStorageTypes'
+      name: "StorageType",
+      value: "AllStorageTypes"
     }
   ]
   period = 86_400 # Daily (24 hours * 60 minutes * 60 seconds = 86400 seconds).
-  unit = 'Count'
+  unit = "Count"
   evaluation_periods = 1 # More than one day.
   threshold = 1 # One object.
-  comparison_operator = 'GreaterThanThreshold' # More than one object.
+  comparison_operator = "GreaterThanThreshold" # More than one object.
   # Replace us-west-2 with the AWS Region you're using for Amazon CloudWatch.
-  region = 'us-east-1'
+  region = "us-east-1"
 
   cloudwatch_client = Aws::CloudWatch::Client.new(region: region)
 

--- a/ruby/example_code/cloudwatch/cw-ruby-example-alarm-basics.rb
+++ b/ruby/example_code/cloudwatch/cw-ruby-example-alarm-basics.rb
@@ -6,7 +6,7 @@
 # 2. Create or update an alarm.
 # 3. Delete an alarm.
 # snippet-start:[cloudwatch.Ruby.getAlarmList]
-require 'aws-sdk-cloudwatch'
+require "aws-sdk-cloudwatch"
 
 # Lists the names of available Amazon CloudWatch alarms.
 #
@@ -21,7 +21,7 @@ def list_alarms(cloudwatch_client)
       puts alarm.alarm_name
     end
   else
-    puts 'No alarms found.'
+    puts "No alarms found."
   end
 rescue StandardError => e
   puts "Error getting information about alarms: #{e.message}"
@@ -136,35 +136,35 @@ end
 
 # Full example call:
 def run_me
-  alarm_name = 'ObjectsInBucket'
-  alarm_description = 'Objects exist in this bucket for more than 1 day.'
-  metric_name = 'NumberOfObjects'
+  alarm_name = "ObjectsInBucket"
+  alarm_description = "Objects exist in this bucket for more than 1 day."
+  metric_name = "NumberOfObjects"
   # Notify this Amazon Simple Notification Service (Amazon SNS) topic when
   # the alarm transitions to the ALARM state.
-  alarm_actions = ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic']
-  namespace = 'AWS/S3'
-  statistic = 'Average'
+  alarm_actions = ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"]
+  namespace = "AWS/S3"
+  statistic = "Average"
   dimensions = [
     {
-      name: 'BucketName',
-      value: 'doc-example-bucket'
+      name: "BucketName",
+      value: "doc-example-bucket"
     },
     {
-      name: 'StorageType',
-      value: 'AllStorageTypes'
+      name: "StorageType",
+      value: "AllStorageTypes"
     }
   ]
   period = 86_400 # Daily (24 hours * 60 minutes * 60 seconds = 86400 seconds).
-  unit = 'Count'
+  unit = "Count"
   evaluation_periods = 1 # More than one day.
   threshold = 1 # One object.
-  comparison_operator = 'GreaterThanThreshold' # More than one object.
+  comparison_operator = "GreaterThanThreshold" # More than one object.
   # Replace us-west-2 with the AWS Region you're using for Amazon CloudWatch.
-  region = 'us-east-1'
+  region = "us-east-1"
 
   cloudwatch_client = Aws::CloudWatch::Client.new(region: region)
 
-  puts 'Available Amazon CloudWatch alarms:'
+  puts "Available Amazon CloudWatch alarms:"
   list_alarms(cloudwatch_client)
 
   if alarm_created_or_updated?(

--- a/ruby/example_code/cloudwatch/cw-ruby-example-create-alarm.rb
+++ b/ruby/example_code/cloudwatch/cw-ruby-example-create-alarm.rb
@@ -5,7 +5,7 @@
 
 # snippet-start:[cloudwatch.Ruby.createAlarm]
 
-require 'aws-sdk-cloudwatch'
+require "aws-sdk-cloudwatch"
 
 # @param cloudwatch_client [Aws::CloudWatch::Client]
 #   An initialized CloudWatch client.
@@ -89,31 +89,31 @@ end
 
 # Full example call:
 def run_me
-  alarm_name = 'ObjectsInBucket'
-  alarm_description = 'Objects exist in this bucket for more than 1 day.'
-  metric_name = 'NumberOfObjects'
+  alarm_name = "ObjectsInBucket"
+  alarm_description = "Objects exist in this bucket for more than 1 day."
+  metric_name = "NumberOfObjects"
   # Notify this Amazon Simple Notification Service (Amazon SNS) topic when
   # the alarm transitions to the ALARM state.
-  alarm_actions = ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic']
-  namespace = 'AWS/S3'
-  statistic = 'Average'
+  alarm_actions = ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"]
+  namespace = "AWS/S3"
+  statistic = "Average"
   dimensions = [
     {
-      name: 'BucketName',
-      value: 'doc-example-bucket'
+      name: "BucketName",
+      value: "doc-example-bucket"
     },
     {
-      name: 'StorageType',
-      value: 'AllStorageTypes'
+      name: "StorageType",
+      value: "AllStorageTypes"
     }
   ]
   period = 86_400 # Daily (24 hours * 60 minutes * 60 seconds = 86400 seconds).
-  unit = 'Count'
+  unit = "Count"
   evaluation_periods = 1 # More than one day.
   threshold = 1 # One object.
-  comparison_operator = 'GreaterThanThreshold' # More than one object.
+  comparison_operator = "GreaterThanThreshold" # More than one object.
   # Replace us-west-2 with the AWS Region you're using for Amazon CloudWatch.
-  region = 'us-east-1'
+  region = "us-east-1"
 
   cloudwatch_client = Aws::CloudWatch::Client.new(region: region)
 

--- a/ruby/example_code/cloudwatch/cw-ruby-example-metrics-basics.rb
+++ b/ruby/example_code/cloudwatch/cw-ruby-example-metrics-basics.rb
@@ -6,7 +6,7 @@
 # 2. List available metrics for a metric namespace in Amazon CloudWatch.
 
 # snippet-start:[cloudwatch.Ruby.addDataPoint]
-require 'aws-sdk-cloudwatch'
+require "aws-sdk-cloudwatch"
 
 # Adds a datapoint to a metric in Amazon CloudWatch.
 #
@@ -84,58 +84,58 @@ def list_metrics_for_namespace(cloudwatch_client, metric_namespace)
     response.metrics.each do |metric|
       puts "  Metric name: #{metric.metric_name}"
       if metric.dimensions.count.positive?
-        puts '    Dimensions:'
+        puts "    Dimensions:"
         metric.dimensions.each do |dimension|
           puts "      Name: #{dimension.name}, Value: #{dimension.value}"
         end
       else
-        puts 'No dimensions found.'
+        puts "No dimensions found."
       end
     end
   else
     puts "No metrics found for namespace '#{metric_namespace}'. " \
-      'Note that it could take up to 15 minutes for recently-added metrics ' \
-      'to become available.'
+      "Note that it could take up to 15 minutes for recently-added metrics " \
+      "to become available."
   end
 end
 
 # Full example call:
 def run_me
-  metric_namespace = 'SITE/TRAFFIC'
+  metric_namespace = "SITE/TRAFFIC"
   # Replace us-west-2 with the AWS Region you're using for Amazon CloudWatch.
-  region = 'us-east-1'
+  region = "us-east-1"
 
   cloudwatch_client = Aws::CloudWatch::Client.new(region: region)
 
   # Add three datapoints.
-  puts 'Continuing...' unless datapoint_added_to_metric?(
+  puts "Continuing..." unless datapoint_added_to_metric?(
     cloudwatch_client,
     metric_namespace,
-    'UniqueVisitors',
-    'SiteName',
-    'example.com',
+    "UniqueVisitors",
+    "SiteName",
+    "example.com",
     5_885.0,
-    'Count'
+    "Count"
   )
 
-  puts 'Continuing...' unless datapoint_added_to_metric?(
+  puts "Continuing..." unless datapoint_added_to_metric?(
     cloudwatch_client,
     metric_namespace,
-    'UniqueVisits',
-    'SiteName',
-    'example.com',
+    "UniqueVisits",
+    "SiteName",
+    "example.com",
     8_628.0,
-    'Count'
+    "Count"
   )
 
-  puts 'Continuing...' unless datapoint_added_to_metric?(
+  puts "Continuing..." unless datapoint_added_to_metric?(
     cloudwatch_client,
     metric_namespace,
-    'PageViews',
-    'PageURL',
-    'example.html',
+    "PageViews",
+    "PageURL",
+    "example.html",
     18_057.0,
-    'Count'
+    "Count"
   )
 
   puts "Metrics for namespace '#{metric_namespace}':"

--- a/ruby/example_code/cloudwatch/cw-ruby-example-show-alarms.rb
+++ b/ruby/example_code/cloudwatch/cw-ruby-example-show-alarms.rb
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require 'aws-sdk-cloudwatch'
+require "aws-sdk-cloudwatch"
 
 # Displays information about available metric alarms in Amazon CloudWatch.
 
@@ -17,52 +17,52 @@ def describe_metric_alarms(cloudwatch_client)
 
   if response.metric_alarms.count.positive?
     response.metric_alarms.each do |alarm|
-      puts '-' * 16
-      puts 'Name:           ' + alarm.alarm_name
-      puts 'State value:    ' + alarm.state_value
-      puts 'State reason:   ' + alarm.state_reason
-      puts 'Metric:         ' + alarm.metric_name
-      puts 'Namespace:      ' + alarm.namespace
-      puts 'Statistic:      ' + alarm.statistic
-      puts 'Period:         ' + alarm.period.to_s
-      puts 'Unit:           ' + alarm.unit.to_s
-      puts 'Eval. periods:  ' + alarm.evaluation_periods.to_s
-      puts 'Threshold:      ' + alarm.threshold.to_s
-      puts 'Comp. operator: ' + alarm.comparison_operator
+      puts "-" * 16
+      puts "Name:           " + alarm.alarm_name
+      puts "State value:    " + alarm.state_value
+      puts "State reason:   " + alarm.state_reason
+      puts "Metric:         " + alarm.metric_name
+      puts "Namespace:      " + alarm.namespace
+      puts "Statistic:      " + alarm.statistic
+      puts "Period:         " + alarm.period.to_s
+      puts "Unit:           " + alarm.unit.to_s
+      puts "Eval. periods:  " + alarm.evaluation_periods.to_s
+      puts "Threshold:      " + alarm.threshold.to_s
+      puts "Comp. operator: " + alarm.comparison_operator
 
       if alarm.key?(:ok_actions) && alarm.ok_actions.count.positive?
-        puts 'OK actions:'
+        puts "OK actions:"
         alarm.ok_actions.each do |a|
-          puts '  ' + a
+          puts "  " + a
         end
       end
 
       if alarm.key?(:alarm_actions) && alarm.alarm_actions.count.positive?
-        puts 'Alarm actions:'
+        puts "Alarm actions:"
         alarm.alarm_actions.each do |a|
-          puts '  ' + a
+          puts "  " + a
         end
       end
 
       if alarm.key?(:insufficient_data_actions) &&
           alarm.insufficient_data_actions.count.positive?
-        puts 'Insufficient data actions:'
+        puts "Insufficient data actions:"
         alarm.insufficient_data_actions.each do |a|
-          puts '  ' + a
+          puts "  " + a
         end
       end
 
-      puts 'Dimensions:'
+      puts "Dimensions:"
       if alarm.key?(:dimensions) && alarm.dimensions.count.positive?
         alarm.dimensions.each do |d|
-          puts '  Name: ' + d.name + ', Value: ' + d.value
+          puts "  Name: " + d.name + ", Value: " + d.value
         end
       else
-        puts '  None for this alarm.'
+        puts "  None for this alarm."
       end
     end
   else
-    puts 'No alarms found.'
+    puts "No alarms found."
   end
 rescue StandardError => e
   puts "Error getting information about alarms: #{e.message}"
@@ -70,23 +70,23 @@ end
 
 # Full example call:
 def run_me
-  region = ''
+  region = ""
 
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby cw-ruby-example-show-alarms.rb REGION'
-    puts 'Example: ruby cw-ruby-example-show-alarms.rb us-east-1'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby cw-ruby-example-show-alarms.rb REGION"
+    puts "Example: ruby cw-ruby-example-show-alarms.rb us-east-1"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   elsif ARGV.count.zero?
-    region = 'us-east-1'
+    region = "us-east-1"
   # Otherwise, use the values as specified at the command prompt.
   else
     region = ARGV[0]
   end
 
   cloudwatch_client = Aws::CloudWatch::Client.new(region: region)
-  puts 'Available alarms:'
+  puts "Available alarms:"
   describe_metric_alarms(cloudwatch_client)
 end
 

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-alarm-actions.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-alarm-actions.rb
@@ -1,32 +1,32 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-alarm-actions'
+require_relative "../cw-ruby-example-alarm-actions"
 
-describe '#alarm_created_or_updated?' do
-  let(:alarm_name) { 'ObjectsInBucket' }
-  let(:alarm_description) { 'Objects exist in this bucket for more than 1 day.' }
-  let(:metric_name) { 'NumberOfObjects' }
-  let(:alarm_actions) { ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic'] }
-  let(:namespace) { 'AWS/S3' }
-  let(:statistic) { 'Average' }
+describe "#alarm_created_or_updated?" do
+  let(:alarm_name) { "ObjectsInBucket" }
+  let(:alarm_description) { "Objects exist in this bucket for more than 1 day." }
+  let(:metric_name) { "NumberOfObjects" }
+  let(:alarm_actions) { ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"] }
+  let(:namespace) { "AWS/S3" }
+  let(:statistic) { "Average" }
   let(:dimensions) do
     [
       {
-        name: 'BucketName',
-        value: 'doc-example-bucket'
+        name: "BucketName",
+        value: "doc-example-bucket"
       },
       {
-        name: 'StorageType',
-        value: 'AllStorageTypes'
+        name: "StorageType",
+        value: "AllStorageTypes"
       }
     ]
   end
   let(:period) { 86_400 }
-  let(:unit) { 'Count' }
+  let(:unit) { "Count" }
   let(:evaluation_periods) { 1 }
   let(:threshold) { 1 }
-  let(:comparison_operator) { 'GreaterThanThreshold' }
+  let(:comparison_operator) { "GreaterThanThreshold" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -35,7 +35,7 @@ describe '#alarm_created_or_updated?' do
     )
   end
 
-  it 'creates or updates an alarm' do
+  it "creates or updates an alarm" do
     expect(
       alarm_created_or_updated?(
         cloudwatch_client,
@@ -56,8 +56,8 @@ describe '#alarm_created_or_updated?' do
   end
 end
 
-describe '#alarm_actions_disabled?' do
-  let(:alarm_name) { 'ObjectsInBucket' }
+describe "#alarm_actions_disabled?" do
+  let(:alarm_name) { "ObjectsInBucket" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -66,7 +66,7 @@ describe '#alarm_actions_disabled?' do
     )
   end
 
-  it 'disables actions for an alarm' do
+  it "disables actions for an alarm" do
     expect(
       alarm_actions_disabled?(cloudwatch_client, alarm_name)
     ).to be(true)

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-alarm-basics.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-alarm-basics.rb
@@ -1,16 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-alarm-basics'
+require_relative "../cw-ruby-example-alarm-basics"
 
-describe '#list_alarms' do
+describe "#list_alarms" do
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
         describe_alarms: {
           metric_alarms: [
             {
-              alarm_name: 'ObjectsInBucket'
+              alarm_name: "ObjectsInBucket"
             }
           ]
         }
@@ -18,35 +18,35 @@ describe '#list_alarms' do
     )
   end
 
-  it 'lists information about alarms' do
+  it "lists information about alarms" do
     expect { list_alarms(cloudwatch_client) }.not_to raise_error
   end
 end
 
-describe '#alarm_created_or_updated?' do
-  let(:alarm_name) { 'ObjectsInBucket' }
-  let(:alarm_description) { 'Objects exist in this bucket for more than 1 day.' }
-  let(:metric_name) { 'NumberOfObjects' }
-  let(:alarm_actions) { ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic'] }
-  let(:namespace) { 'AWS/S3' }
-  let(:statistic) { 'Average' }
+describe "#alarm_created_or_updated?" do
+  let(:alarm_name) { "ObjectsInBucket" }
+  let(:alarm_description) { "Objects exist in this bucket for more than 1 day." }
+  let(:metric_name) { "NumberOfObjects" }
+  let(:alarm_actions) { ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"] }
+  let(:namespace) { "AWS/S3" }
+  let(:statistic) { "Average" }
   let(:dimensions) do
     [
       {
-        name: 'BucketName',
-        value: 'doc-example-bucket'
+        name: "BucketName",
+        value: "doc-example-bucket"
       },
       {
-        name: 'StorageType',
-        value: 'AllStorageTypes'
+        name: "StorageType",
+        value: "AllStorageTypes"
       }
     ]
   end
   let(:period) { 86_400 }
-  let(:unit) { 'Count' }
+  let(:unit) { "Count" }
   let(:evaluation_periods) { 1 }
   let(:threshold) { 1 }
-  let(:comparison_operator) { 'GreaterThanThreshold' }
+  let(:comparison_operator) { "GreaterThanThreshold" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -55,7 +55,7 @@ describe '#alarm_created_or_updated?' do
     )
   end
 
-  it 'creates or updates an alarm' do
+  it "creates or updates an alarm" do
     expect(
       alarm_created_or_updated?(
         cloudwatch_client,
@@ -76,8 +76,8 @@ describe '#alarm_created_or_updated?' do
   end
 end
 
-describe '#alarm_deleted?' do
-  let(:alarm_name) { 'ObjectsInBucket' }
+describe "#alarm_deleted?" do
+  let(:alarm_name) { "ObjectsInBucket" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -86,7 +86,7 @@ describe '#alarm_deleted?' do
     )
   end
 
-  it 'deletes an alarm' do
+  it "deletes an alarm" do
     expect(
       alarm_deleted?(cloudwatch_client, alarm_name)
     ).to be(true)

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-create-alarm.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-create-alarm.rb
@@ -1,32 +1,32 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-create-alarm'
+require_relative "../cw-ruby-example-create-alarm"
 
-describe '#alarm_created_or_updated?' do
-  let(:alarm_name) { 'ObjectsInBucket' }
-  let(:alarm_description) { 'Objects exist in this bucket for more than 1 day.' }
-  let(:metric_name) { 'NumberOfObjects' }
-  let(:alarm_actions) { ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic'] }
-  let(:namespace) { 'AWS/S3' }
-  let(:statistic) { 'Average' }
+describe "#alarm_created_or_updated?" do
+  let(:alarm_name) { "ObjectsInBucket" }
+  let(:alarm_description) { "Objects exist in this bucket for more than 1 day." }
+  let(:metric_name) { "NumberOfObjects" }
+  let(:alarm_actions) { ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"] }
+  let(:namespace) { "AWS/S3" }
+  let(:statistic) { "Average" }
   let(:dimensions) do
     [
       {
-        name: 'BucketName',
-        value: 'doc-example-bucket'
+        name: "BucketName",
+        value: "doc-example-bucket"
       },
       {
-        name: 'StorageType',
-        value: 'AllStorageTypes'
+        name: "StorageType",
+        value: "AllStorageTypes"
       }
     ]
   end
   let(:period) { 86_400 }
-  let(:unit) { 'Count' }
+  let(:unit) { "Count" }
   let(:evaluation_periods) { 1 }
   let(:threshold) { 1 }
-  let(:comparison_operator) { 'GreaterThanThreshold' }
+  let(:comparison_operator) { "GreaterThanThreshold" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -35,7 +35,7 @@ describe '#alarm_created_or_updated?' do
     )
   end
 
-  it 'creates or updates an alarm' do
+  it "creates or updates an alarm" do
     expect(
       alarm_created_or_updated?(
         cloudwatch_client,

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-metrics-basics.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-metrics-basics.rb
@@ -1,15 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-metrics-basics'
+require_relative "../cw-ruby-example-metrics-basics"
 
-describe '#datapoint_added_to_metric?' do
-  let(:metric_namespace) { 'SITE/TRAFFIC' }
-  let(:metric_name) { 'UniqueVisitors' }
-  let(:dimension_name) { 'SiteName' }
-  let(:dimension_value) { 'example.com' }
+describe "#datapoint_added_to_metric?" do
+  let(:metric_namespace) { "SITE/TRAFFIC" }
+  let(:metric_name) { "UniqueVisitors" }
+  let(:dimension_name) { "SiteName" }
+  let(:dimension_value) { "example.com" }
   let(:metric_value) { 5_885.0 }
-  let(:metric_unit) { 'Count' }
+  let(:metric_unit) { "Count" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -18,7 +18,7 @@ describe '#datapoint_added_to_metric?' do
     )
   end
 
-  it 'adds a datapoint to a metric' do
+  it "adds a datapoint to a metric" do
     expect(
       datapoint_added_to_metric?(
         cloudwatch_client,
@@ -33,19 +33,19 @@ describe '#datapoint_added_to_metric?' do
   end
 end
 
-describe 'list_metrics_for_namespace' do
-  let(:metric_namespace) { 'SITE/TRAFFIC' }
+describe "list_metrics_for_namespace" do
+  let(:metric_namespace) { "SITE/TRAFFIC" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
         list_metrics: {
           metrics: [
             {
-              metric_name: 'UniqueVisitors',
+              metric_name: "UniqueVisitors",
               dimensions: [
                 {
-                  name: 'SiteName',
-                  value: 'example.com'
+                  name: "SiteName",
+                  value: "example.com"
                 }
               ]
             }
@@ -55,7 +55,7 @@ describe 'list_metrics_for_namespace' do
     )
   end
 
-  it 'lists the metrics for a namespace' do
+  it "lists the metrics for a namespace" do
     expect {
       list_metrics_for_namespace(cloudwatch_client, metric_namespace)
     }.not_to raise_error

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-send-events-ec2.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-send-events-ec2.rb
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-send-events-ec2'
+require_relative "../cw-ruby-example-send-events-ec2"
 
-describe '#topic_exists?' do
-  let(:topic_arn) { 'arn:aws:sns:us-east-1:111111111111:aws-doc-sdk-examples-topic' }
+describe "#topic_exists?" do
+  let(:topic_arn) { "arn:aws:sns:us-east-1:111111111111:aws-doc-sdk-examples-topic" }
   let(:sns_client) do
     Aws::SNS::Client.new(
       stub_responses: {
@@ -17,16 +17,16 @@ describe '#topic_exists?' do
     )
   end
 
-  it 'checks whether a topic exists' do
+  it "checks whether a topic exists" do
     expect(
       topic_exists?(sns_client, topic_arn)
     ).to be(true)
   end
 end
 
-describe '#create_topic' do
-  let(:topic_name) { 'aws-doc-sdk-examples-topic' }
-  let(:email_address) { 'mary@example.com' }
+describe "#create_topic" do
+  let(:topic_name) { "aws-doc-sdk-examples-topic" }
+  let(:email_address) { "mary@example.com" }
   let(:topic_arn) { "arn:aws:sns:us-east-1:111111111111:#{topic_name}" }
   let(:sns_client) do
     Aws::SNS::Client.new(
@@ -41,15 +41,15 @@ describe '#create_topic' do
     )
   end
 
-  it 'creates a topic' do
+  it "creates a topic" do
     expect(
       create_topic(sns_client, topic_name, email_address)
     ).to eq(topic_arn)
   end
 end
 
-describe '#role_exists?' do
-  let(:role_name) { 'aws-doc-sdk-examples-cloudwatch-events-rule-role' }
+describe "#role_exists?" do
+  let(:role_name) { "aws-doc-sdk-examples-cloudwatch-events-rule-role" }
   let(:role_arn) { "arn:aws:iam::111111111111:role/#{role_name}" }
   let(:iam_client) do
     Aws::IAM::Client.new(
@@ -57,25 +57,25 @@ describe '#role_exists?' do
         list_roles: {
           roles: [
             arn: role_arn,
-            path: '/',
+            path: "/",
             role_name: role_name,
-            role_id: 'AIDAJQABLZS4A3EXAMPLE',
-            create_date: Time.iso8601('2020-11-17T14:19:00-08:00')
+            role_id: "AIDAJQABLZS4A3EXAMPLE",
+            create_date: Time.iso8601("2020-11-17T14:19:00-08:00")
           ]
         }
       }
     )
   end
 
-  it 'checks whether a role exists' do
+  it "checks whether a role exists" do
     expect(
       role_exists?(iam_client, role_arn)
     ).to be(true)
   end
 end
 
-describe '#create_role' do
-  let(:role_name) { 'aws-doc-sdk-examples-cloudwatch-events-rule-role' }
+describe "#create_role" do
+  let(:role_name) { "aws-doc-sdk-examples-cloudwatch-events-rule-role" }
   let(:role_arn) { "arn:aws:iam::111111111111:role/#{role_name}" }
   let(:iam_client) do
     Aws::IAM::Client.new(
@@ -83,25 +83,25 @@ describe '#create_role' do
         create_role: {
           role: {
             arn: role_arn,
-            path: '/',
+            path: "/",
             role_name: role_name,
-            role_id: 'AIDAJQABLZS4A3EXAMPLE',
-            create_date: Time.iso8601('2020-11-17T14:19:00-08:00')
+            role_id: "AIDAJQABLZS4A3EXAMPLE",
+            create_date: Time.iso8601("2020-11-17T14:19:00-08:00")
           }
         }
       }
     )
   end
 
-  it 'creates a role' do
+  it "creates a role" do
     expect(
       create_role(iam_client, role_name)
     ).to eq(role_arn)
   end
 end
 
-describe '#rule_exists?' do
-  let(:rule_name) { 'aws-doc-sdk-examples-ec2-state-change' }
+describe "#rule_exists?" do
+  let(:rule_name) { "aws-doc-sdk-examples-ec2-state-change" }
   let(:cloudwatchevents_client) do
     Aws::CloudWatchEvents::Client.new(
       stub_responses: {
@@ -116,20 +116,20 @@ describe '#rule_exists?' do
     )
   end
 
-  it 'checks whether a rule exists' do
+  it "checks whether a rule exists" do
     expect(
       rule_exists?(cloudwatchevents_client, rule_name)
     ).to be(true)
   end
 end
 
-describe '#rule_created?' do
-  let(:rule_name) { 'aws-doc-sdk-examples-ec2-state-change' }
-  let(:rule_description) { 'Triggers when any available EC2 instance starts.' }
-  let(:instance_state) { 'running' }
-  let(:role_arn) { 'arn:aws:iam::111111111111:role/aws-doc-sdk-examples-cloudwatch-events-rule-role' }
-  let(:target_id) { 'sns-topic' }
-  let(:topic_arn) { 'arn:aws:sns:us-east-1:111111111111:aws-doc-sdk-examples-topic' }
+describe "#rule_created?" do
+  let(:rule_name) { "aws-doc-sdk-examples-ec2-state-change" }
+  let(:rule_description) { "Triggers when any available EC2 instance starts." }
+  let(:instance_state) { "running" }
+  let(:role_arn) { "arn:aws:iam::111111111111:role/aws-doc-sdk-examples-cloudwatch-events-rule-role" }
+  let(:target_id) { "sns-topic" }
+  let(:topic_arn) { "arn:aws:sns:us-east-1:111111111111:aws-doc-sdk-examples-topic" }
   let(:cloudwatchevents_client) do
     Aws::CloudWatchEvents::Client.new(
       stub_responses: {
@@ -141,7 +141,7 @@ describe '#rule_created?' do
     )
   end
 
-  it 'creates a rule' do
+  it "creates a rule" do
     expect(
       rule_created?(
         cloudwatchevents_client,
@@ -156,8 +156,8 @@ describe '#rule_created?' do
   end
 end
 
-describe '#log_group_exists?' do
-  let(:log_group_name) { 'aws-doc-sdk-examples-cloudwatch-log' }
+describe "#log_group_exists?" do
+  let(:log_group_name) { "aws-doc-sdk-examples-cloudwatch-log" }
   let(:cloudwatchlogs_client) do
     Aws::CloudWatchLogs::Client.new(
       stub_responses: {
@@ -170,15 +170,15 @@ describe '#log_group_exists?' do
     )
   end
 
-  it 'checks whether a log group exists' do
+  it "checks whether a log group exists" do
     expect(
       log_group_exists?(cloudwatchlogs_client, log_group_name)
     ).to be(true)
   end
 end
 
-describe '#log_group_created?' do
-  let(:log_group_name) { 'aws-doc-sdk-examples-cloudwatch-log' }
+describe "#log_group_created?" do
+  let(:log_group_name) { "aws-doc-sdk-examples-cloudwatch-log" }
   let(:cloudwatchlogs_client) do
     Aws::CloudWatchLogs::Client.new(
       stub_responses: {
@@ -187,19 +187,20 @@ describe '#log_group_created?' do
     )
   end
 
-  it 'creates a log group' do
+  it "creates a log group" do
     expect(
       log_group_created?(cloudwatchlogs_client, log_group_name)
     ).to be(true)
   end
 end
 
-describe '#log_event' do
-  let(:log_group_name) { 'aws-doc-sdk-examples-cloudwatch-log' }
+describe "#log_event" do
+  let(:log_group_name) { "aws-doc-sdk-examples-cloudwatch-log" }
   let(:log_stream_name) { "#{Time.now.year}/#{Time.now.month}/#{Time.now.day}/" \
-    "#{SecureRandom.uuid}" }
+    "#{SecureRandom.uuid}"
+  }
   let(:message) { "Instance 'i-033c48ef067af3dEX' restarted." }
-  let(:sequence_token) { '495426724868310740095796045676567882148068632824696073EX' }
+  let(:sequence_token) { "495426724868310740095796045676567882148068632824696073EX" }
   let(:cloudwatchlogs_client) do
     Aws::CloudWatchLogs::Client.new(
       stub_responses: {
@@ -210,7 +211,7 @@ describe '#log_event' do
     )
   end
 
-  it 'logs an event' do
+  it "logs an event" do
     expect(
       log_event(
         cloudwatchlogs_client,
@@ -223,9 +224,9 @@ describe '#log_event' do
   end
 end
 
-describe '#instance_restarted?' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
-  let(:log_group_name) { 'aws-doc-sdk-examples-cloudwatch-log' }
+describe "#instance_restarted?" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
+  let(:log_group_name) { "aws-doc-sdk-examples-cloudwatch-log" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -234,12 +235,12 @@ describe '#instance_restarted?' do
             {
               current_state: {
                 code: 80,
-                name: 'stopped'
+                name: "stopped"
               },
               instance_id: instance_id,
               previous_state: {
                 code: 16,
-                name: 'running'
+                name: "running"
               }
             }
           ]
@@ -249,12 +250,12 @@ describe '#instance_restarted?' do
             {
               current_state: {
                 code: 16,
-                name: 'running'
+                name: "running"
               },
               instance_id: instance_id,
               previous_state: {
                 code: 80,
-                name: 'stopped'
+                name: "stopped"
               }
             }
           ]
@@ -266,7 +267,7 @@ describe '#instance_restarted?' do
                 instance_id: instance_id,
                 state: {
                   code: 80,
-                  name: 'stopped'
+                  name: "stopped"
                 }
               ]
             ]
@@ -277,7 +278,7 @@ describe '#instance_restarted?' do
                 instance_id: instance_id,
                 state: {
                   code: 16,
-                  name: 'running'
+                  name: "running"
                 }
               ]
             ]
@@ -294,7 +295,7 @@ describe '#instance_restarted?' do
     )
   end
 
-  it 'restarts an instance and logs related events' do
+  it "restarts an instance and logs related events" do
     expect(
       instance_restarted?(
         ec2_client,
@@ -306,8 +307,8 @@ describe '#instance_restarted?' do
   end
 end
 
-describe '#display_rule_activity' do
-  let(:rule_name) { 'aws-doc-sdk-examples-ec2-state-change' }
+describe "#display_rule_activity" do
+  let(:rule_name) { "aws-doc-sdk-examples-ec2-state-change" }
   let(:start_time) { Time.now - 600 }
   let(:end_time) { Time.now }
   let(:period) { 60 }
@@ -318,11 +319,11 @@ describe '#display_rule_activity' do
           datapoints: [
             {
               sum: 1.0,
-              timestamp: Time.iso8601('2020-11-17T14:19:00-08:00')
+              timestamp: Time.iso8601("2020-11-17T14:19:00-08:00")
             },
             {
               sum: 2.0,
-              timestamp: Time.iso8601('2020-11-17T14:32:00-08:00')
+              timestamp: Time.iso8601("2020-11-17T14:32:00-08:00")
             }
           ]
         }
@@ -330,7 +331,7 @@ describe '#display_rule_activity' do
     )
   end
 
-  it 'displays activity for a rule' do
+  it "displays activity for a rule" do
     expect {
       display_rule_activity(
         cloudwatch_client,
@@ -343,10 +344,11 @@ describe '#display_rule_activity' do
   end
 end
 
-describe '#display_log_data' do
-  let(:log_group_name) { 'aws-doc-sdk-examples-cloudwatch-log' }
+describe "#display_log_data" do
+  let(:log_group_name) { "aws-doc-sdk-examples-cloudwatch-log" }
   let(:log_stream_name) { "#{Time.now.year}/#{Time.now.month}/#{Time.now.day}/" \
-    "#{SecureRandom.uuid}" }
+    "#{SecureRandom.uuid}"
+  }
   let(:cloudwatchlogs_client) do
     Aws::CloudWatchLogs::Client.new(
       stub_responses: {
@@ -371,7 +373,7 @@ describe '#display_log_data' do
     )
   end
 
-  it 'displays log streams data' do
+  it "displays log streams data" do
     expect {
       display_log_data(cloudwatchlogs_client, log_group_name)
     }.not_to raise_error

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-show-alarms.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-show-alarms.rb
@@ -1,43 +1,43 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-show-alarms'
+require_relative "../cw-ruby-example-show-alarms"
 
-describe '#describe_metric_alarms' do
-  let(:metric_namespace) { 'SITE/TRAFFIC' }
-  let(:metric_name) { 'UniqueVisitors' }
-  let(:dimension_name) { 'SiteName' }
-  let(:dimension_value) { 'example.com' }
+describe "#describe_metric_alarms" do
+  let(:metric_namespace) { "SITE/TRAFFIC" }
+  let(:metric_name) { "UniqueVisitors" }
+  let(:dimension_name) { "SiteName" }
+  let(:dimension_value) { "example.com" }
   let(:metric_value) { 5_885.0 }
-  let(:metric_unit) { 'Count' }
+  let(:metric_unit) { "Count" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
         describe_alarms: {
           metric_alarms: [
             {
-              alarm_name: 'ObjectsInBucket',
-              state_value: 'INSUFFICIENT_DATA',
-              state_reason: 'Unchecked: Initial alarm creation',
-              metric_name: 'NumberOfObjects',
-              namespace: 'AWS/S3',
-              statistic: 'Average',
+              alarm_name: "ObjectsInBucket",
+              state_value: "INSUFFICIENT_DATA",
+              state_reason: "Unchecked: Initial alarm creation",
+              metric_name: "NumberOfObjects",
+              namespace: "AWS/S3",
+              statistic: "Average",
               period: 86_400,
-              unit: 'Count',
+              unit: "Count",
               evaluation_periods: 1,
               threshold: 1.0,
-              comparison_operator: 'GreaterThanThreshold',
+              comparison_operator: "GreaterThanThreshold",
               ok_actions: [
-                'arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic'
+                "arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"
               ],
               dimensions: [
                 {
-                  name: 'BucketName',
-                  value: 'doc-example-bucket'
+                  name: "BucketName",
+                  value: "doc-example-bucket"
                 },
                 {
-                    name: 'StorageType',
-                    value: 'AllStorageTypes'
+                    name: "StorageType",
+                    value: "AllStorageTypes"
                 }
               ]
             }
@@ -47,7 +47,7 @@ describe '#describe_metric_alarms' do
     )
   end
 
-  it 'shows information about metric alarms' do
+  it "shows information about metric alarms" do
     expect { describe_metric_alarms(cloudwatch_client) }.not_to raise_error
   end
 end

--- a/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-build-project.rb
+++ b/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-build-project.rb
@@ -8,23 +8,23 @@
 
 # snippet-start:[codebuild.Ruby.buildProject]
 
-require 'aws-sdk-codebuild'  # v2: require 'aws-sdk'
+require "aws-sdk-codebuild"  # v2: require 'aws-sdk'
 
-project_name = ''
+project_name = ""
 
 if ARGV.length != 1
-  puts 'You must supply the name of the project to build'
+  puts "You must supply the name of the project to build"
   exit 1
 else
   project_name = ARGV[0]
 end
 # Replace us-west-2 with the AWS Region you're using for Amazon CodeBuild.
-client = Aws::CodeBuild::Client.new(region: 'us-west-2')
+client = Aws::CodeBuild::Client.new(region: "us-west-2")
 
 begin
   client.start_build(project_name: project_name)
-  puts 'Building project ' + project_name
+  puts "Building project " + project_name
 rescue StandardError => ex
-  puts 'Error building project: ' + ex.message
+  puts "Error building project: " + ex.message
 end
 # snippet-end:[codebuild.Ruby.buildProject]

--- a/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-list-builds.rb
+++ b/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-list-builds.rb
@@ -7,18 +7,18 @@
 
 # snippet-start:[codebuild.Ruby.listBuilds]
 
-require 'aws-sdk-codebuild'  # v2: require 'aws-sdk'
+require "aws-sdk-codebuild"  # v2: require 'aws-sdk'
 
 # Replace us-west-2 with the AWS Region you're using for Amazon CodeBuild.
-client = Aws::CodeBuild::Client.new(region: 'us-west-2')
+client = Aws::CodeBuild::Client.new(region: "us-west-2")
 
-build_list = client.list_builds({sort_order: 'ASCENDING', })
+build_list = client.list_builds({sort_order: "ASCENDING", })
 
 builds = client.batch_get_builds({ids: build_list.ids})
 
 builds.builds.each do |build|
-  puts 'Project:    ' + build.project_name
-  puts 'Phase:      ' + build.current_phase
-  puts 'Status:     ' + build.build_status
+  puts "Project:    " + build.project_name
+  puts "Phase:      " + build.current_phase
+  puts "Status:     " + build.build_status
 end
 # snippet-end:[codebuild.Ruby.listBuilds]

--- a/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-list-projects.rb
+++ b/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-list-projects.rb
@@ -7,14 +7,14 @@
 
 # snippet-start:[codebuild.Ruby.listProjects]
 
-require 'aws-sdk-codebuild'  # v2: require 'aws-sdk'
+require "aws-sdk-codebuild"  # v2: require 'aws-sdk'
 
 # Replace us-west-2 with the AWS Region you're using for Amazon CodeBuild.
-client = Aws::CodeBuild::Client.new(region: 'REGION')
+client = Aws::CodeBuild::Client.new(region: "REGION")
 
 resp = client.list_projects({
-  sort_by: 'NAME', # accepts NAME, CREATED_TIME, LAST_MODIFIED_TIME
-  sort_order: 'ASCENDING' # accepts ASCENDING, DESCENDING
+  sort_by: "NAME", # accepts NAME, CREATED_TIME, LAST_MODIFIED_TIME
+  sort_order: "ASCENDING" # accepts ASCENDING, DESCENDING
 })
 
 resp.projects.each { |p| puts p }

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesCreateTable.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesCreateTable.rb
@@ -9,19 +9,19 @@
 # is then returned, for example 'CREATING'.
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesCreateTable]
-require 'aws-sdk-dynamodb'
+require "aws-sdk-dynamodb"
 
 def create_table(dynamodb_client, table_definition)
   response = dynamodb_client.create_table(table_definition)
   response.table_description.table_status
 rescue StandardError => e
   puts "Error creating table: #{e.message}"
-  'Error'
+  "Error"
 end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
+  region = "us-west-2"
 
   # To use the downloadable version of Amazon DynamoDB,
   # uncomment the endpoint statement.
@@ -33,25 +33,25 @@ def run_me
   dynamodb_client = Aws::DynamoDB::Client.new
 
   table_definition = {
-    table_name: 'Movies',
+    table_name: "Movies",
     key_schema: [
       {
-        attribute_name: 'year',
-        key_type: 'HASH'  # Partition key.
+        attribute_name: "year",
+        key_type: "HASH"  # Partition key.
       },
       {
-        attribute_name: 'title',
-        key_type: 'RANGE' # Sort key.
+        attribute_name: "title",
+        key_type: "RANGE" # Sort key.
       }
     ],
     attribute_definitions: [
       {
-        attribute_name: 'year',
-        attribute_type: 'N'
+        attribute_name: "year",
+        attribute_type: "N"
       },
       {
-        attribute_name: 'title',
-        attribute_type: 'S'
+        attribute_name: "title",
+        attribute_type: "S"
       }
     ],
     provisioned_throughput: {
@@ -63,8 +63,8 @@ def run_me
   puts "Creating the table named 'Movies'..."
   create_table_result = create_table(dynamodb_client, table_definition)
 
-  if create_table_result == 'Error'
-    puts 'Table not created.'
+  if create_table_result == "Error"
+    puts "Table not created."
   else
     puts "Table created with status '#{create_table_result}'."
   end

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesDeleteTable.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesDeleteTable.rb
@@ -5,7 +5,7 @@
 # Amazon DynamoDB named 'Movies'.
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesDeleteTable]
-require 'aws-sdk-dynamodb'
+require "aws-sdk-dynamodb"
 
 def table_deleted?(dynamodb_client, table_name)
   dynamodb_client.delete_table(table_name: table_name)
@@ -17,8 +17,8 @@ end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
-  table_name = 'Movies'
+  region = "us-west-2"
+  table_name = "Movies"
 
   # To use the downloadable version of Amazon DynamoDB,
   # uncomment the endpoint statement.
@@ -32,9 +32,9 @@ def run_me
   puts "Deleting table '#{table_name}'..."
 
   if table_deleted?(dynamodb_client, table_name)
-    puts 'Table deleted.'
+    puts "Table deleted."
   else
-    puts 'Table not deleted.'
+    puts "Table not deleted."
   end
 end
 

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps01.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps01.rb
@@ -10,7 +10,7 @@
 # a 'plot' and 'rating'.
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesItemOps01]
-require 'aws-sdk-dynamodb'
+require "aws-sdk-dynamodb"
 
 def add_item_to_table(dynamodb_client, table_item)
   dynamodb_client.put_item(table_item)
@@ -23,9 +23,9 @@ end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
-  table_name = 'Movies'
-  title = 'The Big New Movie'
+  region = "us-west-2"
+  table_name = "Movies"
+  title = "The Big New Movie"
   year = 2015
 
   # To use the downloadable version of Amazon DynamoDB,
@@ -41,7 +41,7 @@ def run_me
     year: year,
     title: title,
     info: {
-      plot: 'Nothing happens at all.',
+      plot: "Nothing happens at all.",
       rating: 0
     }
   }

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps02.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps02.rb
@@ -9,7 +9,7 @@
 # of 'The Big New Movie'.
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesItemOps02]
-require 'aws-sdk-dynamodb'
+require "aws-sdk-dynamodb"
 
 def get_item_from_table(dynamodb_client, table_item)
   result = dynamodb_client.get_item(table_item)
@@ -23,9 +23,9 @@ end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
-  table_name = 'Movies'
-  title = 'The Big New Movie'
+  region = "us-west-2"
+  table_name = "Movies"
+  title = "The Big New Movie"
   year = 2015
 
   # To use the downloadable version of Amazon DynamoDB,

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps03.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps03.rb
@@ -12,13 +12,13 @@
 # about the updated attributes are returned, as specified by 'UPDATED_NEW'.
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesItemOps03]
-require 'aws-sdk-dynamodb'
+require "aws-sdk-dynamodb"
 
 def table_item_updated?(dynamodb_client, table_item)
   response = dynamodb_client.update_item(table_item)
   puts "Table item updated with the following attributes for 'info':"
-  response.attributes['info'].each do |key, value|
-    if key == 'rating'
+  response.attributes["info"].each do |key, value|
+    if key == "rating"
       puts "#{key}: #{value.to_f}"
     else
       puts "#{key}: #{value}"
@@ -32,9 +32,9 @@ end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
-  table_name = 'Movies'
-  title = 'The Big New Movie'
+  region = "us-west-2"
+  table_name = "Movies"
+  title = "The Big New Movie"
   year = 2015
 
   # To use the downloadable version of Amazon DynamoDB,
@@ -52,22 +52,22 @@ def run_me
       year: year,
       title: title
     },
-    update_expression: 'SET info.rating = :r, info.plot = :p, info.actors = :a',
+    update_expression: "SET info.rating = :r, info.plot = :p, info.actors = :a",
     expression_attribute_values: {
       ':r': 5.5,
-      ':p': 'Everything happens all at once.',
-      ':a': [ 'Larry', 'Moe', 'Curly' ]
+      ':p': "Everything happens all at once.",
+      ':a': ["Larry", "Moe", "Curly"]
     },
-    return_values: 'UPDATED_NEW'
+    return_values: "UPDATED_NEW"
   }
 
   puts "Updating table '#{table_name}' with information about " \
     "'#{title} (#{year})'..."
 
   if table_item_updated?(dynamodb_client, table_item)
-    puts 'Table updated.'
+    puts "Table updated."
   else
-    puts 'Table not updated.'
+    puts "Table not updated."
   end
 end
 

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps04.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps04.rb
@@ -11,13 +11,13 @@
 # attribute is returned, as specified by 'UPDATED_NEW'.
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesItemOps04]
-require 'aws-sdk-dynamodb'
+require "aws-sdk-dynamodb"
 
 def table_item_updated?(dynamodb_client, table_item)
   result = dynamodb_client.update_item(table_item)
   puts "Table item updated with the following attributes for 'info':"
-  result.attributes['info'].each do |key, value|
-    if key == 'rating'
+  result.attributes["info"].each do |key, value|
+    if key == "rating"
       puts "#{key}: #{value.to_f}"
     else
       puts "#{key}: #{value}"
@@ -31,9 +31,9 @@ end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
-  table_name = 'Movies'
-  title = 'The Big New Movie'
+  region = "us-west-2"
+  table_name = "Movies"
+  title = "The Big New Movie"
   year = 2015
 
   # To use the downloadable version of Amazon DynamoDB,
@@ -51,20 +51,20 @@ def run_me
       year: year,
       title: title
     },
-    update_expression: 'SET info.rating = info.rating + :val',
+    update_expression: "SET info.rating = info.rating + :val",
     expression_attribute_values: {
       ':val': 1
     },
-    return_values: 'UPDATED_NEW'
+    return_values: "UPDATED_NEW"
   }
 
   puts "Updating table '#{table_name}' with information about " \
     "'#{title} (#{year})'..."
 
   if table_item_updated?(dynamodb_client, table_item)
-    puts 'Table updated.'
+    puts "Table updated."
   else
-    puts 'Table not updated.'
+    puts "Table not updated."
   end
 end
 

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps05.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps05.rb
@@ -12,13 +12,13 @@
 # returned, as specified by 'UPDATED_NEW'.
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesItemOps05]
-require 'aws-sdk-dynamodb'
+require "aws-sdk-dynamodb"
 
 def table_item_updated?(dynamodb_client, table_item)
   result = dynamodb_client.update_item(table_item)
   puts "Table item updated with the following attributes for 'info':"
-  result.attributes['info'].each do |key, value|
-    if key == 'rating'
+  result.attributes["info"].each do |key, value|
+    if key == "rating"
       puts "#{key}: #{value.to_f}"
     else
       puts "#{key}: #{value}"
@@ -32,9 +32,9 @@ end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
-  table_name = 'Movies'
-  title = 'The Big New Movie'
+  region = "us-west-2"
+  table_name = "Movies"
+  title = "The Big New Movie"
   year = 2015
 
   # To use the downloadable version of Amazon DynamoDB,
@@ -52,21 +52,21 @@ def run_me
       year: year,
       title: title
     },
-    update_expression: 'REMOVE info.actors[0]',
-    condition_expression: 'size(info.actors) > :num',
+    update_expression: "REMOVE info.actors[0]",
+    condition_expression: "size(info.actors) > :num",
     expression_attribute_values: {
       ':num': 3
     },
-    return_values: 'UPDATED_NEW'
+    return_values: "UPDATED_NEW"
   }
 
   puts "Updating table '#{table_name}' with information about " \
     "'#{title} (#{year})'..."
 
   if table_item_updated?(dynamodb_client, table_item)
-    puts 'Table updated.'
+    puts "Table updated."
   else
-    puts 'Table not updated.'
+    puts "Table not updated."
   end
 end
 

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps06.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesItemOps06.rb
@@ -10,7 +10,7 @@
 # 'info' attribute is less than or equal to 5, then that item is deleted.
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesItemOps06]
-require 'aws-sdk-dynamodb'
+require "aws-sdk-dynamodb"
 
 def table_item_deleted?(dynamodb_client, table_item)
   dynamodb_client.delete_item(table_item)
@@ -22,9 +22,9 @@ end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
-  table_name = 'Movies'
-  title = 'The Big New Movie'
+  region = "us-west-2"
+  table_name = "Movies"
+  title = "The Big New Movie"
   year = 2015
 
   # To use the downloadable version of Amazon DynamoDB,
@@ -42,9 +42,9 @@ def run_me
       year: year,
       title: title
     },
-    condition_expression: 'info.rating <= :val',
+    condition_expression: "info.rating <= :val",
     expression_attribute_values: {
-      ':val' => 5
+      ":val" => 5
     }
   }
 
@@ -52,9 +52,9 @@ def run_me
     "'#{title} (#{year})' if specified criteria are met..."
 
   if table_item_deleted?(dynamodb_client, table_item)
-    puts 'Item deleted.'
+    puts "Item deleted."
   else
-    puts 'Item not deleted.'
+    puts "Item not deleted."
   end
 end
 

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesLoadData.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesLoadData.rb
@@ -49,8 +49,8 @@
 # ]
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesLoadData]
-require 'aws-sdk-dynamodb'
-require 'json'
+require "aws-sdk-dynamodb"
+require "json"
 
 $movie_counter = 0
 $total_movies = 0
@@ -64,15 +64,15 @@ def add_item_to_table(dynamodb_client, table_item)
 rescue StandardError => e
   puts "Error adding movie '#{table_item[:item]['title']} " \
     "(#{table_item[:item]['year']})': #{e.message}"
-  puts 'Program stopped.'
+  puts "Program stopped."
   exit 1
 end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
-  table_name = 'Movies'
-  data_file = 'moviedata.json'
+  region = "us-west-2"
+  table_name = "Movies"
+  data_file = "moviedata.json"
 
   # To use the downloadable version of Amazon DynamoDB,
   # uncomment the endpoint statement.
@@ -97,7 +97,7 @@ def run_me
     add_item_to_table(dynamodb_client, table_item)
   end
 
-  puts 'Done.'
+  puts "Done."
 end
 
 run_me if $PROGRAM_NAME == __FILE__

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesQuery01.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesQuery01.rb
@@ -12,7 +12,7 @@
 # must have a 'year' attribute value of 1985.
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesQuery01]
-require 'aws-sdk-dynamodb'
+require "aws-sdk-dynamodb"
 
 def query_for_items_from_table(dynamodb_client, query_condition)
   # To display the elapsed time for the query operation,
@@ -22,7 +22,7 @@ def query_for_items_from_table(dynamodb_client, query_condition)
   # finish = Time.now
   # puts "Search took #{finish - start} seconds."
   if result.items.count.zero?
-    puts 'No matching movies found.'
+    puts "No matching movies found."
   else
     puts "Found #{result.items.count} matching movies:"
     result.items.each do |movie|
@@ -35,8 +35,8 @@ end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
-  table_name = 'Movies'
+  region = "us-west-2"
+  table_name = "Movies"
   year = 1985
 
   # To use the downloadable version of Amazon DynamoDB,
@@ -52,14 +52,14 @@ def run_me
   # hash/partition key, uncomment the following three 'title' comments.
   query_condition = {
     table_name: table_name,
-    key_condition_expression: '#yr = :yyyy', # '#yr = :yyyy AND #t = :title'
+    key_condition_expression: "#yr = :yyyy", # '#yr = :yyyy AND #t = :title'
     expression_attribute_names: {
       # '#t' => 'title',
-      '#yr' => 'year'
+      "#yr" => "year"
     },
     expression_attribute_values: {
       # ':title' => 'After Hours',
-      ':yyyy' => year
+      ":yyyy" => year
     }
   }
 

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesQuery02.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesQuery02.rb
@@ -13,7 +13,7 @@
 # beginning with the letters 'A' through 'L'.
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesQuery02]
-require 'aws-sdk-dynamodb'
+require "aws-sdk-dynamodb"
 
 def query_for_items_from_table(dynamodb_client, query_condition)
   # To display the elapsed time for the query operation,
@@ -23,20 +23,20 @@ def query_for_items_from_table(dynamodb_client, query_condition)
   # finish = Time.now
   # puts "Search took #{finish - start} seconds."
   if result.items.count.zero?
-    puts 'No matching movies found.'
+    puts "No matching movies found."
   else
     puts "Found #{result.items.count} matching movies:"
     result.items.each do |movie|
       puts "#{movie['title']} (#{movie['year'].to_i}):"
-      if movie['info'].key?('genres') && movie['info']['genres'].count.positive?
-        puts '  Genres:'
-        movie['info']['genres'].each do |genre|
+      if movie["info"].key?("genres") && movie["info"]["genres"].count.positive?
+        puts "  Genres:"
+        movie["info"]["genres"].each do |genre|
           puts "    #{genre}"
         end
       end
-      if movie['info'].key?('actors') && movie['info']['actors'].count.positive?
-        puts '  Actors:'
-        movie['info']['actors'].each do |actor|
+      if movie["info"].key?("actors") && movie["info"]["actors"].count.positive?
+        puts "  Actors:"
+        movie["info"]["actors"].each do |actor|
           puts "    #{actor}"
         end
       end
@@ -48,11 +48,11 @@ end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
-  table_name = 'Movies'
+  region = "us-west-2"
+  table_name = "Movies"
   year = 1982
-  letter1 = 'A'
-  letter2 = 'L'
+  letter1 = "A"
+  letter2 = "L"
 
   # To use the downloadable version of Amazon DynamoDB,
   # uncomment the endpoint statement.
@@ -65,13 +65,13 @@ def run_me
 
   query_condition = {
     table_name: table_name,
-    projection_expression: '#yr, title, info.genres, info.actors[0]',
-    key_condition_expression: '#yr = :yyyy AND title BETWEEN :letter1 AND :letter2',
-    expression_attribute_names: { '#yr' => 'year' },
+    projection_expression: "#yr, title, info.genres, info.actors[0]",
+    key_condition_expression: "#yr = :yyyy AND title BETWEEN :letter1 AND :letter2",
+    expression_attribute_names: { "#yr" => "year" },
     expression_attribute_values: {
-      ':yyyy' => year,
-      ':letter1' => letter1,
-      ':letter2' => letter2
+      ":yyyy" => year,
+      ":letter1" => letter1,
+      ":letter2" => letter2
     }
   }
 

--- a/ruby/example_code/dynamodb/GettingStarted/MoviesScan.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/MoviesScan.rb
@@ -12,7 +12,7 @@
 # searched (making it slower than a query operation).
 
 # snippet-start:[dynamodb.Ruby.CodeExample.MoviesScan]
-require 'aws-sdk-dynamodb'
+require "aws-sdk-dynamodb"
 
 def scan_for_items_from_table(dynamodb_client, scan_condition)
   # To display the elapsed time for the query operation,
@@ -22,7 +22,7 @@ def scan_for_items_from_table(dynamodb_client, scan_condition)
     result = dynamodb_client.scan(scan_condition)
 
     if result.items.count.zero?
-      puts 'No matching movies found (yet)...'
+      puts "No matching movies found (yet)..."
     else
       puts "Found #{result.items.count} matching movies (so far):"
       result.items.each do |movie|
@@ -36,7 +36,7 @@ def scan_for_items_from_table(dynamodb_client, scan_condition)
       scan_condition[:exclusive_start_key] = result.last_evaluated_key
     end
   end
-  puts 'Finished searching.'
+  puts "Finished searching."
   # finish = Time.now
   # puts "Search took #{finish - start} seconds."
 rescue StandardError => e
@@ -45,8 +45,8 @@ end
 
 def run_me
 # Replace us-west-2 with the AWS Region you're using for Amazon DynamoDB.
-  region = 'us-west-2'
-  table_name = 'Movies'
+  region = "us-west-2"
+  table_name = "Movies"
   start_year = 1950
   end_year = 1959
 
@@ -61,12 +61,12 @@ def run_me
 
   scan_condition = {
     table_name: table_name,
-    projection_expression: '#yr, title, info.rating',
-    filter_expression: '#yr between :start_yr and :end_yr',
-    expression_attribute_names: { '#yr' => 'year' },
+    projection_expression: "#yr, title, info.rating",
+    filter_expression: "#yr between :start_yr and :end_yr",
+    expression_attribute_names: { "#yr" => "year" },
     expression_attribute_values: {
-      ':start_yr' => start_year,
-      ':end_yr' => end_year
+      ":start_yr" => start_year,
+      ":end_yr" => end_year
     }
   }
 

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesCreateTable.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesCreateTable.rb
@@ -1,31 +1,31 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesCreateTable'
+require_relative "../MoviesCreateTable"
 
-describe '#create_table' do
-  let(:table_status) { 'ACTIVE' }
+describe "#create_table" do
+  let(:table_status) { "ACTIVE" }
   let(:table_definition) do
     {
-      table_name: 'Movies',
+      table_name: "Movies",
       key_schema: [
         {
-          attribute_name: 'year',
-          key_type: 'HASH'  # Partition key.
+          attribute_name: "year",
+          key_type: "HASH"  # Partition key.
         },
         {
-          attribute_name: 'title',
-          key_type: 'RANGE' # Sort key.
+          attribute_name: "title",
+          key_type: "RANGE" # Sort key.
         }
       ],
       attribute_definitions: [
         {
-          attribute_name: 'year',
-          attribute_type: 'N'
+          attribute_name: "year",
+          attribute_type: "N"
         },
         {
-          attribute_name: 'title',
-          attribute_type: 'S'
+          attribute_name: "title",
+          attribute_type: "S"
         }
       ],
       provisioned_throughput: {
@@ -46,7 +46,7 @@ describe '#create_table' do
     )
   end
 
-  it 'creates a table' do
+  it "creates a table" do
     expect(create_table(dynamodb_client, table_definition)).to eq(table_status)
   end
 end

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesDeleteTable.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesDeleteTable.rb
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesDeleteTable'
+require_relative "../MoviesDeleteTable"
 
-describe '#table_deleted?' do
-  let(:table_name) { 'Movies' }
+describe "#table_deleted?" do
+  let(:table_name) { "Movies" }
   let(:dynamodb_client) do
     Aws::DynamoDB::Client.new(
       stub_responses: {
@@ -16,16 +16,16 @@ describe '#table_deleted?' do
               read_capacity_units: 5,
               write_capacity_units: 5
             },
-            table_name: 'Movies',
+            table_name: "Movies",
             table_size_bytes: 0,
-            table_status: 'DELETING'
+            table_status: "DELETING"
           }
         }
       }
     )
   end
 
-  it 'deletes a table' do
+  it "deletes a table" do
     expect(table_deleted?(dynamodb_client, table_name)).to eq(true)
   end
 end

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps01.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps01.rb
@@ -1,17 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesItemOps01'
+require_relative "../MoviesItemOps01"
 
-describe '#add_item_to_table' do
+describe "#add_item_to_table" do
   let(:table_item) do
     {
-      table_name: 'Movies',
+      table_name: "Movies",
       item: {
         year: 2015,
-        title:'The Big New Movie',
+        title: "The Big New Movie",
         info: {
-          plot: 'Nothing happens at all.',
+          plot: "Nothing happens at all.",
           rating: 0
         }
       }
@@ -23,14 +23,14 @@ describe '#add_item_to_table' do
         put_item: {
           consumed_capacity: {
             capacity_units: 1.0,
-            table_name: 'Movies'
+            table_name: "Movies"
           }
         }
       }
     )
   end
 
-  it 'adds an item to a table' do
-    expect {add_item_to_table(dynamodb_client, table_item)}.not_to raise_error
+  it "adds an item to a table" do
+    expect { add_item_to_table(dynamodb_client, table_item) }.not_to raise_error
   end
 end

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps02.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps02.rb
@@ -1,15 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesItemOps02'
+require_relative "../MoviesItemOps02"
 
-describe '#get_item' do
+describe "#get_item" do
   let(:table_item) do
     {
-      table_name: 'Movies',
+      table_name: "Movies",
       key: {
         year: 2015,
-        title:'The Big New Movie'
+        title: "The Big New Movie"
       }
     }
   end
@@ -17,12 +17,12 @@ describe '#get_item' do
     Aws::DynamoDB::Client.new(
       stub_responses: {
         get_item: {
-          :item => {
-            'title' => 'The Big New Movie',
-            'year' => 2015,
-            'info' => { 
-              'plot' => 'Nothing happens at all.',
-              'rating' => 5.5
+          item: {
+            "title" => "The Big New Movie",
+            "year" => 2015,
+            "info" => {
+              "plot" => "Nothing happens at all.",
+              "rating" => 5.5
             }
           }
         }
@@ -30,7 +30,7 @@ describe '#get_item' do
     )
   end
 
-  it 'gets an item from a table' do
-    expect {get_item_from_table(dynamodb_client, table_item)}.not_to raise_error
+  it "gets an item from a table" do
+    expect { get_item_from_table(dynamodb_client, table_item) }.not_to raise_error
   end
 end

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps03.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps03.rb
@@ -1,21 +1,21 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesItemOps03'
+require_relative "../MoviesItemOps03"
 
-describe '#table_item_updated?' do
+describe "#table_item_updated?" do
   let(:table_item) do
     {
-      table_name: 'Movies',
+      table_name: "Movies",
       key: {
         year: 2015,
-        title: 'The Big New Movie'
+        title: "The Big New Movie"
       },
-      update_expression: 'SET info.rating = :r, info.plot = :p, info.actors = :a',
+      update_expression: "SET info.rating = :r, info.plot = :p, info.actors = :a",
       expression_attribute_values: {
         ':r': 5.5,
-        ':p': 'Everything happens all at once.',
-        ':a': [ 'Larry', 'Moe', 'Curly' ]
+        ':p': "Everything happens all at once.",
+        ':a': ["Larry", "Moe", "Curly"]
       },
       return_values: "UPDATED_NEW"
     }
@@ -25,12 +25,12 @@ describe '#table_item_updated?' do
       stub_responses: {
         update_item: {
           attributes: {
-            'year' => 2015,
-            'title' => 'The Big New Movie',
-            'info' => {
-              'actors' => [ 'Larry', 'Moe', 'Curly' ],
-              'plot' => 'Everything happens all at once.',
-              'rating' => 5.5
+            "year" => 2015,
+            "title" => "The Big New Movie",
+            "info" => {
+              "actors" => ["Larry", "Moe", "Curly"],
+              "plot" => "Everything happens all at once.",
+              "rating" => 5.5
             }
           }
         }
@@ -38,7 +38,7 @@ describe '#table_item_updated?' do
     )
   end
 
-  it 'updates an item in a table' do
+  it "updates an item in a table" do
     expect(table_item_updated?(dynamodb_client, table_item)).to eq(true)
   end
 end

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps04.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps04.rb
@@ -1,23 +1,23 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesItemOps04'
+require_relative "../MoviesItemOps04"
 
-describe '#table_item_updated?' do
+describe "#table_item_updated?" do
   let(:table_item) do
     {
-      table_name: 'Movies',
+      table_name: "Movies",
       key: {
         year: 2015,
-        title: 'The Big New Movie'
+        title: "The Big New Movie"
       },
-      update_expression: 'SET info.rating = :r, info.plot = :p, info.actors = :a',
+      update_expression: "SET info.rating = :r, info.plot = :p, info.actors = :a",
       expression_attribute_values: {
         ':r': 5.5,
-        ':p': 'Everything happens all at once.',
-        ':a': [ 'Larry', 'Moe', 'Curly' ]
+        ':p': "Everything happens all at once.",
+        ':a': ["Larry", "Moe", "Curly"]
       },
-      return_values: 'UPDATED_NEW'
+      return_values: "UPDATED_NEW"
     }
   end
   let(:dynamodb_client) do
@@ -25,12 +25,12 @@ describe '#table_item_updated?' do
       stub_responses: {
         update_item: {
           attributes: {
-            'year' => 2015,
-            'title' => 'The Big New Movie',
-            'info' => {
-              'actors' => [ 'Larry', 'Moe', 'Curly' ],
-              'plot' => 'Everything happens all at once.',
-              'rating' => 5.5
+            "year" => 2015,
+            "title" => "The Big New Movie",
+            "info" => {
+              "actors" => ["Larry", "Moe", "Curly"],
+              "plot" => "Everything happens all at once.",
+              "rating" => 5.5
             }
           }
         }
@@ -38,7 +38,7 @@ describe '#table_item_updated?' do
     )
   end
 
-  it 'updates an item in a table' do
+  it "updates an item in a table" do
     expect(table_item_updated?(dynamodb_client, table_item)).to eq(true)
   end
 end

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps05.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps05.rb
@@ -1,22 +1,22 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesItemOps05'
+require_relative "../MoviesItemOps05"
 
-describe '#table_item_updated?' do
+describe "#table_item_updated?" do
   let(:table_item) do
     {
-      table_name: 'Movies',
+      table_name: "Movies",
       key: {
         year: 2015,
-        title: 'The Big New Movie'
+        title: "The Big New Movie"
       },
-      update_expression: 'REMOVE info.actors[0]',
-      condition_expression: 'size(info.actors) > :num',
+      update_expression: "REMOVE info.actors[0]",
+      condition_expression: "size(info.actors) > :num",
       expression_attribute_values: {
         ':num': 3
       },
-      return_values: 'UPDATED_NEW'
+      return_values: "UPDATED_NEW"
     }
   end
   let(:dynamodb_client) do
@@ -24,12 +24,12 @@ describe '#table_item_updated?' do
       stub_responses: {
         update_item: {
           attributes: {
-            'year' => 2015,
-            'title' => 'The Big New Movie',
-            'info' => {
-              'actors' => [ 'Moe', 'Curly' ],
-              'plot' => 'Everything happens all at once.',
-              'rating' => 5.5
+            "year" => 2015,
+            "title" => "The Big New Movie",
+            "info" => {
+              "actors" => ["Moe", "Curly"],
+              "plot" => "Everything happens all at once.",
+              "rating" => 5.5
             }
           }
         }
@@ -37,7 +37,7 @@ describe '#table_item_updated?' do
     )
   end
 
-  it 'updates an item in a table' do
+  it "updates an item in a table" do
     expect(table_item_updated?(dynamodb_client, table_item)).to eq(true)
   end
 end

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps06.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesItemOps06.rb
@@ -1,19 +1,19 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesItemOps06'
+require_relative "../MoviesItemOps06"
 
-describe '#table_item_deleted?' do
+describe "#table_item_deleted?" do
   let(:table_item) do
     {
-      table_name: 'Movies',
+      table_name: "Movies",
       key: {
         year: 2015,
-        title: 'The Big New Movie'
+        title: "The Big New Movie"
       },
-      condition_expression: 'info.rating <= :val',
+      condition_expression: "info.rating <= :val",
       expression_attribute_values: {
-        ':val' => 5
+        ":val" => 5
       }
     }
   end
@@ -23,14 +23,14 @@ describe '#table_item_deleted?' do
         delete_item: {
           consumed_capacity: {
             capacity_units: 1.0,
-            table_name: 'Movies'
+            table_name: "Movies"
           }
         }
       }
     )
   end
 
-  it 'deletes an item from a table' do
+  it "deletes an item from a table" do
     expect(table_item_deleted?(dynamodb_client, table_item)).to eq(true)
   end
 end

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesLoadData.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesLoadData.rb
@@ -1,15 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesLoadData'
+require_relative "../MoviesLoadData"
 
-describe '#add_item_to_table' do
+describe "#add_item_to_table" do
   let(:item) do
     JSON.parse("{\"year\":2015,\"title\":\"The Big New Movie\",\"info\":{\"rating\":5.5,\"plot\":\"Nothing happens at all.\",\"actors\":[\"Larry\",\"Moe\",\"Curly\"]}}")
   end
   let(:table_item) do
     {
-      table_name: 'Movies',
+      table_name: "Movies",
       item: item
     }
   end
@@ -19,14 +19,14 @@ describe '#add_item_to_table' do
         put_item: {
           consumed_capacity: {
             capacity_units: 1.0,
-            table_name: 'Movies'
+            table_name: "Movies"
           }
         }
       }
     )
   end
 
-  it 'adds an item to a table' do
+  it "adds an item to a table" do
     expect { add_item_to_table(dynamodb_client, table_item) }.not_to raise_error
   end
 end

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesQuery01.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesQuery01.rb
@@ -1,15 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesQuery01'
+require_relative "../MoviesQuery01"
 
-describe '#query_for_items_from_table' do
+describe "#query_for_items_from_table" do
   let(:query_condition) do
     {
-      table_name: 'Movies',
-      key_condition_expression: '#yr = :yyyy',
-      expression_attribute_names: { '#yr' => 'year' },
-      expression_attribute_values: { ':yyyy' => 1985 }
+      table_name: "Movies",
+      key_condition_expression: "#yr = :yyyy",
+      expression_attribute_names: { "#yr" => "year" },
+      expression_attribute_values: { ":yyyy" => 1985 }
     }
   end
   let(:dynamodb_client) do
@@ -18,17 +18,17 @@ describe '#query_for_items_from_table' do
         query: {
           consumed_capacity: {
             capacity_units: 1.0,
-            table_name: 'Movies'
+            table_name: "Movies"
           },
-          count: 2, 
+          count: 2,
           items: [
             {
-              'title' => 'The Big Movie',
-              'year' => 1985
+              "title" => "The Big Movie",
+              "year" => 1985
             },
             {
-              'title' => 'The Small Movie',
-              'year' => 1985
+              "title" => "The Small Movie",
+              "year" => 1985
             }
           ],
           scanned_count: 2
@@ -37,7 +37,7 @@ describe '#query_for_items_from_table' do
     )
   end
 
-  it 'searches for matching items in a table' do
+  it "searches for matching items in a table" do
     expect { query_for_items_from_table(dynamodb_client, query_condition) }.not_to raise_error
   end
 end

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesQuery02.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesQuery02.rb
@@ -1,19 +1,19 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesQuery02'
+require_relative "../MoviesQuery02"
 
-describe '#query_for_items_from_table' do
+describe "#query_for_items_from_table" do
   let(:query_condition) do
     {
-      table_name: 'Movies',
-      projection_expression: '#yr, title, info.genres, info.actors[0]',
-      key_condition_expression: '#yr = :yyyy AND title BETWEEN :letter1 AND :letter2',
-      expression_attribute_names: { '#yr' => 'year' },
+      table_name: "Movies",
+      projection_expression: "#yr, title, info.genres, info.actors[0]",
+      key_condition_expression: "#yr = :yyyy AND title BETWEEN :letter1 AND :letter2",
+      expression_attribute_names: { "#yr" => "year" },
       expression_attribute_values: {
-        ':yyyy' => 1982,
-        ':letter1' => 'A',
-        ':letter2' => 'L'
+        ":yyyy" => 1982,
+        ":letter1" => "A",
+        ":letter2" => "L"
       }
     }
   end
@@ -23,35 +23,35 @@ describe '#query_for_items_from_table' do
         query: {
           consumed_capacity: {
             capacity_units: 1.0,
-            table_name: 'Movies'
+            table_name: "Movies"
           },
           count: 2,
           items: [
             {
-              'title' => 'A Big Movie',
-              'year' => 1982,
-              'info' => {
-                'genres' => [
-                  'Drama',
-                  'Action'
+              "title" => "A Big Movie",
+              "year" => 1982,
+              "info" => {
+                "genres" => [
+                  "Drama",
+                  "Action"
                 ],
-                'actors' => [
-                  'Larry',
-                  'Moe',
-                  'Curly'
+                "actors" => [
+                  "Larry",
+                  "Moe",
+                  "Curly"
                 ]
               }
             },
             {
-              'title' => 'Le Grand Film',
-              'year' => 1982,
-              'info' => {
-                'genres' => [
-                  'Drama'
+              "title" => "Le Grand Film",
+              "year" => 1982,
+              "info" => {
+                "genres" => [
+                  "Drama"
                 ],
-                'actors' => [
-                  'Laurel',
-                  'Hardy'
+                "actors" => [
+                  "Laurel",
+                  "Hardy"
                 ]
               }
             }
@@ -62,7 +62,7 @@ describe '#query_for_items_from_table' do
     )
   end
 
-  it 'searches for matching items in a table' do
+  it "searches for matching items in a table" do
     expect { query_for_items_from_table(dynamodb_client, query_condition) }.not_to raise_error
   end
 end

--- a/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesScan.rb
+++ b/ruby/example_code/dynamodb/GettingStarted/tests/test_MoviesScan.rb
@@ -1,18 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../MoviesScan'
+require_relative "../MoviesScan"
 
-describe '#scan_for_items_from_table' do
+describe "#scan_for_items_from_table" do
   let(:scan_condition) do
     {
-      table_name: 'Movies',
-      projection_expression: '#yr, title, info.rating',
-      filter_expression: '#yr between :start_yr and :end_yr',
-      expression_attribute_names: { '#yr' => 'year' },
+      table_name: "Movies",
+      projection_expression: "#yr, title, info.rating",
+      filter_expression: "#yr between :start_yr and :end_yr",
+      expression_attribute_names: { "#yr" => "year" },
       expression_attribute_values: {
-        ':start_yr' => 1950,
-        ':end_yr' => 1959
+        ":start_yr" => 1950,
+        ":end_yr" => 1959
       }
     }
   end
@@ -22,22 +22,22 @@ describe '#scan_for_items_from_table' do
         scan: {
           consumed_capacity: {
             capacity_units: 1.0,
-            table_name: 'Movies'
+            table_name: "Movies"
           },
           count: 2,
           items: [
             {
-              'title' => 'The Big Movie',
-              'year' => 1950,
-              'info' => {
-                'rating' => 5.0
+              "title" => "The Big Movie",
+              "year" => 1950,
+              "info" => {
+                "rating" => 5.0
               }
             },
             {
-              'title' => 'The Big Movie 2',
-              'year' => 1959,
-              'info' => {
-                'rating' => 3.5
+              "title" => "The Big Movie 2",
+              "year" => 1959,
+              "info" => {
+                "rating" => 3.5
               }
             }
           ],
@@ -47,7 +47,7 @@ describe '#scan_for_items_from_table' do
     )
   end
 
-  it 'searches for matching items in a table' do
+  it "searches for matching items in a table" do
     expect { scan_for_items_from_table(dynamodb_client, scan_condition) }.not_to raise_error
   end
 end

--- a/ruby/example_code/ec2/ec2-ruby-example-attach-igw-vpc.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-attach-igw-vpc.rb
@@ -9,7 +9,7 @@
 
 # snippet-start:[ec2.Ruby.attachIgwVpc]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Prerequisites:
 #
@@ -48,32 +48,32 @@ def internet_gateway_created_and_attached?(
   return true
 rescue StandardError => e
   puts "Error creating or attaching internet gateway: #{e.message}"
-  puts 'If the internet gateway was created but not attached, you should ' \
-    'clean up by deleting the internet gateway.'
+  puts "If the internet gateway was created but not attached, you should " \
+    "clean up by deleting the internet gateway."
   return false
 end
 
 # Full example call:
 def run_me
-  vpc_id = ''
-  tag_key = ''
-  tag_value = ''
-  region = ''
+  vpc_id = ""
+  tag_key = ""
+  tag_value = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage: ruby ec2-ruby-example-attach-igw-vpc.rb ' \
-      'VPC_ID TAG_KEY TAG_VALUE REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage: ruby ec2-ruby-example-attach-igw-vpc.rb " \
+      "VPC_ID TAG_KEY TAG_VALUE REGION"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-attach-igw-vpc.rb ' \
-      'vpc-6713dfEX my-key my-value us-west-2'
+    puts "Example: ruby ec2-ruby-example-attach-igw-vpc.rb " \
+      "vpc-6713dfEX my-key my-value us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   elsif ARGV.count.zero?
-    vpc_id = 'vpc-6713dfEX'
-    tag_key = 'my-key'
-    tag_value = 'my-value'
+    vpc_id = "vpc-6713dfEX"
+    tag_key = "my-key"
+    tag_value = "my-value"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    region = 'us-west-2'
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     vpc_id = ARGV[0]

--- a/ruby/example_code/ec2/ec2-ruby-example-create-instance.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-create-instance.rb
@@ -7,8 +7,8 @@
 
 # snippet-start:[ec2.Ruby.createInstances]
 
-require 'aws-sdk-ec2'
-require 'base64'
+require "aws-sdk-ec2"
+require "base64"
 
 # Prerequisites:
 #
@@ -44,12 +44,12 @@ def instance_created?(
   key_pair_name,
   tag_key,
   tag_value,
-  instance_type = 't2.micro',
-  user_data_file = ''
+  instance_type = "t2.micro",
+  user_data_file = ""
 )
-  encoded_script = ''
+  encoded_script = ""
 
-  unless user_data_file == ''
+  unless user_data_file == ""
     script = File.read(user_data_file)
     encoded_script = Base64.encode64(script)
   end
@@ -63,7 +63,7 @@ def instance_created?(
     user_data: encoded_script
   )
 
-  puts 'Creating instance...'
+  puts "Creating instance..."
 
   # Check whether the new instance is in the "running" state.
   polls = 0
@@ -75,7 +75,7 @@ def instance_created?(
       ]
     )
     # Stop polling after 10 minutes (40 polls * 15 seconds per poll) if not running.
-    break if response.reservations[0].instances[0].state.name == 'running' || polls > 40
+    break if response.reservations[0].instances[0].state.name == "running" || polls > 40
 
     sleep(15)
   end
@@ -90,7 +90,7 @@ def instance_created?(
       }
     ]
   )
-  puts 'Instance tagged.'
+  puts "Instance tagged."
 
   return true
 rescue StandardError => e
@@ -100,33 +100,33 @@ end
 
 # Full example call:
 def run_me
-  image_id = ''
-  key_pair_name = ''
-  tag_key = ''
-  tag_value = ''
-  instance_type = ''
-  region = ''
-  user_data_file = ''
+  image_id = ""
+  key_pair_name = ""
+  tag_key = ""
+  tag_value = ""
+  instance_type = ""
+  region = ""
+  user_data_file = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage: ruby ec2-ruby-example-create-instance.rb ' \
-      'IMAGE_ID KEY_PAIR_NAME TAG_KEY TAG_VALUE INSTANCE_TYPE ' \
-      'REGION [USER_DATA_FILE]'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage: ruby ec2-ruby-example-create-instance.rb " \
+      "IMAGE_ID KEY_PAIR_NAME TAG_KEY TAG_VALUE INSTANCE_TYPE " \
+      "REGION [USER_DATA_FILE]"
      # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-create-instance.rb ' \
-      'ami-0947d2ba12EXAMPLE my-key-pair my-key my-value t2.micro ' \
-      'us-west-2 my-user-data.txt'
+    puts "Example: ruby ec2-ruby-example-create-instance.rb " \
+      "ami-0947d2ba12EXAMPLE my-key-pair my-key my-value t2.micro " \
+      "us-west-2 my-user-data.txt"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   elsif ARGV.count.zero?
-    image_id = 'ami-0947d2ba12EXAMPLE'
-    key_pair_name = 'my-key-pair'
-    tag_key = 'my-key'
-    tag_value = 'my-value'
-    instance_type = 't2.micro'
+    image_id = "ami-0947d2ba12EXAMPLE"
+    key_pair_name = "my-key-pair"
+    tag_key = "my-key"
+    tag_value = "my-value"
+    instance_type = "t2.micro"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    region = 'us-west-2'
-    user_data_file = 'my-user-data.txt'
+    region = "us-west-2"
+    user_data_file = "my-user-data.txt"
   # Otherwise, use the values as specified at the command prompt.
   else
     image_id = ARGV[0]
@@ -149,9 +149,9 @@ def run_me
     instance_type,
     user_data_file
   )
-    puts 'Created and tagged instance.'
+    puts "Created and tagged instance."
   else
-    puts 'Could not create or tag instance.'
+    puts "Could not create or tag instance."
   end
 end
 

--- a/ruby/example_code/ec2/ec2-ruby-example-create-key-pair.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-create-key-pair.rb
@@ -9,7 +9,7 @@
 
 # snippet-start:[ec2.Ruby.createKeyPair]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # @param ec2_client [Aws::EC2::Client] An initialized EC2 client.
 # @param key_pair_name [String] The name for the key pair and private
@@ -25,8 +25,8 @@ def key_pair_created?(ec2_client, key_pair_name)
   key_pair = ec2_client.create_key_pair(key_name: key_pair_name)
   puts "Created key pair '#{key_pair.key_name}' with fingerprint " \
     "'#{key_pair.key_fingerprint}' and ID '#{key_pair.key_pair_id}'."
-  filename = File.join(Dir.home, key_pair_name + '.pem')
-  File.open(filename, 'w') { |file| file.write(key_pair.key_material) }
+  filename = File.join(Dir.home, key_pair_name + ".pem")
+  File.open(filename, "w") { |file| file.write(key_pair.key_material) }
   puts "Private key file saved locally as '#{filename}'."
   return true
 rescue StandardError => e
@@ -36,21 +36,21 @@ end
 
 # Full example call:
 def run_me
-  key_pair_name = ''
-  region = ''
+  key_pair_name = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage: ruby ec2-ruby-example-create-key-pair.rb ' \
-      'KEY_PAIR_NAME REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage: ruby ec2-ruby-example-create-key-pair.rb " \
+      "KEY_PAIR_NAME REGION"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-create-key-pair.rb ' \
-      'my-key-pair us-west-2'
+    puts "Example: ruby ec2-ruby-example-create-key-pair.rb " \
+      "my-key-pair us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   elsif ARGV.count.zero?
-    key_pair_name = 'my-key-pair'
+    key_pair_name = "my-key-pair"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    region = 'us-west-2 '
+    region = "us-west-2 "
   # Otherwise, use the values as specified at the command prompt.
   else
     key_pair_name = ARGV[0]
@@ -60,9 +60,9 @@ def run_me
   ec2_client = Aws::EC2::Client.new(region: region)
 
   if key_pair_created?(ec2_client, key_pair_name)
-    puts 'Key pair created and private key file saved.'
+    puts "Key pair created and private key file saved."
   else
-    puts 'Key pair not created or private key file not saved.'
+    puts "Key pair not created or private key file not saved."
   end
 end
 

--- a/ruby/example_code/ec2/ec2-ruby-example-create-route-table.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-create-route-table.rb
@@ -7,7 +7,7 @@
 # and then associates the route table with a subnet in Amazon VPC.
 
 # snippet-start:[ec2.Ruby.createRouteTable]
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Prerequisites:
 #
@@ -55,12 +55,12 @@ def route_table_created_and_associated?(
       }
     ]
   )
-  puts 'Added tags to route table.'
+  puts "Added tags to route table."
   route_table.create_route(
     destination_cidr_block: destination_cidr_block,
     gateway_id: gateway_id
   )
-  puts 'Created route with destination CIDR block ' \
+  puts "Created route with destination CIDR block " \
     "'#{destination_cidr_block}' and associated with gateway " \
     "with ID '#{gateway_id}'."
   route_table.associate_with_subnet(subnet_id: subnet_id)
@@ -68,40 +68,40 @@ def route_table_created_and_associated?(
   return true
 rescue StandardError => e
   puts "Error creating or associating route table: #{e.message}"
-  puts 'If the route table was created but not associated, you should ' \
-    'clean up by deleting the route table.'
+  puts "If the route table was created but not associated, you should " \
+    "clean up by deleting the route table."
   return false
 end
 
 # Full example call:
 def run_me
-  vpc_id = ''
-  subnet_id = ''
-  gateway_id = ''
-  destination_cidr_block = ''
-  tag_key = ''
-  tag_value = ''
-  region = ''
+  vpc_id = ""
+  subnet_id = ""
+  gateway_id = ""
+  destination_cidr_block = ""
+  tag_key = ""
+  tag_value = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage: ruby ec2-ruby-example-create-route-table.rb ' \
-      'VPC_ID SUBNET_ID GATEWAY_ID DESTINATION_CIDR_BLOCK ' \
-      'TAG_KEY TAG_VALUE REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage: ruby ec2-ruby-example-create-route-table.rb " \
+      "VPC_ID SUBNET_ID GATEWAY_ID DESTINATION_CIDR_BLOCK " \
+      "TAG_KEY TAG_VALUE REGION"
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-create-route-table.rb ' \
-      'vpc-0b6f769731EXAMPLE subnet-03d9303b57EXAMPLE igw-06ca90c011EXAMPLE ' \
-      '\'0.0.0.0/0\' my-key my-value us-west-2'
+    puts "Example: ruby ec2-ruby-example-create-route-table.rb " \
+      "vpc-0b6f769731EXAMPLE subnet-03d9303b57EXAMPLE igw-06ca90c011EXAMPLE " \
+      "'0.0.0.0/0' my-key my-value us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   elsif ARGV.count.zero?
-    vpc_id = 'vpc-0b6f769731EXAMPLE'
-    subnet_id = 'subnet-03d9303b57EXAMPLE'
-    gateway_id = 'igw-06ca90c011EXAMPLE'
-    destination_cidr_block = '0.0.0.0/0'
-    tag_key = 'my-key'
-    tag_value = 'my-value'
+    vpc_id = "vpc-0b6f769731EXAMPLE"
+    subnet_id = "subnet-03d9303b57EXAMPLE"
+    gateway_id = "igw-06ca90c011EXAMPLE"
+    destination_cidr_block = "0.0.0.0/0"
+    tag_key = "my-key"
+    tag_value = "my-value"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    region = 'us-west-2'
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     vpc_id = ARGV[0]
@@ -124,9 +124,9 @@ def run_me
     tag_key,
     tag_value
   )
-    puts 'Route table created and associated.'
+    puts "Route table created and associated."
   else
-    puts 'Route table not created or not associated.'
+    puts "Route table not created or not associated."
   end
 end
 

--- a/ruby/example_code/ec2/ec2-ruby-example-create-security-group.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-create-security-group.rb
@@ -8,7 +8,7 @@
 
 # snippet-start:[ec2.Ruby.createSecurityGroup]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Prerequisites:
 #
@@ -78,35 +78,35 @@ end
 
 # Full example call:
 def run_me
-  group_name = ''
-  description = ''
-  vpc_id = ''
-  ip_protocol = ''
-  from_port = ''
-  to_port = ''
-  cidr_ip_range = ''
-  region = ''
+  group_name = ""
+  description = ""
+  vpc_id = ""
+  ip_protocol = ""
+  from_port = ""
+  to_port = ""
+  cidr_ip_range = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage: ruby ec2-ruby-example-create-security-group.rb ' \
-      'GROUP_NAME DESCRIPTION VPC_ID IP_PROTOCOL FROM_PORT TO_PORT ' \
-      'CIDR_IP_RANGE REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage: ruby ec2-ruby-example-create-security-group.rb " \
+      "GROUP_NAME DESCRIPTION VPC_ID IP_PROTOCOL FROM_PORT TO_PORT " \
+      "CIDR_IP_RANGE REGION"
    # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-create-security-group.rb ' \
-      'my-security-group \'This is my security group.\' vpc-6713dfEX ' \
-      'tcp 22 22 \'0.0.0.0/0\' us-west-2'
+    puts "Example: ruby ec2-ruby-example-create-security-group.rb " \
+      "my-security-group 'This is my security group.' vpc-6713dfEX " \
+      "tcp 22 22 '0.0.0.0/0' us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   elsif ARGV.count.zero?
-    group_name = 'my-security-group'
-    description = 'This is my security group.'
-    vpc_id = 'vpc-6713dfEX'
-    ip_protocol = 'tcp'
-    from_port = '22'
-    to_port = '22'
-    cidr_ip_range = '0.0.0.0/0'
+    group_name = "my-security-group"
+    description = "This is my security group."
+    vpc_id = "vpc-6713dfEX"
+    ip_protocol = "tcp"
+    from_port = "22"
+    to_port = "22"
+    cidr_ip_range = "0.0.0.0/0"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    region = 'us-west-2'
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     group_name = ARGV[0]
@@ -131,9 +131,9 @@ def run_me
     to_port,
     cidr_ip_range
   )
-    puts 'Security group created and egress granted.'
+    puts "Security group created and egress granted."
   else
-    puts 'Security group not created or egress not granted.'
+    puts "Security group not created or egress not granted."
   end
 end
 

--- a/ruby/example_code/ec2/ec2-ruby-example-create-subnet.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-create-subnet.rb
@@ -9,7 +9,7 @@
 
 # snippet-start:[ec2.Ruby.createSubnet]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Creates a subnet within a virtual private cloud (VPC) in
 # Amazon Virtual Private Cloud (Amazon VPC) and then tags
@@ -71,29 +71,29 @@ end
 
 # Full example call:
 def run_me
-  vpc_id = ''
-  cidr_block = ''
-  availability_zone = ''
-  tag_key = ''
-  tag_value = ''
-  region = ''
+  vpc_id = ""
+  cidr_block = ""
+  availability_zone = ""
+  tag_key = ""
+  tag_value = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-create-subnet.rb ' \
-      'VPC_ID CIDR_BLOCK AVAILABILITY_ZONE TAG_KEY TAG_VALUE REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-create-subnet.rb " \
+      "VPC_ID CIDR_BLOCK AVAILABILITY_ZONE TAG_KEY TAG_VALUE REGION"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-create-subnet.rb ' \
-      'vpc-6713dfEX 10.0.0.0/24 us-west-2a my-key my-value us-west-2'
+    puts "Example: ruby ec2-ruby-example-create-subnet.rb " \
+      "vpc-6713dfEX 10.0.0.0/24 us-west-2a my-key my-value us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   elsif ARGV.count.zero?
-    vpc_id = 'vpc-6713dfEX'
-    cidr_block = '10.0.0.0/24'
-    availability_zone = 'us-west-2a'
-    tag_key = 'my-key'
-    tag_value = 'my-value'
+    vpc_id = "vpc-6713dfEX"
+    cidr_block = "10.0.0.0/24"
+    availability_zone = "us-west-2a"
+    tag_key = "my-key"
+    tag_value = "my-value"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    region = 'us-west-2'
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     vpc_id = ARGV[0]
@@ -114,9 +114,9 @@ def run_me
     tag_key,
     tag_value
   )
-    puts 'Subnet created and tagged.'
+    puts "Subnet created and tagged."
   else
-    puts 'Subnet not created or not tagged.'
+    puts "Subnet not created or not tagged."
   end
 end
 

--- a/ruby/example_code/ec2/ec2-ruby-example-create-vpc.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-create-vpc.rb
@@ -7,7 +7,7 @@
 
 # snippet-start:[ec2.Ruby.createVpc]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Creates a virtual private cloud (VPC) in
 # Amazon Virtual Private Cloud (Amazon VPC) and then tags
@@ -51,25 +51,25 @@ end
 
 # Full example call:
 def run_me
-  cidr_block = ''
-  tag_key = ''
-  tag_value = ''
-  region = ''
+  cidr_block = ""
+  tag_key = ""
+  tag_value = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-create-vpc.rb ' \
-      'CIDR_BLOCK TAG_KEY TAG_VALUE REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-create-vpc.rb " \
+      "CIDR_BLOCK TAG_KEY TAG_VALUE REGION"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-create-vpc.rb ' \
-      '10.0.0.0/24 my-key my-value us-west-2'
+    puts "Example: ruby ec2-ruby-example-create-vpc.rb " \
+      "10.0.0.0/24 my-key my-value us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   elsif ARGV.count.zero?
-    cidr_block = '10.0.0.0/24'
-    tag_key = 'my-key'
-    tag_value = 'my-value'
+    cidr_block = "10.0.0.0/24"
+    tag_key = "my-key"
+    tag_value = "my-value"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    region = 'us-west-2'
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     cidr_block = ARGV[0]
@@ -86,9 +86,9 @@ def run_me
     tag_key,
     tag_value
   )
-    puts 'VPC created and tagged.'
+    puts "VPC created and tagged."
   else
-    puts 'VPC not created or not tagged.'
+    puts "VPC not created or not tagged."
   end
 end
 

--- a/ruby/example_code/ec2/ec2-ruby-example-elastic-ips.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-elastic-ips.rb
@@ -20,7 +20,7 @@
 # 6. Displays information again about addresses associated with the instance.
 #    This time, the released address should not display.
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Checks whether the specified Amazon Elastic Compute Cloud
 # (Amazon EC2) instance exists.
@@ -51,11 +51,11 @@ end
 # @example
 #   puts allocate_elastic_ip_address(Aws::EC2::Client.new(region: 'us-west-2'))
 def allocate_elastic_ip_address(ec2_client)
-  response = ec2_client.allocate_address(domain: 'vpc')
+  response = ec2_client.allocate_address(domain: "vpc")
   return response.allocation_id
 rescue StandardError => e
   puts "Error allocating Elastic IP address: #{e.message}"
-  return 'Error'
+  return "Error"
 end
 
 # Associates an Elastic IP address with an Amazon Elastic Compute Cloud
@@ -89,7 +89,7 @@ def associate_elastic_ip_address_with_instance(
   return response.association_id
 rescue StandardError => e
   puts "Error associating Elastic IP address with instance: #{e.message}"
-  return 'Error'
+  return "Error"
 end
 
 # Gets information about addresses associated with an
@@ -110,17 +110,17 @@ def describe_addresses_for_instance(ec2_client, instance_id)
   response = ec2_client.describe_addresses(
     filters: [
       {
-        name: 'instance-id',
+        name: "instance-id",
         values: [instance_id]
       }
     ]
   )
   addresses = response.addresses
   if addresses.count.zero?
-    puts 'No addresses.'
+    puts "No addresses."
   else
     addresses.each do |address|
-      puts '-' * 20
+      puts "-" * 20
       puts "Public IP:  #{address.public_ip}"
       puts "Private IP: #{address.private_ip_address}"
     end
@@ -150,27 +150,27 @@ def elastic_ip_address_released?(ec2_client, allocation_id)
   ec2_client.release_address(allocation_id: allocation_id)
   return true
 rescue StandardError => e
-  return "Error releasing Elastic IP address: #{e.message}"
+  puts("Error releasing Elastic IP address: #{e.message}")
   return false
 end
 
 # Full example call:
 def run_me
-  instance_id = ''
-  region = ''
+  instance_id = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-elastic-ips.rb ' \
-      'INSTANCE_ID REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-elastic-ips.rb " \
+      "INSTANCE_ID REGION"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-elastic-ips.rb ' \
-      'i-033c48ef067af3dEX us-west-2'
+    puts "Example: ruby ec2-ruby-example-elastic-ips.rb " \
+      "i-033c48ef067af3dEX us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   elsif ARGV.count.zero?
-    instance_id = 'i-033c48ef067af3dEX'
+    instance_id = "i-033c48ef067af3dEX"
      # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    region = 'us-west-2'
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     instance_id = ARGV[0]
@@ -185,44 +185,44 @@ def run_me
   end
 
   puts "Addresses for instance with ID '#{instance_id}' before allocating " \
-    'Elastic IP address:'
+    "Elastic IP address:"
   describe_addresses_for_instance(ec2_client, instance_id)
 
-  puts 'Allocating Elastic IP address...'
+  puts "Allocating Elastic IP address..."
   allocation_id = allocate_elastic_ip_address(ec2_client)
-  if allocation_id.start_with?('Error')
-    puts 'Stopping program.'
+  if allocation_id.start_with?("Error")
+    puts "Stopping program."
     exit 1
   else
     puts "Elastic IP address created with allocation ID '#{allocation_id}'."
   end
 
-  puts 'Associating Elastic IP address with instance...'
+  puts "Associating Elastic IP address with instance..."
   association_id = associate_elastic_ip_address_with_instance(
     ec2_client,
     allocation_id,
     instance_id
   )
-  if association_id.start_with?('Error')
-    puts 'Stopping program. You must associate the Elastic IP address yourself.'
+  if association_id.start_with?("Error")
+    puts "Stopping program. You must associate the Elastic IP address yourself."
     exit 1
   else
-    puts 'Elastic IP address associated with instance with association ID ' \
+    puts "Elastic IP address associated with instance with association ID " \
       "'#{association_id}'."
   end
 
-  puts 'Addresses for instance after allocating Elastic IP address:'
+  puts "Addresses for instance after allocating Elastic IP address:"
   describe_addresses_for_instance(ec2_client, instance_id)
 
-  puts 'Releasing the Elastic IP address from the instance...'
+  puts "Releasing the Elastic IP address from the instance..."
   if elastic_ip_address_released?(ec2_client, allocation_id) == false
-    puts 'Stopping program. You must release the Elastic IP address yourself.'
+    puts "Stopping program. You must release the Elastic IP address yourself."
     exit 1
   else
-    puts 'Address released.'
+    puts "Address released."
   end
 
-  puts 'Addresses for instance after releasing Elastic IP address:'
+  puts "Addresses for instance after releasing Elastic IP address:"
   describe_addresses_for_instance(ec2_client, instance_id)
 end
 

--- a/ruby/example_code/ec2/ec2-ruby-example-get-all-instance-info.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-get-all-instance-info.rb
@@ -8,7 +8,7 @@
 
 # snippet-start:[ec2.Ruby.getAllInstances]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # @param ec2_resource [Aws::EC2::Resource] An initialized EC2 resource object.
 # @example
@@ -16,9 +16,9 @@ require 'aws-sdk-ec2'
 def list_instance_ids_states(ec2_resource)
   response = ec2_resource.instances
   if response.count.zero?
-    puts 'No instances found.'
+    puts "No instances found."
   else
-    puts 'Instances -- ID, state:'
+    puts "Instances -- ID, state:"
     response.each do |instance|
       puts "#{instance.id}, #{instance.state.name}"
     end
@@ -29,17 +29,17 @@ end
 
 #Full example call:
 def run_me
-  region = ''
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-get-all-instance-info.rb REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-get-all-instance-info.rb REGION"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-get-all-instance-info.rb us-west-2'
+    puts "Example: ruby ec2-ruby-example-get-all-instance-info.rb us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
   elsif ARGV.count.zero?
-    region = 'us-west-2'
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     region = ARGV[0]

--- a/ruby/example_code/ec2/ec2-ruby-example-get-instance-info-by-tag.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-get-instance-info-by-tag.rb
@@ -9,7 +9,7 @@
 
 # snippet-start:[ec2.Ruby.getInstanceInforByTag]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # @param ec2_resource [Aws::EC2::Resource] An initialized EC2 resource object.
 # @param tag_key [String] The key portion of the tag to search on.
@@ -30,9 +30,9 @@ def list_instance_ids_states_by_tag(ec2_resource, tag_key, tag_value)
     ]
   )
   if response.count.zero?
-    puts 'No matching instances found.'
+    puts "No matching instances found."
   else
-    puts 'Matching instances -- ID, state, tag key/value:'
+    puts "Matching instances -- ID, state, tag key/value:"
     response.each do |instance|
       print "#{instance.id}, #{instance.state.name}"
       instance.tags.each do |tag|
@@ -47,23 +47,23 @@ end
 
 #Full example call:
 def run_me
-  tag_key = ''
-  tag_value = ''
-  region = ''
+  tag_key = ""
+  tag_value = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-get-instance-info-by-tag.rb ' \
-      'TAG_KEY TAG_VALUE REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-get-instance-info-by-tag.rb " \
+      "TAG_KEY TAG_VALUE REGION"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-get-instance-info-by-tag.rb ' \
-      'my-key my-value us-west-2'
+    puts "Example: ruby ec2-ruby-example-get-instance-info-by-tag.rb " \
+      "my-key my-value us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
   elsif ARGV.count.zero?
-    tag_key = 'my-key'
-    tag_value = 'my-value'
-    region = 'us-west-2'
+    tag_key = "my-key"
+    tag_value = "my-value"
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     tag_key = ARGV[0]

--- a/ruby/example_code/ec2/ec2-ruby-example-key-pairs.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-key-pairs.rb
@@ -14,7 +14,7 @@
 # 2. Displays information about available key pairs.
 # 3. Deletes the key pair.
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # @param ec2_client [Aws::EC2::Client] An initialized EC2 client.
 # @param key_pair_name [String] The name for the key pair and private
@@ -30,13 +30,13 @@ def key_pair_created?(ec2_client, key_pair_name)
   key_pair = ec2_client.create_key_pair(key_name: key_pair_name)
   puts "Created key pair '#{key_pair.key_name}' with fingerprint " \
     "'#{key_pair.key_fingerprint}' and ID '#{key_pair.key_pair_id}'."
-  filename = File.join(Dir.home, key_pair_name + '.pem')
-  File.open(filename, 'w') { |file| file.write(key_pair.key_material) }
+  filename = File.join(Dir.home, key_pair_name + ".pem")
+  File.open(filename, "w") { |file| file.write(key_pair.key_material) }
   puts "Private key file saved locally as '#{filename}'."
   return true
 rescue Aws::EC2::Errors::InvalidKeyPairDuplicate
   puts "Error creating key pair: a key pair named '#{key_pair_name}' " \
-    'already exists.'
+    "already exists."
   return false
 rescue StandardError => e
   puts "Error creating key pair or saving private key file: #{e.message}"
@@ -52,9 +52,9 @@ end
 def describe_key_pairs(ec2_client)
   result = ec2_client.describe_key_pairs
   if result.key_pairs.count.zero?
-    puts 'No key pairs found.'
+    puts "No key pairs found."
   else
-    puts 'Key pair names:'
+    puts "Key pair names:"
     result.key_pairs.each do |key_pair|
       puts key_pair.key_name
     end
@@ -87,18 +87,18 @@ end
 
 # Full example call:
 def run_me
-  key_pair_name = ''
-  region = ''
+  key_pair_name = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-key-pairs.rb KEY_PAIR_NAME REGION'
-    puts 'Example: ruby ec2-ruby-example-key-pairs.rb my-key-pair us-west-2'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-key-pairs.rb KEY_PAIR_NAME REGION"
+    puts "Example: ruby ec2-ruby-example-key-pairs.rb my-key-pair us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
   elsif ARGV.count.zero?
-    key_pair_name = 'my-key-pair'
-    region = 'us-west-2'
+    key_pair_name = "my-key-pair"
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     key_pair_name = ARGV[0]
@@ -107,41 +107,41 @@ def run_me
 
   ec2_client = Aws::EC2::Client.new(region: region)
 
-  puts 'Displaying existing key pair names before creating this key pair...'
+  puts "Displaying existing key pair names before creating this key pair..."
   describe_key_pairs(ec2_client)
 
-  puts '-' * 10
-  puts 'Creating key pair...'
+  puts "-" * 10
+  puts "Creating key pair..."
   unless key_pair_created?(ec2_client, key_pair_name)
-    puts 'Stopping program.'
+    puts "Stopping program."
     exit 1
   end
 
-  puts '-' * 10
-  puts 'Displaying existing key pair names after creating this key pair...'
+  puts "-" * 10
+  puts "Displaying existing key pair names after creating this key pair..."
   describe_key_pairs(ec2_client)
 
-  puts '-' * 10
-  puts 'Deleting key pair...'
+  puts "-" * 10
+  puts "Deleting key pair..."
   unless key_pair_deleted?(ec2_client, key_pair_name)
-    puts 'Stopping program. You must delete the key pair yourself.'
+    puts "Stopping program. You must delete the key pair yourself."
     exit 1
   end
-  puts 'Key pair deleted.'
+  puts "Key pair deleted."
 
-  puts '-' * 10
-  puts 'Now that the key pair is deleted, ' \
-    'also deleting the related private key pair file...'
-  filename = File.join(Dir.home, key_pair_name + '.pem')
+  puts "-" * 10
+  puts "Now that the key pair is deleted, " \
+    "also deleting the related private key pair file..."
+  filename = File.join(Dir.home, key_pair_name + ".pem")
   File.delete(filename)
   if File.exist?(filename)
     puts "Could not delete file at '#{filename}'. You must delete it yourself."
   else
-    puts 'File deleted.'
+    puts "File deleted."
   end
 
-  puts '-' * 10
-  puts 'Displaying existing key pair names after deleting this key pair...'
+  puts "-" * 10
+  puts "Displaying existing key pair names after deleting this key pair..."
   describe_key_pairs(ec2_client)
 end
 

--- a/ruby/example_code/ec2/ec2-ruby-example-list-state-instance-i-123abc.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-list-state-instance-i-123abc.rb
@@ -6,7 +6,7 @@
 # list the state of an Amazon Elastic Compute Cloud (Amazon EC2) instance.
 
 # snippet-start:[ec2.Ruby.listStateInstance]
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 #
 # Prerequisites:
@@ -25,7 +25,7 @@ def list_instance_state(ec2_client, instance_id)
     instance_ids: [instance_id]
   )
   if response.count.zero?
-    puts 'No matching instance found.'
+    puts "No matching instance found."
   else
     instance = response.reservations[0].instances[0]
     puts "The instance with ID '#{instance_id}' is '#{instance.state.name}'."
@@ -36,21 +36,21 @@ end
 
 # Full example call:
 def run_me
-  instance_id = ''
-  region = ''
+  instance_id = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-list-state-instance-i-123abc.rb ' \
-      'INSTANCE_ID REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-list-state-instance-i-123abc.rb " \
+      "INSTANCE_ID REGION"
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-list-state-instance-i-123abc.rb ' \
-      'i-123abc us-west-2'
+    puts "Example: ruby ec2-ruby-example-list-state-instance-i-123abc.rb " \
+      "i-123abc us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
   elsif ARGV.count.zero?
-    instance_id = 'i-123abc'
-    region = 'us-west-2'
+    instance_id = "i-123abc"
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     instance_id = ARGV[0]

--- a/ruby/example_code/ec2/ec2-ruby-example-manage-instances.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-manage-instances.rb
@@ -17,7 +17,7 @@
 # 4. Enables detailed monitoring for the instance.
 # 5. Displays information about available instances.
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Waits for an Amazon Elastic Compute Cloud (Amazon EC2) instance
 # to reach the specified state.
@@ -149,7 +149,7 @@ def list_instances_information(ec2_client)
   result.reservations.each do |reservation|
     if reservation.instances.count.positive?
       reservation.instances.each do |instance|
-        puts '-' * 12
+        puts "-" * 12
         puts "Instance ID:               #{instance.instance_id}"
         puts "State:                     #{instance.state.name}"
         puts "Image ID:                  #{instance.image_id}"
@@ -164,7 +164,7 @@ def list_instances_information(ec2_client)
         puts "VPC ID:                    #{instance.vpc_id}"
         puts "Subnet ID:                 #{instance.subnet_id}"
         if instance.tags.count.positive?
-          puts 'Tags:'
+          puts "Tags:"
           instance.tags.each do |tag|
             puts "                           #{tag.key}/#{tag.value}"
           end
@@ -176,21 +176,21 @@ end
 
 # Full example call:
 def run_me
-  instance_id = ''
-  region = ''
+  instance_id = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-manage-instances.rb ' \
-      'INSTANCE_ID REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-manage-instances.rb " \
+      "INSTANCE_ID REGION"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-manage-instances.rb ' \
-      'i-033c48ef067af3dEX us-west-2'
+    puts "Example: ruby ec2-ruby-example-manage-instances.rb " \
+      "i-033c48ef067af3dEX us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
   elsif ARGV.count.zero?
-    instance_id = 'i-033c48ef067af3dEX'
-    region = 'us-west-2'
+    instance_id = "i-033c48ef067af3dEX"
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     instance_id = ARGV[0]
@@ -199,28 +199,28 @@ def run_me
 
   ec2_client = Aws::EC2::Client.new(region: region)
 
-  puts 'Attempting to stop the instance. ' \
-    'This might take a few minutes...'
+  puts "Attempting to stop the instance. " \
+    "This might take a few minutes..."
   unless instance_stopped?(ec2_client, instance_id)
-    puts 'Cannot stop the instance. Skipping this step.'
+    puts "Cannot stop the instance. Skipping this step."
   end
 
   puts "\nAttempting to restart the instance. " \
-    'This might take a few minutes...'
+    "This might take a few minutes..."
   unless instance_restarted?(ec2_client, instance_id)
-    puts 'Cannot restart the instance. Skipping this step.'
+    puts "Cannot restart the instance. Skipping this step."
   end
 
   puts "\nAttempting to reboot the instance. " \
-    'This might take a few minutes...'
+    "This might take a few minutes..."
   unless instance_rebooted?(ec2_client, instance_id)
-    puts 'Cannot reboot the instance. Skipping this step.'
+    puts "Cannot reboot the instance. Skipping this step."
   end
 
   puts "\nAttempting to enable detailed monitoring for the instance..."
   unless instance_detailed_monitoring_enabled?(ec2_client, instance_id)
-    puts 'Cannot enable detailed monitoring for the instance. ' \
-      'Skipping this step.'
+    puts "Cannot enable detailed monitoring for the instance. " \
+      "Skipping this step."
   end
 
   puts "\nInformation about available instances:"

--- a/ruby/example_code/ec2/ec2-ruby-example-reboot-instance-i-123abc.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-reboot-instance-i-123abc.rb
@@ -7,7 +7,7 @@
 
 # snippet-start:[ec2.Ruby.rebootInstances]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Prerequisites:
 #
@@ -23,14 +23,14 @@ require 'aws-sdk-ec2'
 def request_instance_reboot(ec2_client, instance_id)
   response = ec2_client.describe_instances(instance_ids: [instance_id])
   if response.count.zero?
-    puts 'Error requesting reboot: no matching instance found.'
+    puts "Error requesting reboot: no matching instance found."
   else
     instance = response.reservations[0].instances[0]
-    if instance.state.name == 'terminated'
-      puts 'Error requesting reboot: the instance is already terminated.'
+    if instance.state.name == "terminated"
+      puts "Error requesting reboot: the instance is already terminated."
     else
       ec2_client.reboot_instances(instance_ids: [instance_id])
-      puts 'Reboot request sent.'
+      puts "Reboot request sent."
     end
   end
 rescue StandardError => e
@@ -39,21 +39,21 @@ end
 
 # Full example call:
 def run_me
-  instance_id = ''
-  region = ''
+  instance_id = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-reboot-instance-i-123abc.rb ' \
-      'INSTANCE_ID REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-reboot-instance-i-123abc.rb " \
+      "INSTANCE_ID REGION"
      # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-reboot-instance-i-123abc.rb ' \
-      'i-123abc us-west-2'
+    puts "Example: ruby ec2-ruby-example-reboot-instance-i-123abc.rb " \
+      "i-123abc us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
   elsif ARGV.count.zero?
-    instance_id = 'i-123abc'
-    region = 'us-west-2'
+    instance_id = "i-123abc"
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     instance_id = ARGV[0]

--- a/ruby/example_code/ec2/ec2-ruby-example-regions-availability-zones.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-regions-availability-zones.rb
@@ -8,7 +8,7 @@
 
 # snippet-start:[ec2.Ruby.regionsAvailabilityZones]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # @param ec2_client [Aws::EC2::Client] An initialized EC2 client.
 # @example
@@ -19,18 +19,18 @@ def list_regions_endpoints(ec2_client)
   max_region_string_length = 16
   max_endpoint_string_length = 33
   # Print header.
-  print 'Region'
-  print ' ' * (max_region_string_length - 'Region'.length)
+  print "Region"
+  print " " * (max_region_string_length - "Region".length)
   print "  Endpoint\n"
-  print '-' * max_region_string_length
-  print '  '
-  print '-' * max_endpoint_string_length
+  print "-" * max_region_string_length
+  print "  "
+  print "-" * max_endpoint_string_length
   print "\n"
   # Print Regions and their endpoints.
   result.regions.each do |region|
     print region.region_name.to_s
-    print ' ' * (max_region_string_length - region.region_name.length)
-    print '  '
+    print " " * (max_region_string_length - region.region_name.length)
+    print "  "
     print region.endpoint.to_s
     print "\n"
   end
@@ -50,30 +50,30 @@ def list_availability_zones(ec2_client)
   max_zone_string_length = 18
   max_state_string_length = 9
   # Print header.
-  print 'Region'
-  print ' ' * (max_region_string_length - 'Region'.length)
-  print '  Zone'
-  print ' ' * (max_zone_string_length - 'Zone'.length)
+  print "Region"
+  print " " * (max_region_string_length - "Region".length)
+  print "  Zone"
+  print " " * (max_zone_string_length - "Zone".length)
   print "  State\n"
-  print '-' * max_region_string_length
-  print '  '
-  print '-' * max_zone_string_length
-  print '  '
-  print '-' * max_state_string_length
+  print "-" * max_region_string_length
+  print "  "
+  print "-" * max_zone_string_length
+  print "  "
+  print "-" * max_state_string_length
   print "\n"
   # Print Regions, Availability Zones, and their states.
   result.availability_zones.each do |zone|
     print zone.region_name
-    print ' ' * (max_region_string_length - zone.region_name.length)
-    print '  '
+    print " " * (max_region_string_length - zone.region_name.length)
+    print "  "
     print zone.zone_name
-    print ' ' * (max_zone_string_length - zone.zone_name.length)
-    print '  '
+    print " " * (max_zone_string_length - zone.zone_name.length)
+    print "  "
     print zone.state
     # Print any messages for this Availability Zone.
     if zone.messages.count.positive?
       print "\n"
-      puts '  Messages for this zone:'
+      puts "  Messages for this zone:"
       zone.messages.each do |message|
         print "    #{message.message}\n"
       end
@@ -84,17 +84,17 @@ end
 
 # Full example call:
 def run_me
-  region = ''
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-regions-availability-zones.rb REGION'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-regions-availability-zones.rb REGION"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-regions-availability-zones.rb us-west-2'
+    puts "Example: ruby ec2-ruby-example-regions-availability-zones.rb us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
   elsif ARGV.count.zero?
-    region = 'us-west-2'
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     region = ARGV[0]
@@ -102,7 +102,7 @@ def run_me
 
   ec2_client = Aws::EC2::Client.new(region: region)
 
-  puts 'AWS Regions for Amazon EC2 that are available to you:'
+  puts "AWS Regions for Amazon EC2 that are available to you:"
   list_regions_endpoints(ec2_client)
   puts "\n\nAmazon EC2 Availability Zones that are available to you for AWS Region '#{region}':"
   list_availability_zones(ec2_client)

--- a/ruby/example_code/ec2/ec2-ruby-example-security-group.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-security-group.rb
@@ -15,7 +15,7 @@
 # 3. Displays information about available security groups.
 # 4. Deletes the security group.
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Creates an Amazon Elastic Compute Cloud (Amazon EC2) security group.
 #
@@ -52,7 +52,7 @@ def create_security_group(
   return security_group.group_id
 rescue StandardError => e
   puts "Error creating security group: #{e.message}"
-  return 'Error'
+  return "Error"
 end
 
 # Adds an inbound rule to an Amazon Elastic Compute Cloud (Amazon EC2)
@@ -130,16 +130,16 @@ def describe_security_group_permissions(perm)
   print "  Protocol: #{perm.ip_protocol == '-1' ? 'All' : perm.ip_protocol}"
 
   unless perm.from_port.nil?
-    if perm.from_port == '-1' || perm.from_port == -1
-      print ', From: All'
+    if perm.from_port == "-1" || perm.from_port == -1
+      print ", From: All"
     else
       print ", From: #{perm.from_port}"
     end
   end
 
   unless perm.to_port.nil?
-    if perm.to_port == '-1' || perm.to_port == -1
-      print ', To: All'
+    if perm.to_port == "-1" || perm.to_port == -1
+      print ", To: All"
     else
       print ", To: #{perm.to_port}"
     end
@@ -167,7 +167,7 @@ def describe_security_groups(ec2_client)
 
   if response.security_groups.count.positive?
     response.security_groups.each do |sg|
-      puts '-' * (sg.group_name.length + 13)
+      puts "-" * (sg.group_name.length + 13)
       puts "Name:        #{sg.group_name}"
       puts "Description: #{sg.description}"
       puts "Group ID:    #{sg.group_id}"
@@ -175,28 +175,28 @@ def describe_security_groups(ec2_client)
       puts "VPC ID:      #{sg.vpc_id}"
 
       if sg.tags.count.positive?
-        puts 'Tags:'
+        puts "Tags:"
         sg.tags.each do |tag|
           puts "  Key: #{tag.key}, Value: #{tag.value}"
         end
       end
 
       unless sg.ip_permissions.empty?
-        puts 'Inbound rules:' if sg.ip_permissions.count.positive?
+        puts "Inbound rules:" if sg.ip_permissions.count.positive?
         sg.ip_permissions.each do |p|
           describe_security_group_permissions(p)
         end
       end
 
       unless sg.ip_permissions_egress.empty?
-        puts 'Outbound rules:' if sg.ip_permissions.count.positive?
+        puts "Outbound rules:" if sg.ip_permissions.count.positive?
         sg.ip_permissions_egress.each do |p|
           describe_security_group_permissions(p)
         end
       end
     end
   else
-    puts 'No security groups found.'
+    puts "No security groups found."
   end
 rescue StandardError => e
   puts "Error getting information about security groups: #{e.message}"
@@ -229,43 +229,43 @@ end
 
 # Full example call:
 def run_me
-  group_name = ''
-  description = ''
-  vpc_id = ''
-  ip_protocol_http = ''
-  from_port_http = ''
-  to_port_http = ''
-  cidr_ip_range_http = ''
-  ip_protocol_ssh = ''
-  from_port_ssh = ''
-  to_port_ssh = ''
-  cidr_ip_range_ssh = ''
-  region = ''
+  group_name = ""
+  description = ""
+  vpc_id = ""
+  ip_protocol_http = ""
+  from_port_http = ""
+  to_port_http = ""
+  cidr_ip_range_http = ""
+  ip_protocol_ssh = ""
+  from_port_ssh = ""
+  to_port_ssh = ""
+  cidr_ip_range_ssh = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-security-group.rb ' \
-      'GROUP_NAME DESCRIPTION VPC_ID IP_PROTOCOL_1 FROM_PORT_1 TO_PORT_1 ' \
-      'CIDR_IP_RANGE_1 IP_PROTOCOL_2 FROM_PORT_2 TO_PORT_2 ' \
-      'CIDR_IP_RANGE_2 REGION'
-    puts 'Example: ruby ec2-ruby-example-security-group.rb ' \
-      'my-security-group \'This is my security group.\' vpc-6713dfEX ' \
-      'tcp 80 80 \'0.0.0.0/0\' tcp 22 22 \'0.0.0.0/0\' us-west-2'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-security-group.rb " \
+      "GROUP_NAME DESCRIPTION VPC_ID IP_PROTOCOL_1 FROM_PORT_1 TO_PORT_1 " \
+      "CIDR_IP_RANGE_1 IP_PROTOCOL_2 FROM_PORT_2 TO_PORT_2 " \
+      "CIDR_IP_RANGE_2 REGION"
+    puts "Example: ruby ec2-ruby-example-security-group.rb " \
+      "my-security-group 'This is my security group.' vpc-6713dfEX " \
+      "tcp 80 80 '0.0.0.0/0' tcp 22 22 '0.0.0.0/0' us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   elsif ARGV.count.zero?
-    group_name = 'my-security-group'
-    description = 'This is my security group.'
-    vpc_id = 'vpc-6713dfEX'
-    ip_protocol_http = 'tcp'
-    from_port_http = '80'
-    to_port_http = '80'
-    cidr_ip_range_http = '0.0.0.0/0'
-    ip_protocol_ssh = 'tcp'
-    from_port_ssh = '22'
-    to_port_ssh = '22'
-    cidr_ip_range_ssh = '0.0.0.0/0'
+    group_name = "my-security-group"
+    description = "This is my security group."
+    vpc_id = "vpc-6713dfEX"
+    ip_protocol_http = "tcp"
+    from_port_http = "80"
+    to_port_http = "80"
+    cidr_ip_range_http = "0.0.0.0/0"
+    ip_protocol_ssh = "tcp"
+    from_port_ssh = "22"
+    to_port_ssh = "22"
+    cidr_ip_range_ssh = "0.0.0.0/0"
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    region = 'us-west-2'
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     group_name = ARGV[0]
@@ -282,25 +282,25 @@ def run_me
     region = ARGV[11]
   end
 
-  security_group_id = ''
+  security_group_id = ""
   security_group_exists = false
   ec2_client = Aws::EC2::Client.new(region: region)
 
-  puts 'Attempting to create security group...'
+  puts "Attempting to create security group..."
   security_group_id = create_security_group(
     ec2_client,
     group_name,
     description,
     vpc_id
   )
-  if security_group_id == 'Error'
-    puts 'Could not create security group. Skipping this step.'
+  if security_group_id == "Error"
+    puts "Could not create security group. Skipping this step."
   else
     security_group_exists = true
   end
 
   if security_group_exists
-    puts 'Attempting to add inbound rules to security group...'
+    puts "Attempting to add inbound rules to security group..."
     unless security_group_ingress_authorized?(
       ec2_client,
       security_group_id,
@@ -309,8 +309,8 @@ def run_me
       to_port_http,
       cidr_ip_range_http
     )
-      puts 'Could not add inbound HTTP rule to security group. ' \
-        'Skipping this step.'
+      puts "Could not add inbound HTTP rule to security group. " \
+        "Skipping this step."
     end
 
     unless security_group_ingress_authorized?(
@@ -321,8 +321,8 @@ def run_me
       to_port_ssh,
       cidr_ip_range_ssh
     )
-      puts 'Could not add inbound SSH rule to security group. ' \
-        'Skipping this step.'
+      puts "Could not add inbound SSH rule to security group. " \
+        "Skipping this step."
     end
   end
 
@@ -332,7 +332,7 @@ def run_me
   if security_group_exists
     puts "\nAttempting to delete security group..."
     unless security_group_deleted?(ec2_client, security_group_id)
-      puts 'Could not delete security group. You must delete it yourself.'
+      puts "Could not delete security group. You must delete it yourself."
     end
   end
 end

--- a/ruby/example_code/ec2/ec2-ruby-example-start-instance-i-123abc.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-start-instance-i-123abc.rb
@@ -8,7 +8,7 @@
 
 # snippet-start:[ec2.Ruby.startInstance]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Attempts to start an Amazon Elastic Compute Cloud (Amazon EC2) instance.
 #
@@ -30,22 +30,22 @@ def instance_started?(ec2_client, instance_id)
   if response.instance_statuses.count.positive?
     state = response.instance_statuses[0].instance_state.name
     case state
-    when 'pending'
-      puts 'Error starting instance: the instance is pending. Try again later.'
+    when "pending"
+      puts "Error starting instance: the instance is pending. Try again later."
       return false
-    when 'running'
-      puts 'The instance is already running.'
+    when "running"
+      puts "The instance is already running."
       return true
-    when 'terminated'
-      puts 'Error starting instance: ' \
-        'the instance is terminated, so you cannot start it.'
+    when "terminated"
+      puts "Error starting instance: " \
+        "the instance is terminated, so you cannot start it."
       return false
     end
   end
 
   ec2_client.start_instances(instance_ids: [instance_id])
   ec2_client.wait_until(:instance_running, instance_ids: [instance_id])
-  puts 'Instance started.'
+  puts "Instance started."
   return true
 rescue StandardError => e
   puts "Error starting instance: #{e.message}"
@@ -54,21 +54,21 @@ end
 
 # Full example call:
 def run_me
-  instance_id = ''
-  region = ''
+  instance_id = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-start-instance-i-123abc.rb ' \
-      'INSTANCE_ID REGION '
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-start-instance-i-123abc.rb " \
+      "INSTANCE_ID REGION "
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-start-instance-i-123abc.rb ' \
-      'i-123abc us-west-2'
+    puts "Example: ruby ec2-ruby-example-start-instance-i-123abc.rb " \
+      "i-123abc us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
   elsif ARGV.count.zero?
-    instance_id = 'i-123abc'
-    region = 'us-west-2'
+    instance_id = "i-123abc"
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     instance_id = ARGV[0]
@@ -78,9 +78,9 @@ def run_me
   ec2_client = Aws::EC2::Client.new(region: region)
 
   puts "Attempting to start instance '#{instance_id}' " \
-    '(this might take a few minutes)...'
+    "(this might take a few minutes)..."
   unless instance_started?(ec2_client, instance_id)
-    puts 'Could not start instance.'
+    puts "Could not start instance."
   end
 end
 

--- a/ruby/example_code/ec2/ec2-ruby-example-stop-instance-i-123abc.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-stop-instance-i-123abc.rb
@@ -7,7 +7,7 @@
 
 # snippet-start:[ec2.Ruby.stopInstances]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Prerequisites:
 #
@@ -27,22 +27,22 @@ def instance_stopped?(ec2_client, instance_id)
   if response.instance_statuses.count.positive?
     state = response.instance_statuses[0].instance_state.name
     case state
-    when 'stopping'
-      puts 'The instance is already stopping.'
+    when "stopping"
+      puts "The instance is already stopping."
       return true
-    when 'stopped'
-      puts 'The instance is already stopped.'
+    when "stopped"
+      puts "The instance is already stopped."
       return true
-    when 'terminated'
-      puts 'Error stopping instance: ' \
-        'the instance is terminated, so you cannot stop it.'
+    when "terminated"
+      puts "Error stopping instance: " \
+        "the instance is terminated, so you cannot stop it."
       return false
     end
   end
 
   ec2_client.stop_instances(instance_ids: [instance_id])
   ec2_client.wait_until(:instance_stopped, instance_ids: [instance_id])
-  puts 'Instance stopped.'
+  puts "Instance stopped."
   return true
 rescue StandardError => e
   puts "Error stopping instance: #{e.message}"
@@ -51,21 +51,21 @@ end
 
 # Full example call:
 def run_me
-  instance_id = ''
-  region = ''
+  instance_id = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-stop-instance-i-123abc.rb ' \
-      'INSTANCE_ID REGION '
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-stop-instance-i-123abc.rb " \
+      "INSTANCE_ID REGION "
     # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-start-instance-i-123abc.rb ' \
-      'i-123abc us-west-2'
+    puts "Example: ruby ec2-ruby-example-start-instance-i-123abc.rb " \
+      "i-123abc us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
   elsif ARGV.count.zero?
-    instance_id = 'i-123abc'
-    region = 'us-west-2'
+    instance_id = "i-123abc"
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     instance_id = ARGV[0]
@@ -75,9 +75,9 @@ def run_me
   ec2_client = Aws::EC2::Client.new(region: region)
 
   puts "Attempting to stop instance '#{instance_id}' " \
-    '(this might take a few minutes)...'
+    "(this might take a few minutes)..."
   unless instance_stopped?(ec2_client, instance_id)
-    puts 'Could not stop instance.'
+    puts "Could not stop instance."
   end
 end
 

--- a/ruby/example_code/ec2/ec2-ruby-example-terminate-instance-i-123abc.rb
+++ b/ruby/example_code/ec2/ec2-ruby-example-terminate-instance-i-123abc.rb
@@ -11,7 +11,7 @@
 
 # snippet-start:[ec2.Ruby.terminateInstances]
 
-require 'aws-sdk-ec2'
+require "aws-sdk-ec2"
 
 # Prerequisites:
 #
@@ -29,15 +29,15 @@ def instance_terminated?(ec2_client, instance_id)
   response = ec2_client.describe_instance_status(instance_ids: [instance_id])
 
   if response.instance_statuses.count.positive? &&
-    response.instance_statuses[0].instance_state.name == 'terminated'
+    response.instance_statuses[0].instance_state.name == "terminated"
 
-    puts 'The instance is already terminated.'
+    puts "The instance is already terminated."
     return true
   end
 
   ec2_client.terminate_instances(instance_ids: [instance_id])
   ec2_client.wait_until(:instance_terminated, instance_ids: [instance_id])
-  puts 'Instance terminated.'
+  puts "Instance terminated."
   return true
 rescue StandardError => e
   puts "Error terminating instance: #{e.message}"
@@ -46,21 +46,21 @@ end
 
 # Full example call:
 def run_me
-  instance_id = ''
-  region = ''
+  instance_id = ""
+  region = ""
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby ec2-ruby-example-terminate-instance-i-123abc.rb ' \
-      'INSTANCE_ID REGION '
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby ec2-ruby-example-terminate-instance-i-123abc.rb " \
+      "INSTANCE_ID REGION "
    # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
-    puts 'Example: ruby ec2-ruby-example-terminate-instance-i-123abc.rb ' \
-      'i-123abc us-west-2'
+    puts "Example: ruby ec2-ruby-example-terminate-instance-i-123abc.rb " \
+      "i-123abc us-west-2"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   # Replace us-west-2 with the AWS Region you're using for Amazon EC2.
   elsif ARGV.count.zero?
-    instance_id = 'i-123abc'
-    region = 'us-west-2'
+    instance_id = "i-123abc"
+    region = "us-west-2"
   # Otherwise, use the values as specified at the command prompt.
   else
     instance_id = ARGV[0]
@@ -70,9 +70,9 @@ def run_me
   ec2_client = Aws::EC2::Client.new(region: region)
 
   puts "Attempting to terminate instance '#{instance_id}' " \
-    '(this might take a few minutes)...'
+    "(this might take a few minutes)..."
   unless instance_terminated?(ec2_client, instance_id)
-    puts 'Could not terminate instance.'
+    puts "Could not terminate instance."
   end
 end
 

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-attach-igw-vpc.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-attach-igw-vpc.rb
@@ -1,18 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-attach-igw-vpc'
+require_relative "../ec2-ruby-example-attach-igw-vpc"
 
-describe '#internet_gateway_created_and_attached?' do
-  let(:vpc_id) { 'vpc-6713dfEX' }
-  let(:tag_key) { 'my-key' }
-  let(:tag_value) { 'my-value' }
+describe "#internet_gateway_created_and_attached?" do
+  let(:vpc_id) { "vpc-6713dfEX" }
+  let(:tag_key) { "my-key" }
+  let(:tag_value) { "my-value" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         create_internet_gateway: {
           internet_gateway: {
-            internet_gateway_id: 'igw-052bf3915781dd0EX'
+            internet_gateway_id: "igw-052bf3915781dd0EX"
           }
         },
         attach_internet_gateway: {},
@@ -22,7 +22,7 @@ describe '#internet_gateway_created_and_attached?' do
   end
   let(:ec2_resource) { Aws::EC2::Resource.new(client: ec2_client) }
 
-  it 'creates an internet gateway and attaches it to a VPC' do
+  it "creates an internet gateway and attaches it to a VPC" do
     expect(
       internet_gateway_created_and_attached?(
         ec2_resource,

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-instance.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-instance.rb
@@ -1,14 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-create-instance'
+require_relative "../ec2-ruby-example-create-instance"
 
-describe '#instance_created?' do
-  let(:image_id) { 'ami-0947d2ba12EXAMPLE' }
-  let(:key_pair_name) { 'my-key-pair' }
-  let(:tag_key) { 'my-key' }
-  let(:tag_value) { 'my-value' }
-  let(:instance_id) { 'i-01c7a43263ddbc7EX' }
+describe "#instance_created?" do
+  let(:image_id) { "ami-0947d2ba12EXAMPLE" }
+  let(:key_pair_name) { "my-key-pair" }
+  let(:tag_key) { "my-key" }
+  let(:tag_value) { "my-value" }
+  let(:instance_id) { "i-01c7a43263ddbc7EX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -22,7 +22,7 @@ describe '#instance_created?' do
             instances: [
               instance_id: instance_id,
               state: {
-                name: 'running'
+                name: "running"
               }
             ]
           ]
@@ -33,7 +33,7 @@ describe '#instance_created?' do
   end
   let(:ec2_resource) { Aws::EC2::Resource.new(client: ec2_client) }
 
-  it 'creates an instance' do
+  it "creates an instance" do
     expect(
       instance_created?(
         ec2_resource,

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-key-pair.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-key-pair.rb
@@ -1,18 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-create-key-pair'
+require_relative "../ec2-ruby-example-create-key-pair"
 
-describe '#key_pair_created?' do
-  let(:key_pair_name) { 'delete-this-key-pair--only-a-test' }
+describe "#key_pair_created?" do
+  let(:key_pair_name) { "delete-this-key-pair--only-a-test" }
   let(:ec2_client) do
 
     Aws::EC2::Client.new(
       stub_responses: {
         create_key_pair: {
           key_name: key_pair_name,
-          key_fingerprint: 'EX:AM:PL:E4:ac:f2:42:71:6d:26:26:8f:31:b7:67:a2:6E:XA:MP:LE',
-          key_pair_id: 'key-08021f7c59EXAMPLE',
+          key_fingerprint: "EX:AM:PL:E4:ac:f2:42:71:6d:26:26:8f:31:b7:67:a2:6E:XA:MP:LE",
+          key_pair_id: "key-08021f7c59EXAMPLE",
           key_material: "-----BEGIN RSA PRIVATE KEY-----\n_omitted_for_brevity\n-----END RSA PRIVATE KEY-----"
         }
       }
@@ -20,7 +20,7 @@ describe '#key_pair_created?' do
   end
   let(:ec2_resource) { Aws::EC2::Resource.new(client: ec2_client) }
 
-  it 'creates a key pair' do
+  it "creates a key pair" do
     expect(key_pair_created?(ec2_client, key_pair_name)).to be(true)
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-route-table.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-route-table.rb
@@ -1,21 +1,21 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-create-route-table'
+require_relative "../ec2-ruby-example-create-route-table"
 
-describe '#route_table_created_and_associated?' do
-  let(:vpc_id) { 'vpc-0b6f769731EXAMPLE' }
-  let(:subnet_id) { 'subnet-03d9303b57EXAMPLE' }
-  let(:gateway_id) { 'igw-06ca90c011EXAMPLE' }
-  let(:destination_cidr_block) { '0.0.0.0/0' }
-  let(:tag_key) { 'my-key' }
-  let(:tag_value) { 'my-value' }
+describe "#route_table_created_and_associated?" do
+  let(:vpc_id) { "vpc-0b6f769731EXAMPLE" }
+  let(:subnet_id) { "subnet-03d9303b57EXAMPLE" }
+  let(:gateway_id) { "igw-06ca90c011EXAMPLE" }
+  let(:destination_cidr_block) { "0.0.0.0/0" }
+  let(:tag_key) { "my-key" }
+  let(:tag_value) { "my-value" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         create_route_table: {
           route_table: {
-            route_table_id: 'rtb-225746EX'
+            route_table_id: "rtb-225746EX"
           }
         },
         create_tags: {},
@@ -23,14 +23,14 @@ describe '#route_table_created_and_associated?' do
           return: true
         },
         associate_route_table: {
-          association_id: 'rtbassoc-781d0dEX'
+          association_id: "rtbassoc-781d0dEX"
         }
       }
     )
   end
   let(:ec2_resource) { Aws::EC2::Resource.new(client: ec2_client) }
 
-  it 'creates and associates a route table' do
+  it "creates and associates a route table" do
     expect(
       route_table_created_and_associated?(
         ec2_resource,

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-security-group.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-security-group.rb
@@ -1,21 +1,21 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-create-security-group'
+require_relative "../ec2-ruby-example-create-security-group"
 
-describe '#security_group_created_with_egress?' do
-  let(:group_name) { 'my-security-group' }
-  let(:description) { 'This is my security group.' }
-  let(:vpc_id) { 'vpc-6713dfEX' }
-  let(:ip_protocol) { 'tcp' }
-  let(:from_port) { '22' }
-  let(:to_port) { '22' }
-  let(:cidr_ip_range) { '0.0.0.0/0' }
+describe "#security_group_created_with_egress?" do
+  let(:group_name) { "my-security-group" }
+  let(:description) { "This is my security group." }
+  let(:vpc_id) { "vpc-6713dfEX" }
+  let(:ip_protocol) { "tcp" }
+  let(:from_port) { "22" }
+  let(:to_port) { "22" }
+  let(:cidr_ip_range) { "0.0.0.0/0" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         create_security_group: {
-          group_id: 'sg-903004EX'
+          group_id: "sg-903004EX"
         },
         authorize_security_group_egress: {}
       }
@@ -23,7 +23,7 @@ describe '#security_group_created_with_egress?' do
   end
   let(:ec2_resource) { Aws::EC2::Resource.new(client: ec2_client) }
 
-  it 'creates a security group and adds an egress rule' do
+  it "creates a security group and adds an egress rule" do
     expect(
       security_group_created_with_egress?(
         ec2_resource,

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-subnet.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-subnet.rb
@@ -1,20 +1,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-create-subnet'
+require_relative "../ec2-ruby-example-create-subnet"
 
-describe '#subnet_created_and_tagged?' do
-  let(:vpc_id) { 'vpc-6713dfEX' }
-  let(:cidr_block) { '10.0.0.0/24' }
-  let(:availability_zone) { 'us-west-2a' }
-  let(:tag_key) { 'my-key' }
-  let(:tag_value) { 'my-value' }
+describe "#subnet_created_and_tagged?" do
+  let(:vpc_id) { "vpc-6713dfEX" }
+  let(:cidr_block) { "10.0.0.0/24" }
+  let(:availability_zone) { "us-west-2a" }
+  let(:tag_key) { "my-key" }
+  let(:tag_value) { "my-value" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         create_subnet: {
           subnet: {
-            subnet_id: 'subnet-03d9303b57c7187EX'
+            subnet_id: "subnet-03d9303b57c7187EX"
           }
         },
         create_tags: {}
@@ -23,7 +23,7 @@ describe '#subnet_created_and_tagged?' do
   end
   let(:ec2_resource) { Aws::EC2::Resource.new(client: ec2_client) }
 
-  it 'creates and tags a subnet' do
+  it "creates and tags a subnet" do
     expect(
       subnet_created_and_tagged?(
         ec2_resource,

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-vpc.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-create-vpc.rb
@@ -1,18 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-create-vpc'
+require_relative "../ec2-ruby-example-create-vpc"
 
-describe '#vpc_created_and_tagged?' do
-  let(:cidr_block) { '10.0.0.0/24' }
-  let(:tag_key) { 'my-key' }
-  let(:tag_value) { 'my-value' }
+describe "#vpc_created_and_tagged?" do
+  let(:cidr_block) { "10.0.0.0/24" }
+  let(:tag_key) { "my-key" }
+  let(:tag_value) { "my-value" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         create_vpc: {
           vpc: {
-            vpc_id: 'vpc-6713dfEX'
+            vpc_id: "vpc-6713dfEX"
           }
         },
         modify_vpc_attribute: {},
@@ -22,7 +22,7 @@ describe '#vpc_created_and_tagged?' do
   end
   let(:ec2_resource) { Aws::EC2::Resource.new(client: ec2_client) }
 
-  it 'creates and tags a VPC' do
+  it "creates and tags a VPC" do
     expect(
       vpc_created_and_tagged?(
         ec2_resource,

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-elastic-ips.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-elastic-ips.rb
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-elastic-ips'
+require_relative "../ec2-ruby-example-elastic-ips"
 
-describe '#instance_exists?' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
+describe "#instance_exists?" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -21,14 +21,14 @@ describe '#instance_exists?' do
     )
   end
 
-  it 'checks whether the instance exists' do
+  it "checks whether the instance exists" do
     expect(instance_exists?(ec2_client, instance_id)).to be(true)
   end
 end
 
-describe '#allocate_elastic_ip_address' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
-  let(:allocation_id) { 'eipalloc-0e7e1c46c5ee5f8EX' }
+describe "#allocate_elastic_ip_address" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
+  let(:allocation_id) { "eipalloc-0e7e1c46c5ee5f8EX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -39,15 +39,15 @@ describe '#allocate_elastic_ip_address' do
     )
   end
 
-  it 'checks for the Elastic IP address allocation ID' do
+  it "checks for the Elastic IP address allocation ID" do
     expect(allocate_elastic_ip_address(ec2_client)).to eq(allocation_id)
   end
 end
 
-describe '#associate_elastic_ip_address_with_instance' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
-  let(:allocation_id) { 'eipalloc-0e7e1c46c5ee5f8EX' }
-  let(:association_id) { 'eipassoc-010e2d189043030EX' }
+describe "#associate_elastic_ip_address_with_instance" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
+  let(:allocation_id) { "eipalloc-0e7e1c46c5ee5f8EX" }
+  let(:association_id) { "eipassoc-010e2d189043030EX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -58,7 +58,7 @@ describe '#associate_elastic_ip_address_with_instance' do
     )
   end
 
-  it 'checks for the Elastic IP address allocation ID' do
+  it "checks for the Elastic IP address allocation ID" do
     expect(
       associate_elastic_ip_address_with_instance(
         ec2_client,
@@ -69,16 +69,16 @@ describe '#associate_elastic_ip_address_with_instance' do
   end
 end
 
-describe '#describe_addresses_for_instance' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
+describe "#describe_addresses_for_instance" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         describe_addresses: {
           addresses: [
             {
-              public_ip: '203.0.113.0',
-              private_ip_address: '10.0.1.241'
+              public_ip: "203.0.113.0",
+              private_ip_address: "10.0.1.241"
             }
           ]
         }
@@ -86,14 +86,14 @@ describe '#describe_addresses_for_instance' do
     )
   end
 
-  it 'lists information about the instance' do
+  it "lists information about the instance" do
     expect { describe_addresses_for_instance(ec2_client, instance_id) }.not_to raise_error
   end
 end
 
-describe '#elastic_ip_address_released?' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
-  let(:allocation_id) { 'eipalloc-0e7e1c46c5ee5f8EX' }
+describe "#elastic_ip_address_released?" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
+  let(:allocation_id) { "eipalloc-0e7e1c46c5ee5f8EX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -102,7 +102,7 @@ describe '#elastic_ip_address_released?' do
     )
   end
 
-  it 'releases the Elastic IP address' do
+  it "releases the Elastic IP address" do
     expect(elastic_ip_address_released?(ec2_client, allocation_id)).to be(true)
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-get-all-instance-info.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-get-all-instance-info.rb
@@ -1,18 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-get-all-instance-info'
+require_relative "../ec2-ruby-example-get-all-instance-info"
 
-describe '#list_instance_ids_states' do
+describe "#list_instance_ids_states" do
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         describe_instances: {
           reservations: [
             instances: [
-              { instance_id: 'i-abc123-1', state: { name: 'running' } },
-              { instance_id: 'i-abc123-2', state: { name: 'running' } },
-              { instance_id: 'i-abc123-3', state: { name: 'running' } }
+              { instance_id: "i-abc123-1", state: { name: "running" } },
+              { instance_id: "i-abc123-2", state: { name: "running" } },
+              { instance_id: "i-abc123-3", state: { name: "running" } }
             ]
           ]
         }
@@ -21,7 +21,7 @@ describe '#list_instance_ids_states' do
   end
   let(:ec2_resource) { Aws::EC2::Resource.new(client: ec2_client) }
 
-  it 'lists instance IDs and states' do
-    expect{ list_instance_ids_states(ec2_resource) }.not_to raise_error
+  it "lists instance IDs and states" do
+    expect { list_instance_ids_states(ec2_resource) }.not_to raise_error
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-get-instance-info-by-tag.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-get-instance-info-by-tag.rb
@@ -1,20 +1,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-get-instance-info-by-tag'
+require_relative "../ec2-ruby-example-get-instance-info-by-tag"
 
-describe '#list_instance_ids_states' do
-  let(:tag_key) { 'my-key' }
-  let(:tag_value) { 'my-value' }
+describe "#list_instance_ids_states" do
+  let(:tag_key) { "my-key" }
+  let(:tag_value) { "my-value" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         describe_instances: {
           reservations: [
             instances: [
-              { instance_id: 'i-abc123-1', state: { name: 'running' }, tags: [key: 'my-key', value: 'my-value'] },
-              { instance_id: 'i-abc123-2', state: { name: 'running' }, tags: [key: 'my-key', value: 'my-value'] },
-              { instance_id: 'i-abc123-3', state: { name: 'running' }, tags: [key: 'my-key', value: 'my-value'] }
+              { instance_id: "i-abc123-1", state: { name: "running" }, tags: [key: "my-key", value: "my-value"] },
+              { instance_id: "i-abc123-2", state: { name: "running" }, tags: [key: "my-key", value: "my-value"] },
+              { instance_id: "i-abc123-3", state: { name: "running" }, tags: [key: "my-key", value: "my-value"] }
             ]
           ]
         }
@@ -23,7 +23,7 @@ describe '#list_instance_ids_states' do
   end
   let(:ec2_resource) { Aws::EC2::Resource.new(client: ec2_client) }
 
-  it 'lists instance IDs and states' do
+  it "lists instance IDs and states" do
     expect { list_instance_ids_states_by_tag(ec2_resource, tag_key, tag_value) }.not_to raise_error
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-key-pairs.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-key-pairs.rb
@@ -1,17 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-key-pairs'
+require_relative "../ec2-ruby-example-key-pairs"
 
-describe '#key_pair_created?' do
-  let(:key_pair_name) { 'delete-this-key-pair--only-a-test' }
+describe "#key_pair_created?" do
+  let(:key_pair_name) { "delete-this-key-pair--only-a-test" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         create_key_pair: {
           key_name: key_pair_name,
-          key_fingerprint: 'EX:AM:PL:E4:ac:f2:42:71:6d:26:26:8f:31:b7:67:a2:6E:XA:MP:LE',
-          key_pair_id: 'key-08021f7c59EXAMPLE',
+          key_fingerprint: "EX:AM:PL:E4:ac:f2:42:71:6d:26:26:8f:31:b7:67:a2:6E:XA:MP:LE",
+          key_pair_id: "key-08021f7c59EXAMPLE",
           key_material: "-----BEGIN RSA PRIVATE KEY-----\n_omitted_for_brevity\n-----END RSA PRIVATE KEY-----"
         }
       }
@@ -19,24 +19,24 @@ describe '#key_pair_created?' do
   end
   let(:ec2_resource) { Aws::EC2::Resource.new(client: ec2_client) }
 
-  it 'creates a key pair' do
+  it "creates a key pair" do
     expect(key_pair_created?(ec2_client, key_pair_name)).to be(true)
   end
 end
 
-describe '#describe_key_pairs' do
+describe "#describe_key_pairs" do
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         describe_key_pairs: {
           key_pairs: [
             {
-              key_name: 'my-key-pair-1',
-              key_fingerprint: 'EX:AM:PL:E4:ac:f2:42:71:6d:26:26:8f:31:b7:67:a2:6E:XA:MP:LE'  
+              key_name: "my-key-pair-1",
+              key_fingerprint: "EX:AM:PL:E4:ac:f2:42:71:6d:26:26:8f:31:b7:67:a2:6E:XA:MP:LE"
             },
             {
-              key_name: 'my-key-pair-2',
-              key_fingerprint: 'EX:AM:PL:E4:bd:f2:42:71:6d:26:26:8f:31:b7:67:a2:6E:XA:MP:LE'
+              key_name: "my-key-pair-2",
+              key_fingerprint: "EX:AM:PL:E4:bd:f2:42:71:6d:26:26:8f:31:b7:67:a2:6E:XA:MP:LE"
             }
           ]
         }
@@ -44,13 +44,13 @@ describe '#describe_key_pairs' do
     )
   end
 
-  it 'lists information about available key pairs' do
-    expect { describe_key_pairs(ec2_client) }.not_to raise_error 
+  it "lists information about available key pairs" do
+    expect { describe_key_pairs(ec2_client) }.not_to raise_error
   end
 end
 
-describe '#key_pair_deleted?' do
-  let(:key_pair_name) { 'my-key-pair' }
+describe "#key_pair_deleted?" do
+  let(:key_pair_name) { "my-key-pair" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -59,7 +59,7 @@ describe '#key_pair_deleted?' do
     )
   end
 
-  it 'deletes a key pair' do
+  it "deletes a key pair" do
     expect(key_pair_deleted?(ec2_client, key_pair_name)).to be(true)
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-list-state-instance-i-123abc.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-list-state-instance-i-123abc.rb
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-list-state-instance-i-123abc'
+require_relative "../ec2-ruby-example-list-state-instance-i-123abc"
 
-describe '#list_instance_state' do
-  let(:instance_id) { 'i-123abc' }
+describe "#list_instance_state" do
+  let(:instance_id) { "i-123abc" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -13,7 +13,7 @@ describe '#list_instance_state' do
             instances: [
               instance_id: instance_id,
               state: {
-                name: 'running'
+                name: "running"
               }
             ]
           ]
@@ -22,7 +22,7 @@ describe '#list_instance_state' do
     )
   end
 
-  it 'displays state information for the instance' do
+  it "displays state information for the instance" do
     expect { list_instance_state(ec2_client, instance_id) }.not_to raise_error
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-manage-instances.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-manage-instances.rb
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-manage-instances'
+require_relative "../ec2-ruby-example-manage-instances"
 
-describe '#wait_for_instance' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
+describe "#wait_for_instance" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
   let(:instance_state) { :instance_stopped }
   let(:ec2_client) do
     Aws::EC2::Client.new(
@@ -14,7 +14,7 @@ describe '#wait_for_instance' do
             instances: [
               instance_id: instance_id,
               state: {
-                name: 'stopped'
+                name: "stopped"
               }
             ]
           ]
@@ -23,13 +23,13 @@ describe '#wait_for_instance' do
     )
   end
 
-  it 'waits for the instance to be in a stopped state' do
+  it "waits for the instance to be in a stopped state" do
     expect { wait_for_instance(ec2_client, instance_state, instance_id) }.not_to raise_error
   end
 end
 
-describe '#instance_stopped?' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
+describe "#instance_stopped?" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -38,12 +38,12 @@ describe '#instance_stopped?' do
             {
               current_state: {
                 code: 64,
-                name: 'stopping'
+                name: "stopping"
               },
               instance_id: instance_id,
               previous_state: {
                 code: 16,
-                name: 'running'
+                name: "running"
               }
             }
           ]
@@ -53,7 +53,7 @@ describe '#instance_stopped?' do
             instances: [
               instance_id: instance_id,
               state: {
-                name: 'stopped'
+                name: "stopped"
               }
             ]
           ]
@@ -62,13 +62,13 @@ describe '#instance_stopped?' do
     )
   end
 
-  it 'stops an instance' do
+  it "stops an instance" do
     expect(instance_stopped?(ec2_client, instance_id)).to be(true)
   end
 end
 
-describe '#instance_restarted?' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
+describe "#instance_restarted?" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -77,12 +77,12 @@ describe '#instance_restarted?' do
             {
               current_state: {
                 code: 0,
-                name: 'pending'
+                name: "pending"
               },
               instance_id: instance_id,
               previous_state: {
                 code: 80,
-                name: 'stopped'
+                name: "stopped"
               }
             }
           ]
@@ -92,7 +92,7 @@ describe '#instance_restarted?' do
             instances: [
               instance_id: instance_id,
               state: {
-                name: 'running'
+                name: "running"
               }
             ]
           ]
@@ -101,13 +101,13 @@ describe '#instance_restarted?' do
     )
   end
 
-  it 'restarts an instance' do
+  it "restarts an instance" do
     expect(instance_restarted?(ec2_client, instance_id)).to be(true)
   end
 end
 
-describe '#instance_rebooted?' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
+describe "#instance_rebooted?" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -116,7 +116,7 @@ describe '#instance_rebooted?' do
           instance_statuses: [
             {
               instance_status: {
-                status: 'ok'
+                status: "ok"
               }
             }
           ]
@@ -125,20 +125,20 @@ describe '#instance_rebooted?' do
     )
   end
 
-  it 'reboots an instance' do
+  it "reboots an instance" do
     expect(instance_rebooted?(ec2_client, instance_id)).to be(true)
   end
 end
 
-describe '#instance_detailed_monitoring_enabled?' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
+describe "#instance_detailed_monitoring_enabled?" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         monitor_instances: {
           instance_monitorings: [
             monitoring: {
-              state: 'enabled'
+              state: "enabled"
             }
           ]
         }
@@ -146,12 +146,12 @@ describe '#instance_detailed_monitoring_enabled?' do
     )
   end
 
-  it 'checks whether detailed instance monitoring is enabled' do
+  it "checks whether detailed instance monitoring is enabled" do
     expect(instance_detailed_monitoring_enabled?(ec2_client, instance_id)).to be(true)
   end
 end
 
-describe '#list_instances_information' do
+describe "#list_instances_information" do
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -159,64 +159,64 @@ describe '#list_instances_information' do
           reservations: [
             instances: [
               {
-                instance_id: 'i-033c48ef067af3dEX',
+                instance_id: "i-033c48ef067af3dEX",
                 state: {
-                  name: 'running'
+                  name: "running"
                 },
-                image_id: 'ami-0947d2ba12ee1ffEX',
-                instance_type: 't2.large',
-                architecture: 'x86_64',
+                image_id: "ami-0947d2ba12ee1ffEX",
+                instance_type: "t2.large",
+                architecture: "x86_64",
                 iam_instance_profile: {
-                  arn: 'arn:aws:iam::111111111111:instance-profile/my-instance-profile'
+                  arn: "arn:aws:iam::111111111111:instance-profile/my-instance-profile"
                 },
-                key_name: 'my-key-pair',
-                launch_time: Time.new(2020, 3, 10, 14, 51, 17, '-08:00'),
+                key_name: "my-key-pair",
+                launch_time: Time.new(2020, 3, 10, 14, 51, 17, "-08:00"),
                 monitoring: {
-                  state: 'enabled'
+                  state: "enabled"
                 },
-                public_ip_address: '192.0.2.0',
-                public_dns_name: 'ec2-12-345-67-8EX.compute-1.amazonaws.com',
-                vpc_id: 'vpc-6713dfEX',
-                subnet_id: 'subnet-ecf662EX',
+                public_ip_address: "192.0.2.0",
+                public_dns_name: "ec2-12-345-67-8EX.compute-1.amazonaws.com",
+                vpc_id: "vpc-6713dfEX",
+                subnet_id: "subnet-ecf662EX",
                 tags: [
                   {
-                    key: 'my-key-1',
-                    value: 'my-value-1'
+                    key: "my-key-1",
+                    value: "my-value-1"
                   },
                   {
-                    key: 'my-key-2',
-                    value: 'my-value-2'
+                    key: "my-key-2",
+                    value: "my-value-2"
                   }
                 ]
               },
               {
-                instance_id: 'i-033c48ef067af4dEX',
+                instance_id: "i-033c48ef067af4dEX",
                 state: {
-                  name: 'running'
+                  name: "running"
                 },
-                image_id: 'ami-0947d2ba12ee1ffEX',
-                instance_type: 'm4.large',
-                architecture: 'x86_64',
+                image_id: "ami-0947d2ba12ee1ffEX",
+                instance_type: "m4.large",
+                architecture: "x86_64",
                 iam_instance_profile: {
-                  arn: 'arn:aws:iam::111111111111:instance-profile/my-instance-profile'
+                  arn: "arn:aws:iam::111111111111:instance-profile/my-instance-profile"
                 },
-                key_name: 'my-key-pair',
-                launch_time: Time.new(2020, 5, 18, 9, 10, 59, '-08:00'),
+                key_name: "my-key-pair",
+                launch_time: Time.new(2020, 5, 18, 9, 10, 59, "-08:00"),
                 monitoring: {
-                  state: 'enabled'
+                  state: "enabled"
                 },
-                public_ip_address: '192.0.2.0',
-                public_dns_name: 'ec2-34-567-89-0EX.compute-1.amazonaws.com',
-                vpc_id: 'vpc-6713dfEX',
-                subnet_id: 'subnet-ecf662EX',
+                public_ip_address: "192.0.2.0",
+                public_dns_name: "ec2-34-567-89-0EX.compute-1.amazonaws.com",
+                vpc_id: "vpc-6713dfEX",
+                subnet_id: "subnet-ecf662EX",
                 tags: [
                   {
-                    key: 'my-other-key-1',
-                    value: 'my-other-value-1'
+                    key: "my-other-key-1",
+                    value: "my-other-value-1"
                   },
                   {
-                    key: 'my-other-key-2',
-                    value: 'my-other-value-2'
+                    key: "my-other-key-2",
+                    value: "my-other-value-2"
                   }
                 ]
               }
@@ -227,7 +227,7 @@ describe '#list_instances_information' do
     )
   end
 
-  it 'displays instance information' do
+  it "displays instance information" do
     expect { list_instances_information(ec2_client) }.not_to raise_error
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-reboot-instance-i-123abc.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-reboot-instance-i-123abc.rb
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-reboot-instance-i-123abc'
+require_relative "../ec2-ruby-example-reboot-instance-i-123abc"
 
-describe '#request_instance_reboot' do
-  let(:instance_id) { 'i-123abc' }
+describe "#request_instance_reboot" do
+  let(:instance_id) { "i-123abc" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -13,7 +13,7 @@ describe '#request_instance_reboot' do
             instances: [
               instance_id: instance_id,
               state: {
-                name: 'running'
+                name: "running"
               }
             ]
           ]
@@ -23,7 +23,7 @@ describe '#request_instance_reboot' do
     )
   end
 
-  it 'sends an instance reboot request' do
+  it "sends an instance reboot request" do
     expect { request_instance_reboot(ec2_client, instance_id) }.not_to raise_error
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-regions-availability-zones.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-regions-availability-zones.rb
@@ -1,57 +1,57 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-regions-availability-zones'
+require_relative "../ec2-ruby-example-regions-availability-zones"
 
-describe '#list_regions_endpoints' do
+describe "#list_regions_endpoints" do
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         describe_regions: {
           regions: [
             {
-              endpoint: 'ec2.ap-south-1.amazonaws.com',
-              region_name: 'ap-south-1'
+              endpoint: "ec2.ap-south-1.amazonaws.com",
+              region_name: "ap-south-1"
             },
             {
-              endpoint: 'ec2.eu-west-1.amazonaws.com',
-              region_name: 'eu-west-1'
+              endpoint: "ec2.eu-west-1.amazonaws.com",
+              region_name: "eu-west-1"
             },
             {
-              endpoint: 'ec2.ap-southeast-1.amazonaws.com',
-              region_name: 'ap-southeast-1'
+              endpoint: "ec2.ap-southeast-1.amazonaws.com",
+              region_name: "ap-southeast-1"
             },
             {
-              endpoint: 'ec2.ap-southeast-2.amazonaws.com',
-              region_name: 'ap-southeast-2'
+              endpoint: "ec2.ap-southeast-2.amazonaws.com",
+              region_name: "ap-southeast-2"
             },
             {
-              endpoint: 'ec2.eu-central-1.amazonaws.com',
-              region_name: 'eu-central-1'
+              endpoint: "ec2.eu-central-1.amazonaws.com",
+              region_name: "eu-central-1"
             },
             {
-              endpoint: 'ec2.ap-northeast-2.amazonaws.com',
-              region_name: 'ap-northeast-2'
+              endpoint: "ec2.ap-northeast-2.amazonaws.com",
+              region_name: "ap-northeast-2"
             },
             {
-              endpoint: 'ec2.ap-northeast-1.amazonaws.com',
-              region_name: 'ap-northeast-1'
+              endpoint: "ec2.ap-northeast-1.amazonaws.com",
+              region_name: "ap-northeast-1"
             },
             {
-              endpoint: 'ec2.us-west-2.amazonaws.com',
-              region_name: 'us-west-2'
+              endpoint: "ec2.us-west-2.amazonaws.com",
+              region_name: "us-west-2"
             },
             {
-              endpoint: 'ec2.sa-east-1.amazonaws.com',
-              region_name: 'sa-east-1'
+              endpoint: "ec2.sa-east-1.amazonaws.com",
+              region_name: "sa-east-1"
             },
             {
-              endpoint: 'ec2.us-west-1.amazonaws.com',
-              region_name: 'us-west-1'
+              endpoint: "ec2.us-west-1.amazonaws.com",
+              region_name: "us-west-1"
             },
             {
-              endpoint: 'ec2.us-west-2.amazonaws.com',
-              region_name: 'us-west-2'
+              endpoint: "ec2.us-west-2.amazonaws.com",
+              region_name: "us-west-2"
             }
           ]
         }
@@ -59,12 +59,12 @@ describe '#list_regions_endpoints' do
     )
   end
 
-  it 'displays information about regions and endpoints' do
+  it "displays information about regions and endpoints" do
     expect { list_regions_endpoints(ec2_client) }.not_to raise_error
   end
 end
 
-describe '#list_availability_zones' do
+describe "#list_availability_zones" do
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -72,41 +72,41 @@ describe '#list_availability_zones' do
           availability_zones: [
             {
               messages: [],
-              region_name: 'us-west-2',
-              state: 'available',
-              zone_name: 'us-west-2a'
+              region_name: "us-west-2",
+              state: "available",
+              zone_name: "us-west-2a"
             },
             {
               messages: [],
-              region_name: 'us-west-2',
-              state: 'available',
-              zone_name: 'us-west-2b'
+              region_name: "us-west-2",
+              state: "available",
+              zone_name: "us-west-2b"
             },
             {
               messages: [],
-              region_name: 'us-west-2',
-              state: 'available',
-              zone_name: 'us-west-2c'
+              region_name: "us-west-2",
+              state: "available",
+              zone_name: "us-west-2c"
             },
             {
               messages: [],
-              region_name: 'us-west-2',
-              state: 'available',
-              zone_name: 'us-west-2d',
+              region_name: "us-west-2",
+              state: "available",
+              zone_name: "us-west-2d",
             },
             {
               messages: [],
-              region_name: 'us-west-2',
-              state: 'available',
-              zone_name: 'us-west-2e'
-            } 
+              region_name: "us-west-2",
+              state: "available",
+              zone_name: "us-west-2e"
+            }
           ]
         }
       }
     )
   end
 
-  it 'displays information about availability zones' do
+  it "displays information about availability zones" do
     expect { list_availability_zones(ec2_client) }.not_to raise_error
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-security-group.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-security-group.rb
@@ -1,13 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-security-group'
+require_relative "../ec2-ruby-example-security-group"
 
-describe '#create_security_group' do
-  let(:group_name) { 'my-security-group' }
-  let(:description) { 'This is my security group.' }
-  let(:vpc_id) { 'vpc-6713dfEX' }
-  let(:group_id) { 'sg-0050f059851d102EX' }
+describe "#create_security_group" do
+  let(:group_name) { "my-security-group" }
+  let(:description) { "This is my security group." }
+  let(:vpc_id) { "vpc-6713dfEX" }
+  let(:group_id) { "sg-0050f059851d102EX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -18,7 +18,7 @@ describe '#create_security_group' do
     )
   end
 
-  it 'creates a security group' do
+  it "creates a security group" do
     expect(
       create_security_group(
         ec2_client,
@@ -30,12 +30,12 @@ describe '#create_security_group' do
   end
 end
 
-describe '#security_group_ingress_authorized?' do
-  let(:security_group_id) { 'sg-0050f059851d102EX' }
-  let(:ip_protocol) { 'tcp' }
-  let(:from_port) { '22' }
-  let(:to_port) { '22' }
-  let(:cidr_ip_range) { '0.0.0.0/0' }
+describe "#security_group_ingress_authorized?" do
+  let(:security_group_id) { "sg-0050f059851d102EX" }
+  let(:ip_protocol) { "tcp" }
+  let(:from_port) { "22" }
+  let(:to_port) { "22" }
+  let(:cidr_ip_range) { "0.0.0.0/0" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -44,7 +44,7 @@ describe '#security_group_ingress_authorized?' do
     )
   end
 
-  it 'adds an inbound rule to a security group' do
+  it "adds an inbound rule to a security group" do
     expect(
       security_group_ingress_authorized?(
         ec2_client,
@@ -58,44 +58,44 @@ describe '#security_group_ingress_authorized?' do
   end
 end
 
-describe '#describe_security_groups' do
+describe "#describe_security_groups" do
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
         describe_security_groups: {
           security_groups: [
             {
-              group_name: 'launch-wizard-1',
-              description: 'launch-wizard-1 created',
-              group_id: 'sg-03d327b2d28d827EX',
-              owner_id: '111111111111',
-              vpc_id: 'vpc-6713dfEX',
+              group_name: "launch-wizard-1",
+              description: "launch-wizard-1 created",
+              group_id: "sg-03d327b2d28d827EX",
+              owner_id: "111111111111",
+              vpc_id: "vpc-6713dfEX",
               tags: [
                 {
-                  key: 'my-key',
-                  value: 'my-value'
+                  key: "my-key",
+                  value: "my-value"
                 }
               ],
               ip_permissions: [
                 {
-                  ip_protocol: 'tcp',
+                  ip_protocol: "tcp",
                   from_port: 22,
                   to_port: 22,
                   ip_ranges: [
                     {
-                      cidr_ip: '0.0.0.0/0'
+                      cidr_ip: "0.0.0.0/0"
                     }
                   ]
                 }
               ],
               ip_permissions_egress: [
                 {
-                  ip_protocol: '-1',
+                  ip_protocol: "-1",
                   from_port: -1,
                   to_port: -1,
                   ip_ranges: [
                     {
-                      cidr_ip: '0.0.0.0/0'
+                      cidr_ip: "0.0.0.0/0"
                     }
                   ]
                 }
@@ -107,13 +107,13 @@ describe '#describe_security_groups' do
     )
   end
 
-  it 'displays information about available security groups' do
+  it "displays information about available security groups" do
     expect { describe_security_groups(ec2_client) }.not_to raise_error
   end
 end
 
-describe '#security_group_deleted?' do
-  let(:security_group_id) { 'sg-0050f059851d102EX' }
+describe "#security_group_deleted?" do
+  let(:security_group_id) { "sg-0050f059851d102EX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -122,7 +122,7 @@ describe '#security_group_deleted?' do
     )
   end
 
-  it 'deletes a security group' do
+  it "deletes a security group" do
     expect(security_group_deleted?(ec2_client, security_group_id)).to be(true)
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-start-instance-i-123abc.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-start-instance-i-123abc.rb
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-start-instance-i-123abc'
+require_relative "../ec2-ruby-example-start-instance-i-123abc"
 
-describe '#instance_started?' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
+describe "#instance_started?" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -12,7 +12,7 @@ describe '#instance_started?' do
           instance_statuses: [
             {
               instance_state: {
-                name: 'stopped'
+                name: "stopped"
               }
             }
           ]
@@ -22,12 +22,12 @@ describe '#instance_started?' do
             {
               current_state: {
                 code: 16,
-                name: 'running'
+                name: "running"
               },
               instance_id: instance_id,
               previous_state: {
                 code: 80,
-                name: 'stopped'
+                name: "stopped"
               }
             }
           ]
@@ -38,7 +38,7 @@ describe '#instance_started?' do
               instance_id: instance_id,
               state: {
                 code: 16,
-                name: 'running'
+                name: "running"
               }
             ]
           ]
@@ -47,7 +47,7 @@ describe '#instance_started?' do
     )
   end
 
-  it 'starts an instance' do
+  it "starts an instance" do
     expect(instance_started?(ec2_client, instance_id)).to be(true)
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-stop-instance-i-123abc.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-stop-instance-i-123abc.rb
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-stop-instance-i-123abc'
+require_relative "../ec2-ruby-example-stop-instance-i-123abc"
 
-describe '#instance_stopped?' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
+describe "#instance_stopped?" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -12,7 +12,7 @@ describe '#instance_stopped?' do
           instance_statuses: [
             {
               instance_state: {
-                name: 'running'
+                name: "running"
               }
             }
           ]
@@ -22,12 +22,12 @@ describe '#instance_stopped?' do
             {
               current_state: {
                 code: 80,
-                name: 'stopped'
+                name: "stopped"
               },
               instance_id: instance_id,
               previous_state: {
                 code: 16,
-                name: 'running'
+                name: "running"
               }
             }
           ]
@@ -38,7 +38,7 @@ describe '#instance_stopped?' do
               instance_id: instance_id,
               state: {
                 code: 80,
-                name: 'stopped'
+                name: "stopped"
               }
             ]
           ]
@@ -47,7 +47,7 @@ describe '#instance_stopped?' do
     )
   end
 
-  it 'stops an instance' do
+  it "stops an instance" do
     expect(instance_stopped?(ec2_client, instance_id)).to be(true)
   end
 end

--- a/ruby/example_code/ec2/tests/test_ec2-ruby-example-terminate-instance-i-123abc.rb
+++ b/ruby/example_code/ec2/tests/test_ec2-ruby-example-terminate-instance-i-123abc.rb
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../ec2-ruby-example-terminate-instance-i-123abc'
+require_relative "../ec2-ruby-example-terminate-instance-i-123abc"
 
-describe '#instance_terminated?' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
+describe "#instance_terminated?" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -12,7 +12,7 @@ describe '#instance_terminated?' do
           instance_statuses: [
             {
               instance_state: {
-                name: 'running'
+                name: "running"
               }
             }
           ]
@@ -22,12 +22,12 @@ describe '#instance_terminated?' do
             {
               current_state: {
                 code: 48,
-                name: 'terminated'
+                name: "terminated"
               },
               instance_id: instance_id,
               previous_state: {
                 code: 16,
-                name: 'running'
+                name: "running"
               }
             }
           ]
@@ -38,7 +38,7 @@ describe '#instance_terminated?' do
               instance_id: instance_id,
               state: {
                 code: 48,
-                name: 'terminated'
+                name: "terminated"
               }
             ]
           ]
@@ -47,7 +47,7 @@ describe '#instance_terminated?' do
     )
   end
 
-  it 'terminates an instance' do
+  it "terminates an instance" do
     expect(instance_terminated?(ec2_client, instance_id)).to be(true)
   end
 end

--- a/ruby/example_code/elasticbeanstalk/eb_list_stacks.rb
+++ b/ruby/example_code/elasticbeanstalk/eb_list_stacks.rb
@@ -6,8 +6,8 @@
 # solution stacks using the AWS SDK for Ruby.
 
 # snippet-start:[eb.Ruby.listStacks]
-require 'aws-sdk-elasticbeanstalk'  # v2: require 'aws-sdk'
-require 'os'
+require "aws-sdk-elasticbeanstalk"  # v2: require 'aws-sdk'
+require "os"
 
 if OS.windows?
   Aws.use_bundled_cert!
@@ -37,22 +37,22 @@ If REGION is not supplied, defaults to 'us-east-1'
 
 DOC
 # Replace us-west-2 with the AWS Region you're using for Elastic Beanstalk.
-region = 'us-west-2'
-filter = ''
+region = "us-west-2"
+filter = ""
 
 i = 0
 
 while i < ARGV.length
   case ARGV[i]
-    when '-F'
+    when "-F"
       i += 1
       filter = ARGV[i]
 
-    when '-r'
+    when "-r"
       i += 1
       region = ARGV[i]
 
-    when '-h'
+    when "-h"
       puts USAGE
       exit 1
 
@@ -72,8 +72,8 @@ filtered_length = 0
 
 stacks.each do |s|
 
-  if filter != ''
-      d = s.downcase
+  if filter != ""
+    d = s.downcase
 
       if d.include? filter
         puts s
@@ -86,7 +86,7 @@ end
 
 puts
 
-if filter != ''
+if filter != ""
   puts "Showed #{filtered_length} stack(s) of #{orig_length}"
 else
   puts "Showed #{orig_length} stack(s)"

--- a/ruby/example_code/elasticbeanstalk/elb-ruby-example-list-all-apps.rb
+++ b/ruby/example_code/elasticbeanstalk/elb-ruby-example-list-all-apps.rb
@@ -7,10 +7,10 @@
 
 # snippet-start:[eb.Ruby.listApps]
 
-require 'aws-sdk-elasticbeanstalk'  # v2: require 'aws-sdk'
+require "aws-sdk-elasticbeanstalk"  # v2: require 'aws-sdk'
 
 # Replace us-west-2 with the AWS Region you're using for Elastic Beanstalk.
-eb = Aws::ElasticBeanstalk::Client.new(region: 'us-west-2')
+eb = Aws::ElasticBeanstalk::Client.new(region: "us-west-2")
 
 eb.describe_applications.applications.each do |a|
   puts "Name:         #{a.application_name}"

--- a/ruby/example_code/elasticbeanstalk/elb-ruby-example-list-name-description-url-myrailsapp.rb
+++ b/ruby/example_code/elasticbeanstalk/elb-ruby-example-list-name-description-url-myrailsapp.rb
@@ -8,9 +8,9 @@
 
 # snippet-start:[eb.Ruby.listNameDescription]
 
-require 'aws-sdk-elasticbeanstalk'  # v2: require 'aws-sdk'
+require "aws-sdk-elasticbeanstalk"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Elastic Beanstalk.
-eb = Aws::ElasticBeanstalk::Client.new(region: 'us-west-2')
+eb = Aws::ElasticBeanstalk::Client.new(region: "us-west-2")
 
 app = eb.describe_applications({application_names: [args[0]]})
 

--- a/ruby/example_code/elasticbeanstalk/elb-ruby-example-update-myrailsapp.rb
+++ b/ruby/example_code/elasticbeanstalk/elb-ruby-example-update-myrailsapp.rb
@@ -5,14 +5,14 @@
 # eb_list_stacks.rb demonstrates how to update a Ruby on Rails application the AWS SDK for Ruby.
 
 # snippet-start:[eb.Ruby.updateMyRailsApp]
-require 'aws-sdk-elasticbeanstalk'  # v2: require 'aws-sdk'
+require "aws-sdk-elasticbeanstalk"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Elastic Beanstalk.
-Aws.config.update({region: 'us-west-2'})
+Aws.config.update({region: "us-west-2"})
 
 eb = Aws::ElasticBeanstalk::Client.new
 s3 = Aws::S3::Client.new
 
-app_name = 'MyRailsApp'
+app_name = "MyRailsApp"
 
 # Get S3 bucket containing app
 app_versions = eb.describe_application_versions({ application_name: app_name })
@@ -26,7 +26,7 @@ env = envs.environments[0]
 env_name = env.environment_name
 
 # Create new storage location
-resp = eb.create_storage_location()
+resp = eb.create_storage_location
 
 puts "Created storage location in bucket #{resp.s3_bucket}"
 
@@ -37,7 +37,7 @@ s3.list_objects({
 
 # Create ZIP file
 zip_file_basename = SecureRandom.urlsafe_base64.to_s
-zip_file_name = zip_file_basename + '.zip'
+zip_file_name = zip_file_basename + ".zip"
 
 # Call out to OS to produce ZIP file
 cmd = "git archive --format=zip -o #{zip_file_name} HEAD"

--- a/ruby/example_code/eventbridge/cw-ruby-example-send-events-ec2.rb
+++ b/ruby/example_code/eventbridge/cw-ruby-example-send-events-ec2.rb
@@ -30,13 +30,13 @@
 # The run_me function toward the end of this code example calls the
 # functions in the correct order.
 # snippet-start:[cloudwatch.cross-service.Ruby.require]
-require 'aws-sdk-sns'
-require 'aws-sdk-iam'
-require 'aws-sdk-cloudwatchevents'
-require 'aws-sdk-ec2'
-require 'aws-sdk-cloudwatch'
-require 'aws-sdk-cloudwatchlogs'
-require 'securerandom'
+require "aws-sdk-sns"
+require "aws-sdk-iam"
+require "aws-sdk-cloudwatchevents"
+require "aws-sdk-ec2"
+require "aws-sdk-cloudwatch"
+require "aws-sdk-cloudwatchlogs"
+require "securerandom"
 # snippet-end:[cloudwatch.cross-service.Ruby.require]
 # snippet-start:[cloudwatch.cross-service.Ruby.sns]
 # Checks whether the specified Amazon SNS
@@ -80,20 +80,20 @@ def topic_exists?(sns_client, topic_arn)
   response = sns_client.list_topics
   if response.topics.count.positive?
     if topic_found?(response.topics, topic_arn)
-      puts 'Topic found.'
+      puts "Topic found."
       return true
     end
     while response.next_page? do
       response = response.next_page
       if response.topics.count.positive?
         if topic_found?(response.topics, topic_arn)
-          puts 'Topic found.'
+          puts "Topic found."
           return true
         end
       end
     end
   end
-  puts 'Topic not found.'
+  puts "Topic not found."
   return false
 rescue StandardError => e
   puts "Topic not found: #{e.message}"
@@ -120,18 +120,18 @@ def create_topic(sns_client, topic_name, email_address)
   puts "Topic created with ARN '#{topic_response.topic_arn}'."
   subscription_response = sns_client.subscribe(
     topic_arn: topic_response.topic_arn,
-    protocol: 'email',
+    protocol: "email",
     endpoint: email_address,
     return_subscription_arn: true
   )
-  puts 'Subscription created with ARN ' \
+  puts "Subscription created with ARN " \
     "'#{subscription_response.subscription_arn}'. Have the owner of the " \
     "email address '#{email_address}' check their inbox in a few minutes " \
-    'and confirm the subscription to start receiving notification emails.'
+    "and confirm the subscription to start receiving notification emails."
   return topic_response.topic_arn
 rescue StandardError => e
   puts "Error creating or subscribing to topic: #{e.message}"
-  return 'Error'
+  return "Error"
 end
 # snippet-end:[cloudwatch.cross-service.Ruby.createSnsTopic]
 # snippet-start:[cloudwatch.cross-service.Ruby.IamRole]
@@ -175,20 +175,20 @@ def role_exists?(iam_client, role_arn)
   response = iam_client.list_roles
   if response.roles.count.positive?
     if role_found?(response.roles, role_arn)
-      puts 'Role found.'
+      puts "Role found."
       return true
     end
     while response.next_page? do
       response = response.next_page
       if response.roles.count.positive?
         if role_found?(response.roles, role_arn)
-          puts 'Role found.'
+          puts "Role found."
           return true
         end
       end
     end
   end
-  puts 'Role not found.'
+  puts "Role not found."
   return false
 rescue StandardError => e
   puts "Role not found: #{e.message}"
@@ -213,51 +213,51 @@ def create_role(iam_client, role_name)
   puts "Creating the role named '#{role_name}'..."
   response = iam_client.create_role(
     assume_role_policy_document: {
-      'Version': '2012-10-17',
+      'Version': "2012-10-17",
       'Statement': [
         {
-          'Sid': '',
-          'Effect': 'Allow',
+          'Sid': "",
+          'Effect': "Allow",
           'Principal': {
-            'Service': 'events.amazonaws.com'
+            'Service': "events.amazonaws.com"
           },
-          'Action': 'sts:AssumeRole'
+          'Action': "sts:AssumeRole"
         }
       ]
     }.to_json,
-    path: '/',
+    path: "/",
     role_name: role_name
   )
   puts "Role created with ARN '#{response.role.arn}'."
-  puts 'Adding access policy to role...'
+  puts "Adding access policy to role..."
   iam_client.put_role_policy(
     policy_document: {
-      'Version': '2012-10-17',
+      'Version': "2012-10-17",
       'Statement': [
         {
-          'Sid': 'CloudWatchEventsFullAccess',
-          'Effect': 'Allow',
-          'Resource': '*',
-          'Action': 'events:*'
+          'Sid': "CloudWatchEventsFullAccess",
+          'Effect': "Allow",
+          'Resource': "*",
+          'Action': "events:*"
         },
         {
-          'Sid': 'IAMPassRoleForCloudWatchEvents',
-          'Effect': 'Allow',
-          'Resource': 'arn:aws:iam::*:role/AWS_Events_Invoke_Targets',
-          'Action': 'iam:PassRole'
+          'Sid': "IAMPassRoleForCloudWatchEvents",
+          'Effect': "Allow",
+          'Resource': "arn:aws:iam::*:role/AWS_Events_Invoke_Targets",
+          'Action': "iam:PassRole"
         }
       ]
     }.to_json,
-    policy_name: 'CloudWatchEventsPolicy',
+    policy_name: "CloudWatchEventsPolicy",
     role_name: role_name
   )
-  puts 'Access policy added to role.'
+  puts "Access policy added to role."
   return response.role.arn
 rescue StandardError => e
   puts "Error creating role or adding policy to it: #{e.message}"
-  puts 'If the role was created, you must add the access policy ' \
-    'to the role yourself, or delete the role yourself and try again.'
-  return 'Error'
+  puts "If the role was created, you must add the access policy " \
+    "to the role yourself, or delete the role yourself and try again."
+  return "Error"
 end
 # snippet-end:[cloudwatch.cross-service.Ruby.createIamRole]
 # snippet-start:[cloudwatch.cross-service.Ruby.checkRuleExists]
@@ -299,20 +299,20 @@ def rule_exists?(cloudwatchevents_client, rule_name)
   response = cloudwatchevents_client.list_rules
   if response.rules.count.positive?
     if rule_found?(response.rules, rule_name)
-      puts 'Rule found.'
+      puts "Rule found."
       return true
     end
     while response.next_page? do
       response = response.next_page
       if response.rules.count.positive?
         if rule_found?(response.rules, rule_name)
-          puts 'Rule found.'
+          puts "Rule found."
           return true
         end
       end
     end
   end
-  puts 'Rule not found.'
+  puts "Rule not found."
   return false
 rescue StandardError => e
   puts "Rule not found: #{e.message}"
@@ -367,10 +367,10 @@ def rule_created?(
     description: rule_description,
     event_pattern: {
       'source': [
-        'aws.ec2'
+        "aws.ec2"
       ],
       'detail-type': [
-        'EC2 Instance State-change Notification'
+        "EC2 Instance State-change Notification"
       ],
       'detail': {
         'state': [
@@ -378,7 +378,7 @@ def rule_created?(
         ]
       }
     }.to_json,
-    state: 'ENABLED',
+    state: "ENABLED",
     role_arn: role_arn
   )
   puts "Rule created with ARN '#{put_rule_response.rule_arn}'."
@@ -394,7 +394,7 @@ def rule_created?(
   )
   if put_targets_response.key?(:failed_entry_count) &&
       put_targets_response.failed_entry_count > 0
-    puts 'Error(s) adding target to rule:'
+    puts "Error(s) adding target to rule:"
     put_targets_response.failed_entries.each do |failure|
       puts failure.error_message
     end
@@ -404,8 +404,8 @@ def rule_created?(
   end
 rescue StandardError => e
   puts "Error creating rule or adding target to rule: #{e.message}"
-  puts 'If the rule was created, you must add the target ' \
-    'to the rule yourself, or delete the rule yourself and try again.'
+  puts "If the rule was created, you must add the target " \
+    "to the rule yourself, or delete the rule yourself and try again."
   return false
 end
 # snippet-end:[cloudwatch.cross-service.Ruby.createRule]
@@ -430,12 +430,12 @@ def log_group_exists?(cloudwatchlogs_client, log_group_name)
   if response.log_groups.count.positive?
     response.log_groups.each do |log_group|
       if log_group.log_group_name == log_group_name
-        puts 'Log group found.'
+        puts "Log group found."
         return true
       end
     end
   end
-  puts 'Log group not found.'
+  puts "Log group not found."
   return false
 rescue StandardError => e
   puts "Log group not found: #{e.message}"
@@ -457,7 +457,7 @@ end
 def log_group_created?(cloudwatchlogs_client, log_group_name)
   puts "Attempting to create log group with the name '#{log_group_name}'..."
   cloudwatchlogs_client.create_log_group(log_group_name: log_group_name)
-  puts 'Log group created.'
+  puts "Log group created."
   return true
 rescue StandardError => e
   puts "Error creating log group: #{e.message}"
@@ -516,7 +516,7 @@ def log_event(
   end
 
   response = cloudwatchlogs_client.put_log_events(event)
-  puts 'Message logged.'
+  puts "Message logged."
   return response.next_sequence_token
 rescue StandardError => e
   puts "Message not logged: #{e.message}"
@@ -560,13 +560,13 @@ def instance_restarted?(
     log_group_name: log_group_name,
     log_stream_name: log_stream_name
   )
-  sequence_token = ''
+  sequence_token = ""
 
   puts "Attempting to stop the instance with the ID '#{instance_id}'. " \
-    'This might take a few minutes...'
+    "This might take a few minutes..."
   ec2_client.stop_instances(instance_ids: [instance_id])
   ec2_client.wait_until(:instance_stopped, instance_ids: [instance_id])
-  puts 'Instance stopped.'
+  puts "Instance stopped."
   sequence_token = log_event(
     cloudwatchlogs_client,
     log_group_name,
@@ -575,10 +575,10 @@ def instance_restarted?(
     sequence_token
   )
 
-  puts 'Attempting to restart the instance. This might take a few minutes...'
+  puts "Attempting to restart the instance. This might take a few minutes..."
   ec2_client.start_instances(instance_ids: [instance_id])
   ec2_client.wait_until(:instance_running, instance_ids: [instance_id])
-  puts 'Instance restarted.'
+  puts "Instance restarted."
   sequence_token = log_event(
     cloudwatchlogs_client,
     log_group_name,
@@ -589,7 +589,7 @@ def instance_restarted?(
 
   return true
 rescue StandardError => e
-  puts 'Error creating log stream or stopping or restarting the instance: ' \
+  puts "Error creating log stream or stopping or restarting the instance: " \
     "#{e.message}"
   log_event(
     cloudwatchlogs_client,
@@ -631,21 +631,21 @@ def display_rule_activity(
   end_time,
   period
 )
-  puts 'Attempting to display rule activity...'
+  puts "Attempting to display rule activity..."
   response = cloudwatch_client.get_metric_statistics(
-    namespace: 'AWS/Events',
-    metric_name: 'Invocations',
+    namespace: "AWS/Events",
+    metric_name: "Invocations",
     dimensions: [
       {
-        name: 'RuleName',
+        name: "RuleName",
         value: rule_name
       }
     ],
     start_time: start_time,
     end_time: end_time,
     period: period,
-    statistics: ['Sum'],
-    unit: 'Count'
+    statistics: ["Sum"],
+    unit: "Count"
   )
 
   if response.key?(:datapoints) && response.datapoints.count.positive?
@@ -655,7 +655,7 @@ def display_rule_activity(
     end
   else
     puts "The event rule '#{rule_name}' was not triggered during the " \
-      'specified time period.'
+      "specified time period."
   end
 rescue StandardError => e
   puts "Error getting information about event rule activity: #{e.message}"
@@ -678,11 +678,11 @@ end
 #     'aws-doc-sdk-examples-cloudwatch-log'
 #   )
 def display_log_data(cloudwatchlogs_client, log_group_name)
-  puts 'Attempting to display log stream data for the log group ' \
+  puts "Attempting to display log stream data for the log group " \
     "named '#{log_group_name}'..."
   describe_log_streams_response = cloudwatchlogs_client.describe_log_streams(
     log_group_name: log_group_name,
-    order_by: 'LastEventTime',
+    order_by: "LastEventTime",
     descending: true
   )
   if describe_log_streams_response.key?(:log_streams) &&
@@ -693,19 +693,19 @@ def display_log_data(cloudwatchlogs_client, log_group_name)
         log_stream_name: log_stream.log_stream_name
       )
       puts "\nLog messages for '#{log_stream.log_stream_name}':"
-      puts '-' * (log_stream.log_stream_name.length + 20)
+      puts "-" * (log_stream.log_stream_name.length + 20)
       if get_log_events_response.key?(:events) &&
           get_log_events_response.events.count.positive?
         get_log_events_response.events.each do |event|
           puts event.message
         end
       else
-        puts 'No log messages for this log stream.'
+        puts "No log messages for this log stream."
       end
     end
   end
 rescue StandardError => e
-  puts 'Error getting information about the log streams or their messages: ' \
+  puts "Error getting information about the log streams or their messages: " \
     "#{e.message}"
 end
 # snippet-end:[cloudwatch.cross-service.Ruby.displayLogInfo]
@@ -730,11 +730,11 @@ end
 def manual_cleanup_notice(
   topic_name, role_name, rule_name, log_group_name, instance_id
 )
-  puts '-' * 10
-  puts 'Some of the following AWS resources might still exist in your account.'
-  puts 'If you no longer want to use this code example, then to clean up'
-  puts 'your AWS account and avoid unexpected costs, you might want to'
-  puts 'manually delete any of the following resources if they exist:'
+  puts "-" * 10
+  puts "Some of the following AWS resources might still exist in your account."
+  puts "If you no longer want to use this code example, then to clean up"
+  puts "your AWS account and avoid unexpected costs, you might want to"
+  puts "manually delete any of the following resources if they exist:"
   puts "- The Amazon SNS topic named '#{topic_name}'."
   puts "- The IAM role named '#{role_name}'."
   puts "- The Amazon EventBridge rule named '#{rule_name}'."
@@ -745,26 +745,26 @@ end
 # Full example call:
 def run_me
   # Properties for the Amazon SNS topic.
-  topic_name = 'aws-doc-sdk-examples-topic'
-  email_address = 'mary@example.com'
+  topic_name = "aws-doc-sdk-examples-topic"
+  email_address = "mary@example.com"
   # Properties for the IAM role.
-  role_name = 'aws-doc-sdk-examples-cloudwatch-events-rule-role'
+  role_name = "aws-doc-sdk-examples-cloudwatch-events-rule-role"
   # Properties for the Amazon EventBridge rule.
-  rule_name = 'aws-doc-sdk-examples-ec2-state-change'
-  rule_description = 'Triggers when any available EC2 instance starts.'
-  instance_state = 'running'
-  target_id = 'sns-topic'
+  rule_name = "aws-doc-sdk-examples-ec2-state-change"
+  rule_description = "Triggers when any available EC2 instance starts."
+  instance_state = "running"
+  target_id = "sns-topic"
   # Properties for the Amazon EC2 instance.
-  instance_id = 'i-033c48ef067af3dEX'
+  instance_id = "i-033c48ef067af3dEX"
   # Properties for displaying the event rule's activity.
   start_time = Time.now - 600 # Go back over the past 10 minutes
                               # (10 minutes * 60 seconds = 600 seconds).
   end_time = Time.now
   period = 60 # Look back every 60 seconds over the past 10 minutes.
   # Properties for the Amazon CloudWatch Logs log group.
-  log_group_name = 'aws-doc-sdk-examples-cloudwatch-log'
+  log_group_name = "aws-doc-sdk-examples-cloudwatch-log"
   # AWS service clients for this code example.
-  region = 'us-east-1'
+  region = "us-east-1"
   sts_client = Aws::STS::Client.new(region: region)
   sns_client = Aws::SNS::Client.new(region: region)
   iam_client = Aws::IAM::Client.new(region: region)
@@ -781,8 +781,8 @@ def run_me
   topic_arn = "arn:aws:sns:#{region}:#{account_id}:#{topic_name}"
   unless topic_exists?(sns_client, topic_arn)
     topic_arn = create_topic(sns_client, topic_name, email_address)
-    if topic_arn == 'Error'
-      puts 'Could not create the Amazon SNS topic correctly. Program stopped.'
+    if topic_arn == "Error"
+      puts "Could not create the Amazon SNS topic correctly. Program stopped."
       manual_cleanup_notice(
         topic_name, role_name, rule_name, log_group_name, instance_id
       )
@@ -794,8 +794,8 @@ def run_me
   role_arn = "arn:aws:iam::#{account_id}:role/#{role_name}"
   unless role_exists?(iam_client, role_arn)
     role_arn = create_role(iam_client, role_name)
-    if role_arn == 'Error'
-      puts 'Could not create the IAM role correctly. Program stopped.'
+    if role_arn == "Error"
+      puts "Could not create the IAM role correctly. Program stopped."
       manual_cleanup_notice(
         topic_name, role_name, rule_name, log_group_name, instance_id
       )
@@ -813,8 +813,8 @@ def run_me
       target_id,
       topic_arn
     )
-      puts 'Could not create the Amazon EventBridge rule correctly. ' \
-        'Program stopped.'
+      puts "Could not create the Amazon EventBridge rule correctly. " \
+        "Program stopped."
       manual_cleanup_notice(
         topic_name, role_name, rule_name, log_group_name, instance_id
       )
@@ -824,8 +824,8 @@ def run_me
   # If the Amazon CloudWatch Logs log group doesn't exist, create it.
   unless log_group_exists?(cloudwatchlogs_client, log_group_name)
     unless log_group_created?(cloudwatchlogs_client, log_group_name)
-      puts 'Could not create the Amazon CloudWatch Logs log group ' \
-      'correctly. Program stopped.'
+      puts "Could not create the Amazon CloudWatch Logs log group " \
+      "correctly. Program stopped."
       manual_cleanup_notice(
         topic_name, role_name, rule_name, log_group_name, instance_id
       )
@@ -839,8 +839,8 @@ def run_me
     instance_id,
     log_group_name
   )
-    puts 'Could not restart the instance to trigger the rule. ' \
-      'Continuing anyway to show information about the rule and logs...'
+    puts "Could not restart the instance to trigger the rule. " \
+      "Continuing anyway to show information about the rule and logs..."
   end
 
   # Display how many times the rule was triggered over the past 10 minutes.

--- a/ruby/example_code/iam/iam_wrapper.rb
+++ b/ruby/example_code/iam/iam_wrapper.rb
@@ -188,27 +188,27 @@ class IamWrapper
   #
   # @param role [Aws::IAM::Role] The role to delete.
   def delete_service_linked_role(role)
-      response = @iam_resource.client.delete_service_linked_role(role_name: role.name)
-      task_id = response.deletion_task_id
-      while true
-        response = @iam_resource.client.get_service_linked_role_deletion_status(
-          deletion_task_id: task_id)
-        status = response.status
-        puts("Deletion of #{role.name} #{status}.")
-        if %w(SUCCEEDED FAILED).include?(status)
-          break
-        else
-          sleep(3)
-        end
+    response = @iam_resource.client.delete_service_linked_role(role_name: role.name)
+    task_id = response.deletion_task_id
+    while true
+      response = @iam_resource.client.get_service_linked_role_deletion_status(
+        deletion_task_id: task_id)
+      status = response.status
+      puts("Deletion of #{role.name} #{status}.")
+      if %w(SUCCEEDED FAILED).include?(status)
+        break
+      else
+        sleep(3)
       end
-  rescue Aws::Errors::ServiceError => e
-    # If AWS has not yet fully propagated the role, it deletes the role but
-    # returns NoSuchEntity.
-    if e.code != "NoSuchEntity"
-      puts("Couldn't delete #{role.name}. Here's why:")
-      puts("\t#{e.code}: #{e.message}")
-      raise
     end
+rescue Aws::Errors::ServiceError => e
+  # If AWS has not yet fully propagated the role, it deletes the role but
+  # returns NoSuchEntity.
+  if e.code != "NoSuchEntity"
+    puts("Couldn't delete #{role.name}. Here's why:")
+    puts("\t#{e.code}: #{e.message}")
+    raise
+  end
   end
   # snippet-end:[ruby.example_code.iam.DeleteServiceLinkedRole]
 end

--- a/ruby/example_code/polly/polly_describe_voices.rb
+++ b/ruby/example_code/polly/polly_describe_voices.rb
@@ -7,7 +7,7 @@
 
 # snippet-start:[polly.ruby.describeVoices]
 
-require 'aws-sdk-polly'  # In v2: require 'aws-sdk'
+require "aws-sdk-polly"  # In v2: require 'aws-sdk'
 
 begin
   # Create an Amazon Polly client using
@@ -16,16 +16,16 @@ begin
   polly = Aws::Polly::Client.new
 
   # Get US English voices
-  resp = polly.describe_voices(language_code: 'en-US')
+  resp = polly.describe_voices(language_code: "en-US")
 
   resp.voices.each do |v|
     puts v.name
-    puts '  ' + v.gender
+    puts "  " + v.gender
     puts
   end
 rescue StandardError => ex
-  puts 'Could not get voices'
-  puts 'Error message:'
+  puts "Could not get voices"
+  puts "Error message:"
   puts ex.message
 end
 # snippet-end:[polly.ruby.describeVoices]

--- a/ruby/example_code/polly/polly_list_lexicons.rb
+++ b/ruby/example_code/polly/polly_list_lexicons.rb
@@ -7,7 +7,7 @@
 
 # snippet-start:[polly.ruby.listLexicons]
 
-require 'aws-sdk-polly'  # In v2: require 'aws-sdk'
+require "aws-sdk-polly"  # In v2: require 'aws-sdk'
 
 begin
   # Create an Amazon Polly client using
@@ -19,13 +19,13 @@ begin
 
   resp.lexicons.each do |l|
     puts l.name
-    puts '  Alphabet:' + l.attributes.alphabet
-    puts '  Language:' + l.attributes.language
+    puts "  Alphabet:" + l.attributes.alphabet
+    puts "  Language:" + l.attributes.language
     puts
   end
 rescue StandardError => ex
-  puts 'Could not get lexicons'
-  puts 'Error message:'
+  puts "Could not get lexicons"
+  puts "Error message:"
   puts ex.message
 end
 # snippet-end:[polly.ruby.listLexicons]

--- a/ruby/example_code/polly/polly_synthesize_speech.rb
+++ b/ruby/example_code/polly/polly_synthesize_speech.rb
@@ -7,12 +7,12 @@
 
 # snippet-start:[polly.ruby.synthesizeSpeech]
 
-require 'aws-sdk-polly'  # In v2: require 'aws-sdk'
+require "aws-sdk-polly"  # In v2: require 'aws-sdk'
 
 begin
   # Get the filename from the command line
-  if ARGV.empty?()
-    puts 'You must supply a filename'
+  if ARGV.empty?
+    puts "You must supply a filename"
     exit 1
   end
 
@@ -22,7 +22,7 @@ begin
   if File.exist?(filename)
     contents = IO.read(filename)
   else
-    puts 'No such file: ' + filename
+    puts "No such file: " + filename
     exit 1
   end
 
@@ -43,16 +43,16 @@ begin
   name = File.basename(filename)
 
   # Split up name so we get just the xyz part
-  parts = name.split('.')
+  parts = name.split(".")
   first_part = parts[0]
-  mp3_file = first_part + '.mp3'
+  mp3_file = first_part + ".mp3"
 
   IO.copy_stream(resp.audio_stream, mp3_file)
 
-  puts 'Wrote MP3 content to: ' + mp3_file
+  puts "Wrote MP3 content to: " + mp3_file
 rescue StandardError => ex
-  puts 'Got error:'
-  puts 'Error message:'
+  puts "Got error:"
+  puts "Error message:"
   puts ex.message
 end
 # snippet-end:[polly.ruby.synthesizeSpeech]

--- a/ruby/example_code/s3/encryption_v2/spec/test_s3_get_cskms_decrypt_item.rb
+++ b/ruby/example_code/s3/encryption_v2/spec/test_s3_get_cskms_decrypt_item.rb
@@ -43,15 +43,15 @@ describe "#get_decrypted_object_content" do
   def stub_decrypt(kms_client, opts)
     kms_client.stub_responses(
       :decrypt, lambda do |context|
-      if opts[:any_kms_key]
-        expect(context.params["key_id"]).to be_nil
-      else
-        if opts[:raise] && context.params["key_id"] != opts[:response][:key_id]
-          raise Aws::KMS::Errors::IncorrectKeyException.new(context, "")
+        if opts[:any_kms_key]
+          expect(context.params["key_id"]).to be_nil
         else
-          expect(context.params[:key_id]).to eq(opts[:response][:key_id])
+          if opts[:raise] && context.params["key_id"] != opts[:response][:key_id]
+            raise Aws::KMS::Errors::IncorrectKeyException.new(context, "")
+          else
+            expect(context.params[:key_id]).to eq(opts[:response][:key_id])
+          end
         end
-      end
       opts[:response]
       end
     )

--- a/ruby/example_code/secretsmanager/sm_get_secrets.rb
+++ b/ruby/example_code/secretsmanager/sm_get_secrets.rb
@@ -9,24 +9,24 @@
 
 # snippet-start:[s3.ruby.sm_get_secrets.rb]
 
-require 'aws-sdk-secretsmanager'
+require "aws-sdk-secretsmanager"
 
 # Gets all secrets in us-west-2
 # Replace us-west-2 with the AWS Region you're using for Amazon Secrets Manager.
-sm = Aws::SecretsManager::Client.new(region: 'us-west-2')
+sm = Aws::SecretsManager::Client.new(region: "us-west-2")
 
 resp = sm.list_secrets
 
-puts 'Secrets:'
+puts "Secrets:"
 
 resp.secret_list.each do |s|
-  puts '  name: ' + s.name
-  puts '  key/value:'
+  puts "  name: " + s.name
+  puts "  key/value:"
 
   resp = sm.get_secret_value(secret_id: s.name)
 
   if resp.secret_string
-    puts '    ' + resp.secret_string
+    puts "    " + resp.secret_string
   else
     # do something with resp.secret_binary
   end

--- a/ruby/example_code/ses/ses_get_statistics.rb
+++ b/ruby/example_code/ses/ses_get_statistics.rb
@@ -6,11 +6,11 @@
 
 # snippet-start:[s3.ruby.ses_get_statistics.rb]
 
-require 'aws-sdk-ses'  # v2: require 'aws-sdk'
+require "aws-sdk-ses"  # v2: require 'aws-sdk'
 
 # Create a new SES resource in the us-west-2 region.
 # Replace us-west-2 with the AWS Region you're using for Amazon SES.
-ses = Aws::SES::Client.new(region: 'us-west-2')
+ses = Aws::SES::Client.new(region: "us-west-2")
 
 begin
   # Get send statistics so we don't ruin our reputation

--- a/ruby/example_code/ses/ses_list_emails.rb
+++ b/ruby/example_code/ses/ses_list_emails.rb
@@ -6,11 +6,11 @@
 
 # snippet-start:[s3.ruby.ses_list_emails.rb]
 
-require 'aws-sdk-ses'  # v2: require 'aws-sdk'
+require "aws-sdk-ses"  # v2: require 'aws-sdk'
 
 # Create client in us-west-2 region
 # Replace us-west-2 with the AWS Region you're using for Amazon SES.
-client = Aws::SES::Client.new(region: 'us-west-2')
+client = Aws::SES::Client.new(region: "us-west-2")
 
 # Get up to 1000 identities
 ids = client.list_identities({

--- a/ruby/example_code/ses/ses_send_email.rb
+++ b/ruby/example_code/ses/ses_send_email.rb
@@ -6,39 +6,39 @@
 
 # snippet-start:[s3.ruby.ses_send_email.rb]
 
-require 'aws-sdk-ses'  # v2: require 'aws-sdk'
+require "aws-sdk-ses"  # v2: require 'aws-sdk'
 
 # Replace sender@example.com with your "From" address.
 # This address must be verified with Amazon SES.
-sender = 'sender@example.com'
+sender = "sender@example.com"
 
 # Replace recipient@example.com with a "To" address. If your account
 # is still in the sandbox, this address must be verified.
-recipient = 'recipient@example.com'
+recipient = "recipient@example.com"
 
 # Specify a configuration set. To use a configuration
 # set, uncomment the next line and line 74.
 #   configsetname = "ConfigSet"
 
 # The subject line for the email.
-subject = 'Amazon SES test (AWS SDK for Ruby)'
+subject = "Amazon SES test (AWS SDK for Ruby)"
 
 # The HTML body of the email.
 htmlbody =
-  '<h1>Amazon SES test (AWS SDK for Ruby)</h1>'\
+  "<h1>Amazon SES test (AWS SDK for Ruby)</h1>"\
   '<p>This email was sent with <a href="https://aws.amazon.com/ses/">'\
   'Amazon SES</a> using the <a href="https://aws.amazon.com/sdk-for-ruby/">'\
-  'AWS SDK for Ruby</a>.'
+  "AWS SDK for Ruby</a>."
 
 # The email body for recipients with non-HTML email clients.
-textbody = 'This email was sent with Amazon SES using the AWS SDK for Ruby.'
+textbody = "This email was sent with Amazon SES using the AWS SDK for Ruby."
 
 # Specify the text encoding scheme.
-encoding = 'UTF-8'
+encoding = "UTF-8"
 
 # Create a new SES client in the us-west-2 region.
 # Replace us-west-2 with the AWS Region you're using for Amazon SES.
-ses = Aws::SES::Client.new(region: 'us-west-2')
+ses = Aws::SES::Client.new(region: "us-west-2")
 
 # Try to send the email.
 begin
@@ -70,7 +70,7 @@ begin
     # configuration_set_name: configsetname,
   )
 
-  puts 'Email sent to ' + recipient
+  puts "Email sent to " + recipient
 
 
 # If something goes wrong, display an error message.

--- a/ruby/example_code/ses/ses_send_verification.rb
+++ b/ruby/example_code/ses/ses_send_verification.rb
@@ -6,14 +6,14 @@
 
 # snippet-start:[s3.ruby.ses_send_verification.rb]
 
-require 'aws-sdk-ses'  # v2: require 'aws-sdk'
+require "aws-sdk-ses"  # v2: require 'aws-sdk'
 
 # Replace recipient@example.com with a "To" address.
 recipient = "recipient@example.com"
 
 # Create a new SES resource in the us-west-2 region.
 # Replace us-west-2 with the AWS Region you're using for Amazon SES.
-ses = Aws::SES::Client.new(region: 'us-west-2')
+ses = Aws::SES::Client.new(region: "us-west-2")
 
 # Try to verify email address.
 begin
@@ -21,7 +21,7 @@ begin
     email_address: recipient
   })
 
-  puts 'Email sent to ' + recipient
+  puts "Email sent to " + recipient
 
 # If something goes wrong, display an error message.
 rescue Aws::SES::Errors::ServiceError => error

--- a/ruby/example_code/sns/sns-ruby-example-create-subscription.rb
+++ b/ruby/example_code/sns/sns-ruby-example-create-subscription.rb
@@ -12,7 +12,7 @@
 
 # snippet-start:[sns.Ruby.createSubscription]
 
-require 'aws-sdk-sns'  # v2: require 'aws-sdk'
+require "aws-sdk-sns"  # v2: require 'aws-sdk'
 
 def subscription_created?(sns_client, topic_arn, protocol, endpoint)
 
@@ -25,19 +25,19 @@ end
 # Full example call:
 def run_me
 
-protocol = 'email'
-endpoint = 'EMAIL_ADDRESS'
-topic_arn = 'TOPIC_ARN'
-region = 'REGION'
+  protocol = "email"
+endpoint = "EMAIL_ADDRESS"
+topic_arn = "TOPIC_ARN"
+region = "REGION"
 
 sns_client = Aws::SNS::Client.new(region: region)
 
 puts "Creating the subscription."
 
   if subscription_created?(sns_client, topic_arn, protocol, endpoint)
-    puts 'The subscriptions was created.'
+    puts "The subscriptions was created."
   else
-    puts 'The subscription was not created. Stopping program.'
+    puts "The subscription was not created. Stopping program."
     exit 1
   end
 end

--- a/ruby/example_code/sns/sns-ruby-example-create-topic.rb
+++ b/ruby/example_code/sns/sns-ruby-example-create-topic.rb
@@ -11,28 +11,28 @@
 
 # snippet-start:[sns.Ruby.createTopic]
 
-require 'aws-sdk-sns'  # v2: require 'aws-sdk'
+require "aws-sdk-sns"  # v2: require 'aws-sdk'
 
 def topic_created?(sns_client, topic_name)
 
-sns_client.create_topic(name: topic_name)
-rescue StandardError => e
-  puts "Error while creating the topic named '#{topic_name}': #{e.message}"
+  sns_client.create_topic(name: topic_name)
+  rescue StandardError => e
+    puts "Error while creating the topic named '#{topic_name}': #{e.message}"
 end
 
 # Full example call:
 def run_me
-  topic_name = 'TOPIC_NAME'
-  region = 'REGION'
+  topic_name = "TOPIC_NAME"
+  region = "REGION"
 
   sns_client = Aws::SNS::Client.new(region: region)
 
   puts "Creating the topic '#{topic_name}'..."
 
   if topic_created?(sns_client, topic_name)
-    puts 'The topic was created.'
+    puts "The topic was created."
   else
-    puts 'The topic was not created. Stopping program.'
+    puts "The topic was not created. Stopping program."
     exit 1
   end
 end

--- a/ruby/example_code/sns/sns-ruby-example-enable-resource.rb
+++ b/ruby/example_code/sns/sns-ruby-example-enable-resource.rb
@@ -13,7 +13,7 @@
 
 # snippet-start:[sns.Ruby.enableResource]
 
-require 'aws-sdk-sns'  # v2: require 'aws-sdk'
+require "aws-sdk-sns"  # v2: require 'aws-sdk'
 
 policy  = '{
   "Version":"2008-10-17",
@@ -33,7 +33,7 @@ policy  = '{
   }]
 }'
 # Replace us-west-2 with the AWS Region you're using for Amazon SNS.
-sns = Aws::SNS::Resource.new(region: 'REGION')
+sns = Aws::SNS::Resource.new(region: "REGION")
 
 # Get topic by ARN
 topic = sns.topic()

--- a/ruby/example_code/sns/sns-ruby-example-send-message.rb
+++ b/ruby/example_code/sns/sns-ruby-example-send-message.rb
@@ -12,32 +12,32 @@
 
 # snippet-start:[sns.Ruby.sendMessage]
 
-require 'aws-sdk-sns'  # v2: require 'aws-sdk'
+require "aws-sdk-sns"  # v2: require 'aws-sdk'
 
 def message_sent?(sns_client, topic_arn, message)
 
   sns_client.publish(topic_arn: topic_arn, message: message)
 rescue StandardError => e
   puts "Error while sending the message: #{e.message}"
-  end
+end
 
 def run_me
 
-  topic_arn = 'SNS_TOPIC_ARN'
-  region = 'REGION'
-  message = 'MESSAGE' # The text of the message to send.
+  topic_arn = "SNS_TOPIC_ARN"
+  region = "REGION"
+  message = "MESSAGE" # The text of the message to send.
 
   sns_client = Aws::SNS::Client.new(region: region)
 
   puts "Message sending."
 
   if message_sent?(sns_client, topic_arn, message)
-    puts 'The message was sent.'
+    puts "The message was sent."
   else
-    puts 'The message was not sent. Stopping program.'
+    puts "The message was not sent. Stopping program."
     exit 1
   end
-  end
+end
 
 run_me if $PROGRAM_NAME == __FILE__
 

--- a/ruby/example_code/sns/sns-ruby-example-show-subscriptions.rb
+++ b/ruby/example_code/sns/sns-ruby-example-show-subscriptions.rb
@@ -11,12 +11,12 @@
 
 # snippet-start:[sns.Ruby.showSubscription]
 
-require 'aws-sdk-sns'  # v2: require 'aws-sdk'
+require "aws-sdk-sns"  # v2: require 'aws-sdk'
 
 def show_subscriptions?(sns_client, topic_arn)
   topic = sns_client.topic(topic_arn)
   topic.subscriptions.each do |s|
-    puts s.attributes['Endpoint']
+    puts s.attributes["Endpoint"]
   end
 
 rescue StandardError => e
@@ -25,8 +25,8 @@ end
 
 def run_me
 
-  topic_arn = 'SNS_TOPIC_ARN'
-  region = 'REGION'
+  topic_arn = "SNS_TOPIC_ARN"
+  region = "REGION"
 
   sns_client = Aws::SNS::Resource.new(region: region)
 
@@ -34,7 +34,7 @@ def run_me
 
   if show_subscriptions?(sns_client, topic_arn)
   else
-    puts 'There was an error. Stopping program.'
+    puts "There was an error. Stopping program."
     exit 1
   end
 end

--- a/ruby/example_code/sns/sns-ruby-example-show-topics.rb
+++ b/ruby/example_code/sns/sns-ruby-example-show-topics.rb
@@ -10,7 +10,7 @@
 
 # snippet-start:[sns.Ruby.showTopics]
 
-require 'aws-sdk-sns'  # v2: require 'aws-sdk'
+require "aws-sdk-sns"  # v2: require 'aws-sdk'
 
 def list_topics?(sns_client)
   sns_client.topics.each do |topic|
@@ -18,18 +18,18 @@ def list_topics?(sns_client)
 rescue StandardError => e
   puts "Error while listing the topics: #{e.message}"
   end
-  end
+end
 
 def run_me
 
-  region = 'REGION'
+  region = "REGION"
   sns_client = Aws::SNS::Resource.new(region: region)
 
   puts "Listing the topics."
 
   if list_topics?(sns_client)
   else
-    puts 'The bucket was not created. Stopping program.'
+    puts "The bucket was not created. Stopping program."
     exit 1
   end
 end

--- a/ruby/example_code/sns/tests/test-sns-ruby-example-create-subscription.rb
+++ b/ruby/example_code/sns/tests/test-sns-ruby-example-create-subscription.rb
@@ -1,13 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../sns-ruby-example-create-subscription'
+require_relative "../sns-ruby-example-create-subscription"
 
-describe '#subscription_created?' do
+describe "#subscription_created?" do
   let(:sns_client) { Aws::SNS::Client.new(stub_responses: true) }
-  let(:endpoint) { 'example@server.com' }
+  let(:endpoint) { "example@server.com" }
 
-  it 'confirms the subscriptions was created' do
+  it "confirms the subscriptions was created" do
     subscriptions_data = sns_client.stub_data(
       :create_subscriptions
     )

--- a/ruby/example_code/sns/tests/test-sns-ruby-example-create-topic.rb
+++ b/ruby/example_code/sns/tests/test-sns-ruby-example-create-topic.rb
@@ -1,13 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../sns-ruby-example-create-topic'
+require_relative "../sns-ruby-example-create-topic"
 
-describe '#topic_created?' do
+describe "#topic_created?" do
   let(:sns_client) { Aws::SNS::Client.new(stub_responses: true) }
-  let(:name) { 'doc-example-topic' }
+  let(:name) { "doc-example-topic" }
 
-  it 'confirms the topic was created' do
+  it "confirms the topic was created" do
     topic_data = sns_client.stub_data(
       :create_topic
     )

--- a/ruby/example_code/sns/tests/test_create_bucket_snippet.rb
+++ b/ruby/example_code/sns/tests/test_create_bucket_snippet.rb
@@ -1,20 +1,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../create_bucket_snippet'
+require_relative "../create_bucket_snippet"
 
-describe '#bucket_created?' do
+describe "#bucket_created?" do
   let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
-  let(:bucket_name) { 'doc-example-bucket' }
+  let(:bucket_name) { "doc-example-bucket" }
 
-  it 'confirms the bucket was created' do
+  it "confirms the bucket was created" do
     bucket_data = s3_client.stub_data(
       :create_bucket,
       {
-        location: 'us-west-2'
+        location: "us-west-2"
       }
     )
     s3_client.stub_responses(:create_bucket, bucket_data)
-    expect(bucket_created?(s3_client, bucket_name).location).to eq('us-west-2')
+    expect(bucket_created?(s3_client, bucket_name).location).to eq("us-west-2")
   end
 end

--- a/ruby/example_code/sqs/sqs-ruby-example-create-queue.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-create-queue.rb
@@ -6,7 +6,7 @@
 # snippet-start:[s3.ruby.sqs-ruby-example-create-queue.rb]
 # This code example demonstrates how to create a queue in Amazon Simple Queue Service (Amazon SQS).
 
-require 'aws-sdk-sqs'
+require "aws-sdk-sqs"
 
 # @param sqs_client [Aws::SQS::Client] An initialized Amazon SQS client.
 # @param queue_name [String] The name of the queue.
@@ -27,16 +27,16 @@ end
 # Full example call:
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
 def run_me
-  region = 'us-west-2'
-  queue_name = 'my-queue'
+  region = "us-west-2"
+  queue_name = "my-queue"
   sqs_client = Aws::SQS::Client.new(region: region)
 
   puts "Creating the queue named '#{queue_name}'..."
 
   if queue_created?(sqs_client, queue_name)
-    puts 'Queue created.'
+    puts "Queue created."
   else
-    puts 'Queue not created.'
+    puts "Queue not created."
   end
 end
 

--- a/ruby/example_code/sqs/sqs-ruby-example-dead-letter-queue.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-dead-letter-queue.rb
@@ -7,12 +7,12 @@
 
 # snippet-start:[s3.ruby.sqs-ruby-example-dead-letter-queue.rb]
 
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 
 # Uncomment for Windows.
 # Aws.use_bundled_cert!
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-sqs = Aws::SQS::Client.new(region: 'us-west-2')
+sqs = Aws::SQS::Client.new(region: "us-west-2")
 
 # Create a queue representing a dead-letter queue.
 dead_letter_queue_name = "dead-letter-queue"
@@ -69,7 +69,7 @@ puts "\n"
 
 poller = Aws::SQS::QueuePoller.new(queue_url)
 # Receive 5 messages max and stop polling after 20 seconds of no received messages.
-poller.poll(max_number_of_messages:5, idle_timeout: 20) do |messages|
+poller.poll(max_number_of_messages: 5, idle_timeout: 20) do |messages|
   messages.each do |msg|
     puts "Received message ID: #{msg.message_id}"
   end

--- a/ruby/example_code/sqs/sqs-ruby-example-delete-queue.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-delete-queue.rb
@@ -6,9 +6,9 @@
 
 # snippet-start:[s3.ruby.sqs-ruby-example-delete-queue.rb]
 
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-sqs = Aws::SQS::Client.new(region: 'us-west-2')
+sqs = Aws::SQS::Client.new(region: "us-west-2")
 
 sqs.delete_queue(queue_url: URL)
 # snippet-end:[s3.ruby.sqs-ruby-example-delete-queue.rb]

--- a/ruby/example_code/sqs/sqs-ruby-example-enable-long-polling.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-enable-long-polling.rb
@@ -9,10 +9,10 @@
 
 # snippet-start:[s3.ruby.sqs-ruby-example-enable-long-polling.rb]
 
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
 
-sqs = Aws::SQS::Client.new(region: 'us-west-2')
+sqs = Aws::SQS::Client.new(region: "us-west-2")
 
 # Create a queue and set it for long polling.
 new_queue_name = "new-queue"

--- a/ruby/example_code/sqs/sqs-ruby-example-enable-resource.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-enable-resource.rb
@@ -7,9 +7,9 @@
 
 # snippet-start:[s3.ruby.sqs-ruby-example-enable-resource.rb]
 
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-sqs = Aws::SQS::Client.new(region: 'us-west-2')
+sqs = Aws::SQS::Client.new(region: "us-west-2")
 
 policy  = '{
   "Version":"2008-10-17",

--- a/ruby/example_code/sqs/sqs-ruby-example-get-messages-with-long-polling.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-get-messages-with-long-polling.rb
@@ -7,9 +7,9 @@
 
 # snippet-start:[s3.ruby.sqs-ruby-example-get-messages-with-long-polling.rb]
 
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-sqs = Aws::SQS::Client.new(region: 'us-west-2')
+sqs = Aws::SQS::Client.new(region: "us-west-2")
 
 resp = sqs.receive_message(queue_url: URL, max_number_of_messages: 10, wait_time_seconds: 10)
 

--- a/ruby/example_code/sqs/sqs-ruby-example-get-messages.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-get-messages.rb
@@ -6,8 +6,8 @@
 
 # snippet-start:[s3.ruby.sqs-ruby-example-get-messages.rb]
 
-require 'aws-sdk-sqs'
-require 'aws-sdk-sts'
+require "aws-sdk-sqs"
+require "aws-sdk-sts"
 
 # Receives messages in a queue in Amazon Simple Queue Service (Amazon SQS).
 #
@@ -24,8 +24,8 @@ require 'aws-sdk-sts'
 def receive_messages(sqs_client, queue_url, max_number_of_messages = 10)
 
   if max_number_of_messages > 10
-    puts 'Maximum number of messages to receive must be 10 or less. ' \
-      'Stopping program.'
+    puts "Maximum number of messages to receive must be 10 or less. " \
+      "Stopping program."
     return
   end
 
@@ -35,13 +35,13 @@ def receive_messages(sqs_client, queue_url, max_number_of_messages = 10)
   )
 
   if response.messages.count.zero?
-    puts 'No messages to receive, or all messages have already ' \
-      'been previously received.'
+    puts "No messages to receive, or all messages have already " \
+      "been previously received."
     return
   end
 
   response.messages.each do |message|
-    puts '-' * 20
+    puts "-" * 20
     puts "Message body: #{message.body}"
     puts "Message ID:   #{message.message_id}"
   end
@@ -53,16 +53,16 @@ end
 # Full example call:
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
 def run_me
-  region = 'us-west-2'
-  queue_name = 'my-queue'
+  region = "us-west-2"
+  queue_name = "my-queue"
   max_number_of_messages = 10
 
   sts_client = Aws::STS::Client.new(region: region)
 
   # For example:
   # 'https://sqs.us-west-2.amazonaws.com/111111111111/my-queue'
-  queue_url = 'https://sqs.' + region + '.amazonaws.com/' +
-    sts_client.get_caller_identity.account + '/' + queue_name
+  queue_url = "https://sqs." + region + ".amazonaws.com/" +
+    sts_client.get_caller_identity.account + "/" + queue_name
 
   sqs_client = Aws::SQS::Client.new(region: region)
 

--- a/ruby/example_code/sqs/sqs-ruby-example-long-polling.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-long-polling.rb
@@ -6,9 +6,9 @@
 # Amazon Simple Queue Service (Amazon SQS) queue.
 
 # snippet-start:[s3.ruby.sqs-ruby-example-long-polling.rb]
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-Aws.config.update({region: 'us-west-2'})
+Aws.config.update({region: "us-west-2"})
 
 poller = Aws::SQS::QueuePoller.new(URL)
 

--- a/ruby/example_code/sqs/sqs-ruby-example-message-visibility-timeout.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-message-visibility-timeout.rb
@@ -7,9 +7,9 @@
 
 # snippet-start:[s3.sqs-ruby-example-message-visibility-timeout.rb]
 
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-sqs = Aws::SQS::Client.new(region: 'us-west-2')
+sqs = Aws::SQS::Client.new(region: "us-west-2")
 
 begin
   queue_name = "my-queue"
@@ -42,4 +42,3 @@ rescue Aws::SQS::Errors::NonExistentQueue
   puts "Cannot receive messages for a queue named '#{receive_queue_name}', as it does not exist."
 end
 # snippet-end:[s3.sqs-ruby-example-message-visibility-timeout.rb]
-

--- a/ruby/example_code/sqs/sqs-ruby-example-poll-messages.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-poll-messages.rb
@@ -7,9 +7,9 @@
 
 # snippet-start:[s3.sqs-ruby-example-poll-messages.rb]
 
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-Aws.config.update({region: 'us-west-2'})
+Aws.config.update({region: "us-west-2"})
 
 poller = Aws::SQS::QueuePoller.new(URL)
 

--- a/ruby/example_code/sqs/sqs-ruby-example-redirect-queue-deadletters.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-redirect-queue-deadletters.rb
@@ -6,15 +6,15 @@
 # queue to another.
 
 # snippet-start:[s3.sqs-ruby-example-redirect-queue-deadletters.rb]
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-sqs = Aws::SQS::Client.new(region: 'us-west-2')
+sqs = Aws::SQS::Client.new(region: "us-west-2")
 
 sqs.set_queue_attributes({
   queue_url: URL,
   attributes:
     {
-      'RedrivePolicy' => "{\"maxReceiveCount\":\"5\", \"deadLetterTargetArn\":\"#{ARN}\"}"
+      "RedrivePolicy" => "{\"maxReceiveCount\":\"5\", \"deadLetterTargetArn\":\"#{ARN}\"}"
     }
 })
 # snippet-end:[s3.sqs-ruby-example-redirect-queue-deadletters.rb]

--- a/ruby/example_code/sqs/sqs-ruby-example-send-message-batch.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-send-message-batch.rb
@@ -6,8 +6,8 @@
 
 # snippet-start:[s3.sqs-ruby-example-send-message-batch.rb]
 
-require 'aws-sdk-sqs'
-require 'aws-sdk-sts'
+require "aws-sdk-sqs"
+require "aws-sdk-sts"
 
 #
 # @param sqs_client [Aws::SQS::Client] An initialized Amazon SQS client.
@@ -44,16 +44,16 @@ end
 # Full example call:
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
 def run_me
-  region = 'us-west-2'
-  queue_name = 'my-queue'
+  region = "us-west-2"
+  queue_name = "my-queue"
   entries = [
     {
-      id: 'Message1',
-      message_body: 'This is the first message.'
+      id: "Message1",
+      message_body: "This is the first message."
     },
     {
-      id: 'Message2',
-      message_body: 'This is the second message.'
+      id: "Message2",
+      message_body: "This is the second message."
     }
   ]
 
@@ -61,17 +61,17 @@ def run_me
 
   # For example:
   # 'https://sqs.us-west-2.amazonaws.com/111111111111/my-queue'
-  queue_url = 'https://sqs.' + region + '.amazonaws.com/' +
-    sts_client.get_caller_identity.account + '/' + queue_name
+  queue_url = "https://sqs." + region + ".amazonaws.com/" +
+    sts_client.get_caller_identity.account + "/" + queue_name
 
   sqs_client = Aws::SQS::Client.new(region: region)
 
   puts "Sending messages to the queue named '#{queue_name}'..."
 
   if messages_sent?(sqs_client, queue_url, entries)
-    puts 'Messages sent.'
+    puts "Messages sent."
   else
-    puts 'Messages not sent.'
+    puts "Messages not sent."
   end
 end
 

--- a/ruby/example_code/sqs/sqs-ruby-example-send-message.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-send-message.rb
@@ -5,8 +5,8 @@
 # This code example demonstrates how to send a message to a queue in Amazon Simple Queue Service (Amazon SQS).
 
 # snippet-start:[s3.sqs-ruby-example-send-message.rb]
-require 'aws-sdk-sqs'
-require 'aws-sdk-sts'
+require "aws-sdk-sqs"
+require "aws-sdk-sts"
 
 # @param sqs_client [Aws::SQS::Client] An initialized Amazon SQS client.
 # @param queue_url [String] The URL of the queue.
@@ -32,25 +32,25 @@ end
 # Full example call:
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
 def run_me
-  region = 'us-west-2'
-  queue_name = 'my-queue'
-  message_body = 'This is my message.'
+  region = "us-west-2"
+  queue_name = "my-queue"
+  message_body = "This is my message."
 
   sts_client = Aws::STS::Client.new(region: region)
 
   # For example:
   # 'https://sqs.us-west-2.amazonaws.com/111111111111/my-queue'
-  queue_url = 'https://sqs.' + region + '.amazonaws.com/' +
-    sts_client.get_caller_identity.account + '/' + queue_name
+  queue_url = "https://sqs." + region + ".amazonaws.com/" +
+    sts_client.get_caller_identity.account + "/" + queue_name
 
   sqs_client = Aws::SQS::Client.new(region: region)
 
   puts "Sending a message to the queue named '#{queue_name}'..."
 
   if message_sent?(sqs_client, queue_url, message_body)
-    puts 'Message sent.'
+    puts "Message sent."
   else
-    puts 'Message not sent.'
+    puts "Message not sent."
   end
 end
 

--- a/ruby/example_code/sqs/sqs-ruby-example-send-receive-messages.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-send-receive-messages.rb
@@ -9,9 +9,9 @@
 # 4. Delete the message from the queue.
 # snippet-start:[s3.sqs-ruby-example-send-receive-messages.rb]
 
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-sqs = Aws::SQS::Client.new(region: 'us-west-2')
+sqs = Aws::SQS::Client.new(region: "us-west-2")
 
 # Send a message to a queue.
 queue_name = "my-queue"

--- a/ruby/example_code/sqs/sqs-ruby-example-show-queues.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-show-queues.rb
@@ -6,8 +6,8 @@
 
 # snippet-start:[s3.sqs-ruby-example-show-queues.rb]
 
-require 'aws-sdk-sqs'
-require 'aws-sdk-sts'
+require "aws-sdk-sqs"
+require "aws-sdk-sts"
 
 # @param sqs_client [Aws::SQS::Client] An initialized Amazon SQS client.
 # @example
@@ -34,7 +34,7 @@ end
 def list_queue_attributes(sqs_client, queue_url)
   attributes = sqs_client.get_queue_attributes(
     queue_url: queue_url,
-    attribute_names: [ "All" ]
+    attribute_names: ["All"]
   )
 
   attributes.attributes.each do |key, value|
@@ -48,20 +48,20 @@ end
 # Full example call:
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
 def run_me
-  region = 'us-west-2'
-  queue_name = 'my-queue'
+  region = "us-west-2"
+  queue_name = "my-queue"
 
   sqs_client = Aws::SQS::Client.new(region: region)
 
-  puts 'Listing available queue URLs...'
+  puts "Listing available queue URLs..."
   list_queue_urls(sqs_client)
 
   sts_client = Aws::STS::Client.new(region: region)
 
   # For example:
   # 'https://sqs.us-west-2.amazonaws.com/111111111111/my-queue'
-  queue_url = 'https://sqs.' + region + '.amazonaws.com/' +
-    sts_client.get_caller_identity.account + '/' + queue_name
+  queue_url = "https://sqs." + region + ".amazonaws.com/" +
+    sts_client.get_caller_identity.account + "/" + queue_name
 
   puts "\nGetting information about queue '#{queue_name}'..."
   list_queue_attributes(sqs_client, queue_url)

--- a/ruby/example_code/sqs/sqs-ruby-example-using-queues.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-using-queues.rb
@@ -10,9 +10,9 @@
 
 # snippet-start:[s3.sqs-ruby-example-using-queues.rb]
 
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-sqs = Aws::SQS::Client.new(region: 'us-west-2')
+sqs = Aws::SQS::Client.new(region: "us-west-2")
 
 # Get a list of your queues.
 sqs.list_queues.queue_urls.each do |queue_url|

--- a/ruby/example_code/sqs/sqs-ruby-example-visibility-timeout.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-visibility-timeout.rb
@@ -6,14 +6,14 @@
 
 
 # snippet-start:[s3.sqs-ruby-example-visibility-timeout.rb]
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 
 # Process the message
 def do_something(msg)
   puts msg.body
 end
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-Aws.config.update({region: 'us-west-2'})
+Aws.config.update({region: "us-west-2"})
 
 poller = Aws::SQS::QueuePoller.new(URL)
 

--- a/ruby/example_code/sqs/sqs-ruby-example-visibility-timeout2.rb
+++ b/ruby/example_code/sqs/sqs-ruby-example-visibility-timeout2.rb
@@ -5,7 +5,7 @@
 # This code example demonstrates how to perform an operation on a message from an Amazon Simple Queue Service (Amazon SQS) queue.
 
 # snippet-start:[s3.sqs-ruby-example-visibility-timeout2.rb]
-require 'aws-sdk-sqs'  # v2: require 'aws-sdk'
+require "aws-sdk-sqs"  # v2: require 'aws-sdk'
 
 # Process the message
 def do_something(_)
@@ -17,7 +17,7 @@ def do_something2(msg)
   puts msg.body
 end
 # Replace us-west-2 with the AWS Region you're using for Amazon SQS.
-Aws.config.update({region: 'us-west-2'})
+Aws.config.update({region: "us-west-2"})
 
 poller = Aws::SQS::QueuePoller.new(URL)
 

--- a/ruby/example_code/sqs/tests/test_sqs-ruby-example-create-queue.rb
+++ b/ruby/example_code/sqs/tests/test_sqs-ruby-example-create-queue.rb
@@ -1,11 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../sqs-ruby-example-create-queue'
+require_relative "../sqs-ruby-example-create-queue"
 
-describe '#queue_created?' do
-  let(:queue_name) { 'my-queue' }
-  let(:queue_url) { 'https://sqs.us-west-2.amazonaws.com/111111111111/' + queue_name }
+describe "#queue_created?" do
+  let(:queue_name) { "my-queue" }
+  let(:queue_url) { "https://sqs.us-west-2.amazonaws.com/111111111111/" + queue_name }
   let(:sqs_client) do
     Aws::SQS::Client.new(
       stub_responses: {
@@ -16,7 +16,7 @@ describe '#queue_created?' do
     )
   end
 
-  it 'creates a queue' do
+  it "creates a queue" do
     expect(queue_created?(sqs_client, queue_name)).to be(true)
   end
 end

--- a/ruby/example_code/sqs/tests/test_sqs-ruby-example-get-messages.rb
+++ b/ruby/example_code/sqs/tests/test_sqs-ruby-example-get-messages.rb
@@ -1,11 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../sqs-ruby-example-get-messages'
+require_relative "../sqs-ruby-example-get-messages"
 
-describe '#receive_messages' do
-  let(:queue_name) { 'my-queue' }
-  let(:queue_url) { 'https://sqs.us-west-2.amazonaws.com/111111111111/' + queue_name }
+describe "#receive_messages" do
+  let(:queue_name) { "my-queue" }
+  let(:queue_url) { "https://sqs.us-west-2.amazonaws.com/111111111111/" + queue_name }
   let(:max_number_of_messages) { 10 }
   let(:sqs_client) do
     Aws::SQS::Client.new(
@@ -13,10 +13,10 @@ describe '#receive_messages' do
         receive_message: {
           messages: [
             {
-              body: 'This is my first message.'
+              body: "This is my first message."
             },
             {
-              body: 'This is my second message.'
+              body: "This is my second message."
             }
           ]
         }
@@ -24,7 +24,7 @@ describe '#receive_messages' do
     )
   end
 
-  it 'receives messages' do
-    expect{ receive_messages(sqs_client, queue_url, max_number_of_messages) }.to_not raise_error
+  it "receives messages" do
+    expect { receive_messages(sqs_client, queue_url, max_number_of_messages) }.to_not raise_error
   end
 end

--- a/ruby/example_code/sqs/tests/test_sqs-ruby-example-send-message-batch.rb
+++ b/ruby/example_code/sqs/tests/test_sqs-ruby-example-send-message-batch.rb
@@ -1,20 +1,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../sqs-ruby-example-send-message-batch'
+require_relative "../sqs-ruby-example-send-message-batch"
 
-describe '#messages_sent?' do
-  let(:queue_name) { 'my-queue' }
-  let(:queue_url) { 'https://sqs.us-west-2.amazonaws.com/111111111111/' + queue_name }
+describe "#messages_sent?" do
+  let(:queue_name) { "my-queue" }
+  let(:queue_url) { "https://sqs.us-west-2.amazonaws.com/111111111111/" + queue_name }
   let(:entries) do
     [
       {
-        id: 'Message1',
-        message_body: 'This is the first message.'
+        id: "Message1",
+        message_body: "This is the first message."
       },
       {
-        id: 'Message2',
-        message_body: 'This is the second message.'
+        id: "Message2",
+        message_body: "This is the second message."
       }
     ]
   end
@@ -24,14 +24,14 @@ describe '#messages_sent?' do
         send_message_batch: {
           successful: [
             {
-              id: 'Message1',
-              md5_of_message_body: 'c49f3d613918add9690e54615EXAMPLE',
-              message_id: '3fd53020-3da2-4a7e-afef-d36dfEXAMPLE'
+              id: "Message1",
+              md5_of_message_body: "c49f3d613918add9690e54615EXAMPLE",
+              message_id: "3fd53020-3da2-4a7e-afef-d36dfEXAMPLE"
             },
             {
-              id: 'Message2',
-              md5_of_message_body: '8fa387fa05fc48179f1f052cbEXAMPLE',
-              message_id: '7365097c-b104-4f41-b7b7-fa31eEXAMPLE'
+              id: "Message2",
+              md5_of_message_body: "8fa387fa05fc48179f1f052cbEXAMPLE",
+              message_id: "7365097c-b104-4f41-b7b7-fa31eEXAMPLE"
             }
           ],
           failed: []
@@ -40,7 +40,7 @@ describe '#messages_sent?' do
     )
   end
 
-  it 'sends messages in a batch' do
+  it "sends messages in a batch" do
     expect(messages_sent?(sqs_client, queue_url, entries)).to be(true)
   end
 end

--- a/ruby/example_code/sqs/tests/test_sqs-ruby-example-send-message.rb
+++ b/ruby/example_code/sqs/tests/test_sqs-ruby-example-send-message.rb
@@ -1,23 +1,23 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../sqs-ruby-example-send-message'
+require_relative "../sqs-ruby-example-send-message"
 
-describe '#message_sent?' do
-  let(:queue_name) { 'my-queue' }
-  let(:queue_url) { 'https://sqs.us-west-2.amazonaws.com/111111111111/' + queue_name }
-  let(:message_body) { 'This is my message.' }
+describe "#message_sent?" do
+  let(:queue_name) { "my-queue" }
+  let(:queue_url) { "https://sqs.us-west-2.amazonaws.com/111111111111/" + queue_name }
+  let(:message_body) { "This is my message." }
   let(:sqs_client) do
     Aws::SQS::Client.new(
       stub_responses: {
         send_message: {
-          message_id: '3fd53020-3da2-4a7e-afef-d36dfEXAMPLE'
+          message_id: "3fd53020-3da2-4a7e-afef-d36dfEXAMPLE"
         }
       }
     )
   end
 
-  it 'sends a message' do
+  it "sends a message" do
     expect(message_sent?(sqs_client, queue_url, message_body)).to be(true)
   end
 end

--- a/ruby/example_code/sqs/tests/test_sqs-ruby-example-show-queues.rb
+++ b/ruby/example_code/sqs/tests/test_sqs-ruby-example-show-queues.rb
@@ -1,53 +1,53 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require_relative '../sqs-ruby-example-show-queues'
+require_relative "../sqs-ruby-example-show-queues"
 
-describe '#list_queue_urls' do
+describe "#list_queue_urls" do
   let(:sqs_client) do
     Aws::SQS::Client.new(
       stub_responses: {
         list_queues: {
           queue_urls: [
-            'https://sqs.us-west-2.amazonaws.com/111111111111/my-queue',
-            'https://sqs.us-west-2.amazonaws.com/111111111111/my-queue-2'
+            "https://sqs.us-west-2.amazonaws.com/111111111111/my-queue",
+            "https://sqs.us-west-2.amazonaws.com/111111111111/my-queue-2"
           ]
         }
       }
     )
   end
 
-  it 'lists available queue URLs' do
-    expect{ list_queue_urls(sqs_client) }.to_not raise_error
+  it "lists available queue URLs" do
+    expect { list_queue_urls(sqs_client) }.to_not raise_error
   end
 end
 
-describe '#list_queue_attributes' do
-  let(:queue_name) { 'my-queue' }
-  let(:queue_url) { 'https://sqs.us-west-2.amazonaws.com/111111111111/' + queue_name }
+describe "#list_queue_attributes" do
+  let(:queue_name) { "my-queue" }
+  let(:queue_url) { "https://sqs.us-west-2.amazonaws.com/111111111111/" + queue_name }
   let(:sqs_client) do
     Aws::SQS::Client.new(
       stub_responses: {
         get_queue_attributes: {
           attributes: {
-           'QueueArn' => 'arn:aws:sqs:us-west-2:992648334831:my-queue',
-           'ApproximateNumberOfMessages' => '2',
-           'ApproximateNumberOfMessagesNotVisible' => '0',
-           'ApproximateNumberOfMessagesDelayed' => '0',
-           'CreatedTimestamp' => '1612302412',
-           'LastModifiedTimestamp' => '1612302412',
-           'VisibilityTimeout' => '30',
-           'MaximumMessageSize' => '262144',
-           'MessageRetentionPeriod' => '345600',
-           'DelaySeconds' => '0',
-           'ReceiveMessageWaitTimeSeconds' => '0'
+           "QueueArn" => "arn:aws:sqs:us-west-2:992648334831:my-queue",
+           "ApproximateNumberOfMessages" => "2",
+           "ApproximateNumberOfMessagesNotVisible" => "0",
+           "ApproximateNumberOfMessagesDelayed" => "0",
+           "CreatedTimestamp" => "1612302412",
+           "LastModifiedTimestamp" => "1612302412",
+           "VisibilityTimeout" => "30",
+           "MaximumMessageSize" => "262144",
+           "MessageRetentionPeriod" => "345600",
+           "DelaySeconds" => "0",
+           "ReceiveMessageWaitTimeSeconds" => "0"
           }
         }
       }
     )
   end
 
-  it 'lists a queue\'s attributes' do
-    expect{ list_queue_attributes(sqs_client, queue_url) }.to_not raise_error
+  it "lists a queue's attributes" do
+    expect { list_queue_attributes(sqs_client, queue_url) }.to_not raise_error
   end
 end

--- a/ruby/example_code/workdocs/wd_list_user_docs.rb
+++ b/ruby/example_code/workdocs/wd_list_user_docs.rb
@@ -6,10 +6,10 @@
 
 # snippet-start:[s3.wd_list_user_docs.rb]
 
-require 'aws-sdk-workdocs'  # v2: require 'aws-sdk'
+require "aws-sdk-workdocs"  # v2: require 'aws-sdk'
 
 def get_user_folder(client, orgId, user_email)
-  root_folder = ''
+  root_folder = ""
 
   resp = client.describe_users({
     organization_id: orgId,
@@ -25,18 +25,18 @@ def get_user_folder(client, orgId, user_email)
   return root_folder
 end
 # Replace us-west-2 with the AWS Region you're using for Amazon WorkDocs.
-client = Aws::WorkDocs::Client.new(region: 'us-west-2')
+client = Aws::WorkDocs::Client.new(region: "us-west-2")
 
 # Set to the email address of a user
-user_email = 'someone@somewhere'
+user_email = "someone@somewhere"
 
 # Set to the OrganizationId of your WorkDocs site.
-orgId = 'd-123456789c'
+orgId = "d-123456789c"
 
 user_folder = get_user_folder(client, orgId, user_email)
 
-if user_folder == ''
-  puts 'Could not get root folder for user with email address ' + user_email
+if user_folder == ""
+  puts "Could not get root folder for user with email address " + user_email
   exit(1)
 end
 

--- a/ruby/example_code/workdocs/wd_list_users.rb
+++ b/ruby/example_code/workdocs/wd_list_users.rb
@@ -6,12 +6,12 @@
 
 # snippet-start:[s3.wd_list_users.rb]
 
-require 'aws-sdk-workdocs'  # v2: require 'aws-sdk'
+require "aws-sdk-workdocs"  # v2: require 'aws-sdk'
 # Replace us-west-2 with the AWS Region you're using for Amazon WorkDocs.
-client = Aws::WorkDocs::Client.new(region: 'us-west-2')
+client = Aws::WorkDocs::Client.new(region: "us-west-2")
 
 # Set to the OrganizationId of your WorkDocs site
-orgId = 'd-123456789c'
+orgId = "d-123456789c"
 
 resp = client.describe_users({
   organization_id: orgId,


### PR DESCRIPTION
# what's in this PR?
This is the result of our existing Ruby linting config applied to all Ruby files.

There were 1745 offenses, and 1744 were "auto-corrected".

The 1 remaining offense was manually fixed by removing a duplicate `return` statement.

# risks
There are no risks, because 99.9% of these fixes were automated and bring the Ruby code into best practice. SOS tags were not touched, nor were any functions or logic.