### PR TITLE
Bug/rust/s3/if modified since

### DIFF
--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -818,6 +818,22 @@ s3_GetObject:
                 - s3.swift.basics.handler.readfile
   services:
     s3: {GetObject}
+s3_GetObject_IfModifiedSince:
+  title: Get an object from an &S3; bucket using an &AWS; SDK, specifying an If-Modified-Since header
+  title_abbrev: Get an object from a bucket if it has been modified
+  synopsis: read data from an object in an S3 bucket, but only if that bucket has not been modified since the last retrieval time.
+  category:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rust_dev_preview/s3
+          excerpts:
+            - description:
+              snippet_tags:
+                - s3.rust.if-modified-since
+  services:
+    s3: {GetObject}
 s3_GetBucketLifecycleConfiguration:
   title: Get the lifecycle configuration of an &S3; bucket using an &AWS; SDK
   title_abbrev: Get the lifecycle configuration of a bucket

--- a/rust_dev_preview/s3/Cargo.toml
+++ b/rust_dev_preview/s3/Cargo.toml
@@ -27,8 +27,10 @@ aws-endpoint = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next
 # snippet-end:[s3.rust.s3-object-lambda-cargo.toml]
 aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["rt-tokio"] }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 bytes = "0.4.12"
 futures-util = { version = "0.3.21", features = ["alloc"] }
+http = "0.2.8"
 http-body = "0.4.5"
 md-5 = "0.10.1"
 rand = "0.5.0"
@@ -36,5 +38,6 @@ structopt = { version = "0.3", default-features = false }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = "0.1.8"
+tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/rust_dev_preview/s3/src/bin/if-modified-since.rs
+++ b/rust_dev_preview/s3/src/bin/if-modified-since.rs
@@ -1,0 +1,127 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0.
+
+// snippet-start:[s3.rust.if-modified-since]
+use aws_sdk_s3::{
+    error::HeadObjectError,
+    types::{ByteStream, DateTime, SdkError},
+    Client, Error,
+};
+use aws_smithy_types::date_time::Format;
+use http::StatusCode;
+use tracing::{error, warn};
+
+const KEY: &str = "key";
+const BODY: &str = "Hello, world!";
+
+/// Lists your tables in DynamoDB local.
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+    let uuid = uuid::Uuid::new_v4();
+    let client = Client::new(&aws_config::load_from_env().await);
+
+    // Create bucket.
+    // Put an object in the bucket.
+    // Get the bucket.
+    // Get the bucket again, but it hasn't been modified.
+    // Delete the bucket.
+
+    let bucket = format!("if-modified-since-{uuid}");
+
+    client.create_bucket().bucket(bucket.clone()).send().await?;
+
+    let put_object = client
+        .put_object()
+        .bucket(bucket.as_str())
+        .key(KEY)
+        .body(ByteStream::from_static(BODY.as_bytes()))
+        .send()
+        .await;
+
+    // A normal successful 200, which we can grab the etag from.
+    let e_tag = match put_object {
+        Ok(output) => output.e_tag,
+        Err(err) => {
+            error!("{err:?}");
+            None
+        }
+    };
+
+    let head_object = client
+        .head_object()
+        .bucket(bucket.as_str())
+        .key(KEY)
+        .send()
+        .await;
+
+    // Get Object will also 200, and again let us us politely ask for the last_modified and the etag.
+    let (last_modified, e_tag_2) = match head_object {
+        Ok(output) => (Ok(output.last_modified().cloned()), output.e_tag),
+        Err(err) => (Err(err), None),
+    };
+
+    warn!("last modified: {last_modified:?}");
+    assert_eq!(e_tag, e_tag_2, "Put and first Get had differing etags");
+
+    let head_object = client
+        .head_object()
+        .bucket(bucket.as_str())
+        .key(KEY)
+        .if_modified_since(last_modified.unwrap().unwrap())
+        .send()
+        .await;
+
+    // And then.
+    // The second Get Object, with the set `id_modified_since`, is a 304, which is an SdkError::ServiceError.
+    // Go through it and pull the parts out (when it's actually a 304).
+    let (last_modified, e_tag_2): (
+        Result<Option<DateTime>, SdkError<HeadObjectError>>,
+        Option<String>,
+    ) = match head_object {
+        Ok(output) => (Ok(output.last_modified().cloned()), output.e_tag),
+        Err(err) => match err {
+            aws_sdk_s3::types::SdkError::ServiceError(err) => {
+                let http = err.raw().http();
+                match http.status() {
+                    StatusCode::NOT_MODIFIED => (
+                        Ok(Some(
+                            DateTime::from_str(
+                                http.headers()
+                                    .get("last-modified")
+                                    .map(|t| t.to_str().unwrap())
+                                    .unwrap(),
+                                Format::HttpDate,
+                            )
+                            .unwrap(),
+                        )),
+                        http.headers()
+                            .get("etag")
+                            .map(|t| t.to_str().unwrap().into()),
+                    ),
+                    _ => (Err(aws_sdk_s3::types::SdkError::ServiceError(err)), None),
+                }
+            }
+            _ => (Err(err), None),
+        },
+    };
+
+    warn!("last modified: {last_modified:?}");
+    assert_eq!(e_tag, e_tag_2, "Put and second Get had differing etags");
+
+    client
+        .delete_object()
+        .bucket(bucket.as_str())
+        .key(KEY)
+        .send()
+        .await?;
+
+    client
+        .delete_bucket()
+        .bucket(bucket.as_str())
+        .send()
+        .await?;
+
+    Ok(())
+}
+// snippet-end:[s3.rust.if-modified-since]

--- a/rust_dev_preview/s3/tests/test-s3-getting-started.rs
+++ b/rust_dev_preview/s3/tests/test-s3-getting-started.rs
@@ -12,10 +12,8 @@ use uuid::Uuid;
 #[tokio::test]
 async fn test_it_runs() {
     let (region, client, bucket_name, file_name, key, target_key) = setup().await;
-    match run_s3_operations(region, client, bucket_name, file_name, key, target_key).await {
-        Err(_e) => assert!(false),
-        _ => assert!(true),
-    }
+    let run = run_s3_operations(region, client, bucket_name, file_name, key, target_key).await;
+    run.expect("Failed to perform s3 actions");
 }
 
 async fn run_s3_operations(


### PR DESCRIPTION
This adds an example for setting and checking an S3 Get/Head Object if-modified-since. When the object hasn't changed, this returns a 304 instead of a 200, with no body. However, checking that is... extensive. This shows how to do that check in the Rust SDK.