### PR TITLE
Pin clap to 4.0

### DIFF
--- a/rust_dev_preview/concurrency/Cargo.toml
+++ b/rust_dev_preview/concurrency/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.0.26", features = ["derive"] }
+clap = { version = "~4.0.26", features = ["derive"] }
 futures = "0.3.25"
 tokio = { version = "1.20.1", features = ["full"] }
 tracing = "0.1.37"

--- a/rust_dev_preview/glue/Cargo.toml
+++ b/rust_dev_preview/glue/Cargo.toml
@@ -32,7 +32,8 @@ tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing = "0.1.37"
 async_once = "0.2.6"
 lazy_static = "1.4.0"
-clap = { version = "4.0.18", features = ["derive"] }
+clap = { version = "~4.0.18", features = ["derive"] }
+clap_lex = "=0.3.0"
 thiserror = "1.0.37"
 secrecy = "0.8.0"
 uuid = { version = "1.2.1", features = ["v4"] }


### PR DESCRIPTION
This pins clap to 4.0. Clap 4.1 bumps the MSRV to 1.64, while the SDK is at 1.62.1.