### PR TITLE
Ruby Cleanup : Cloudwatch and Codebuild Errors

### DIFF
--- a/ruby/example_code/cloudwatch/cw-ruby-example-alarm-actions.rb
+++ b/ruby/example_code/cloudwatch/cw-ruby-example-alarm-actions.rb
@@ -6,7 +6,7 @@
 # 2. Disable all actions for an alarm.
 
 # snippet-start:[cloudwatch.Ruby.createAnAlarm]
-require 'aws-sdk-cloudwatch'
+require "aws-sdk-cloudwatch"
 
 # Creates or updates an alarm in Amazon CloudWatch.
 
@@ -116,31 +116,31 @@ end
 
 # Full example call:
 def run_me
-  alarm_name = 'ObjectsInBucket'
-  alarm_description = 'Objects exist in this bucket for more than 1 day.'
-  metric_name = 'NumberOfObjects'
+  alarm_name = "ObjectsInBucket"
+  alarm_description = "Objects exist in this bucket for more than 1 day."
+  metric_name = "NumberOfObjects"
   # Notify this Amazon Simple Notification Service (Amazon SNS) topic when
   # the alarm transitions to the ALARM state.
-  alarm_actions = ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic']
-  namespace = 'AWS/S3'
-  statistic = 'Average'
+  alarm_actions = ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"]
+  namespace = "AWS/S3"
+  statistic = "Average"
   dimensions = [
     {
-      name: 'BucketName',
-      value: 'doc-example-bucket'
+      name: "BucketName",
+      value: "doc-example-bucket"
     },
     {
-      name: 'StorageType',
-      value: 'AllStorageTypes'
+      name: "StorageType",
+      value: "AllStorageTypes"
     }
   ]
   period = 86_400 # Daily (24 hours * 60 minutes * 60 seconds = 86400 seconds).
-  unit = 'Count'
+  unit = "Count"
   evaluation_periods = 1 # More than one day.
   threshold = 1 # One object.
-  comparison_operator = 'GreaterThanThreshold' # More than one object.
+  comparison_operator = "GreaterThanThreshold" # More than one object.
   # Replace us-west-2 with the AWS Region you're using for Amazon CloudWatch.
-  region = 'us-east-1'
+  region = "us-east-1"
 
   cloudwatch_client = Aws::CloudWatch::Client.new(region: region)
 

--- a/ruby/example_code/cloudwatch/cw-ruby-example-alarm-basics.rb
+++ b/ruby/example_code/cloudwatch/cw-ruby-example-alarm-basics.rb
@@ -6,7 +6,7 @@
 # 2. Create or update an alarm.
 # 3. Delete an alarm.
 # snippet-start:[cloudwatch.Ruby.getAlarmList]
-require 'aws-sdk-cloudwatch'
+require "aws-sdk-cloudwatch"
 
 # Lists the names of available Amazon CloudWatch alarms.
 #
@@ -21,7 +21,7 @@ def list_alarms(cloudwatch_client)
       puts alarm.alarm_name
     end
   else
-    puts 'No alarms found.'
+    puts "No alarms found."
   end
 rescue StandardError => e
   puts "Error getting information about alarms: #{e.message}"
@@ -136,35 +136,35 @@ end
 
 # Full example call:
 def run_me
-  alarm_name = 'ObjectsInBucket'
-  alarm_description = 'Objects exist in this bucket for more than 1 day.'
-  metric_name = 'NumberOfObjects'
+  alarm_name = "ObjectsInBucket"
+  alarm_description = "Objects exist in this bucket for more than 1 day."
+  metric_name = "NumberOfObjects"
   # Notify this Amazon Simple Notification Service (Amazon SNS) topic when
   # the alarm transitions to the ALARM state.
-  alarm_actions = ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic']
-  namespace = 'AWS/S3'
-  statistic = 'Average'
+  alarm_actions = ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"]
+  namespace = "AWS/S3"
+  statistic = "Average"
   dimensions = [
     {
-      name: 'BucketName',
-      value: 'doc-example-bucket'
+      name: "BucketName",
+      value: "doc-example-bucket"
     },
     {
-      name: 'StorageType',
-      value: 'AllStorageTypes'
+      name: "StorageType",
+      value: "AllStorageTypes"
     }
   ]
   period = 86_400 # Daily (24 hours * 60 minutes * 60 seconds = 86400 seconds).
-  unit = 'Count'
+  unit = "Count"
   evaluation_periods = 1 # More than one day.
   threshold = 1 # One object.
-  comparison_operator = 'GreaterThanThreshold' # More than one object.
+  comparison_operator = "GreaterThanThreshold" # More than one object.
   # Replace us-west-2 with the AWS Region you're using for Amazon CloudWatch.
-  region = 'us-east-1'
+  region = "us-east-1"
 
   cloudwatch_client = Aws::CloudWatch::Client.new(region: region)
 
-  puts 'Available Amazon CloudWatch alarms:'
+  puts "Available Amazon CloudWatch alarms:"
   list_alarms(cloudwatch_client)
 
   if alarm_created_or_updated?(

--- a/ruby/example_code/cloudwatch/cw-ruby-example-create-alarm.rb
+++ b/ruby/example_code/cloudwatch/cw-ruby-example-create-alarm.rb
@@ -5,7 +5,7 @@
 
 # snippet-start:[cloudwatch.Ruby.createAlarm]
 
-require 'aws-sdk-cloudwatch'
+require "aws-sdk-cloudwatch"
 
 # @param cloudwatch_client [Aws::CloudWatch::Client]
 #   An initialized CloudWatch client.
@@ -89,31 +89,31 @@ end
 
 # Full example call:
 def run_me
-  alarm_name = 'ObjectsInBucket'
-  alarm_description = 'Objects exist in this bucket for more than 1 day.'
-  metric_name = 'NumberOfObjects'
+  alarm_name = "ObjectsInBucket"
+  alarm_description = "Objects exist in this bucket for more than 1 day."
+  metric_name = "NumberOfObjects"
   # Notify this Amazon Simple Notification Service (Amazon SNS) topic when
   # the alarm transitions to the ALARM state.
-  alarm_actions = ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic']
-  namespace = 'AWS/S3'
-  statistic = 'Average'
+  alarm_actions = ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"]
+  namespace = "AWS/S3"
+  statistic = "Average"
   dimensions = [
     {
-      name: 'BucketName',
-      value: 'doc-example-bucket'
+      name: "BucketName",
+      value: "doc-example-bucket"
     },
     {
-      name: 'StorageType',
-      value: 'AllStorageTypes'
+      name: "StorageType",
+      value: "AllStorageTypes"
     }
   ]
   period = 86_400 # Daily (24 hours * 60 minutes * 60 seconds = 86400 seconds).
-  unit = 'Count'
+  unit = "Count"
   evaluation_periods = 1 # More than one day.
   threshold = 1 # One object.
-  comparison_operator = 'GreaterThanThreshold' # More than one object.
+  comparison_operator = "GreaterThanThreshold" # More than one object.
   # Replace us-west-2 with the AWS Region you're using for Amazon CloudWatch.
-  region = 'us-east-1'
+  region = "us-east-1"
 
   cloudwatch_client = Aws::CloudWatch::Client.new(region: region)
 

--- a/ruby/example_code/cloudwatch/cw-ruby-example-metrics-basics.rb
+++ b/ruby/example_code/cloudwatch/cw-ruby-example-metrics-basics.rb
@@ -6,7 +6,7 @@
 # 2. List available metrics for a metric namespace in Amazon CloudWatch.
 
 # snippet-start:[cloudwatch.Ruby.addDataPoint]
-require 'aws-sdk-cloudwatch'
+require "aws-sdk-cloudwatch"
 
 # Adds a datapoint to a metric in Amazon CloudWatch.
 #
@@ -84,58 +84,58 @@ def list_metrics_for_namespace(cloudwatch_client, metric_namespace)
     response.metrics.each do |metric|
       puts "  Metric name: #{metric.metric_name}"
       if metric.dimensions.count.positive?
-        puts '    Dimensions:'
+        puts "    Dimensions:"
         metric.dimensions.each do |dimension|
           puts "      Name: #{dimension.name}, Value: #{dimension.value}"
         end
       else
-        puts 'No dimensions found.'
+        puts "No dimensions found."
       end
     end
   else
     puts "No metrics found for namespace '#{metric_namespace}'. " \
-      'Note that it could take up to 15 minutes for recently-added metrics ' \
-      'to become available.'
+      "Note that it could take up to 15 minutes for recently-added metrics " \
+      "to become available."
   end
 end
 
 # Full example call:
 def run_me
-  metric_namespace = 'SITE/TRAFFIC'
+  metric_namespace = "SITE/TRAFFIC"
   # Replace us-west-2 with the AWS Region you're using for Amazon CloudWatch.
-  region = 'us-east-1'
+  region = "us-east-1"
 
   cloudwatch_client = Aws::CloudWatch::Client.new(region: region)
 
   # Add three datapoints.
-  puts 'Continuing...' unless datapoint_added_to_metric?(
+  puts "Continuing..." unless datapoint_added_to_metric?(
     cloudwatch_client,
     metric_namespace,
-    'UniqueVisitors',
-    'SiteName',
-    'example.com',
+    "UniqueVisitors",
+    "SiteName",
+    "example.com",
     5_885.0,
-    'Count'
+    "Count"
   )
 
-  puts 'Continuing...' unless datapoint_added_to_metric?(
+  puts "Continuing..." unless datapoint_added_to_metric?(
     cloudwatch_client,
     metric_namespace,
-    'UniqueVisits',
-    'SiteName',
-    'example.com',
+    "UniqueVisits",
+    "SiteName",
+    "example.com",
     8_628.0,
-    'Count'
+    "Count"
   )
 
-  puts 'Continuing...' unless datapoint_added_to_metric?(
+  puts "Continuing..." unless datapoint_added_to_metric?(
     cloudwatch_client,
     metric_namespace,
-    'PageViews',
-    'PageURL',
-    'example.html',
+    "PageViews",
+    "PageURL",
+    "example.html",
     18_057.0,
-    'Count'
+    "Count"
   )
 
   puts "Metrics for namespace '#{metric_namespace}':"

--- a/ruby/example_code/cloudwatch/cw-ruby-example-show-alarms.rb
+++ b/ruby/example_code/cloudwatch/cw-ruby-example-show-alarms.rb
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-require 'aws-sdk-cloudwatch'
+require "aws-sdk-cloudwatch"
 
 # Displays information about available metric alarms in Amazon CloudWatch.
 
@@ -17,52 +17,52 @@ def describe_metric_alarms(cloudwatch_client)
 
   if response.metric_alarms.count.positive?
     response.metric_alarms.each do |alarm|
-      puts '-' * 16
-      puts 'Name:           ' + alarm.alarm_name
-      puts 'State value:    ' + alarm.state_value
-      puts 'State reason:   ' + alarm.state_reason
-      puts 'Metric:         ' + alarm.metric_name
-      puts 'Namespace:      ' + alarm.namespace
-      puts 'Statistic:      ' + alarm.statistic
-      puts 'Period:         ' + alarm.period.to_s
-      puts 'Unit:           ' + alarm.unit.to_s
-      puts 'Eval. periods:  ' + alarm.evaluation_periods.to_s
-      puts 'Threshold:      ' + alarm.threshold.to_s
-      puts 'Comp. operator: ' + alarm.comparison_operator
+      puts "-" * 16
+      puts "Name:           " + alarm.alarm_name
+      puts "State value:    " + alarm.state_value
+      puts "State reason:   " + alarm.state_reason
+      puts "Metric:         " + alarm.metric_name
+      puts "Namespace:      " + alarm.namespace
+      puts "Statistic:      " + alarm.statistic
+      puts "Period:         " + alarm.period.to_s
+      puts "Unit:           " + alarm.unit.to_s
+      puts "Eval. periods:  " + alarm.evaluation_periods.to_s
+      puts "Threshold:      " + alarm.threshold.to_s
+      puts "Comp. operator: " + alarm.comparison_operator
 
       if alarm.key?(:ok_actions) && alarm.ok_actions.count.positive?
-        puts 'OK actions:'
+        puts "OK actions:"
         alarm.ok_actions.each do |a|
-          puts '  ' + a
+          puts "  " + a
         end
       end
 
       if alarm.key?(:alarm_actions) && alarm.alarm_actions.count.positive?
-        puts 'Alarm actions:'
+        puts "Alarm actions:"
         alarm.alarm_actions.each do |a|
-          puts '  ' + a
+          puts "  " + a
         end
       end
 
       if alarm.key?(:insufficient_data_actions) &&
           alarm.insufficient_data_actions.count.positive?
-        puts 'Insufficient data actions:'
+        puts "Insufficient data actions:"
         alarm.insufficient_data_actions.each do |a|
-          puts '  ' + a
+          puts "  " + a
         end
       end
 
-      puts 'Dimensions:'
+      puts "Dimensions:"
       if alarm.key?(:dimensions) && alarm.dimensions.count.positive?
         alarm.dimensions.each do |d|
-          puts '  Name: ' + d.name + ', Value: ' + d.value
+          puts "  Name: " + d.name + ", Value: " + d.value
         end
       else
-        puts '  None for this alarm.'
+        puts "  None for this alarm."
       end
     end
   else
-    puts 'No alarms found.'
+    puts "No alarms found."
   end
 rescue StandardError => e
   puts "Error getting information about alarms: #{e.message}"
@@ -70,23 +70,23 @@ end
 
 # Full example call:
 def run_me
-  region = ''
+  region = ""
 
   # Print usage information and then stop.
-  if ARGV[0] == '--help' || ARGV[0] == '-h'
-    puts 'Usage:   ruby cw-ruby-example-show-alarms.rb REGION'
-    puts 'Example: ruby cw-ruby-example-show-alarms.rb us-east-1'
+  if ARGV[0] == "--help" || ARGV[0] == "-h"
+    puts "Usage:   ruby cw-ruby-example-show-alarms.rb REGION"
+    puts "Example: ruby cw-ruby-example-show-alarms.rb us-east-1"
     exit 1
   # If no values are specified at the command prompt, use these default values.
   elsif ARGV.count.zero?
-    region = 'us-east-1'
+    region = "us-east-1"
   # Otherwise, use the values as specified at the command prompt.
   else
     region = ARGV[0]
   end
 
   cloudwatch_client = Aws::CloudWatch::Client.new(region: region)
-  puts 'Available alarms:'
+  puts "Available alarms:"
   describe_metric_alarms(cloudwatch_client)
 end
 

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-alarm-actions.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-alarm-actions.rb
@@ -1,32 +1,32 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-alarm-actions'
+require_relative "../cw-ruby-example-alarm-actions"
 
-describe '#alarm_created_or_updated?' do
-  let(:alarm_name) { 'ObjectsInBucket' }
-  let(:alarm_description) { 'Objects exist in this bucket for more than 1 day.' }
-  let(:metric_name) { 'NumberOfObjects' }
-  let(:alarm_actions) { ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic'] }
-  let(:namespace) { 'AWS/S3' }
-  let(:statistic) { 'Average' }
+describe "#alarm_created_or_updated?" do
+  let(:alarm_name) { "ObjectsInBucket" }
+  let(:alarm_description) { "Objects exist in this bucket for more than 1 day." }
+  let(:metric_name) { "NumberOfObjects" }
+  let(:alarm_actions) { ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"] }
+  let(:namespace) { "AWS/S3" }
+  let(:statistic) { "Average" }
   let(:dimensions) do
     [
       {
-        name: 'BucketName',
-        value: 'doc-example-bucket'
+        name: "BucketName",
+        value: "doc-example-bucket"
       },
       {
-        name: 'StorageType',
-        value: 'AllStorageTypes'
+        name: "StorageType",
+        value: "AllStorageTypes"
       }
     ]
   end
   let(:period) { 86_400 }
-  let(:unit) { 'Count' }
+  let(:unit) { "Count" }
   let(:evaluation_periods) { 1 }
   let(:threshold) { 1 }
-  let(:comparison_operator) { 'GreaterThanThreshold' }
+  let(:comparison_operator) { "GreaterThanThreshold" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -35,7 +35,7 @@ describe '#alarm_created_or_updated?' do
     )
   end
 
-  it 'creates or updates an alarm' do
+  it "creates or updates an alarm" do
     expect(
       alarm_created_or_updated?(
         cloudwatch_client,
@@ -56,8 +56,8 @@ describe '#alarm_created_or_updated?' do
   end
 end
 
-describe '#alarm_actions_disabled?' do
-  let(:alarm_name) { 'ObjectsInBucket' }
+describe "#alarm_actions_disabled?" do
+  let(:alarm_name) { "ObjectsInBucket" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -66,7 +66,7 @@ describe '#alarm_actions_disabled?' do
     )
   end
 
-  it 'disables actions for an alarm' do
+  it "disables actions for an alarm" do
     expect(
       alarm_actions_disabled?(cloudwatch_client, alarm_name)
     ).to be(true)

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-alarm-basics.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-alarm-basics.rb
@@ -1,16 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-alarm-basics'
+require_relative "../cw-ruby-example-alarm-basics"
 
-describe '#list_alarms' do
+describe "#list_alarms" do
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
         describe_alarms: {
           metric_alarms: [
             {
-              alarm_name: 'ObjectsInBucket'
+              alarm_name: "ObjectsInBucket"
             }
           ]
         }
@@ -18,35 +18,35 @@ describe '#list_alarms' do
     )
   end
 
-  it 'lists information about alarms' do
+  it "lists information about alarms" do
     expect { list_alarms(cloudwatch_client) }.not_to raise_error
   end
 end
 
-describe '#alarm_created_or_updated?' do
-  let(:alarm_name) { 'ObjectsInBucket' }
-  let(:alarm_description) { 'Objects exist in this bucket for more than 1 day.' }
-  let(:metric_name) { 'NumberOfObjects' }
-  let(:alarm_actions) { ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic'] }
-  let(:namespace) { 'AWS/S3' }
-  let(:statistic) { 'Average' }
+describe "#alarm_created_or_updated?" do
+  let(:alarm_name) { "ObjectsInBucket" }
+  let(:alarm_description) { "Objects exist in this bucket for more than 1 day." }
+  let(:metric_name) { "NumberOfObjects" }
+  let(:alarm_actions) { ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"] }
+  let(:namespace) { "AWS/S3" }
+  let(:statistic) { "Average" }
   let(:dimensions) do
     [
       {
-        name: 'BucketName',
-        value: 'doc-example-bucket'
+        name: "BucketName",
+        value: "doc-example-bucket"
       },
       {
-        name: 'StorageType',
-        value: 'AllStorageTypes'
+        name: "StorageType",
+        value: "AllStorageTypes"
       }
     ]
   end
   let(:period) { 86_400 }
-  let(:unit) { 'Count' }
+  let(:unit) { "Count" }
   let(:evaluation_periods) { 1 }
   let(:threshold) { 1 }
-  let(:comparison_operator) { 'GreaterThanThreshold' }
+  let(:comparison_operator) { "GreaterThanThreshold" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -55,7 +55,7 @@ describe '#alarm_created_or_updated?' do
     )
   end
 
-  it 'creates or updates an alarm' do
+  it "creates or updates an alarm" do
     expect(
       alarm_created_or_updated?(
         cloudwatch_client,
@@ -76,8 +76,8 @@ describe '#alarm_created_or_updated?' do
   end
 end
 
-describe '#alarm_deleted?' do
-  let(:alarm_name) { 'ObjectsInBucket' }
+describe "#alarm_deleted?" do
+  let(:alarm_name) { "ObjectsInBucket" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -86,7 +86,7 @@ describe '#alarm_deleted?' do
     )
   end
 
-  it 'deletes an alarm' do
+  it "deletes an alarm" do
     expect(
       alarm_deleted?(cloudwatch_client, alarm_name)
     ).to be(true)

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-create-alarm.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-create-alarm.rb
@@ -1,32 +1,32 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-create-alarm'
+require_relative "../cw-ruby-example-create-alarm"
 
-describe '#alarm_created_or_updated?' do
-  let(:alarm_name) { 'ObjectsInBucket' }
-  let(:alarm_description) { 'Objects exist in this bucket for more than 1 day.' }
-  let(:metric_name) { 'NumberOfObjects' }
-  let(:alarm_actions) { ['arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic'] }
-  let(:namespace) { 'AWS/S3' }
-  let(:statistic) { 'Average' }
+describe "#alarm_created_or_updated?" do
+  let(:alarm_name) { "ObjectsInBucket" }
+  let(:alarm_description) { "Objects exist in this bucket for more than 1 day." }
+  let(:metric_name) { "NumberOfObjects" }
+  let(:alarm_actions) { ["arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"] }
+  let(:namespace) { "AWS/S3" }
+  let(:statistic) { "Average" }
   let(:dimensions) do
     [
       {
-        name: 'BucketName',
-        value: 'doc-example-bucket'
+        name: "BucketName",
+        value: "doc-example-bucket"
       },
       {
-        name: 'StorageType',
-        value: 'AllStorageTypes'
+        name: "StorageType",
+        value: "AllStorageTypes"
       }
     ]
   end
   let(:period) { 86_400 }
-  let(:unit) { 'Count' }
+  let(:unit) { "Count" }
   let(:evaluation_periods) { 1 }
   let(:threshold) { 1 }
-  let(:comparison_operator) { 'GreaterThanThreshold' }
+  let(:comparison_operator) { "GreaterThanThreshold" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -35,7 +35,7 @@ describe '#alarm_created_or_updated?' do
     )
   end
 
-  it 'creates or updates an alarm' do
+  it "creates or updates an alarm" do
     expect(
       alarm_created_or_updated?(
         cloudwatch_client,

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-metrics-basics.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-metrics-basics.rb
@@ -1,15 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-metrics-basics'
+require_relative "../cw-ruby-example-metrics-basics"
 
-describe '#datapoint_added_to_metric?' do
-  let(:metric_namespace) { 'SITE/TRAFFIC' }
-  let(:metric_name) { 'UniqueVisitors' }
-  let(:dimension_name) { 'SiteName' }
-  let(:dimension_value) { 'example.com' }
+describe "#datapoint_added_to_metric?" do
+  let(:metric_namespace) { "SITE/TRAFFIC" }
+  let(:metric_name) { "UniqueVisitors" }
+  let(:dimension_name) { "SiteName" }
+  let(:dimension_value) { "example.com" }
   let(:metric_value) { 5_885.0 }
-  let(:metric_unit) { 'Count' }
+  let(:metric_unit) { "Count" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
@@ -18,7 +18,7 @@ describe '#datapoint_added_to_metric?' do
     )
   end
 
-  it 'adds a datapoint to a metric' do
+  it "adds a datapoint to a metric" do
     expect(
       datapoint_added_to_metric?(
         cloudwatch_client,
@@ -33,19 +33,19 @@ describe '#datapoint_added_to_metric?' do
   end
 end
 
-describe 'list_metrics_for_namespace' do
-  let(:metric_namespace) { 'SITE/TRAFFIC' }
+describe "list_metrics_for_namespace" do
+  let(:metric_namespace) { "SITE/TRAFFIC" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
         list_metrics: {
           metrics: [
             {
-              metric_name: 'UniqueVisitors',
+              metric_name: "UniqueVisitors",
               dimensions: [
                 {
-                  name: 'SiteName',
-                  value: 'example.com'
+                  name: "SiteName",
+                  value: "example.com"
                 }
               ]
             }
@@ -55,7 +55,7 @@ describe 'list_metrics_for_namespace' do
     )
   end
 
-  it 'lists the metrics for a namespace' do
+  it "lists the metrics for a namespace" do
     expect {
       list_metrics_for_namespace(cloudwatch_client, metric_namespace)
     }.not_to raise_error

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-send-events-ec2.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-send-events-ec2.rb
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-send-events-ec2'
+require_relative "../cw-ruby-example-send-events-ec2"
 
-describe '#topic_exists?' do
-  let(:topic_arn) { 'arn:aws:sns:us-east-1:111111111111:aws-doc-sdk-examples-topic' }
+describe "#topic_exists?" do
+  let(:topic_arn) { "arn:aws:sns:us-east-1:111111111111:aws-doc-sdk-examples-topic" }
   let(:sns_client) do
     Aws::SNS::Client.new(
       stub_responses: {
@@ -17,16 +17,16 @@ describe '#topic_exists?' do
     )
   end
 
-  it 'checks whether a topic exists' do
+  it "checks whether a topic exists" do
     expect(
       topic_exists?(sns_client, topic_arn)
     ).to be(true)
   end
 end
 
-describe '#create_topic' do
-  let(:topic_name) { 'aws-doc-sdk-examples-topic' }
-  let(:email_address) { 'mary@example.com' }
+describe "#create_topic" do
+  let(:topic_name) { "aws-doc-sdk-examples-topic" }
+  let(:email_address) { "mary@example.com" }
   let(:topic_arn) { "arn:aws:sns:us-east-1:111111111111:#{topic_name}" }
   let(:sns_client) do
     Aws::SNS::Client.new(
@@ -41,15 +41,15 @@ describe '#create_topic' do
     )
   end
 
-  it 'creates a topic' do
+  it "creates a topic" do
     expect(
       create_topic(sns_client, topic_name, email_address)
     ).to eq(topic_arn)
   end
 end
 
-describe '#role_exists?' do
-  let(:role_name) { 'aws-doc-sdk-examples-cloudwatch-events-rule-role' }
+describe "#role_exists?" do
+  let(:role_name) { "aws-doc-sdk-examples-cloudwatch-events-rule-role" }
   let(:role_arn) { "arn:aws:iam::111111111111:role/#{role_name}" }
   let(:iam_client) do
     Aws::IAM::Client.new(
@@ -57,25 +57,25 @@ describe '#role_exists?' do
         list_roles: {
           roles: [
             arn: role_arn,
-            path: '/',
+            path: "/",
             role_name: role_name,
-            role_id: 'AIDAJQABLZS4A3EXAMPLE',
-            create_date: Time.iso8601('2020-11-17T14:19:00-08:00')
+            role_id: "AIDAJQABLZS4A3EXAMPLE",
+            create_date: Time.iso8601("2020-11-17T14:19:00-08:00")
           ]
         }
       }
     )
   end
 
-  it 'checks whether a role exists' do
+  it "checks whether a role exists" do
     expect(
       role_exists?(iam_client, role_arn)
     ).to be(true)
   end
 end
 
-describe '#create_role' do
-  let(:role_name) { 'aws-doc-sdk-examples-cloudwatch-events-rule-role' }
+describe "#create_role" do
+  let(:role_name) { "aws-doc-sdk-examples-cloudwatch-events-rule-role" }
   let(:role_arn) { "arn:aws:iam::111111111111:role/#{role_name}" }
   let(:iam_client) do
     Aws::IAM::Client.new(
@@ -83,25 +83,25 @@ describe '#create_role' do
         create_role: {
           role: {
             arn: role_arn,
-            path: '/',
+            path: "/",
             role_name: role_name,
-            role_id: 'AIDAJQABLZS4A3EXAMPLE',
-            create_date: Time.iso8601('2020-11-17T14:19:00-08:00')
+            role_id: "AIDAJQABLZS4A3EXAMPLE",
+            create_date: Time.iso8601("2020-11-17T14:19:00-08:00")
           }
         }
       }
     )
   end
 
-  it 'creates a role' do
+  it "creates a role" do
     expect(
       create_role(iam_client, role_name)
     ).to eq(role_arn)
   end
 end
 
-describe '#rule_exists?' do
-  let(:rule_name) { 'aws-doc-sdk-examples-ec2-state-change' }
+describe "#rule_exists?" do
+  let(:rule_name) { "aws-doc-sdk-examples-ec2-state-change" }
   let(:cloudwatchevents_client) do
     Aws::CloudWatchEvents::Client.new(
       stub_responses: {
@@ -116,20 +116,20 @@ describe '#rule_exists?' do
     )
   end
 
-  it 'checks whether a rule exists' do
+  it "checks whether a rule exists" do
     expect(
       rule_exists?(cloudwatchevents_client, rule_name)
     ).to be(true)
   end
 end
 
-describe '#rule_created?' do
-  let(:rule_name) { 'aws-doc-sdk-examples-ec2-state-change' }
-  let(:rule_description) { 'Triggers when any available EC2 instance starts.' }
-  let(:instance_state) { 'running' }
-  let(:role_arn) { 'arn:aws:iam::111111111111:role/aws-doc-sdk-examples-cloudwatch-events-rule-role' }
-  let(:target_id) { 'sns-topic' }
-  let(:topic_arn) { 'arn:aws:sns:us-east-1:111111111111:aws-doc-sdk-examples-topic' }
+describe "#rule_created?" do
+  let(:rule_name) { "aws-doc-sdk-examples-ec2-state-change" }
+  let(:rule_description) { "Triggers when any available EC2 instance starts." }
+  let(:instance_state) { "running" }
+  let(:role_arn) { "arn:aws:iam::111111111111:role/aws-doc-sdk-examples-cloudwatch-events-rule-role" }
+  let(:target_id) { "sns-topic" }
+  let(:topic_arn) { "arn:aws:sns:us-east-1:111111111111:aws-doc-sdk-examples-topic" }
   let(:cloudwatchevents_client) do
     Aws::CloudWatchEvents::Client.new(
       stub_responses: {
@@ -141,7 +141,7 @@ describe '#rule_created?' do
     )
   end
 
-  it 'creates a rule' do
+  it "creates a rule" do
     expect(
       rule_created?(
         cloudwatchevents_client,
@@ -156,8 +156,8 @@ describe '#rule_created?' do
   end
 end
 
-describe '#log_group_exists?' do
-  let(:log_group_name) { 'aws-doc-sdk-examples-cloudwatch-log' }
+describe "#log_group_exists?" do
+  let(:log_group_name) { "aws-doc-sdk-examples-cloudwatch-log" }
   let(:cloudwatchlogs_client) do
     Aws::CloudWatchLogs::Client.new(
       stub_responses: {
@@ -170,15 +170,15 @@ describe '#log_group_exists?' do
     )
   end
 
-  it 'checks whether a log group exists' do
+  it "checks whether a log group exists" do
     expect(
       log_group_exists?(cloudwatchlogs_client, log_group_name)
     ).to be(true)
   end
 end
 
-describe '#log_group_created?' do
-  let(:log_group_name) { 'aws-doc-sdk-examples-cloudwatch-log' }
+describe "#log_group_created?" do
+  let(:log_group_name) { "aws-doc-sdk-examples-cloudwatch-log" }
   let(:cloudwatchlogs_client) do
     Aws::CloudWatchLogs::Client.new(
       stub_responses: {
@@ -187,19 +187,20 @@ describe '#log_group_created?' do
     )
   end
 
-  it 'creates a log group' do
+  it "creates a log group" do
     expect(
       log_group_created?(cloudwatchlogs_client, log_group_name)
     ).to be(true)
   end
 end
 
-describe '#log_event' do
-  let(:log_group_name) { 'aws-doc-sdk-examples-cloudwatch-log' }
+describe "#log_event" do
+  let(:log_group_name) { "aws-doc-sdk-examples-cloudwatch-log" }
   let(:log_stream_name) { "#{Time.now.year}/#{Time.now.month}/#{Time.now.day}/" \
-    "#{SecureRandom.uuid}" }
+    "#{SecureRandom.uuid}"
+  }
   let(:message) { "Instance 'i-033c48ef067af3dEX' restarted." }
-  let(:sequence_token) { '495426724868310740095796045676567882148068632824696073EX' }
+  let(:sequence_token) { "495426724868310740095796045676567882148068632824696073EX" }
   let(:cloudwatchlogs_client) do
     Aws::CloudWatchLogs::Client.new(
       stub_responses: {
@@ -210,7 +211,7 @@ describe '#log_event' do
     )
   end
 
-  it 'logs an event' do
+  it "logs an event" do
     expect(
       log_event(
         cloudwatchlogs_client,
@@ -223,9 +224,9 @@ describe '#log_event' do
   end
 end
 
-describe '#instance_restarted?' do
-  let(:instance_id) { 'i-033c48ef067af3dEX' }
-  let(:log_group_name) { 'aws-doc-sdk-examples-cloudwatch-log' }
+describe "#instance_restarted?" do
+  let(:instance_id) { "i-033c48ef067af3dEX" }
+  let(:log_group_name) { "aws-doc-sdk-examples-cloudwatch-log" }
   let(:ec2_client) do
     Aws::EC2::Client.new(
       stub_responses: {
@@ -234,12 +235,12 @@ describe '#instance_restarted?' do
             {
               current_state: {
                 code: 80,
-                name: 'stopped'
+                name: "stopped"
               },
               instance_id: instance_id,
               previous_state: {
                 code: 16,
-                name: 'running'
+                name: "running"
               }
             }
           ]
@@ -249,12 +250,12 @@ describe '#instance_restarted?' do
             {
               current_state: {
                 code: 16,
-                name: 'running'
+                name: "running"
               },
               instance_id: instance_id,
               previous_state: {
                 code: 80,
-                name: 'stopped'
+                name: "stopped"
               }
             }
           ]
@@ -266,7 +267,7 @@ describe '#instance_restarted?' do
                 instance_id: instance_id,
                 state: {
                   code: 80,
-                  name: 'stopped'
+                  name: "stopped"
                 }
               ]
             ]
@@ -277,7 +278,7 @@ describe '#instance_restarted?' do
                 instance_id: instance_id,
                 state: {
                   code: 16,
-                  name: 'running'
+                  name: "running"
                 }
               ]
             ]
@@ -294,7 +295,7 @@ describe '#instance_restarted?' do
     )
   end
 
-  it 'restarts an instance and logs related events' do
+  it "restarts an instance and logs related events" do
     expect(
       instance_restarted?(
         ec2_client,
@@ -306,8 +307,8 @@ describe '#instance_restarted?' do
   end
 end
 
-describe '#display_rule_activity' do
-  let(:rule_name) { 'aws-doc-sdk-examples-ec2-state-change' }
+describe "#display_rule_activity" do
+  let(:rule_name) { "aws-doc-sdk-examples-ec2-state-change" }
   let(:start_time) { Time.now - 600 }
   let(:end_time) { Time.now }
   let(:period) { 60 }
@@ -318,11 +319,11 @@ describe '#display_rule_activity' do
           datapoints: [
             {
               sum: 1.0,
-              timestamp: Time.iso8601('2020-11-17T14:19:00-08:00')
+              timestamp: Time.iso8601("2020-11-17T14:19:00-08:00")
             },
             {
               sum: 2.0,
-              timestamp: Time.iso8601('2020-11-17T14:32:00-08:00')
+              timestamp: Time.iso8601("2020-11-17T14:32:00-08:00")
             }
           ]
         }
@@ -330,7 +331,7 @@ describe '#display_rule_activity' do
     )
   end
 
-  it 'displays activity for a rule' do
+  it "displays activity for a rule" do
     expect {
       display_rule_activity(
         cloudwatch_client,
@@ -343,10 +344,11 @@ describe '#display_rule_activity' do
   end
 end
 
-describe '#display_log_data' do
-  let(:log_group_name) { 'aws-doc-sdk-examples-cloudwatch-log' }
+describe "#display_log_data" do
+  let(:log_group_name) { "aws-doc-sdk-examples-cloudwatch-log" }
   let(:log_stream_name) { "#{Time.now.year}/#{Time.now.month}/#{Time.now.day}/" \
-    "#{SecureRandom.uuid}" }
+    "#{SecureRandom.uuid}"
+  }
   let(:cloudwatchlogs_client) do
     Aws::CloudWatchLogs::Client.new(
       stub_responses: {
@@ -371,7 +373,7 @@ describe '#display_log_data' do
     )
   end
 
-  it 'displays log streams data' do
+  it "displays log streams data" do
     expect {
       display_log_data(cloudwatchlogs_client, log_group_name)
     }.not_to raise_error

--- a/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-show-alarms.rb
+++ b/ruby/example_code/cloudwatch/tests/test_cw-ruby-example-show-alarms.rb
@@ -1,43 +1,43 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX - License - Identifier: Apache - 2.0
 
-require_relative '../cw-ruby-example-show-alarms'
+require_relative "../cw-ruby-example-show-alarms"
 
-describe '#describe_metric_alarms' do
-  let(:metric_namespace) { 'SITE/TRAFFIC' }
-  let(:metric_name) { 'UniqueVisitors' }
-  let(:dimension_name) { 'SiteName' }
-  let(:dimension_value) { 'example.com' }
+describe "#describe_metric_alarms" do
+  let(:metric_namespace) { "SITE/TRAFFIC" }
+  let(:metric_name) { "UniqueVisitors" }
+  let(:dimension_name) { "SiteName" }
+  let(:dimension_value) { "example.com" }
   let(:metric_value) { 5_885.0 }
-  let(:metric_unit) { 'Count' }
+  let(:metric_unit) { "Count" }
   let(:cloudwatch_client) do
     Aws::CloudWatch::Client.new(
       stub_responses: {
         describe_alarms: {
           metric_alarms: [
             {
-              alarm_name: 'ObjectsInBucket',
-              state_value: 'INSUFFICIENT_DATA',
-              state_reason: 'Unchecked: Initial alarm creation',
-              metric_name: 'NumberOfObjects',
-              namespace: 'AWS/S3',
-              statistic: 'Average',
+              alarm_name: "ObjectsInBucket",
+              state_value: "INSUFFICIENT_DATA",
+              state_reason: "Unchecked: Initial alarm creation",
+              metric_name: "NumberOfObjects",
+              namespace: "AWS/S3",
+              statistic: "Average",
               period: 86_400,
-              unit: 'Count',
+              unit: "Count",
               evaluation_periods: 1,
               threshold: 1.0,
-              comparison_operator: 'GreaterThanThreshold',
+              comparison_operator: "GreaterThanThreshold",
               ok_actions: [
-                'arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic'
+                "arn:aws:sns:us-east-1:111111111111:Default_CloudWatch_Alarms_Topic"
               ],
               dimensions: [
                 {
-                  name: 'BucketName',
-                  value: 'doc-example-bucket'
+                  name: "BucketName",
+                  value: "doc-example-bucket"
                 },
                 {
-                    name: 'StorageType',
-                    value: 'AllStorageTypes'
+                    name: "StorageType",
+                    value: "AllStorageTypes"
                 }
               ]
             }
@@ -47,7 +47,7 @@ describe '#describe_metric_alarms' do
     )
   end
 
-  it 'shows information about metric alarms' do
+  it "shows information about metric alarms" do
     expect { describe_metric_alarms(cloudwatch_client) }.not_to raise_error
   end
 end

--- a/ruby/example_code/codebuild/README.md
+++ b/ruby/example_code/codebuild/README.md
@@ -43,7 +43,7 @@ and produces artifacts that are ready to deploy.
 Most of these code example files can be run with very little to no modification. For example, to use Ruby to run the `aws-ruby-sdk-codebuild-example-build-project.rb` file, replace the hard-coded values in the file with your own values, save the file, and then run the file. For example:
 
 ```
-ruby aws-ruby-sdk-codebuild-example-build-project.rb
+ruby aws-ruby-sdk-codebuild-example-build-project.rb my-project
 ```
 
 ## Additional information

--- a/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-build-project.rb
+++ b/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-build-project.rb
@@ -8,23 +8,23 @@
 
 # snippet-start:[codebuild.Ruby.buildProject]
 
-require 'aws-sdk-codebuild'  # v2: require 'aws-sdk'
+require "aws-sdk-codebuild"  # v2: require 'aws-sdk'
 
-project_name = ''
+project_name = ""
 
 if ARGV.length != 1
-  puts 'You must supply the name of the project to build'
+  puts "You must supply the name of the project to build"
   exit 1
 else
   project_name = ARGV[0]
 end
 # Replace us-west-2 with the AWS Region you're using for Amazon CodeBuild.
-client = Aws::CodeBuild::Client.new(region: 'us-west-2')
+client = Aws::CodeBuild::Client.new(region: "us-west-2")
 
 begin
   client.start_build(project_name: project_name)
-  puts 'Building project ' + project_name
+  puts "Building project " + project_name
 rescue StandardError => ex
-  puts 'Error building project: ' + ex.message
+  puts "Error building project: " + ex.message
 end
 # snippet-end:[codebuild.Ruby.buildProject]

--- a/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-list-builds.rb
+++ b/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-list-builds.rb
@@ -7,18 +7,22 @@
 
 # snippet-start:[codebuild.Ruby.listBuilds]
 
-require 'aws-sdk-codebuild'  # v2: require 'aws-sdk'
+require "aws-sdk-codebuild"  # v2: require 'aws-sdk'
 
 # Replace us-west-2 with the AWS Region you're using for Amazon CodeBuild.
-client = Aws::CodeBuild::Client.new(region: 'us-west-2')
+client = Aws::CodeBuild::Client.new(region: "us-east-1")
 
-build_list = client.list_builds({sort_order: 'ASCENDING', })
+build_list = client.list_builds({sort_order: "ASCENDING", })
 
-builds = client.batch_get_builds({ids: build_list.ids})
+if build_list.ids.empty?
+  puts "No builds found!"
+else
+  builds = client.batch_get_builds({ids: build_list.ids})
 
-builds.builds.each do |build|
-  puts 'Project:    ' + build.project_name
-  puts 'Phase:      ' + build.current_phase
-  puts 'Status:     ' + build.build_status
+  builds.builds.each do |build|
+    puts "Project:    " + build.project_name
+    puts "Phase:      " + build.current_phase
+    puts "Status:     " + build.build_status
+  end
 end
 # snippet-end:[codebuild.Ruby.listBuilds]

--- a/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-list-projects.rb
+++ b/ruby/example_code/codebuild/aws-ruby-sdk-codebuild-example-list-projects.rb
@@ -7,17 +7,21 @@
 
 # snippet-start:[codebuild.Ruby.listProjects]
 
-require 'aws-sdk-codebuild'  # v2: require 'aws-sdk'
+require "aws-sdk-codebuild"  # v2: require 'aws-sdk'
 
 # Replace us-west-2 with the AWS Region you're using for Amazon CodeBuild.
-client = Aws::CodeBuild::Client.new(region: 'REGION')
+client = Aws::CodeBuild::Client.new(region: "us-east-1")
 
 resp = client.list_projects({
-  sort_by: 'NAME', # accepts NAME, CREATED_TIME, LAST_MODIFIED_TIME
-  sort_order: 'ASCENDING' # accepts ASCENDING, DESCENDING
+  sort_by: "NAME", # accepts NAME, CREATED_TIME, LAST_MODIFIED_TIME
+  sort_order: "ASCENDING" # accepts ASCENDING, DESCENDING
 })
 
-resp.projects.each { |p| puts p }
+if resp.projects.empty?
+  puts "No projects found!"
+else
+  resp.projects.each { |p| puts p }
+end
 
 puts
 # snippet-end:[codebuild.Ruby.listProjects]


### PR DESCRIPTION
# what's in this PR
A few simple fixes to make the CloudWatch and CodeBuild examples "work" when invoked via the CLI.