### PR TITLE
Update routing control state examples to recommend accessing a random…

### DIFF
--- a/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/GetRoutingControlState.java
+++ b/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/GetRoutingControlState.java
@@ -68,7 +68,7 @@ public class GetRoutingControlState {
     //snippet-start:[route53_rec.java2.get_routing.main]
     public static GetRoutingControlStateResponse getRoutingControlState(List<ClusterEndpoint> clusterEndpoints,
                                                                         String routingControlArn) {
-        // Best practice is to choose a random cluster endpoint to get routing control states.
+        // As a best practice, we recommend choosing a random cluster endpoint to get or set routing control states.
         // For more information, see https://docs.aws.amazon.com/r53recovery/latest/dg/route53-arc-best-practices.html#route53-arc-best-practices.regional
         Collections.shuffle(clusterEndpoints);
         for (ClusterEndpoint clusterEndpoint : clusterEndpoints) {

--- a/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/GetRoutingControlState.java
+++ b/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/GetRoutingControlState.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 //snippet-end:[route53_rec.java2.get_routing.import]
@@ -67,6 +68,9 @@ public class GetRoutingControlState {
     //snippet-start:[route53_rec.java2.get_routing.main]
     public static GetRoutingControlStateResponse getRoutingControlState(List<ClusterEndpoint> clusterEndpoints,
                                                                         String routingControlArn) {
+        // Best practice is to choose a random cluster endpoint to get routing control states.
+        // For more information, see https://docs.aws.amazon.com/r53recovery/latest/dg/route53-arc-best-practices.html#route53-arc-best-practices.regional
+        Collections.shuffle(clusterEndpoints);
         for (ClusterEndpoint clusterEndpoint : clusterEndpoints) {
             try {
                 System.out.println(clusterEndpoint);

--- a/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/UpdateRoutingControlState.java
+++ b/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/UpdateRoutingControlState.java
@@ -72,7 +72,7 @@ public class UpdateRoutingControlState {
     public static UpdateRoutingControlStateResponse updateRoutingControlState(List<ClusterEndpoint> clusterEndpoints,
                                                                               String routingControlArn,
                                                                               String routingControlState) {
-        // Best practice is to choose a random cluster endpoint to update routing control states.
+        // As a best practice, we recommend choosing a random cluster endpoint to get or set routing control states.
         // For more information, see https://docs.aws.amazon.com/r53recovery/latest/dg/route53-arc-best-practices.html#route53-arc-best-practices.regional
         Collections.shuffle(clusterEndpoints);
         for (ClusterEndpoint clusterEndpoint : clusterEndpoints) {

--- a/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/UpdateRoutingControlState.java
+++ b/javav2/example_code/route53recoverycluster/src/main/java/com/example/route53recoverycluster/UpdateRoutingControlState.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 //snippet-end:[route53_rec.java2.update_routing_state.import]
@@ -71,6 +72,9 @@ public class UpdateRoutingControlState {
     public static UpdateRoutingControlStateResponse updateRoutingControlState(List<ClusterEndpoint> clusterEndpoints,
                                                                               String routingControlArn,
                                                                               String routingControlState) {
+        // Best practice is to choose a random cluster endpoint to update routing control states.
+        // For more information, see https://docs.aws.amazon.com/r53recovery/latest/dg/route53-arc-best-practices.html#route53-arc-best-practices.regional
+        Collections.shuffle(clusterEndpoints);
         for (ClusterEndpoint clusterEndpoint : clusterEndpoints) {
             try {
                 System.out.println(clusterEndpoint);

--- a/python/example_code/route53-recovery-cluster/routing_control_states.py
+++ b/python/example_code/route53-recovery-cluster/routing_control_states.py
@@ -42,7 +42,7 @@ def get_routing_control_state(routing_control_arn, cluster_endpoints):
     :return: The routing control state response.
     """
 
-    # Best practice is to choose a random cluster endpoint to get routing control states.
+    # As a best practice, we recommend choosing a random cluster endpoint to get or set routing control states.
     # For more information, see https://docs.aws.amazon.com/r53recovery/latest/dg/route53-arc-best-practices.html#route53-arc-best-practices.regional
     random.shuffle(cluster_endpoints)
     for cluster_endpoint in cluster_endpoints:
@@ -70,7 +70,7 @@ def update_routing_control_state(
     :return: The routing control update response.
     """
 
-    # Best practice is to choose a random cluster endpoint to update routing control states.
+    # As a best practice, we recommend choosing a random cluster endpoint to get or set routing control states.
     # For more information, see https://docs.aws.amazon.com/r53recovery/latest/dg/route53-arc-best-practices.html#route53-arc-best-practices.regional
     random.shuffle(cluster_endpoints)
     for cluster_endpoint in cluster_endpoints:

--- a/python/example_code/route53-recovery-cluster/routing_control_states.py
+++ b/python/example_code/route53-recovery-cluster/routing_control_states.py
@@ -10,6 +10,7 @@ Recovery Controller to manage routing controls.
 
 import argparse
 import json
+import random
 
 # snippet-start:[python.example_code.route53-recovery-cluster.helper.get_recovery_client]
 import boto3
@@ -40,6 +41,10 @@ def get_routing_control_state(routing_control_arn, cluster_endpoints):
     :param cluster_endpoints: The list of cluster endpoints to query.
     :return: The routing control state response.
     """
+
+    # Best practice is to choose a random cluster endpoint to get routing control states.
+    # For more information, see https://docs.aws.amazon.com/r53recovery/latest/dg/route53-arc-best-practices.html#route53-arc-best-practices.regional
+    random.shuffle(cluster_endpoints)
     for cluster_endpoint in cluster_endpoints:
         try:
             recovery_client = create_recovery_client(cluster_endpoint)
@@ -48,6 +53,7 @@ def get_routing_control_state(routing_control_arn, cluster_endpoints):
             return response
         except Exception as error:
             print(error)
+            raise error
 # snippet-end:[python.example_code.route53-recovery-cluster.GetRoutingControlState]
 
 
@@ -63,6 +69,10 @@ def update_routing_control_state(
     :param routing_control_state: The new routing control state.
     :return: The routing control update response.
     """
+
+    # Best practice is to choose a random cluster endpoint to update routing control states.
+    # For more information, see https://docs.aws.amazon.com/r53recovery/latest/dg/route53-arc-best-practices.html#route53-arc-best-practices.regional
+    random.shuffle(cluster_endpoints)
     for cluster_endpoint in cluster_endpoints:
         try:
             recovery_client = create_recovery_client(cluster_endpoint)
@@ -105,5 +115,5 @@ if __name__ == '__main__':
         'cluster_endpoints', help="A JSON file containing the list of endpoints for the cluster.")
     args = parser.parse_args()
     with open(args.cluster_endpoints) as endpoints_file:
-        cluster_endpoints = json.load(endpoints_file)['ClusterEndpoints']
-    toggle_routing_control_state(args.routing_control_arn, cluster_endpoints)
+        loaded_cluster_endpoints = json.load(endpoints_file)['ClusterEndpoints']
+    toggle_routing_control_state(args.routing_control_arn, loaded_cluster_endpoints)


### PR DESCRIPTION
Changes documentation for the examples for Route53 Recovery Cluster to recommend communicating with random endpoints.

# aws-doc-sdk-examples Pull Request

Thank you for making a submission to the *aws-doc-sdk-examples* repository. For more information about submitting pull requests to this repository, see [Guidelines for contributing](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/CONTRIBUTING.md).

*NOTE:* This pull request (PR) template contains two sections. Use the section that applies to your submission, and remove the section which doesn't apply.
***
## I'm resolving an issue with an existing code example

Describe the changes you have made here, including any issue numbers.
  * Changes documentation for the examples for Route53 Recovery Cluster to recommend communicating with random endpoints.

Confirm you have met the following minimum requirements:

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [x] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
  - Linting passed for changed code.
***
## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
