### PR TITLE
Fix iam-getting-started broken by signature change for credentials_provider

### DIFF
--- a/rust_dev_preview/iam/src/bin/iam-getting-started.rs
+++ b/rust_dev_preview/iam/src/bin/iam-getting-started.rs
@@ -27,6 +27,7 @@ use aws_sdk_iam::{Client as iamClient, Credentials as iamCredentials, Region};
 use aws_sdk_s3::Client as s3Client;
 use aws_sdk_sts::Client as stsClient;
 use std::borrow::Borrow;
+use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 use uuid::Uuid;
 
@@ -161,11 +162,11 @@ async fn run_iam_operations(
     println!("Created inline policy.");
 
     //First, fail to list the buckets with the user.
-    let creds = iamCredentials::from_keys(
+    let creds = Arc::new(iamCredentials::from_keys(
         key.access_key_id.as_ref().unwrap(),
         key.secret_access_key.as_ref().unwrap(),
         None,
-    );
+    ));
     let fail_config = aws_config::from_env()
         .credentials_provider(creds.clone())
         .load()
@@ -227,7 +228,7 @@ async fn run_iam_operations(
     );
 
     let succeed_config = aws_config::from_env()
-        .credentials_provider(assumed_credentials)
+        .credentials_provider(Arc::new(assumed_credentials))
         .load()
         .await;
     println!("succeed config: {:?}", succeed_config);


### PR DESCRIPTION
***
## I'm resolving an issue with an existing code example

This commit fixes `iam-getting-starged` broken by the signature change for `ConfigLoader::credentials_provider` in https://github.com/awslabs/smithy-rs/pull/2122.

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [x] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
***
## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
