### PR TITLE
Update Shirriff to mention the correct group.

### DIFF
--- a/.github/workflows/shirriff.yml
+++ b/.github/workflows/shirriff.yml
@@ -18,5 +18,5 @@ jobs:
           stale-issue-label: "status/stale"
           days-before-stale: 21
           days-before-close: -1
-          stale-issue-message: "Marked stale by the Shirriff. Notifying @aws-sdk-docs-code-maintainers"
-          stale-pr-message: "Marked stale by the Shirriff. Notifying @aws-sdk-docs-code-maintainers"
+          stale-issue-message: "Marked stale by the Shirriff. Notifying @awsdocs/aws-sdk-docs-code-maintainers"
+          stale-pr-message: "Marked stale by the Shirriff. Notifying @awsdocs/aws-sdk-docs-code-maintainers"


### PR DESCRIPTION
`@awsdocs` was missing from the maintainers group. Fixed that.