### PR TITLE
Fix dynamodb query example

### DIFF
--- a/javascriptv3/example_code/dynamodb/src/ddb_query.js
+++ b/javascriptv3/example_code/dynamodb/src/ddb_query.js
@@ -14,7 +14,7 @@ node ddb_query.js
 // snippet-start:[dynamodb.JavaScript.table.queryV3]
 
 // Import required AWS SDK clients and commands for Node.js
-import { QueryCommand } from "@aws-sdk/client-dynamodb";
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { ddbClient } from "./libs/ddbClient.js";
 
 // Set the parameters


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

## I'm resolving an issue with an existing code example

The QueryCommand was imported from the wrong library.