### PR TITLE
Rust SDK: use main after release

### DIFF
--- a/rust_dev_preview/sdk-config/Cargo.toml
+++ b/rust_dev_preview/sdk-config/Cargo.toml
@@ -10,12 +10,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
   "rustls",
 ] }
-aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }


### PR DESCRIPTION
Update some Cargo.tomls to use main, now that their release is complete.