### PR TITLE
fix(sec): upgrade org.jetbrains.kotlin:kotlin-stdlib to 1.6.0

### DIFF
--- a/kotlin/usecases/creating_workflows_stepfunctions/pom.xml
+++ b/kotlin/usecases/creating_workflows_stepfunctions/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.5.21</version>
+            <version>1.6.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl -->
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.jetbrains.kotlin:kotlin-stdlib 1.5.21
- [CVE-2022-24329](https://www.oscs1024.com/hd/CVE-2022-24329)


### What did I do？
Upgrade org.jetbrains.kotlin:kotlin-stdlib from 1.5.21 to 1.6.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS