### PR TITLE
Use the "https" protocol instead of "http" in SubscribeHTTPS.java

### DIFF
--- a/javav2/example_code/sns/src/main/java/com/example/sns/SubscribeHTTPS.java
+++ b/javav2/example_code/sns/src/main/java/com/example/sns/SubscribeHTTPS.java
@@ -57,7 +57,7 @@ public class SubscribeHTTPS {
 
         try {
             SubscribeRequest request = SubscribeRequest.builder()
-                .protocol("http")
+                .protocol("https")
                 .endpoint(url)
                 .returnSubscriptionArn(true)
                 .topicArn(topicArn)


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

## I'm resolving an issue with an existing code example

In the `SubscribeHTTPS.java` example, all code references (class name, method names, etc.) indicate the intention to use the `"https"` protocol. However, `"http"` is used instead. Since `"http"` and `"https"` are separate SNS protocol options, I'm submitting this PR to include `"https"` in the example.

Confirm you have met the following minimum requirements:

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [x] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
***
## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
