### PR TITLE
README.md: Fix broken link to Java 2 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Code examples for each language's SDK can be found within the following subdirec
 | C++        | [cpp/](cpp)                           | 1           | ![[]](https://img.shields.io/badge/-GA-blue)          |
 | Go         | [gov2/](gov2)                         | 2           | ![[]](https://img.shields.io/badge/-GA-blue)          |
 | Go         | [go/](go)                             | 1           | ![[]](https://img.shields.io/badge/-deprecated-red)  |
-| Java       | [javav2/]()                           | 2           | ![[]](https://img.shields.io/badge/-GA-blue) (Recommended version) |
+| Java       | [javav2/](java2)                      | 2           | ![[]](https://img.shields.io/badge/-GA-blue) (Recommended version) |
 | Java       | [java/](java)                         | 1           | ![[]](https://img.shields.io/badge/-GA-blue) (Not Recommended) |
 | JavaScript | [javascriptv3/](javascriptv3)         | 3           | ![[]](https://img.shields.io/badge/-GA-blue)          |
 | JavaScript | [javascript/](javascript)             | 2           | ![[]](https://img.shields.io/badge/-deprecated-red)  |


### PR DESCRIPTION
## I'm resolving an issue with an existing code example

The `README.md` has a broken link: There's no link target for "java". See this screencast: https://app.screencast.com/ReQ2fvBhULLz0

Confirm you have met the following minimum requirements:

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [x] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
***
## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
