### PR TITLE
Use next tag, for release that fixes TLS

### DIFF
--- a/rust_dev_preview/using-native-tls-instead-of-rustls/Cargo.toml
+++ b/rust_dev_preview/using-native-tls-instead-of-rustls/Cargo.toml
@@ -9,16 +9,16 @@ edition = "2021"
 [dependencies]
 # aws-config pulls in rustls and several other things by default. We have to disable defaults in order to use native-tls
 # and then manually bring the other defaults back
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false, features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false, features = [
   "native-tls",
   "rt-tokio",
 ] }
 # aws-sdk-s3 brings in rustls by default so we disable that in order to use native-tls only
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false, features = [
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false, features = [
   "native-tls",
 ] }
 # aws-sdk-sts is the same as aws-sdk-s3
-aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false, features = [
+aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false, features = [
   "native-tls",
 ] }
 tokio = { version = "1.20.1", features = ["full"] }


### PR DESCRIPTION
This fixes an upstream issue in the Rust SDK. They have a fix for it released, but not yet in sdk main.