### PR TITLE
fix Rust link 

### DIFF
--- a/rust_dev_preview/README.md
+++ b/rust_dev_preview/README.md
@@ -68,7 +68,7 @@ hosted on [Amazon Elastic Container Registry (ECR)](https://docs.aws.amazon.com/
 with all Rust examples with dependencies pre-resolved, allowing you to explore
 these examples in an isolated environment.
 
-⚠️ As of January 2023, the [SDK for Rust image](https://gallery.ecr.aws/aws-docs-sdk-examples/rust_dev_preview) is available on ECR Public but is still
+⚠️ As of January 2023, the [SDK for Rust image](https://gallery.ecr.aws/b4v4v1s0/rust_dev_preview) is available on ECR Public but is still
 undergoing active development. Refer to
 [this GitHub issue](https://github.com/awsdocs/aws-doc-sdk-examples/issues/4134)
 for more information.


### PR DESCRIPTION
Creating this as a separate PR for whenever the error upstream is fixed. 