### PR TITLE
Template update to support example service chapter title override

### DIFF
--- a/.doc_gen/templates/zonbook/service_chapter_template.xml
+++ b/.doc_gen/templates/zonbook/service_chapter_template.xml
@@ -1,6 +1,13 @@
 {{- template "prologue"}}
 {{- $doc_id := "service_code_examples"}}
+{{- $title := printf "Code examples for %s using &AWS; SDKs" .ServiceEntity.Short }}
+{{- if .ChapterOverrideTitle }}
+    {{- $title = .ChapterOverrideTitle }}
+{{- end }}
 {{- $title_abbrev := "Code examples"}}
+{{- if .ChapterOverrideTitleAbbrev }}
+    {{- $title_abbrev = .ChapterOverrideTitleAbbrev }}
+{{- end }}
 {{- $cross_service := index .CategorizedExampleSets "Cross-service examples"}}
 {{- $scenarios :=  index .CategorizedExampleSets "Scenarios"}}
 {{- $actions := index .CategorizedExampleSets "Actions"}}
@@ -16,7 +23,7 @@
 <chapter id="{{$doc_id}}" role="topic">
 {{end}}
     <info>
-        <title id="{{$doc_id}}.title">Code examples for {{.ServiceEntity.Short}} using &AWS; SDKs</title>
+        <title id="{{$doc_id}}.title">{{$title}}</title>
         <titleabbrev id="{{$doc_id}}.titleabbrev">{{$title_abbrev}}</titleabbrev>
         <abstract>
             <para>Code examples that show how to use {{.ServiceEntity.Short}} with an &AWS; SDK.</para>

--- a/.doc_gen/validation/services_schema.yaml
+++ b/.doc_gen/validation/services_schema.yaml
@@ -6,6 +6,7 @@ service:
   long: include('entity_regex')
   short: include('entity_regex')
   sort: regex('^[^&]\w', name='non-entity')
+  chapter_override: include('chapter_override', required=False)
   expanded:
     long: str(upper_start=True, end_punc=False, check_aws=False)
     short: str(upper_start=True, end_punc=False, check_aws=False)
@@ -18,6 +19,10 @@ service:
   caveat: str(required=False, upper_start=True, end_punc=True)
   bundle: service_name(required=False)
   tags: map(key=enum('product_categories'))
+
+chapter_override:
+    title: str(upper_start=True, end_punc=False)
+    title_abbrev: str(upper_start=True, end_punc=False)
 
 entity_regex: regex('^[&]([\dA-Za-z-_])+[;]$|^&AWS; SDK for Kotlin Developer Guide$', name='valid entity')
 doc_url: regex('^(?!https://docs.aws.amazon.com/).+', name="relative documentation URL")


### PR DESCRIPTION
This is the template side of the update to allow a title override of the code example chapter in a service guide.

* Update the service chapter template to use a chapter title override if it exists.
* Update the metadata schema to allow a `chapter_override` block and check the strings.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
