### PR TITLE
script locally disables auto-prompt

### DIFF
--- a/aws-cli/bash-linux/ec2/change-ec2-instance-type/change_ec2_instance_type.sh
+++ b/aws-cli/bash-linux/ec2/change-ec2-instance-type/change_ec2_instance_type.sh
@@ -44,7 +44,7 @@
 source awsdocs_general.sh
 
 ###############################################################################
-# function instance-exists
+# function get_instance_info
 #
 # This function checks to see if the specified instance already exists. If it
 # does, it sets two global parameters to return the running state and the
@@ -100,6 +100,9 @@ function get_instance_info {
 ######################################
 
 function change_ec2_instance_type {
+
+    local -x AWS_CLI_AUTO_PROMPT
+    AWS_CLI_AUTO_PROMPT=off
 
     function usage() (
         echo ""


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

## I'm resolving an issue with an existing code example

Describe the changes you have made here, including any issue numbers.

1. Script didn't work for me without disabling auto-prompt, so I set that variable to "off" locally.
2. Renamed a function to match its actual name in the code.

Confirm you have met the following minimum requirements:

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [ ] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
***
## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
