### PR TITLE
Fix the Rust examples after the errors refactor

### DIFF
--- a/rust_dev_preview/apigateway/Cargo.toml
+++ b/rust_dev_preview/apigateway/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-apigateway = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-apigateway = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
-tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
+thiserror = "1.0"
+tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/apigateway/src/lib.rs
+++ b/rust_dev_preview/apigateway/src/lib.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::error::Error as StdError;
+
+#[derive(thiserror::Error, Debug)]
+#[error("unhandled error")]
+pub struct Error {
+    #[source]
+    source: Box<dyn StdError + Send + Sync + 'static>,
+}
+
+impl Error {
+    pub fn unhandled(source: impl Into<Box<dyn StdError + Send + Sync + 'static>>) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+impl From<aws_sdk_apigateway::Error> for Error {
+    fn from(source: aws_sdk_apigateway::Error) -> Self {
+        Error::unhandled(source)
+    }
+}
+
+impl<T> From<aws_sdk_apigateway::types::SdkError<T>> for Error
+where
+    T: StdError + Send + Sync + 'static,
+{
+    fn from(source: aws_sdk_apigateway::types::SdkError<T>) -> Self {
+        Error::unhandled(source)
+    }
+}
+
+impl From<aws_smithy_types_convert::date_time::Error> for Error {
+    fn from(source: aws_smithy_types_convert::date_time::Error) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}

--- a/rust_dev_preview/cognitoidentity/Cargo.toml
+++ b/rust_dev_preview/cognitoidentity/Cargo.toml
@@ -10,12 +10,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cognitoidentity = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cognitoidentity = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
-tokio = { version = "1.20.1", features = ["full"] }
 chrono = "0.4"
 structopt = { version = "0.3", default-features = false }
+thiserror = "1.0"
+tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/cognitoidentity/src/lib.rs
+++ b/rust_dev_preview/cognitoidentity/src/lib.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::error::Error as StdError;
+
+#[derive(thiserror::Error, Debug)]
+#[error("unhandled error")]
+pub struct Error {
+    #[from]
+    source: Box<dyn StdError + Send + Sync + 'static>,
+}
+
+impl From<aws_sdk_cognitoidentity::Error> for Error {
+    fn from(source: aws_sdk_cognitoidentity::Error) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+impl<T> From<aws_sdk_cognitoidentity::types::SdkError<T>> for Error
+where
+    T: StdError + Send + Sync + 'static,
+{
+    fn from(source: aws_sdk_cognitoidentity::types::SdkError<T>) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+impl From<aws_smithy_types_convert::date_time::Error> for Error {
+    fn from(source: aws_smithy_types_convert::date_time::Error) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}

--- a/rust_dev_preview/cognitoidentityprovider/Cargo.toml
+++ b/rust_dev_preview/cognitoidentityprovider/Cargo.toml
@@ -10,11 +10,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cognitoidentityprovider = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cognitoidentityprovider = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
-tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
+thiserror = "1.0"
+tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/cognitoidentityprovider/src/lib.rs
+++ b/rust_dev_preview/cognitoidentityprovider/src/lib.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::error::Error as StdError;
+
+#[derive(thiserror::Error, Debug)]
+#[error("unhandled error")]
+pub struct Error {
+    #[source]
+    source: Box<dyn StdError + Send + Sync + 'static>,
+}
+
+impl Error {
+    pub fn unhandled(source: impl Into<Box<dyn StdError + Send + Sync + 'static>>) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+impl From<aws_sdk_cognitoidentityprovider::Error> for Error {
+    fn from(source: aws_sdk_cognitoidentityprovider::Error) -> Self {
+        Error::unhandled(source)
+    }
+}
+
+impl<T> From<aws_sdk_cognitoidentityprovider::types::SdkError<T>> for Error
+where
+    T: StdError + Send + Sync + 'static,
+{
+    fn from(source: aws_sdk_cognitoidentityprovider::types::SdkError<T>) -> Self {
+        Error::unhandled(source)
+    }
+}
+
+impl From<aws_smithy_types_convert::date_time::Error> for Error {
+    fn from(source: aws_smithy_types_convert::date_time::Error) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}

--- a/rust_dev_preview/cognitosync/Cargo.toml
+++ b/rust_dev_preview/cognitosync/Cargo.toml
@@ -10,11 +10,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cognitosync = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cognitosync = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
-tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
+thiserror = "1.0"
+tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/cognitosync/src/lib.rs
+++ b/rust_dev_preview/cognitosync/src/lib.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::error::Error as StdError;
+
+#[derive(thiserror::Error, Debug)]
+#[error("unhandled error")]
+pub struct Error {
+    #[source]
+    source: Box<dyn StdError + Send + Sync + 'static>,
+}
+
+impl Error {
+    pub fn unhandled(source: impl Into<Box<dyn StdError + Send + Sync + 'static>>) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+impl From<aws_sdk_cognitosync::Error> for Error {
+    fn from(source: aws_sdk_cognitosync::Error) -> Self {
+        Error::unhandled(source)
+    }
+}
+
+impl<T> From<aws_sdk_cognitosync::types::SdkError<T>> for Error
+where
+    T: StdError + Send + Sync + 'static,
+{
+    fn from(source: aws_sdk_cognitosync::types::SdkError<T>) -> Self {
+        Error::unhandled(source)
+    }
+}
+
+impl From<aws_smithy_types_convert::date_time::Error> for Error {
+    fn from(source: aws_smithy_types_convert::date_time::Error) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}

--- a/rust_dev_preview/dynamodb/Cargo.toml
+++ b/rust_dev_preview/dynamodb/Cargo.toml
@@ -10,18 +10,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "client-hyper",
   "rustls",
   "rt-tokio",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "rt-tokio",
 ] }
-aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 axum = "0.5.16"
 http = "0.2.5"
 futures = "0.3"

--- a/rust_dev_preview/dynamodb/src/bin/create-table.rs
+++ b/rust_dev_preview/dynamodb/src/bin/create-table.rs
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_dynamodb::{Client, Error};
-use dynamodb_code_examples::{make_config, scenario::create::create_table, Opt as BaseOpt};
+use aws_sdk_dynamodb::{types::DisplayErrorContext, Client};
+use dynamodb_code_examples::{
+    make_config, scenario::create::create_table, scenario::error::Error, Opt as BaseOpt,
+};
+use std::process;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -31,12 +34,20 @@ struct Opt {
 ///    If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() {
     tracing_subscriber::fmt::init();
-    let Opt { table, key, base } = Opt::from_args();
 
+    if let Err(err) = run_example(Opt::from_args()).await {
+        eprintln!("Error: {}", DisplayErrorContext(err));
+        process::exit(1);
+    }
+}
+
+async fn run_example(Opt { table, key, base }: Opt) -> Result<(), Error> {
     let shared_config = make_config(base).await?;
     let client = Client::new(&shared_config);
 
-    create_table(&client, &table, &key).await
+    create_table(&client, &table, &key).await?;
+
+    Ok(())
 }

--- a/rust_dev_preview/dynamodb/src/bin/delete-item.rs
+++ b/rust_dev_preview/dynamodb/src/bin/delete-item.rs
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_dynamodb::{Client, Error};
-use dynamodb_code_examples::{make_config, scenario::delete::delete_item, Opt as BaseOpt};
+use aws_sdk_dynamodb::{types::DisplayErrorContext, Client};
+use dynamodb_code_examples::{
+    make_config, scenario::delete::delete_item, scenario::error::Error, Opt as BaseOpt,
+};
+use std::process;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -37,18 +40,27 @@ struct Opt {
 ///   If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() {
     tracing_subscriber::fmt::init();
 
-    let Opt {
+    if let Err(err) = run_example(Opt::from_args()).await {
+        eprintln!("Error: {}", DisplayErrorContext(err));
+        process::exit(1);
+    }
+}
+
+async fn run_example(
+    Opt {
         key,
         table,
         value,
         base,
-    } = Opt::from_args();
-
+    }: Opt,
+) -> Result<(), Error> {
     let shared_config = make_config(base).await?;
     let client = Client::new(&shared_config);
 
-    delete_item(&client, &table, &key, &value).await
+    delete_item(&client, &table, &key, &value).await?;
+
+    Ok(())
 }

--- a/rust_dev_preview/dynamodb/src/bin/delete-table.rs
+++ b/rust_dev_preview/dynamodb/src/bin/delete-table.rs
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_dynamodb::{Client, Error};
-use dynamodb_code_examples::{make_config, scenario::delete::delete_table, Opt as BaseOpt};
+use aws_sdk_dynamodb::{types::DisplayErrorContext, Client};
+use dynamodb_code_examples::{
+    make_config, scenario::delete::delete_table, scenario::error::Error, Opt as BaseOpt,
+};
+use std::process;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -26,11 +29,18 @@ struct Opt {
 ///    If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
-async fn main() -> Result<(), Error> {
-    let Opt { table, base } = Opt::from_args();
+async fn main() {
+    if let Err(err) = run_example(Opt::from_args()).await {
+        eprintln!("Error: {}", DisplayErrorContext(err));
+        process::exit(1);
+    }
+}
 
+async fn run_example(Opt { table, base }: Opt) -> Result<(), Error> {
     let shared_config = make_config(base).await?;
     let client = Client::new(&shared_config);
 
-    delete_table(&client, &table).await
+    delete_table(&client, &table).await?;
+
+    Ok(())
 }

--- a/rust_dev_preview/dynamodb/src/bin/movies.rs
+++ b/rust_dev_preview/dynamodb/src/bin/movies.rs
@@ -5,11 +5,13 @@
 
 use std::net::{Ipv4Addr, SocketAddr};
 
-use aws_sdk_dynamodb::{Client, Error};
+use aws_sdk_dynamodb::{types::DisplayErrorContext, Client};
 use axum::extract::Extension;
+use dynamodb_code_examples::scenario::error::Error;
 use dynamodb_code_examples::scenario::movies::server::{make_app, movies_in_year};
 use dynamodb_code_examples::scenario::movies::shutdown::{remove_table, shutdown_signal};
 use dynamodb_code_examples::scenario::movies::{startup::initialize, TABLE_NAME};
+use std::process;
 
 async fn run(client: Client) {
     let app = make_app()
@@ -51,9 +53,16 @@ async fn verify(client: &Client) -> Result<(), Error> {
 /// 2. Verify the table has data.
 /// 3. Start an HTTP server to return subsets of those rows.
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() {
     tracing_subscriber::fmt::init();
 
+    if let Err(err) = run_example().await {
+        eprintln!("Error: {}", DisplayErrorContext(err));
+        process::exit(1);
+    }
+}
+
+async fn run_example() -> Result<(), Error> {
     let config = aws_config::from_env().load().await;
     let client = Client::new(&config);
 

--- a/rust_dev_preview/dynamodb/src/scenario/create.rs
+++ b/rust_dev_preview/dynamodb/src/scenario/create.rs
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+use crate::scenario::error::Error;
 use aws_sdk_dynamodb::model::{
     AttributeDefinition, KeySchemaElement, KeyType, ProvisionedThroughput, ScalarAttributeType,
 };
-use aws_sdk_dynamodb::{Client, Error};
+use aws_sdk_dynamodb::Client;
 
 // Create a table.
 // snippet-start:[dynamodb.rust.create-table]
@@ -46,7 +47,7 @@ pub async fn create_table(client: &Client, table: &str, key: &str) -> Result<(),
         Err(e) => {
             eprintln!("Got an error creating table:");
             eprintln!("{}", e);
-            Err(Error::Unhandled(Box::new(e)))
+            Err(Error::unhandled(e))
         }
     }
 }

--- a/rust_dev_preview/dynamodb/src/scenario/delete.rs
+++ b/rust_dev_preview/dynamodb/src/scenario/delete.rs
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_dynamodb::{model::AttributeValue, Client, Error};
+use crate::scenario::error::Error;
+use aws_sdk_dynamodb::{model::AttributeValue, Client};
 
 // Deletes an item from the table.
 // snippet-start:[dynamodb.rust.delete-item]
@@ -24,7 +25,7 @@ pub async fn delete_item(
             println!("Deleted item from table");
             Ok(())
         }
-        Err(e) => Err(Error::Unhandled(Box::new(e))),
+        Err(e) => Err(Error::unhandled(e)),
     }
 }
 // snippet-end:[dynamodb.rust.delete-item]

--- a/rust_dev_preview/dynamodb/src/scenario/error.rs
+++ b/rust_dev_preview/dynamodb/src/scenario/error.rs
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::error::Error as StdError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("table was not ready after several attempts: {0}")]
+    TableNotReady(String),
+    #[error("unhandled error")]
+    Unhandled(#[source] Box<dyn StdError + Send + Sync + 'static>),
+}
+
+impl Error {
+    pub fn table_not_ready(table_name: impl Into<String>) -> Self {
+        Self::TableNotReady(table_name.into())
+    }
+
+    pub fn unhandled(source: impl Into<Box<dyn StdError + Send + Sync + 'static>>) -> Self {
+        Self::Unhandled(source.into())
+    }
+}
+
+impl From<aws_sdk_dynamodb::Error> for Error {
+    fn from(source: aws_sdk_dynamodb::Error) -> Self {
+        Error::unhandled(source)
+    }
+}
+
+impl<T> From<aws_sdk_dynamodb::types::SdkError<T>> for Error
+where
+    T: StdError + Send + Sync + 'static,
+{
+    fn from(source: aws_sdk_dynamodb::types::SdkError<T>) -> Self {
+        Error::unhandled(source)
+    }
+}

--- a/rust_dev_preview/dynamodb/src/scenario/mod.rs
+++ b/rust_dev_preview/dynamodb/src/scenario/mod.rs
@@ -6,5 +6,6 @@
 pub mod add;
 pub mod create;
 pub mod delete;
+pub mod error;
 pub mod list;
 pub mod movies;

--- a/rust_dev_preview/s3/Cargo.toml
+++ b/rust_dev_preview/s3/Cargo.toml
@@ -21,19 +21,20 @@ assert_cmd = "2.0"
 predicates = "2.1"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 # snippet-start:[s3.rust.s3-object-lambda-cargo.toml]
-aws-endpoint = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-endpoint = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 # snippet-end:[s3.rust.s3-object-lambda-cargo.toml]
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-tokio = { version = "1.20.1", features = ["full"] }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["rt-tokio"] }
+bytes = "0.4.12"
+futures-util = { version = "0.3.21", features = ["alloc"] }
+http-body = "0.4.5"
+md-5 = "0.10.1"
+rand = "0.5.0"
 structopt = { version = "0.3", default-features = false }
+thiserror = "1.0"
+tokio = { version = "1.20.1", features = ["full"] }
+tokio-stream = "0.1.8"
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["rt-tokio"] }
-tokio-stream = "0.1.8"
-md-5 = "0.10.1"
-bytes = "0.4.12"
-http-body = "0.4.5"
-rand = "0.5.0"
-futures-util = { version = "0.3.21", features = ["alloc"] }

--- a/rust_dev_preview/s3/src/bin/s3-getting-started.rs
+++ b/rust_dev_preview/s3/src/bin/s3-getting-started.rs
@@ -20,7 +20,8 @@ user guide.
 // snippet-start:[rust.example_code.s3.basics.imports]
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::{Client, Error, Region};
+use aws_sdk_s3::{Client, Region};
+use s3_service::error::Error;
 use uuid::Uuid;
 
 // snippet-end:[rust.example_code.s3.basics.imports]

--- a/rust_dev_preview/s3/src/bin/s3-multipart-upload.rs
+++ b/rust_dev_preview/s3/src/bin/s3-multipart-upload.rs
@@ -13,10 +13,13 @@ use std::path::Path;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::model::{CompletedMultipartUpload, CompletedPart};
 use aws_sdk_s3::output::{CreateMultipartUploadOutput, GetObjectOutput};
-use aws_sdk_s3::{Client as S3Client, Error, Region};
+use aws_sdk_s3::types::DisplayErrorContext;
+use aws_sdk_s3::{Client as S3Client, Region};
 use aws_smithy_http::byte_stream::{ByteStream, Length};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
+use s3_service::error::Error;
+use std::process;
 use uuid::Uuid;
 
 //In bytes, minimum chunk size of 5MB. Increase CHUNK_SIZE to send larger chunks.
@@ -24,7 +27,14 @@ const CHUNK_SIZE: u64 = 1024 * 1024 * 5;
 const MAX_CHUNKS: u64 = 10000;
 
 #[tokio::main]
-pub async fn main() -> Result<(), Error> {
+pub async fn main() {
+    if let Err(err) = run_example().await {
+        eprintln!("Error: {}", DisplayErrorContext(err));
+        process::exit(1);
+    }
+}
+
+async fn run_example() -> Result<(), Error> {
     let shared_config = aws_config::load_from_env().await;
     let client = S3Client::new(&shared_config);
 

--- a/rust_dev_preview/s3/src/error.rs
+++ b/rust_dev_preview/s3/src/error.rs
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::error::Error as StdError;
+
+#[derive(thiserror::Error, Debug)]
+#[error("unhandled error")]
+pub struct Error {
+    #[from]
+    source: Box<dyn StdError + Send + Sync + 'static>,
+}
+
+impl Error {
+    pub fn unhandled(source: impl Into<Box<dyn StdError + Send + Sync + 'static>>) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+impl From<aws_sdk_s3::Error> for Error {
+    fn from(source: aws_sdk_s3::Error) -> Self {
+        Self::unhandled(source)
+    }
+}
+
+impl<T> From<aws_sdk_s3::types::SdkError<T>> for Error
+where
+    T: StdError + Send + Sync + 'static,
+{
+    fn from(source: aws_sdk_s3::types::SdkError<T>) -> Self {
+        Self::unhandled(source)
+    }
+}

--- a/rust_dev_preview/s3/src/s3-service-lib.rs
+++ b/rust_dev_preview/s3/src/s3-service-lib.rs
@@ -10,9 +10,12 @@ use aws_sdk_s3::model::{
 };
 use aws_sdk_s3::output::{GetObjectOutput, ListObjectsV2Output};
 use aws_sdk_s3::types::ByteStream;
-use aws_sdk_s3::{Client, Error};
+use aws_sdk_s3::Client;
+use error::Error;
 use std::path::Path;
 use std::str;
+
+pub mod error;
 
 // snippet-start:[rust.example_code.s3.basics.delete_bucket]
 pub async fn delete_bucket(client: &Client, bucket_name: &str) -> Result<(), Error> {
@@ -43,9 +46,9 @@ pub async fn delete_objects(client: &Client, bucket_name: &str) -> Result<(), Er
     let objects: ListObjectsV2Output = client.list_objects_v2().bucket(bucket_name).send().await?;
     match objects.key_count {
         0 => Ok(()),
-        _ => Err(Error::Unhandled(Box::from(
+        _ => Err(Error::unhandled(
             "There were still objects left in the bucket.",
-        ))),
+        )),
     }
 }
 // snippet-end:[rust.example_code.s3.basics.delete_objects]

--- a/rust_dev_preview/s3/tests/test-s3-getting-started.rs
+++ b/rust_dev_preview/s3/tests/test-s3-getting-started.rs
@@ -4,7 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::{Client, Error, Region};
+use aws_sdk_s3::{Client, Region};
+use s3_service::error::Error;
 use uuid::Uuid;
 
 #[ignore]

--- a/rust_dev_preview/sagemaker/Cargo.toml
+++ b/rust_dev_preview/sagemaker/Cargo.toml
@@ -10,11 +10,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sagemaker = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sagemaker = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
-tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
+thiserror = "1.0"
+tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/sagemaker/src/bin/list-training-jobs.rs
+++ b/rust_dev_preview/sagemaker/src/bin/list-training-jobs.rs
@@ -4,8 +4,9 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sagemaker::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sagemaker::{Client, Region, PKG_VERSION};
 use aws_smithy_types_convert::date_time::DateTimeExt;
+use sagemaker_code_examples::Error;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -28,8 +29,8 @@ async fn show_jobs(client: &Client) -> Result<(), Error> {
 
     for j in job_details.training_job_summaries().unwrap_or_default() {
         let name = j.training_job_name().unwrap_or_default();
-        let creation_time = j.creation_time().unwrap().to_chrono_utc();
-        let training_end_time = j.training_end_time().unwrap().to_chrono_utc();
+        let creation_time = j.creation_time().unwrap().to_chrono_utc()?;
+        let training_end_time = j.training_end_time().unwrap().to_chrono_utc()?;
 
         let status = j.training_job_status().unwrap();
         let duration = training_end_time - creation_time;

--- a/rust_dev_preview/sagemaker/src/lib.rs
+++ b/rust_dev_preview/sagemaker/src/lib.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::error::Error as StdError;
+
+#[derive(thiserror::Error, Debug)]
+#[error("unhandled error")]
+pub struct Error {
+    #[from]
+    source: Box<dyn StdError + Send + Sync + 'static>,
+}
+
+impl From<aws_sdk_sagemaker::Error> for Error {
+    fn from(source: aws_sdk_sagemaker::Error) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+impl<T> From<aws_sdk_sagemaker::types::SdkError<T>> for Error
+where
+    T: StdError + Send + Sync + 'static,
+{
+    fn from(source: aws_sdk_sagemaker::types::SdkError<T>) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+impl From<aws_smithy_types_convert::date_time::Error> for Error {
+    fn from(source: aws_smithy_types_convert::date_time::Error) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}

--- a/rust_dev_preview/sitewise/Cargo.toml
+++ b/rust_dev_preview/sitewise/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2021"
 # For more keys and their definitions, see https://doc.rust-lang.org/cargo/reference/manifest.html.
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-iotsitewise = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-iotsitewise = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
-tokio = { version = "1.20.1", features = ["full"] } 
 structopt = { version = "0.3", default-features = false }
+thiserror = "1.0"
+tokio = { version = "1.20.1", features = ["full"] } 
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/sitewise/src/bin/describe-asset.rs
+++ b/rust_dev_preview/sitewise/src/bin/describe-asset.rs
@@ -4,8 +4,11 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iotsitewise::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_iotsitewise::types::DisplayErrorContext;
+use aws_sdk_iotsitewise::{Client, Region, PKG_VERSION};
 use aws_smithy_types_convert::date_time::DateTimeExt;
+use sitewise_code_examples::Error;
+use std::process;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -43,11 +46,11 @@ async fn list_assets(client: &Client, asset_id: Option<String>) -> Result<(), Er
     );
     println!(
         "  Asset Creation Date:   {}",
-        asset.asset_creation_date().unwrap().to_chrono_utc()
+        asset.asset_creation_date().unwrap().to_chrono_utc()?
     );
     println!(
         "  Asset Last Update Date:   {}",
-        asset.asset_last_update_date().unwrap().to_chrono_utc()
+        asset.asset_last_update_date().unwrap().to_chrono_utc()?
     );
     println!(
         "  Asset Status:   {}",
@@ -175,14 +178,22 @@ async fn list_assets(client: &Client, asset_id: Option<String>) -> Result<(), Er
 ///   If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display information.
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() {
     tracing_subscriber::fmt::init();
-    let Opt {
+
+    if let Err(err) = run_example(Opt::from_args()).await {
+        eprintln!("Error: {}", DisplayErrorContext(err));
+        process::exit(1);
+    }
+}
+
+async fn run_example(
+    Opt {
         region,
         asset_id,
         verbose,
-    } = Opt::from_args();
-
+    }: Opt,
+) -> Result<(), Error> {
     let region_provider = RegionProviderChain::first_try(region.map(Region::new))
         .or_default_provider()
         .or_else(Region::new("us-west-2"));

--- a/rust_dev_preview/sitewise/src/bin/list-asset-models.rs
+++ b/rust_dev_preview/sitewise/src/bin/list-asset-models.rs
@@ -4,8 +4,11 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iotsitewise::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_iotsitewise::types::DisplayErrorContext;
+use aws_sdk_iotsitewise::{Client, Region, PKG_VERSION};
 use aws_smithy_types_convert::date_time::DateTimeExt;
+use sitewise_code_examples::Error;
+use std::process;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -36,11 +39,11 @@ async fn list_asset_models(client: &Client) -> Result<(), Error> {
         );
         println!(
             "  Creation Date:   {}",
-            asset.creation_date().unwrap().to_chrono_utc()
+            asset.creation_date().unwrap().to_chrono_utc()?
         );
         println!(
             "  Last Update Date:   {}",
-            asset.last_update_date().unwrap().to_chrono_utc()
+            asset.last_update_date().unwrap().to_chrono_utc()?
         );
         println!(
             "  Current Status:   {}",
@@ -66,10 +69,16 @@ async fn list_asset_models(client: &Client) -> Result<(), Error> {
 ///   If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display information.
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() {
     tracing_subscriber::fmt::init();
-    let Opt { region, verbose } = Opt::from_args();
 
+    if let Err(err) = run_example(Opt::from_args()).await {
+        eprintln!("Error: {}", DisplayErrorContext(err));
+        process::exit(1);
+    }
+}
+
+async fn run_example(Opt { region, verbose }: Opt) -> Result<(), Error> {
     let region_provider = RegionProviderChain::first_try(region.map(Region::new))
         .or_default_provider()
         .or_else(Region::new("us-west-2"));

--- a/rust_dev_preview/sitewise/src/bin/list-assets.rs
+++ b/rust_dev_preview/sitewise/src/bin/list-assets.rs
@@ -4,8 +4,11 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iotsitewise::{model::ListAssetsFilter, Client, Error, Region, PKG_VERSION};
+use aws_sdk_iotsitewise::types::DisplayErrorContext;
+use aws_sdk_iotsitewise::{model::ListAssetsFilter, Client, Region, PKG_VERSION};
 use aws_smithy_types_convert::date_time::DateTimeExt;
+use sitewise_code_examples::Error;
+use std::process;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -53,11 +56,11 @@ async fn list_assets(
         );
         println!(
             "  Creation Date:   {}",
-            asset.creation_date.unwrap().to_chrono_utc()
+            asset.creation_date.unwrap().to_chrono_utc()?
         );
         println!(
             "  Last Update Date:   {}",
-            asset.last_update_date.unwrap().to_chrono_utc()
+            asset.last_update_date.unwrap().to_chrono_utc()?
         );
         println!(
             "  Current Status:   {}",
@@ -103,15 +106,23 @@ async fn list_assets(
 ///   If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display information.
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() {
     tracing_subscriber::fmt::init();
-    let Opt {
+
+    if let Err(err) = run_example(Opt::from_args()).await {
+        eprintln!("Error: {}", DisplayErrorContext(err));
+        process::exit(1);
+    }
+}
+
+async fn run_example(
+    Opt {
         region,
         asset_model_id,
         filter,
         verbose,
-    } = Opt::from_args();
-
+    }: Opt,
+) -> Result<(), Error> {
     let region_provider = RegionProviderChain::first_try(region.map(Region::new))
         .or_default_provider()
         .or_else(Region::new("us-west-2"));

--- a/rust_dev_preview/sitewise/src/bin/list-portals.rs
+++ b/rust_dev_preview/sitewise/src/bin/list-portals.rs
@@ -4,8 +4,11 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iotsitewise::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_iotsitewise::types::DisplayErrorContext;
+use aws_sdk_iotsitewise::{Client, Region, PKG_VERSION};
 use aws_smithy_types_convert::date_time::DateTimeExt;
+use sitewise_code_examples::Error;
+use std::process;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -36,11 +39,11 @@ async fn list_portals(client: &Client) -> Result<(), Error> {
         );
         println!(
             "  Creation Date:   {}",
-            asset.creation_date().unwrap().to_chrono_utc()
+            asset.creation_date().unwrap().to_chrono_utc()?
         );
         println!(
             "  Last Update Date:   {}",
-            asset.last_update_date().unwrap().to_chrono_utc()
+            asset.last_update_date().unwrap().to_chrono_utc()?
         );
         println!("  Start Url:   {}", asset.start_url().unwrap_or_default());
         println!(
@@ -68,10 +71,16 @@ async fn list_portals(client: &Client) -> Result<(), Error> {
 ///   If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display information.
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() {
     tracing_subscriber::fmt::init();
-    let Opt { region, verbose } = Opt::from_args();
 
+    if let Err(err) = run_example(Opt::from_args()).await {
+        eprintln!("Error: {}", DisplayErrorContext(err));
+        process::exit(1);
+    }
+}
+
+async fn run_example(Opt { region, verbose }: Opt) -> Result<(), Error> {
     let region_provider = RegionProviderChain::first_try(region.map(Region::new))
         .or_default_provider()
         .or_else(Region::new("us-west-2"));

--- a/rust_dev_preview/sitewise/src/lib.rs
+++ b/rust_dev_preview/sitewise/src/lib.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::error::Error as StdError;
+
+#[derive(thiserror::Error, Debug)]
+#[error("unhandled error")]
+pub struct Error {
+    #[source]
+    source: Box<dyn StdError + Send + Sync + 'static>,
+}
+
+impl Error {
+    pub fn unhandled(source: impl Into<Box<dyn StdError + Send + Sync + 'static>>) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+impl From<aws_sdk_iotsitewise::Error> for Error {
+    fn from(source: aws_sdk_iotsitewise::Error) -> Self {
+        Error::unhandled(source)
+    }
+}
+
+impl<T> From<aws_sdk_iotsitewise::types::SdkError<T>> for Error
+where
+    T: StdError + Send + Sync + 'static,
+{
+    fn from(source: aws_sdk_iotsitewise::types::SdkError<T>) -> Self {
+        Error::unhandled(source)
+    }
+}
+
+impl From<aws_smithy_types_convert::date_time::Error> for Error {
+    fn from(source: aws_smithy_types_convert::date_time::Error) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}


### PR DESCRIPTION
## I'm resolving an issue with an existing code example

Fixes the examples broken by the changes from [smithy-rs#1926](https://github.com/awslabs/smithy-rs/issues/1926).

Confirm you have met the following minimum requirements:

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [x] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
***

## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
