### PR TITLE
Add DetectCustomLabels example for Go

### DIFF
--- a/gov2/rekognition/DetectCustomLabels/DetectCustomLabels.go
+++ b/gov2/rekognition/DetectCustomLabels/DetectCustomLabels.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/rekognition"
+	"github.com/aws/aws-sdk-go-v2/service/rekognition/types"
+)
+
+func main() {
+
+	bucketName := flag.String("b", "", "The name of the bucket to get the object")
+	image := flag.String("i", "", "The path to the image file (JPEG, JPG, PNG)")
+	modelArn := flag.String("arn", "", "The rekognition custom labels model arn")
+	minConfidence := float32(*flag.Float64("min", 95, "The minimum confidence value "))
+
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		log.Fatalf("unable to load SDK config, %v", err)
+	}
+
+	// Using the Config value, create the DynamoDB client
+	svc := rekognition.NewFromConfig(cfg)
+	var s3Obj = types.S3Object{
+		Bucket: bucketName,
+		Name:   image}
+
+	resp, err := svc.DetectCustomLabels(context.TODO(), &rekognition.DetectCustomLabelsInput{
+		Image: &types.Image{
+			S3Object: &s3Obj},
+		ProjectVersionArn: modelArn,
+		MinConfidence:     aws.Float32(minConfidence),
+	})
+
+	if err != nil {
+		log.Fatalf("unable to detect custom labels, %v", err)
+	}
+
+	log.Printf("Detected %v labels", len(resp.CustomLabels))
+
+	for _, label := range resp.CustomLabels {
+		log.Printf("%v: %v\b", label.Name, label.Confidence)
+	}
+
+}

--- a/gov2/rekognition/DetectCustomLabels/DetectCustomLabels.go
+++ b/gov2/rekognition/DetectCustomLabels/DetectCustomLabels.go
@@ -32,11 +32,13 @@ func main() {
 	svc := rekognition.NewFromConfig(cfg)
 	var s3Obj = types.S3Object{
 		Bucket: bucketName,
-		Name:   image}
+		Name:   image,
+	}
 
 	resp, err := svc.DetectCustomLabels(context.TODO(), &rekognition.DetectCustomLabelsInput{
 		Image: &types.Image{
-			S3Object: &s3Obj},
+			S3Object: &s3Obj,
+		},
 		ProjectVersionArn: modelArn,
 		MinConfidence:     aws.Float32(minConfidence),
 	})

--- a/gov2/rekognition/DetectCustomLabels/DetectCustomLabels.go
+++ b/gov2/rekognition/DetectCustomLabels/DetectCustomLabels.go
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
@@ -11,6 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rekognition/types"
 )
 
+// main will call the Rekognition DetectCustomLabels API with the arguments
+// specified from command line flags
+// It will print the custom labels detected
 func main() {
 
 	bucketName := flag.String("b", "", "The name of the bucket to get the object")

--- a/gov2/rekognition/DetectCustomLabels/README.md
+++ b/gov2/rekognition/DetectCustomLabels/README.md
@@ -1,0 +1,14 @@
+### DetectCustomLabels/DetectCustomLabels.go
+
+
+This example reads the specified image from the bucket, 
+and detects custom labels using the DetectCustomLabels model specified.
+The number of detected labels is output, along with the label names and confidence values
+
+`go run DetectFaces.go -b BUCKET -i IMAGE -arn MODEL_ARN -min-confidence MIN_CONFIDENCE`
+
+- _BUCKET_ is the name of the bucket containing the image.
+- _IMAGE_ is the name of the JPEG, JPG, or PNG image as the fully-qualified path in the bucket.
+  Other formats are not supported.
+- _MODEL_ARN_ is the Rekogniton Custom Labels model
+- _MIN_CONFIDENCE_ is the minimum confidence parameter supplied to the DetectCustomerLabels API


### PR DESCRIPTION
Hi. I've created a small snippet for using the `DetectCustomLabels` API for Go V2 SDK.


## I'm submitting a new SDK code example

Confirm you have met the following minimum requirements:

- [X] Add the following copyright notice to the top of each file. See the [LICENSE agreement](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/LICENSE) for the terms of the copyright. 
>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\
>SPDX-License-Identifier: Apache-2.0
- [X] Create unit tests for all paths through the code, and confirm that the all the tests pass. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
Single command example. No test required, as suggested in the guidelines
- [X] Run a linter against all code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
- [X] Add minimum usage documentation as comments in the code. For recommendations, see [Code comment guidelines](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-comment-guidelines).
*## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
