### PR TITLE
Restore aws-cli folder because it's referenced in the AWS CLI guide

### DIFF
--- a/aws-cli/README.md
+++ b/aws-cli/README.md
@@ -1,0 +1,52 @@
+<!-- 
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+This file is licensed under the Apache License, Version 2.0 (the "License").
+
+You may not use this file except in compliance with the License. A copy of
+the License is located at http://aws.amazon.com/apache2.0/.
+
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+# AWS CLI examples
+
+These are examples for the AWS Command Line Interface (AWS CLI) public 
+documentation. All examples have been tested and verified to work with 
+the AWS CLI version 2.
+
+## Prerequisites
+
+To run these examples, you'll need:
+
+ * The AWS CLI, downloaded and running on your machine
+ * AWS credentials in a shared credentials file
+
+## Running the examples
+
+Examples are typically written as functions in shell script files that can be
+sourced from other files. Most are accompanied by a unit or integration test
+script that you can run to validate that each example works. The test scripts
+include setup and teardown to create and destroy any prerequisite resources. 
+We take care that all AWS resources that the example creates are also destroyed
+to avoid incurring any unwanted costs. When you're done with an example, we do
+recommend that you check the resources in your account to ensure that the 
+teardown worked as expected and didn't accidentally leave any resources behind.
+
+To run the examples, you need to create a shared credentials file. For more 
+information about how to set up a shared credentials file, see [Configuration 
+and Credential File Settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+in the _AWS CLI User Guide_.
+
+## AWS CLI downloads
+
+For information about how to download and install the AWS CLI, see [Installing
+the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+in the _AWS CLI User Guide_.
+
+## Documentation
+
+For detailed documentation for the AWS CLI, see the following:
+
+ * [AWS CLI User Guide](https://docs.aws.amazon.com/cli/latest/userguide/)
+ * [AWS CLI Reference Guide](https://docs.aws.amazon.com/cli/latest/reference/)

--- a/aws-cli/bash-linux/README.md
+++ b/aws-cli/bash-linux/README.md
@@ -1,0 +1,54 @@
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+This file is licensed under the Apache License, Version 2.0 (the "License").
+
+You may not use this file except in compliance with the License. A copy of
+the License is located at http://aws.amazon.com/apache2.0/.
+
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# AWS CLI examples for BASH shell on Linux
+
+These are examples for the AWS Command Line Interface (CLI) public 
+documentation. All examples have been tested and verified to work with AWS CLI
+version 2. The testing platforms include Amazon Linux 2 and MacOS 10.14, both
+using a BASH shell.
+
+## Prerequisites
+
+To run these examples, you need:
+
+ * The AWS CLI, downloaded and running on your machine
+ * AWS credentials in a shared credentials file
+
+## Running the examples
+
+Examples are typically written as functions in shell script files that can be
+sourced from other files. Most are accompanied by a unit or integration test
+script that you can run to validate that each example works. The test scripts
+include setup and teardown to create and destroy any prerequisite resources. 
+We take care that all AWS resources that the example creates are also destroyed
+to avoid incurring any unwanted costs. When you're done with an example, we do
+recommend that you check the resources in your account to ensure that the 
+teardown worked as expected and didn't accidentally leave any resources behind.
+
+To run the examples, you need to create a shared credentials file. For more 
+information about how to set up a shared credentials file, see [Configuration 
+and Credential File Settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+in the _AWS CLI User Guide_.
+
+## AWS CLI downloads
+
+For information about how to download and install the AWS CLI, see [Installing
+the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+in the _AWS CLI User Guide_.
+
+## Documentation
+
+For detailed documentation for the AWS CLI, see the following:
+
+ * [AWS CLI User Guide](https://docs.aws.amazon.com/cli/latest/userguide/)
+ * [AWS CLI Reference Guide](https://docs.aws.amazon.com/cli/latest/reference/)

--- a/aws-cli/bash-linux/ec2/change-ec2-instance-type/README.md
+++ b/aws-cli/bash-linux/ec2/change-ec2-instance-type/README.md
@@ -1,0 +1,73 @@
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+This file is licensed under the Apache License, Version 2.0 (the "License").
+
+You may not use this file except in compliance with the License. A copy of
+the License is located at http://aws.amazon.com/apache2.0/.
+
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# Change Amazon EC2 Instance Type
+
+This example demonstrates how to change the instance type of an Amazon EC2
+instance. It stops the instance if it's running, changes the instance type,
+and then, if requested, restarts the instance.
+
+## Files
+  * change_ec2_instance_type.sh - main script example file
+  * test_change_ec2_instance_type.sh - unit/integration test file
+  * general.sh - common test support function file
+
+## Purpose
+The main script file contains the `change_ec2_instance_type()` function that perform the following tasks:
+
+ * Verifies that the specified EC2 instance exists
+ * Warns the user (unless -f was selected) before stopping the instance
+ * Changes the instance type
+ * If requested (by selecting -r), restarts the instance and confirms that the instance is running
+
+## Prerequisites
+
+ * An Amazon Web Services (AWS) account.
+ * A shared credentials file with a default profile. The profile that you use must have permissions that allow the AWS operations performed by the script. For more information about how to set up a shared credentials file, see [Configuration and Credential File Settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) in the _AWS CLI User Guide_.
+ * A running EC2 instance in the account for which you have permission to stop and modify. If you run the test script, it launches an instance for you, tests changing the type, and then terminates the instance. 
+
+## Running the Code
+This example is written as a function in a shell script file (*`change_ec2_instance_type.sh`*) that you can `source` from another script or from the command line. Once the function is in memory, you can invoke it from the command line. For example, the following commands change the type of the specified instance to `t2.nano`:
+
+```
+source change_ec2_instance_type.sh
+change_ec2_instance_type -i *instance-id* -t t2.nano
+```
+
+## Parameters
+
+**-i** - *(string)* Specifies the instance ID to modify.
+
+**-t** - *(string)* Specifies the EC2 instance type to switch to.
+
+**-r** - *(switch)* If set, the function restarts the instance after the type switch. Default: the function doesn't restart the instance.
+
+**-f** - *(switch)* If set, the function doesn't prompt the user before shutting down the instance to make the type switch. Default: the script prompts the user to confirm shutting down the instance before making the switch.
+
+**-v** - *(switch)* If set, the function displays status throughout its operation. Default: the script operates silently and displays output only in the event of an error.
+
+## Testing the Example
+The file *change_ec2_instance_type_test.sh* script tests the various code paths for the `change_ec2_instance_type` function.
+
+If all steps in the test script work correctly, the test script removes all resources that it created.
+
+You can run the test script with the following parameters:
+
+**-v** - *(switch)* The tests each show a pass/failure status as they run. Default: the tests runs silently and the output includes only the final overall pass/failure status.
+
+**-i** - *(switch)* The script pauses after each test to enable you to browse the intermediate results of each step. When run this way, you can examine the current status of the instance using the Amazon EC2 console. The script  proceeds to the next step after you press *ENTER* at the prompt.
+
+## Additional Information
+
+ * As an AWS best practice, grant this code least privilege, or only the permissions required to perform a task. For more information, see [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege) in the _AWS Identity and Access Management (IAM) User Guide_.
+ * This code has not been tested in all AWS Regions. Some AWS services are available only in specific Regions. For more information, see [Service Endpoints and Quotas](https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html) in the _AWS General Reference Guide_.
+ * Running this code can result in charges to your AWS account. It's your responsibility to ensure that any resources created by this script are removed when you are done with them.

--- a/aws-cli/bash-linux/ec2/change-ec2-instance-type/awsdocs_general.sh
+++ b/aws-cli/bash-linux/ec2/change-ec2-instance-type/awsdocs_general.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+###############################################################################
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+#
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at http://aws.amazon.com/apache2.0/.
+#
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+###############################################################################
+#
+# This script contains general-purpose functions that are used throughout
+# the AWS Command Line Interface (AWS CLI) code examples that are maintained
+# in the repo at https://github.com/awsdocs/aws-doc-sdk-examples.
+#
+# They are intended to abstract functionality that is required for the tests
+# to work without cluttering up the code. The intent is to ensure that the
+# purpose of the code is clear.
+
+# Set global defaults:
+VERBOSE=false
+
+###############################################################################
+# function run_test
+#
+# This function is used to perform a command and compare its output to both
+# the expected error code and the expected output string. If there isn't a
+# match, then the function invokes the test_failed function.
+###############################################################################
+function run_test {
+    local DESCRIPTION COMMAND EXPECTED_ERR_CODE EXPECTED_OUTPUT RESPONSE
+
+    DESCRIPTION="$1"
+    COMMAND="$2"
+    EXPECTED_ERR_CODE="$3"
+    if [[ -z "$4" ]]; then EXPECTED_OUTPUT="$4"; else EXPECTED_OUTPUT=""; fi
+
+    iecho -n "Running test: $DESCRIPTION..."
+    RESPONSE="$($COMMAND)"
+    ERR="${?}"
+
+    # Check to see if we got the expected error code.
+    if [[ "$EXPECTED_ERR_CODE" -ne "$ERR" ]]; then
+        test_failed "The test \"$DESCRIPTION\" returned an unexpected error code: $ERR"
+    fi
+
+    # Now check the error message, if we provided other than "".
+    if [[ -n "$EXPECTED_OUTPUT" ]]; then
+        MATCH=$(echo "$RESPONSE" | grep "$EXPECTED_OUTPUT")
+        # If there was no match (it's an empty string), then fail.
+        if [[ -z "$MATCH" ]]; then
+            test_failed "The test \"$DESCRIPTION\" returned an unexpected output: $RESPONSE"
+        fi
+    fi
+
+    iecho "OK"
+    ipause
+}
+
+###############################################################################
+# function test_failed
+#
+# This function is used to terminate a failed test and to warn the customer
+# about possible undeleted resources that could incur costs to their account.
+###############################################################################
+
+function test_failed {
+    errecho ""
+    errecho "===TEST FAILED==="
+    errecho "$@"
+    errecho ""
+    errecho "    One or more of the tests failed to complete successfully. This means that"
+    errecho "    any tests after the one that failed didn't run and might have left resources"
+    errecho "    still active in your account."
+    errecho ""
+    errecho "IMPORTANT:"
+    errecho "    Resources created by this script can incur charges to your AWS account. If the"
+    errecho "    script didn't complete successfully, then you must review and manually delete"
+    errecho "    any resources created by this script that were not automatically removed."
+    errecho ""
+    exit 1
+}
+
+
+###############################################################################
+# function errecho
+#
+# This function outputs everything sent to it to STDERR (standard error output).
+###############################################################################
+function errecho {
+    printf "%b\n" "$*" 2>&1
+}
+
+###############################################################################
+# function iecho
+#
+# This function enables the script to display the specified text only if
+# the global variable $VERBOSE is set to true.
+###############################################################################
+function iecho {
+    if [[ $VERBOSE == true ]]; then
+        echo -e "$@"
+    fi
+}
+
+###############################################################################
+# function ipause
+#
+# This function enables the script to pause after each command if interactive
+# mode is set (by including -i on the script invocation command).
+###############################################################################
+function ipause {
+    if [[ $INTERACTIVE == true ]]; then
+        read -r -p "Press ENTER to continue..."
+    fi
+}
+
+# Initialize the shell's RANDOM variable.
+RANDOM=$$
+###############################################################################
+# function generate_random_name
+#
+# This function generates a random file name with using the specified root,
+# followed by 4 groups that each have 4 digits.
+# The default root name is "test".
+###############################################################################
+function generate_random_name {
+
+    ROOTNAME="test"
+    if [[ -n $1 ]]; then
+        ROOTNAME=$1
+    fi
+
+    # Initialize the FILENAME variable
+    FILENAME="$ROOTNAME"
+    # Configure random number generator to issue numbers between 1000 and 9999,
+    # inclusive.
+    DIFF=$((9999-1000+1))
+
+    for _ in {1..4}
+    do
+        rnd=$(($((RANDOM%DIFF))+X))
+        # Make sure that the number is 4 digits long.
+        while [ "${#rnd}" -lt 4 ]; do rnd="0$rnd"; done
+        FILENAME+="-$rnd"
+    done
+    echo $FILENAME
+}

--- a/aws-cli/bash-linux/ec2/change-ec2-instance-type/change_ec2_instance_type.sh
+++ b/aws-cli/bash-linux/ec2/change-ec2-instance-type/change_ec2_instance_type.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+###############################################################################
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+#
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at http://aws.amazon.com/apache2.0/.
+#
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+###############################################################################
+#// snippet-start:[ec2.bash.change-instance-type.complete]
+###############################################################################
+#
+# function change_ec2_instance_type
+#
+# This function changes the instance type of the specified Amazon EC2 instance.
+#
+# Parameters:
+#   -i   [string, mandatory] The instance ID of the instance whose type you
+#                            want to change.
+#   -t   [string, mandatory] The instance type to switch the instance to.
+#   -f   [switch, optional]  If set, the function doesn't pause and ask before
+#                            stopping the instance.
+#   -r   [switch, optional]  If set, the function restarts the instance after
+#                            changing the type.
+#   -v   [switch, optional]  Enable verbose logging.
+#   -h   [switch, optional]  Displays this help.
+#
+# Example:
+#      The following example converts the specified instance to type "t2.micro"
+#      without pausing to ask permission. It automatically restarts the
+#      instance after changing the type.
+#
+#      change_ec2_instance_type -i i-123456789012 -t t2.micro -f -r
+#
+# Returns:
+#      0 if successful
+#      1 if it fails
+###############################################################################
+
+# Import the general_purpose functions.
+source awsdocs_general.sh
+
+###############################################################################
+# function instance-exists
+#
+# This function checks to see if the specified instance already exists. If it
+# does, it sets two global parameters to return the running state and the
+# instance type.
+#
+# Input parameters:
+#       $1 - The id of the instance to check
+#
+# Returns:
+#       0 if the instance already exists
+#       1 if the instance doesn't exist
+#     AND:
+#       Sets two global variables:
+#            EXISTING_STATE - Contains the running/stopped state of the instance.
+#            EXISTING_TYPE  - Contains the current type of the instance.
+###############################################################################
+function get_instance_info {
+
+    # Declare local variables.
+    local INSTANCE_ID RESPONSE
+
+    # This function accepts a single parameter.
+    INSTANCE_ID=$1
+
+    # The following --filters parameter causes server-side filtering to limit
+    # results to only the records that match the specified ID. The --query
+    # parameter causes CLI client-side filtering to include only the values of
+    # the InstanceType and State.Code fields.
+
+    RESPONSE=$(aws ec2 describe-instances \
+                   --query 'Reservations[*].Instances[*].[State.Name, InstanceType]' \
+                   --filters Name=instance-id,Values="$INSTANCE_ID" \
+                   --output text \
+               )
+
+    if [[ $? -ne 0 ]] || [[ -z "$RESPONSE" ]]; then
+        # There was no response, so no such instance.
+        return 1        # 1 in Bash script means error/false
+    fi
+
+    # If we got a response, the instance exists.
+    # Retrieve the values of interest and set them as global variables.
+    EXISTING_STATE=$(echo "$RESPONSE" | cut -f 1 )
+    EXISTING_TYPE=$(echo "$RESPONSE" | cut -f 2 )
+
+    return 0        # 0 in Bash script means no error/true
+}
+
+######################################
+#
+#  See header at top of this file
+#
+######################################
+
+function change_ec2_instance_type {
+
+    function usage() (
+        echo ""
+        echo "This function changes the instance type of the specified instance."
+        echo "Parameter:"
+        echo "  -i  Specify the instance ID whose type you want to modify."
+        echo "  -t  Specify the instance type to convert the instance to."
+        echo "  -f  If the instance was originally running, this option prevents"
+        echo "      the script from asking permission before stopping the instance."
+        echo "  -r  Start instance after changing the type."
+        echo "  -v  Enable verbose logging."
+        echo ""
+    )
+
+    local FORCE RESTART REQUESTED_TYPE INSTANCE_ID VERBOSE OPTION RESPONSE ANSWER
+    local OPTIND OPTARG # Required to use getopts command in a function.
+
+    # Set default values.
+    FORCE=false
+    RESTART=false
+    REQUESTED_TYPE=""
+    INSTANCE_ID=""
+    VERBOSE=false
+
+    # Retrieve the calling parameters.
+    while getopts "i:t:frvh" OPTION; do
+        case "${OPTION}"
+        in
+            i)  INSTANCE_ID="${OPTARG}";;
+            t)  REQUESTED_TYPE="${OPTARG}";;
+            f)  FORCE=true;;
+            r)  RESTART=true;;
+            v)  VERBOSE=true;;
+            h)  usage; return 0;;
+            \?) echo "Invalid parameter"; usage; return 1;;
+        esac
+    done
+
+    if [[ -z "$INSTANCE_ID" ]]; then
+        errecho "ERROR: You must provide an instance ID with the -i parameter."
+        usage
+        return 1
+    fi
+
+    if [[ -z "$REQUESTED_TYPE" ]]; then
+        errecho "ERROR: You must provide an instance type with the -t parameter."
+        usage
+        return 1
+    fi
+
+    iecho "Parameters:\n"
+    iecho "    Instance ID:   $INSTANCE_ID"
+    iecho "    Requests type: $REQUESTED_TYPE"
+    iecho "    Force stop:    $FORCE"
+    iecho "    Restart:       $RESTART"
+    iecho "    Verbose:       $VERBOSE"
+    iecho ""
+
+    # Check that the specified instance exists.
+    iecho -n "Confirming that instance $INSTANCE_ID exists..."
+    get_instance_info "$INSTANCE_ID"
+    # If the instance doesn't exist, the function returns an error code <> 0.
+    if [[ ${?} -ne 0 ]]; then
+        errecho "ERROR: I can't find the instance \"$INSTANCE_ID\" in the current AWS account."
+        return 1
+    fi
+    # Function get_instance_info has returned two global values:
+    #   $EXISTING_TYPE  -- The instance type of the specified instance
+    #   $EXISTING_STATE -- Whether the specified instance is running
+
+    iecho "confirmed $INSTANCE_ID exists."
+    iecho "      Current type: $EXISTING_TYPE"
+    iecho "      Current state code: $EXISTING_STATE"
+
+    # Are we trying to change the instance to the same type?
+    if [[ "$EXISTING_TYPE" == "$REQUESTED_TYPE" ]]; then
+        errecho "ERROR: Can't change instance type to the same type: $REQUESTED_TYPE."
+        return 1
+    fi
+
+    # Check if the instance is currently running.
+    # 16="running"
+    if [[ "$EXISTING_STATE" == "running" ]]; then
+        # If it is, we need to stop it.
+        # Do we have permission to stop it?
+        # If -f (FORCE) was set, we do.
+        # If not, we need to ask the user.
+        if [[ $FORCE == false ]]; then
+            while true; do
+                echo ""
+                echo "The instance $INSTANCE_ID is currently running. It must be stopped to change the type."
+                read -r -p "ARE YOU SURE YOU WANT TO STOP THE INSTANCE? (Y or N) " ANSWER
+                case $ANSWER in
+                    [yY]* )
+                        break;;
+                    [nN]* )
+                        echo "Aborting."
+                        exit;;
+                    * )
+                        echo "Please answer Y or N."
+                        ;;
+                esac
+            done
+        else
+            iecho "Forcing stop of instance without prompt because of -f."
+        fi
+
+        # stop the instance
+        iecho -n "Attempting to stop instance $INSTANCE_ID..."
+        RESPONSE=$( aws ec2 stop-instances \
+                        --instance-ids "$INSTANCE_ID" )
+
+        if [[ ${?} -ne 0 ]]; then
+            echo "ERROR - AWS reports that it's unable to stop instance $INSTANCE_ID.\n$RESPONSE"
+            return 1
+        fi
+        iecho "request accepted."
+    else
+        iecho "Instance is not in running state, so not requesting a stop."
+    fi;
+
+    # Wait until stopped.
+    iecho "Waiting for $INSTANCE_ID to report 'stopped' state..."
+    aws ec2 wait instance-stopped \
+        --instance-ids "$INSTANCE_ID"
+    if [[ ${?} -ne 0 ]]; then
+        echo "\nERROR - AWS reports that Wait command failed.\n$RESPONSE"
+        return 1
+    fi
+    iecho "stopped.\n"
+
+    # Change the type - command produces no output.
+    iecho "Attempting to change type from $EXISTING_TYPE to $REQUESTED_TYPE..."
+    RESPONSE=$(aws ec2 modify-instance-attribute \
+                   --instance-id "$INSTANCE_ID" \
+                   --instance-type "{\"Value\":\"$REQUESTED_TYPE\"}"
+              )
+    if [[ ${?} -ne 0 ]]; then
+        errecho "ERROR - AWS reports that it's unable to change the instance type for instance $INSTANCE_ID from $EXISTING_TYPE to $REQUESTED_TYPE.\n$RESPONSE"
+        return 1
+    fi
+    iecho "changed.\n"
+
+    # Restart if asked
+    if [[ "$RESTART" == "true" ]]; then
+
+        iecho "Requesting to restart instance $INSTANCE_ID..."
+        RESPONSE=$(aws ec2 start-instances \
+                        --instance-ids "$INSTANCE_ID" \
+                   )
+        if [[ ${?} -ne 0 ]]; then
+            errecho "ERROR - AWS reports that it's unable to restart instance $INSTANCE_ID.\n$RESPONSE"
+            return 1
+        fi
+        iecho "started.\n"
+        iecho "Waiting for instance $INSTANCE_ID to report 'running' state..."
+        RESPONSE=$(aws ec2 wait instance-running \
+                       --instance-ids "$INSTANCE_ID" )
+        if [[ ${?} -ne 0 ]]; then
+            errecho "ERROR - AWS reports that Wait command failed.\n$RESPONSE"
+            return 1
+        fi
+
+        iecho "running.\n"
+
+    else
+        iecho "Restart was not requested with -r.\n"
+    fi
+}
+
+#// snippet-end:[ec2.bash.change-instance-type.complete]

--- a/aws-cli/bash-linux/ec2/change-ec2-instance-type/test_change_ec2_instance_type.sh
+++ b/aws-cli/bash-linux/ec2/change-ec2-instance-type/test_change_ec2_instance_type.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+#
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at http://aws.amazon.com/apache2.0/.
+#
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+###############################################################################
+
+source ./awsdocs_general.sh
+source ./change_ec2_instance_type.sh
+
+function usage {
+    echo "This script tests the change_ec2_instance_type function by calling the"
+    echo "function in a variety of ways and checking the output. It converts the"
+    echo "instance between types t2.nano and t2.micro."
+    echo ""
+    echo "Parameters:"
+    echo ""
+    echo "  -v  Verbose. Shows diagnostic messages about the tests as they run."
+    echo "  -i  Interactive. Pauses the script between steps so you can browse"
+    echo "      the results in the AWS Management Console as they occur."
+    echo ""
+    echo "IMPORTANT: Running this test script creates an Amazon EC2 instance in"
+    echo "   your Amazon account that can incur charges. It is your responsibility"
+    echo "   to ensure that no resources are left in your account after the script"
+    echo "   completes. If an error occurs during the operation of the script,this"
+    echo "   instance can remain. Check for the instance and delete it manually to"
+    echo "   avoid charges."
+}
+
+# Set default values.
+INTERACTIVE=false
+
+# Retrieve the calling parameters.
+while getopts "ivh" OPTION; do
+    case "${OPTION}"
+    in
+        i)
+            INTERACTIVE=true
+            VERBOSE=true
+            ;;
+        v)
+            VERBOSE=true
+            ;;
+        h)
+            usage
+            return 0
+            ;;
+        \?)
+            echo "Invalid parameter."
+            usage
+            return 1
+            ;;
+    esac
+done
+
+if [ "$VERBOSE" == "true" ]; then iecho "Tests running in verbose mode."; fi
+if [ "$INTERACTIVE" == "true" ]; then iecho "Tests running in interactive mode."; fi
+
+iecho ""
+iecho "***************SETUP STEPS******************"
+    # First, get the AMI ID for the one running the latest Amazon Linux 2.
+    iecho -n "Retrieving the AMI ID for the latest Amazon Linux 2 AMI..."
+    AMI_ID=$(aws ec2 describe-images \
+                --owners 'amazon' \
+                --filters 'Name=name,Values=amzn2-ami-hvm-2.0.????????-x86_64-gp2' 'Name=state,Values=available' \
+                --query 'sort_by(Images, &CreationDate)[-1].[ImageId]' \
+                --output 'text')
+    if [ ${?} -ne 0 ]; then
+        echo "ERROR: Unable to retrieve latest Amazon Linux 2 AMI ID: $AMI_ID"
+        echo "Tests canceled."
+        return 1
+    else
+        iecho "retrieved $AMI_ID."
+    fi
+
+    # Now launch the instance as a t2.micro and capture its instance ID.
+    # All other instance settings are left to default.
+    iecho -n "Requesting new Amazon EC2 instance of type t2.micro..."
+    EC2_INSTANCE_ID=$(aws ec2 run-instances \
+                        --image-id "$AMI_ID" \
+                        --instance-type t2.micro \
+                        --query 'Instances[0].InstanceId' \
+                        --output text)
+    if [ ${?} -ne 0 ]; then
+        echo "ERROR: Unable to launch EC2 instance: $EC2_INSTANCE_ID"
+        echo "Tests canceled."
+        return 1
+    else
+        iecho "launched. ID:$EC2_INSTANCE_ID"
+    fi
+
+    iecho -n "Waiting for instance $EC2_INSTANCE_ID to exist..."
+    aws ec2 wait instance-exists \
+        --instance-id "$EC2_INSTANCE_ID"
+    iecho "confirmed."
+
+iecho "***************END OF SETUP*****************"
+iecho ""
+
+
+run_test "1. Missing mandatory -i parameter" \
+         "change_ec2_instance_type" \
+         1 \
+         "ERROR: You must provide an instance id."
+
+run_test "2. Missing mandatory -t parameter" \
+         "change_ec2_instance_type -i abc" \
+         1 \
+         "ERROR: You must provide an instance type."
+
+run_test "3. Using an instance ID that doesn't exist" \
+         "change_ec2_instance_type -i abc -t t2.micro" \
+         1 \
+         "ERROR: I can't find the instance."
+
+# Test changing to the same type. We can do this while the instance is starting up.
+run_test "4. Trying to change to same type" \
+         "change_ec2_instance_type -v -i $EC2_INSTANCE_ID -t t2.micro" \
+         1 \
+         "ERROR: Can't change instance type to the same type."
+
+iecho -n "Waiting for instance $EC2_INSTANCE_ID to reach running state..."
+RESPONSE=$(aws ec2 wait instance-running --instance-id "$EC2_INSTANCE_ID")
+if [[ ${?} -ne 0 ]]; then
+    errecho "\nERROR: AWS reports that the Wait command failed.\n$RESPONSE"
+    return 1
+fi 
+iecho "running."
+
+# Test changing to t2.micro without -r : should still be in stopped state.
+run_test "5. Changing to type t2.nano without restart" \
+         "change_ec2_instance_type -f -i $EC2_INSTANCE_ID -t t2.nano" \
+         0
+
+         # Validate result was "t2.nano" and that it's in "stopped" state.
+         get_instance_info "$EC2_INSTANCE_ID"
+         if [ "$EXISTING_TYPE" != "t2.nano" ]; then
+             test_failed "Unable to validate change. Should be t2.nano. Found $EXISTING_TYPE."
+         fi
+         if [ "$EXISTING_STATE" != "stopped" ]; then
+             test_failed "Unable to validate state. Should be stopped. Found $EXISTING_STATE."
+         fi
+
+# Test changing back to t2.micro with -r. Should now be in running state
+run_test "6. Changing to type t2.micro with restart" \
+         "change_ec2_instance_type -f -r -i $EC2_INSTANCE_ID -t t2.micro" \
+         0
+
+         # Validate result was "t2.micro" and that it's in "running" state.
+         get_instance_info "$EC2_INSTANCE_ID"
+         if [ "$EXISTING_TYPE" != "t2.micro" ]; then
+             test_failed "Unable to validate change. Should be t2.micro. Found $EXISTING_TYPE."
+         fi
+         if [ "$EXISTING_STATE" != "running" ]; then
+             test_failed "Unable to validate state. Should be running. Found $EXISTING_STATE."
+         fi
+
+iecho ""
+iecho "*************TEAR DOWN STEPS****************"
+    iecho -n "Requesting termination of instance $EC2_INSTANCE_ID..."
+    # Delete and terminate the instance.
+    RESPONSE=$(aws ec2 terminate-instances \
+                        --instance-ids "$EC2_INSTANCE_ID"
+              )
+    if [ ${?} -ne 0 ]; then
+        errecho "**** ERROR ****"
+        errecho "AWS reported a failure to terminate EC2 instance: $EC2_INSTANCE_ID"
+        errecho "You must terminate the instance using the AWS Management Console"
+        errecho "or CLI commands. Failure to terminate the instance can result in"
+        errecho "charges to your AWS account.\n"
+    else
+        iecho "request accepted."
+    fi
+
+    iecho -n "Waiting for instance $EC2_INSTANCE_ID to terminate..."
+    aws ec2 wait instance-terminated \
+        --instance-id "$EC2_INSTANCE_ID"
+    iecho "confirmed."
+    if [[ ${?} -ne 0 ]]; then
+        errecho "ERROR - AWS reports that Wait command failed."
+        errecho "You must ensure that the instance terminated successfully yourself using the"
+        errecho "AWS Management Console or CLI commands. Failure to terminate the instance can" 
+        errecho "result in charges to your AWS account.\n"
+        return 1
+    fi 
+
+
+iecho "************END OF TEAR DOWN****************"
+iecho ""
+
+echo "Tests completed successfully."

--- a/aws-cli/bash-linux/s3/bucket-lifecycle-operations/README.md
+++ b/aws-cli/bash-linux/s3/bucket-lifecycle-operations/README.md
@@ -1,0 +1,49 @@
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+This file is licensed under the Apache License, Version 2.0 (the "License").
+
+You may not use this file except in compliance with the License. A copy of
+the License is located at http://aws.amazon.com/apache2.0/.
+
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# Amazon S3 Bucket Lifecycle Operations
+
+This example demonstrates how to interact with some of the basic Amazon S3 operations. 
+
+## Files
+  * bucket-operations.sh - main script example file
+  * test-bucket-operations.sh - unit/integration test file
+  * general.sh - common test support function file
+
+## Purpose
+The main script file includes functions that perform the following tasks:
+
+ * Creating a bucket and verifying that it exists
+ * Copying a file from the local computer to a bucket
+ * Copying a file from one bucket location to a different bucket location
+ * Listing the contents of a bucket
+ * Deleting a file from a bucket
+ * Deleting a bucket
+
+## Prerequisites
+
+ * An Amazon Web Services (AWS) account.
+ * A shared credentials file with a default profile. The profile that you use must have permissions that allow the AWS operations performed by the script. For more information about how to set up a shared credentials file, see [Configuration and Credential File Settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) in the _AWS CLI User Guide_.
+
+## Running the Code
+
+This example is written as a set of functions in a shell script file (bucket-operations.sh) that can be sourced from another file. The file *`bucket-operations-test.sh`* script demonstrates how to call the functions by sourcing the *`bucket-operations.sh`* file and calling each of the functions.
+
+If all steps work correctly, the test script removes all resources that it created.
+
+To see the intermediate results of each step, run the script with a `-i` parameter. When run this way, you can view the current status of the bucket or its contents using the Amazon S3 console. The script only proceeds to the next step when you press *ENTER* at the prompt.
+
+## Additional Information
+
+ * As an AWS best practice, grant this code least privilege, or only the permissions required to perform a task. For more information, see [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege) in the _AWS Identity and Access Management (IAM) User Guide_.
+ * This code has not been tested in all AWS Regions. Some AWS services are available only in specific Regions. For more information, see [Service Endpoints and Quotas](https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html) in the _AWS General Reference Guide_.
+ * Running this code can result in charges to your AWS account. It is your responsibility to ensure that any resources created by this script are removed when you are done with them.

--- a/aws-cli/bash-linux/s3/bucket-lifecycle-operations/awsdocs_general.sh
+++ b/aws-cli/bash-linux/s3/bucket-lifecycle-operations/awsdocs_general.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+###############################################################################
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+#
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at http://aws.amazon.com/apache2.0/.
+#
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+###############################################################################
+#
+# This script contains general purpose functions that are used throughout 
+# the AWS Command Line Interface (AWS CLI) code samples that are maintained
+# in the repo at https://github.com/awsdocs/aws-doc-sdk-examples
+#
+# They are intended to abstract functionality that is required for the tests
+# to work without cluttering up the code. The intent is to ensure the purpose
+# of the code is clear.
+
+# Set global defaults:
+VERBOSE=false
+
+###############################################################################
+# function run_test
+#
+# This function is used to perform a command and compare its output to both
+# the expected error code and the expected output string. If there isn't a 
+# match, then the function invokes the test_failed function.
+###############################################################################
+function run_test {
+    local DESCRIPTION COMMAND EXPECTED_ERR_CODE EXPECTED_OUTPUT RESPONSE
+    
+    DESCRIPTION="$1"
+    COMMAND="$2"
+    EXPECTED_ERR_CODE="$3"
+    if [[ -z "$4" ]]; then EXPECTED_OUTPUT="$4"; else EXPECTED_OUTPUT=""; fi
+    
+    iecho -n "Running test: $DESCRIPTION..."
+    RESPONSE="$($COMMAND)"
+    ERR="${?}"
+
+    # Check to see if we got the expected error code.
+    if [[ "$EXPECTED_ERR_CODE" -ne "$ERR" ]]; then
+        test_failed "The test \"$DESCRIPTION\" returned an unexpected error code: $ERR"
+    fi
+
+    #now check the error message, if we provided other than "".
+    if [[ -n "$EXPECTED_OUTPUT" ]]; then
+        MATCH=$(echo "$RESPONSE" | grep "$EXPECTED_OUTPUT")
+        # If there was no match (it's an empty string), then fail.
+        if [[ -z "$MATCH" ]]; then
+            test_failed "The test \"$DESCRIPTION\" returned an unexpected output: $RESPONSE"
+        fi
+    fi
+    
+    iecho "OK"
+    ipause
+}
+
+###############################################################################
+# function test_failed
+#
+# This function is used to terminate a failed test and to warn the customer
+# about possible undeleted resources that could incur costs to their account.
+###############################################################################
+
+function test_failed {
+    
+    errecho ""
+    errecho "===TEST FAILED==="
+    errecho "$@"
+    errecho ""
+    errecho "    One or more of the tests failed to complete successfully. This means that any"
+    errecho "    tests after the one that failed test didn't run and might have left resources"
+    errecho "    still active in your account."
+    errecho ""
+    errecho "IMPORTANT:"
+    errecho "    Resources created by this script can incur charges to your AWS account. If the"
+    errecho "    script did not complete successfully, then you must review and manually delete"
+    errecho "    any resources created by this script that were not automatically removed."
+    errecho ""
+    exit 1 
+}
+
+
+###############################################################################
+# function errecho
+#
+# This function outputs everything sent to it to STDERR (standard error output).
+###############################################################################
+function errecho {
+    printf "%s\n" "$*" 2>&1
+}
+
+###############################################################################
+# function iecho
+#
+# This function enables the script to display the specified text only if 
+# the global variable $VERBOSE is set to true.
+###############################################################################
+function iecho {
+    if [[ $VERBOSE == true ]]; then
+        echo "$@"
+    fi
+}
+
+###############################################################################
+# function ipause
+#
+# This function enables the script to pause after each command if interactive
+# mode is set (by including -i on the script invocation command).
+###############################################################################
+function ipause {
+    if [[ $INTERACTIVE == true ]]; then
+        read -r -p "Press ENTER to continue..."
+    fi
+}
+
+# Initialize the shell's RANDOM variable
+RANDOM=$$
+###############################################################################
+# function generate_random_name
+#
+# This function generates a random file name with using the specified root
+# followed by 4 groups that each have 4 digits.
+# The default root name is "test"
+function generate_random_name {
+
+    ROOTNAME="test"
+    if [[ -n $1 ]]; then
+        ROOTNAME=$1
+    fi
+
+    # Initialize the filename variable
+    FILENAME="$ROOTNAME"
+    # Configure random number generator to issue numbers between 1000 and 9999, inclusive
+    DIFF=$((9999-1000+1))
+
+    for _ in {1..4}
+    do
+        rnd=$(($((RANDOM%DIFF))+X))
+        # make sure that the number is 4 digits long
+        while [ "${#rnd}" -lt 4 ]; do rnd="0$rnd"; done
+        FILENAME+="-$rnd"
+    done
+    echo $FILENAME
+}

--- a/aws-cli/bash-linux/s3/bucket-lifecycle-operations/bucket_operations.sh
+++ b/aws-cli/bash-linux/s3/bucket-lifecycle-operations/bucket_operations.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+###############################################################################
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+#
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at http://aws.amazon.com/apache2.0/.
+#
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+###############################################################################
+#// snippet-start:[s3.bash.bucket-operations.complete]
+source ./awsdocs_general.sh
+
+###############################################################################
+# function bucket_exists
+#
+# This function checks to see if the specified bucket already exists.
+#
+# Parameters:
+#       $1 - The name of the bucket to check
+# 
+# Returns:
+#       0 if the bucket already exists
+#       1 if the bucket doesn't exist
+###############################################################################
+function bucket_exists {
+    be_bucketname=$1
+
+    # Check whether the bucket already exists. 
+    # We suppress all output - we're interested only in the return code.
+
+    aws s3api head-bucket \
+        --bucket $be_bucketname \
+        >/dev/null 2>&1
+
+    if [[ ${?} -eq 0 ]]; then
+        return 0        # 0 in Bash script means true.
+    else
+        return 1        # 1 in Bash script means false.
+    fi
+}
+###############################################################################
+# function create-bucket
+#
+# This function creates the specified bucket in the specified AWS Region, unless
+# it already exists.
+# 
+# Parameters:
+#       -b bucket_name  -- The name of the bucket to create
+#       -r region_code  -- The code for an AWS Region in which to 
+#                          create the bucket
+# 
+# Returns:
+#       The URL of the bucket that was created.
+#     And:
+#       0 if successful
+#       1 if it fails
+###############################################################################
+function create_bucket {
+    local BUCKET_NAME REGION_CODE RESPONSE
+    local OPTION OPTIND OPTARG # Required to use getopts command in a function 
+
+    function usage {
+        echo "function create_bucket"
+        echo "Creates an Amazon S3 bucket. You must supply both of the following parameters:"
+        echo "  -b bucket_name    The name of the bucket. It must be globally unique."
+        echo "  -r region_code    The code for an AWS Region in which the bucket is created."
+        echo ""
+    }
+
+    # Retrieve the calling parameters
+    while getopts "b:r:" OPTION; do
+        case "${OPTION}"
+        in
+            b)  BUCKET_NAME="${OPTARG}";;
+            r)  REGION_CODE="${OPTARG}";;
+            h)  usage; return 0;;
+            \?) echo "Invalid parameter"; usage; return 1;; 
+        esac
+    done
+
+    if [[ -z "$BUCKET_NAME" ]]; then
+        errecho "ERROR: You must provide a bucket name with the -b parameter."
+        usage
+        return 1
+    fi
+
+    if [[ -z "$REGION_CODE" ]]; then
+        errecho "ERROR: You must provide an AWS Region code with the -r parameter."
+        usage
+        return 1
+    fi
+
+    iecho "Parameters:\n"
+    iecho "    Bucket name:   $BUCKET_NAME"
+    iecho "    Region code:   $REGION_CODE"
+    iecho ""
+    
+    
+    # If the bucket already exists, we don't want to try to create it.
+    if (bucket_exists $BUCKET_NAME); then 
+        errecho "ERROR: A bucket with that name already exists. Try again."
+        return 1
+    fi
+
+    # The bucket doesn't exist, so try to create it.
+    
+    RESPONSE=$(aws s3api create-bucket \
+                --bucket $BUCKET_NAME \
+                --create-bucket-configuration LocationConstraint=$REGION_CODE)
+
+    if [[ ${?} -ne 0 ]]; then
+        errecho "ERROR: AWS reports create-bucket operation failed.\n$RESPONSE"
+        return 1
+    fi
+}
+
+###############################################################################
+# function copy_file_to_bucket
+#
+# This function creates a file in the specified bucket. 
+#
+# Parameters:
+#       -b bucket_name$1 - The name of the bucket to copy the file to
+#       $2 - The path and file name of the local file to copy to the bucket
+#       $3 - The key (name) to call the copy of the file in the bucket
+# 
+# Returns:
+#       0 if successful
+#       1 if it fails
+###############################################################################
+function copy_file_to_bucket {
+    cftb_bucketname=$1
+    cftb_sourcefile=$2
+    cftb_destfilename=$3
+    local RESPONSE
+    
+    RESPONSE=$(aws s3api put-object \
+                --bucket $cftb_bucketname \
+                --body $cftb_sourcefile \
+                --key $cftb_destfilename)
+
+    if [[ ${?} -ne 0 ]]; then
+        errecho "ERROR: AWS reports put-object operation failed.\n$RESPONSE"
+        return 1
+    fi
+}
+
+###############################################################################
+# function copy_item_in_bucket
+#
+# This function creates a copy of the specified file in the same bucket.
+#
+# Parameters:
+#       $1 - The name of the bucket to copy the file from and to
+#       $2 - The key of the source file to copy
+#       $3 - The key of the destination file
+# 
+# Returns:
+#       0 if successful
+#       1 if it fails
+###############################################################################
+function copy_item_in_bucket {
+    ciib_bucketname=$1
+    ciib_sourcefile=$2
+    ciib_destfile=$3
+    local RESPONSE
+    
+    RESPONSE=$(aws s3api copy-object \
+                --bucket $ciib_bucketname \
+                --copy-source $ciib_bucketname/$ciib_sourcefile \
+                --key $ciib_destfile)
+
+    if [[ $? -ne 0 ]]; then
+        errecho "ERROR:  AWS reports s3api copy-object operation failed.\n$RESPONSE"
+        return 1
+    fi
+}
+
+###############################################################################
+# function list_items_in_bucket
+#
+# This function displays a list of the files in the bucket with each file's 
+# size. The function uses the --query parameter to retrieve only the Key and 
+# Size fields from the Contents collection.
+#
+# Parameters:
+#       $1 - The name of the bucket
+# 
+# Returns:
+#       The list of files in text format
+#     And:
+#       0 if successful
+#       1 if it fails
+###############################################################################
+function list_items_in_bucket {
+    liib_bucketname=$1
+    local RESPONSE
+
+    RESPONSE=$(aws s3api list-objects \
+                --bucket $liib_bucketname \
+                --output text \
+                --query 'Contents[].{Key: Key, Size: Size}' )
+
+    if [[ ${?} -eq 0 ]]; then
+        echo "$RESPONSE"
+    else
+        errecho "ERROR: AWS reports s3api list-objects operation failed.\n$RESPONSE"
+        return 1
+    fi
+}
+
+###############################################################################
+# function delete_item_in_bucket
+#
+# This function deletes the specified file from the specified bucket. 
+#
+# Parameters:
+#       $1 - The name of the bucket
+#       $2 - The key (file name) in the bucket to delete
+
+# Returns:
+#       0 if successful
+#       1 if it fails
+###############################################################################
+function delete_item_in_bucket {
+    diib_bucketname=$1
+    diib_key=$2
+    local RESPONSE
+    
+    RESPONSE=$(aws s3api delete-object \
+                --bucket $diib_bucketname \
+                --key $diib_key)
+
+    if [[ $? -ne 0 ]]; then
+        errecho "ERROR:  AWS reports s3api delete-object operation failed.\n$RESPONSE"
+        return 1
+    fi
+}
+
+###############################################################################
+# function delete_bucket
+#
+# This function deletes the specified bucket.
+#
+# Parameters:
+#       $1 - The name of the bucket
+
+# Returns:
+#       0 if successful
+#       1 if it fails
+###############################################################################
+ function delete_bucket {
+    db_bucketname=$1
+    local RESPONSE
+
+    RESPONSE=$(aws s3api delete-bucket \
+                --bucket $db_bucketname)
+
+    if [[ $? -ne 0 ]]; then
+        errecho "ERROR: AWS reports s3api delete-bucket failed.\n$RESPONSE"
+        return 1
+    fi
+}
+#// snippet-end:[s3.bash.bucket-operations.complete]

--- a/aws-cli/bash-linux/s3/bucket-lifecycle-operations/test_bucket_operations.sh
+++ b/aws-cli/bash-linux/s3/bucket-lifecycle-operations/test_bucket_operations.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+#
+# You may not use this file except in compliance with the License. A copy of
+# the License is located at http://aws.amazon.com/apache2.0/.
+#
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+###############################################################################
+
+source ./awsdocs_general.sh
+source ./bucket_operations.sh
+
+function usage {
+    echo "This script tests Amazon S3 bucket operations in the AWS CLI."
+    echo "It creates a randomly named bucket, copies files to it, then"
+    echo "deletes the files and the bucket."
+    echo ""
+    echo "To pause the script between steps so you can see the results in the"
+    echo "AWS Management Console, include the parameter -i."
+    echo ""
+    echo "IMPORTANT: Running this script creates resources in your Amazon"
+    echo "   account that can incur charges. It is your responsibility to"
+    echo "   ensure that no resources are left in your account after the script"
+    echo "   completes. If an error occurs during the operation of the script,"
+    echo "   then resources can remain that you might need to delete manually."
+}
+
+    # Set default values.
+    INTERACTIVE=false
+    VERBOSE=false
+
+    # Retrieve the calling parameters
+    while getopts "ivh" OPTION; do
+        case "${OPTION}"
+        in
+            i)  INTERACTIVE=true;VERBOSE=true; iecho;;
+            v)  VERBOSE=true;;
+            h)  usage; return 0;;
+            \?) echo "Invalid parameter"; usage; return 1;; 
+        esac
+    done
+
+
+if [ "$INTERACTIVE" == "true" ]; then iecho "Tests running in interactive mode."; fi
+if [ "$VERBOSE" == "true" ]; then iecho "Tests running in verbose mode."; fi
+
+iecho "***************SETUP STEPS******************"
+BUCKETNAME=$(generate_random_name s3test)
+REGION="us-west-2"
+FILENAME1=$(generate_random_name s3testfile)
+FILENAME2=$(generate_random_name s3testfile)
+
+iecho "BUCKETNAME=$BUCKETNAME"
+iecho "REGION=$REGION"
+iecho "FILENAME1=$FILENAME1"
+iecho "FILENAME2=$FILENAME2"
+
+iecho "**************END OF STEPS******************"
+
+run_test "1. Creating bucket with missing bucket_name" \
+         "create_bucket -r $REGION" \
+         1 \
+         "ERROR: You must provide a bucket name" \
+
+
+run_test "2. Creating bucket with missing region_name" \
+         "create_bucket -b $BUCKETNAME" \
+         1 \
+         "ERROR: You must provide an AWS Region code"
+
+run_test "3. Creating bucket with valid parameters" \
+         "create_bucket -r $REGION -b $BUCKETNAME" \
+         0
+
+run_test "4. Creating bucket with duplicate name and region" \
+         "create_bucket -r $REGION -b $BUCKETNAME" \
+         1 \
+         "ERROR: A bucket with that name already exists"
+
+run_test "5. Copying local file (copy of this script) to bucket" \
+         "copy_file_to_bucket $BUCKETNAME ./$0 $FILENAME1" \
+         0
+
+run_test "6. Duplicating existing file in bucket" \
+         "copy_item_in_bucket $BUCKETNAME $FILENAME1 $FILENAME2" \
+         0
+
+run_test "7. Listing contents of bucket" \
+         "list_items_in_bucket $BUCKETNAME" \
+         0
+
+run_test "8. Deleting first file from bucket" \
+         "delete_item_in_bucket $BUCKETNAME $FILENAME1" \
+         0
+
+run_test "9. Deleting second file from bucket" \
+         "delete_item_in_bucket $BUCKETNAME $FILENAME2" \
+         0
+
+run_test "10. Deleting bucket" \
+         "delete_bucket $BUCKETNAME" \
+         0
+
+echo "Tests completed successfully."


### PR DESCRIPTION
It turns out we got a little overzealous in our cleanup effort and deleted this folder that's referenced in the AWS CLI guide. This PR restores the folder for now.

Long term, we will look for a different solution, because the goals of this repo have changed and we no longer intend to add or maintain CLI examples.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
