### PR TITLE
Fix some Python gitignore issues

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -29,7 +29,6 @@ MANIFEST
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
 *.spec
 
 # Installer logs

--- a/python/cross_service/dynamodb_item_tracker/.gitignore
+++ b/python/cross_service/dynamodb_item_tracker/.gitignore
@@ -1,1 +1,0 @@
-config.py

--- a/python/cross_service/dynamodb_item_tracker/config.py
+++ b/python/cross_service/dynamodb_item_tracker/config.py
@@ -1,0 +1,3 @@
+TABLE_NAME = 'NEED-TABLE-NAME'
+SENDER_EMAIL = 'NEED-SENDER-EMAIL'
+SECRET_KEY = 'change-for-production!'


### PR DESCRIPTION
Fix a couple of issues with Python .gitignore files:

* Remove *.manifest from Python .gitignore because these are used in some tests and should be included.
* Remove .gitignore from DDB item tracker because we don't want to ignore config.py.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
