### PR TITLE
Fix some UI issues with Item Tracker

### DIFF
--- a/resources/clients/react/elwing/src/plugins/item-tracker/ItemTrackerComponent.tsx
+++ b/resources/clients/react/elwing/src/plugins/item-tracker/ItemTrackerComponent.tsx
@@ -15,8 +15,8 @@ const Component = () => {
         <Grid gridDefinition={[{ colspan: 9 }, { colspan: 3 }]}>
           <WorkItems />
           <WorkItemControls />
-          <AddWorkItem />
         </Grid>
+        <AddWorkItem />
       </Container>
     </>
   );

--- a/resources/clients/react/elwing/src/plugins/item-tracker/ItemTrackerReadmeComponent.tsx
+++ b/resources/clients/react/elwing/src/plugins/item-tracker/ItemTrackerReadmeComponent.tsx
@@ -10,7 +10,7 @@ export function Readme() {
         A sample application that shows you how to track work items served by a
         REST endpoint.
       </Box>
-      <Box variant="p">
+      <Box variant="div">
         <Header variant="h2">Services used</Header>
         <ul>
           <li>
@@ -25,7 +25,7 @@ export function Readme() {
           </li>
         </ul>
       </Box>
-      <Box variant="p">
+      <Box variant="div">
         <Header variant="h2">Available backends</Header>
         <ul>
           <li>

--- a/resources/clients/react/elwing/src/plugins/item-tracker/work-item/WorkItemListComponent.tsx
+++ b/resources/clients/react/elwing/src/plugins/item-tracker/work-item/WorkItemListComponent.tsx
@@ -91,6 +91,7 @@ export const WorkItems = () => {
     <Table
       variant="embedded"
       selectedItems={selected}
+      sortingDisabled
       onSelectionChange={({ detail }) =>
         setSelected(detail.selectedItems as WorkItem[])
       }


### PR DESCRIPTION
* Address warning about column definition/children mismatch
* Address warning about 'h2' being child of 'p'
* Disable sorting. Implementing it is more complicated than it's worth for now.