### PR TITLE
fix import statement of fs and path

### DIFF
--- a/javascriptv3/example_code/s3/src/s3_upload_object.js
+++ b/javascriptv3/example_code/s3/src/s3_upload_object.js
@@ -22,8 +22,8 @@ Uploads the specified file to the specified bucket.
 // Import required AWS SDK clients and commands for Node.js.
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { s3Client } from "./libs/s3Client.js"; // Helper function that creates an Amazon S3 service client module.
-import {path} from "path";
-import {fs} from "fs";
+import path from "path";
+import fs from "fs";
 
 const file = "OBJECT_PATH_AND_NAME"; // Path to and name of object. For example '../myFiles/index.js'.
 const fileStream = fs.createReadStream(file);


### PR DESCRIPTION
## I'm resolving an issue with an existing code example

Just fix import statement of fs and path module.

without this fix, when you run `node s3_upload_object.js`, you'll see following syntax error:

> import {path} from "path";
>         ^^^^
> SyntaxError: The requested module 'path' does not provide an export named 'path' at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21) at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [x] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
