### PR TITLE
remove comment for BUCKET_NAME input

### DIFF
--- a/javascriptv3/example_code/s3/src/s3_listbuckets.js
+++ b/javascriptv3/example_code/s3/src/s3_listbuckets.js
@@ -8,9 +8,6 @@ https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/s3-example-cre
 Purpose:
 s3_listbuckets.js demonstrates how to list all the buckets in an AWS account.
 
-Inputs (replace in code):
-- BUCKET_NAME
-
 Running the code:
 s3_getbucketwebsite s3_listobjects.js
 */


### PR DESCRIPTION
## I'm resolving an issue with an existing code example

Remove comment about BUCKET_NAME input since it's not used in s3_listbuckets.js.

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [x] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).