### PR TITLE
Update Go test tools

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,3 +30,5 @@ jobs:
           golangci-lint run
           cd ../dynamodb
           golangci-lint run
+          cd ../testtools
+          golangci-lint run

--- a/gov2/demotools/mocks.go
+++ b/gov2/demotools/mocks.go
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package testtools
+package demotools
 
 import (
-	"github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools"
+	"fmt"
 	"strconv"
 )
 
@@ -17,30 +17,30 @@ type MockQuestioner struct {
 }
 
 // Next returns the next answer in the slice of answers.
-func (mock *MockQuestioner) Next() string {
+func (mock *MockQuestioner) Next(question string) string {
 	if mock.answerIndex < len(mock.Answers) {
 		answer := mock.Answers[mock.answerIndex]
 		mock.answerIndex++
 		return answer
 	} else {
-		panic("No more answers in the questioner mock!")
+		panic(fmt.Sprintf("No mock answer to question: %v", question))
 	}
 }
 
-func (mock *MockQuestioner) Ask(question string, validators []demotools.IAnswerValidator) string {
-	return mock.Next()
+func (mock *MockQuestioner) Ask(question string, validators ...IAnswerValidator) string {
+	return mock.Next(question)
 }
 
 func (mock *MockQuestioner) AskBool(question string, expected string) bool {
-	return mock.Next() == expected
+	return mock.Next(question) == expected
 }
 
-func (mock *MockQuestioner) AskInt(question string, validators []demotools.IAnswerValidator) int {
-	answerInt, _ := strconv.Atoi(mock.Next())
+func (mock *MockQuestioner) AskInt(question string, validators ...IAnswerValidator) int {
+	answerInt, _ := strconv.Atoi(mock.Next(question))
 	return answerInt
 }
 
-func (mock *MockQuestioner) AskFloat64(question string, validators []demotools.IAnswerValidator) float64 {
-	answerFloat, _ := strconv.ParseFloat(mock.Next(), 64)
+func (mock *MockQuestioner) AskFloat64(question string, validators ...IAnswerValidator) float64 {
+	answerFloat, _ := strconv.ParseFloat(mock.Next(question), 64)
 	return answerFloat
 }

--- a/gov2/testtools/go.mod
+++ b/gov2/testtools/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.16.2
 	github.com/aws/aws-sdk-go-v2/config v1.15.3
 	github.com/aws/smithy-go v1.11.2
-	github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20220706224858-5c7f475624dc
 )
 
 require (

--- a/gov2/testtools/go.sum
+++ b/gov2/testtools/go.sum
@@ -20,8 +20,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.3 h1:cJGRyzCSVwZC7zZZ1xbx9m32UnrK
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.3/go.mod h1:bfBj0iVmsUyUg4weDB4NxktD9rDGeKSVWnjTnwbx9b8=
 github.com/aws/smithy-go v1.11.2 h1:eG/N+CcUMAvsdffgMvjMKwfyDzIkjM6pfxMJ8Mzc6mE=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
-github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20220706224858-5c7f475624dc h1:GXIhJ+DrwX3Jy97Tvr0RsMSWa71jkZMHEJA906F/dMs=
-github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20220706224858-5c7f475624dc/go.mod h1:0r22nlw0YYkUMowQkNluzs2dc8kf6s2bg9Oema9TzlE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=

--- a/gov2/testtools/scenarios.go
+++ b/gov2/testtools/scenarios.go
@@ -23,6 +23,7 @@ import (
 type IScenarioTest interface {
 	SetupDataAndStubs() []Stub
 	RunSubTest(stubber *AwsmStubber)
+	Cleanup()
 }
 
 // RunScenarioTests runs the scenario multiple times. The first time, it
@@ -77,4 +78,6 @@ func SubTestRunScenario(scenarioTest IScenarioTest, stubs []Stub, stubErr *StubE
 			t.Logf("Here's the log: \n%v", buf.String())
 		}
 	}
+
+	scenarioTest.Cleanup()
 }


### PR DESCRIPTION
Update Go test tools.

* Add list of ignorable fields to stubber. This lets a test specify that a field should be ignored when comparing inputs on a stub in a unit test. This is needed for struct inputs like io.Reader that are otherwise difficult (or impossible) to compare without excessive dependency injection.
* Move MockQuestioner to demotools, remove dependency on demotools from testtools.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
