### PR TITLE
update: Rust example CI to target 1.62.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,7 @@ jobs:
           profile: minimal
           toolchain: 1.62.1
           override: true
+          components: clippy, rustfmt
       - uses: actions-rs/cargo@v1
         name: cargo check
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,13 +22,19 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.62.1
           override: true
       - uses: actions-rs/cargo@v1
         name: cargo check
         with:
           command: check
-          args: --all-targets --manifest-path rust_dev_preview/Cargo.toml
+          args: --manifest-path rust_dev_preview/Cargo.toml --all-targets
+      - uses: actions-rs/cargo@v1
+        if: success() || failure()
+        name: cargo fmt
+        with:
+          command: fmt
+          args: --manifest-path rust_dev_preview/Cargo.toml --all --check -- -D warnings
       - uses: actions-rs/cargo@v1
         if: success() || failure()
         name: cargo clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
         name: cargo fmt
         with:
           command: fmt
-          args: --manifest-path rust_dev_preview/Cargo.toml --all --check -- -D warnings
+          args: --manifest-path rust_dev_preview/Cargo.toml --all --check
       - uses: actions-rs/cargo@v1
         if: success() || failure()
         name: cargo clippy

--- a/rust_dev_preview/cross_service/rest_ses/Cargo.toml
+++ b/rust_dev_preview/cross_service/rest_ses/Cargo.toml
@@ -18,18 +18,22 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-cloudwatchlogs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-rdsdata = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-ses = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
-chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"] }
+chrono = { version = "0.4.22", default-features = false, features = [
+    "clock",
+    "serde",
+] }
 color-eyre = "0.6.2"
 config = "0.13.2"
 derive_more = "0.99.17"
 futures = "0.3.24"
-mail-builder = "0.2.2"
+# newer versions of this crate aren't yet compatible with our MSRV
+mail-builder = "=0.2.2"
 reqwest = "0.11.12"
 secrecy = { version = "0.8.0", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.86"
 thiserror = "1.0.37"
-tokio = {version = "1", features = ["macros", "rt-multi-thread"]}
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.37"
 tracing-actix-web = "0.6.1"
 tracing-bunyan-formatter = "0.3.4"

--- a/rust_dev_preview/eks/src/bin/create-cluster.rs
+++ b/rust_dev_preview/eks/src/bin/create-cluster.rs
@@ -35,7 +35,6 @@ struct Opt {
 }
 
 #[tokio::main]
-#[allow(clippy::result_large_err)]
 async fn main() -> Result<(), aws_sdk_eks::Error> {
     let Opt {
         region,

--- a/rust_dev_preview/eks/src/bin/create-delete-cluster.rs
+++ b/rust_dev_preview/eks/src/bin/create-delete-cluster.rs
@@ -82,7 +82,6 @@ async fn remove_cluster(
 ///   If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
-#[allow(clippy::result_large_err)]
 async fn main() -> Result<(), aws_sdk_eks::Error> {
     let Opt {
         arn,

--- a/rust_dev_preview/eks/src/bin/list-clusters.rs
+++ b/rust_dev_preview/eks/src/bin/list-clusters.rs
@@ -43,7 +43,6 @@ async fn show_clusters(client: &aws_sdk_eks::Client) -> Result<(), aws_sdk_eks::
 ///   If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display additional information.
 #[tokio::main]
-#[allow(clippy::result_large_err)]
 async fn main() -> Result<(), aws_sdk_eks::Error> {
     let Opt { region, verbose } = Opt::from_args();
 

--- a/rust_dev_preview/glue/Cargo.toml
+++ b/rust_dev_preview/glue/Cargo.toml
@@ -5,13 +5,9 @@ authors = [
   "David Souther <davidsouther+github@gmail.com>",
 ]
 edition = "2021"
-about = "MVP Scenario to show many features of the Rust AWS Glue SDK. https://github.com/awsdocs/aws-doc-sdk-examples/issues/2941"
-
-[lib]
-path = "src/lib.rs"
+description = "MVP Scenario to show many features of the Rust AWS Glue SDK. https://github.com/awsdocs/aws-doc-sdk-examples/issues/2941"
 
 [[bin]]
-path = "src/bin/scenario.rs"
 name = "scenario"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust_dev_preview/greengrassv2/src/bin/list-core-devices.rs
+++ b/rust_dev_preview/greengrassv2/src/bin/list-core-devices.rs
@@ -53,7 +53,6 @@ async fn show_cores(client: &Client) -> Result<(), Error> {
 ///   If the environment variable is not set, defaults to **us-west-2**.
 /// * `[-v]` - Whether to display information.
 #[tokio::main]
-#[allow(clippy::result_large_err)]
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt::init();
     let Opt { region, verbose } = Opt::from_args();

--- a/rust_dev_preview/rust-toolchain.toml
+++ b/rust_dev_preview/rust-toolchain.toml
@@ -1,0 +1,3 @@
+# This should be kept in sync with https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv
+[toolchain]
+channel = "1.62.1"

--- a/rust_dev_preview/tls/tests/test-tls.rs
+++ b/rust_dev_preview/tls/tests/test-tls.rs
@@ -1,5 +1,3 @@
-
-
 #[ignore]
 #[tokio::test]
 async fn test_it_runs() {


### PR DESCRIPTION
This PR also does the following:

add: rust-toolchain.toml for Rust examples
fix: glue example Cargo.toml

## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
