### PR TITLE
Update Cargo.toml

### DIFF
--- a/rust_dev_preview/Cargo.toml
+++ b/rust_dev_preview/Cargo.toml
@@ -62,6 +62,5 @@ members = [
     "test-utils",
     "testing",
     "tls",
-    "transcribestreaming",
-    "webassembly"
+    "transcribestreaming"
 ]

--- a/rust_dev_preview/webassembly/Cargo.toml
+++ b/rust_dev_preview/webassembly/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Eduardo Rodrigues <16357187+eduardomourar@users.noreply.github.com>"]
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[workspace]
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Remove webassembly from top level cargo as it has specific rustup requirements.
