### PR TITLE
Fix mismatched regions for rek and s3

### DIFF
--- a/rust_dev_preview/cross_service/detect_faces/src/main.rs
+++ b/rust_dev_preview/cross_service/detect_faces/src/main.rs
@@ -176,12 +176,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let rek_region = region.clone();
 
     let rek_region_provider =
-        RegionProviderChain::first_try(s3_region.map(aws_sdk_rekognition::Region::new))
+        RegionProviderChain::first_try(rek_region.map(aws_sdk_rekognition::Region::new))
             .or_default_provider()
             .or_else(aws_sdk_rekognition::Region::new("us-west-2"));
 
     let s3_region_provider =
-        RegionProviderChain::first_try(rek_region.map(aws_sdk_s3::Region::new))
+        RegionProviderChain::first_try(s3_region.map(aws_sdk_s3::Region::new))
             .or_default_provider()
             .or_else(aws_sdk_s3::Region::new("us-west-2"));
     println!();

--- a/rust_dev_preview/cross_service/detect_faces/src/main.rs
+++ b/rust_dev_preview/cross_service/detect_faces/src/main.rs
@@ -180,10 +180,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .or_default_provider()
             .or_else(aws_sdk_rekognition::Region::new("us-west-2"));
 
-    let s3_region_provider =
-        RegionProviderChain::first_try(s3_region.map(aws_sdk_s3::Region::new))
-            .or_default_provider()
-            .or_else(aws_sdk_s3::Region::new("us-west-2"));
+    let s3_region_provider = RegionProviderChain::first_try(s3_region.map(aws_sdk_s3::Region::new))
+        .or_default_provider()
+        .or_else(aws_sdk_s3::Region::new("us-west-2"));
     println!();
 
     if verbose {


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

Thank you for making a submission to the *aws-doc-sdk-examples* repository. For more information about submitting pull requests to this repository, see [Guidelines for contributing](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/CONTRIBUTING.md).

*NOTE:* This pull request (PR) template contains two sections. Use the section that applies to your submission, and remove the section which doesn't apply.
## I'm resolving an issue with an existing code example

Small fix where Rekognition region and s3 region was applied to wrong region provider

Confirm you have met the following minimum requirements:

- [ ] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [ ] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
***
## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
