### PR TITLE
Fix Rust examples after reorganizing the SDK crates

### DIFF
--- a/rust_dev_preview/apigateway/Cargo.toml
+++ b/rust_dev_preview/apigateway/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-apigateway = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-apigateway = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/apigateway/src/bin/get_rest_apis.rs
+++ b/rust_dev_preview/apigateway/src/bin/get_rest_apis.rs
@@ -5,8 +5,8 @@
 
 use apigateway_code_examples::Error;
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_apigateway::types::DisplayErrorContext;
-use aws_sdk_apigateway::{Client, Region, PKG_VERSION};
+use aws_sdk_apigateway::error::DisplayErrorContext;
+use aws_sdk_apigateway::{config::Region, meta::PKG_VERSION, Client};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use std::process;
 use structopt::StructOpt;

--- a/rust_dev_preview/apigateway/src/bin/get_rest_apis.rs
+++ b/rust_dev_preview/apigateway/src/bin/get_rest_apis.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use apigateway_code_examples::Error;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_apigateway::error::DisplayErrorContext;

--- a/rust_dev_preview/apigateway/src/lib.rs
+++ b/rust_dev_preview/apigateway/src/lib.rs
@@ -26,11 +26,11 @@ impl From<aws_sdk_apigateway::Error> for Error {
     }
 }
 
-impl<T> From<aws_sdk_apigateway::types::SdkError<T>> for Error
+impl<T> From<aws_sdk_apigateway::error::SdkError<T>> for Error
 where
     T: StdError + Send + Sync + 'static,
 {
-    fn from(source: aws_sdk_apigateway::types::SdkError<T>) -> Self {
+    fn from(source: aws_sdk_apigateway::error::SdkError<T>) -> Self {
         Error::unhandled(source)
     }
 }

--- a/rust_dev_preview/apigatewaymanagement/Cargo.toml
+++ b/rust_dev_preview/apigatewaymanagement/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-apigatewaymanagement = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-apigatewaymanagement = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 http = "0.2.5"
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/apigatewaymanagement/src/bin/post_to_connection.rs
+++ b/rust_dev_preview/apigatewaymanagement/src/bin/post_to_connection.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_apigatewaymanagement::types::Blob;
-use aws_sdk_apigatewaymanagement::{config, Client, Error, Region, PKG_VERSION};
+use aws_sdk_apigatewaymanagement::primitives::Blob;
+use aws_sdk_apigatewaymanagement::{config, config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/apigatewaymanagement/src/bin/post_to_connection.rs
+++ b/rust_dev_preview/apigatewaymanagement/src/bin/post_to_connection.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_apigatewaymanagement::primitives::Blob;
 use aws_sdk_apigatewaymanagement::{config, config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/applicationautoscaling/Cargo.toml
+++ b/rust_dev_preview/applicationautoscaling/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-applicationautoscaling = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-applicationautoscaling = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/applicationautoscaling/src/bin/describe-scaling-policies.rs
+++ b/rust_dev_preview/applicationautoscaling/src/bin/describe-scaling-policies.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_applicationautoscaling::model::ServiceNamespace;
-use aws_sdk_applicationautoscaling::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_applicationautoscaling::types::ServiceNamespace;
+use aws_sdk_applicationautoscaling::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/applicationautoscaling/src/bin/describe-scaling-policies.rs
+++ b/rust_dev_preview/applicationautoscaling/src/bin/describe-scaling-policies.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_applicationautoscaling::types::ServiceNamespace;
 use aws_sdk_applicationautoscaling::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/autoscaling/Cargo.toml
+++ b/rust_dev_preview/autoscaling/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-autoscaling = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-autoscaling = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/autoscaling/src/bin/create-autoscaling-group.rs
+++ b/rust_dev_preview/autoscaling/src/bin/create-autoscaling-group.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_autoscaling::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/autoscaling/src/bin/create-autoscaling-group.rs
+++ b/rust_dev_preview/autoscaling/src/bin/create-autoscaling-group.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_autoscaling::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_autoscaling::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/autoscaling/src/bin/delete-autoscaling-group.rs
+++ b/rust_dev_preview/autoscaling/src/bin/delete-autoscaling-group.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_autoscaling::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/autoscaling/src/bin/delete-autoscaling-group.rs
+++ b/rust_dev_preview/autoscaling/src/bin/delete-autoscaling-group.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_autoscaling::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_autoscaling::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/autoscaling/src/bin/list-autoscaling-groups.rs
+++ b/rust_dev_preview/autoscaling/src/bin/list-autoscaling-groups.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_autoscaling::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/autoscaling/src/bin/list-autoscaling-groups.rs
+++ b/rust_dev_preview/autoscaling/src/bin/list-autoscaling-groups.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_autoscaling::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_autoscaling::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/autoscaling/src/bin/update-autoscaling-group.rs
+++ b/rust_dev_preview/autoscaling/src/bin/update-autoscaling-group.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_autoscaling::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/autoscaling/src/bin/update-autoscaling-group.rs
+++ b/rust_dev_preview/autoscaling/src/bin/update-autoscaling-group.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_autoscaling::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_autoscaling::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/autoscalingplans/Cargo.toml
+++ b/rust_dev_preview/autoscalingplans/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-autoscalingplans = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-sdk-autoscalingplans = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/autoscalingplans/src/bin/describe-scaling-plans.rs
+++ b/rust_dev_preview/autoscalingplans/src/bin/describe-scaling-plans.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_autoscalingplans::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/autoscalingplans/src/bin/describe-scaling-plans.rs
+++ b/rust_dev_preview/autoscalingplans/src/bin/describe-scaling-plans.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_autoscalingplans::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_autoscalingplans::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/batch/Cargo.toml
+++ b/rust_dev_preview/batch/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-batch = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-batch = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/batch/src/bin/batch-helloworld.rs
+++ b/rust_dev_preview/batch/src/bin/batch-helloworld.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_batch::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_batch::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/batch/src/bin/batch-helloworld.rs
+++ b/rust_dev_preview/batch/src/bin/batch-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_batch::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/cloudformation/Cargo.toml
+++ b/rust_dev_preview/cloudformation/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cloudformation = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cloudformation = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/cloudformation/src/bin/create-stack.rs
+++ b/rust_dev_preview/cloudformation/src/bin/create-stack.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cloudformation::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::fs;

--- a/rust_dev_preview/cloudformation/src/bin/create-stack.rs
+++ b/rust_dev_preview/cloudformation/src/bin/create-stack.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cloudformation::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_cloudformation::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::fs;
 use structopt::StructOpt;
 

--- a/rust_dev_preview/cloudformation/src/bin/delete-stack.rs
+++ b/rust_dev_preview/cloudformation/src/bin/delete-stack.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cloudformation::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/cloudformation/src/bin/delete-stack.rs
+++ b/rust_dev_preview/cloudformation/src/bin/delete-stack.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cloudformation::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_cloudformation::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/cloudformation/src/bin/describe-stack.rs
+++ b/rust_dev_preview/cloudformation/src/bin/describe-stack.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cloudformation::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/cloudformation/src/bin/describe-stack.rs
+++ b/rust_dev_preview/cloudformation/src/bin/describe-stack.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cloudformation::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_cloudformation::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/cloudformation/src/bin/list-stacks.rs
+++ b/rust_dev_preview/cloudformation/src/bin/list-stacks.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cloudformation::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/cloudformation/src/bin/list-stacks.rs
+++ b/rust_dev_preview/cloudformation/src/bin/list-stacks.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cloudformation::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_cloudformation::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/cloudwatch/Cargo.toml
+++ b/rust_dev_preview/cloudwatch/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cloudwatch = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cloudwatch = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/cloudwatch/src/bin/list-metrics.rs
+++ b/rust_dev_preview/cloudwatch/src/bin/list-metrics.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cloudwatch::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/cloudwatch/src/bin/list-metrics.rs
+++ b/rust_dev_preview/cloudwatch/src/bin/list-metrics.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cloudwatch::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_cloudwatch::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/cloudwatchlogs/Cargo.toml
+++ b/rust_dev_preview/cloudwatchlogs/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cloudwatchlogs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cloudwatchlogs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/cloudwatchlogs/src/bin/get-log-events.rs
+++ b/rust_dev_preview/cloudwatchlogs/src/bin/get-log-events.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cloudwatchlogs::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_cloudwatchlogs::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/cloudwatchlogs/src/bin/get-log-events.rs
+++ b/rust_dev_preview/cloudwatchlogs/src/bin/get-log-events.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cloudwatchlogs::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/cloudwatchlogs/src/bin/list-log-groups.rs
+++ b/rust_dev_preview/cloudwatchlogs/src/bin/list-log-groups.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cloudwatchlogs::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_cloudwatchlogs::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/cloudwatchlogs/src/bin/list-log-groups.rs
+++ b/rust_dev_preview/cloudwatchlogs/src/bin/list-log-groups.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cloudwatchlogs::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/cloudwatchlogs/src/bin/list-log-streams.rs
+++ b/rust_dev_preview/cloudwatchlogs/src/bin/list-log-streams.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cloudwatchlogs::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_cloudwatchlogs::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/cloudwatchlogs/src/bin/list-log-streams.rs
+++ b/rust_dev_preview/cloudwatchlogs/src/bin/list-log-streams.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cloudwatchlogs::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/cognitoidentity/Cargo.toml
+++ b/rust_dev_preview/cognitoidentity/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cognitoidentity = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cognitoidentity = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 chrono = "0.4"

--- a/rust_dev_preview/cognitoidentity/src/bin/describe-identity-pool.rs
+++ b/rust_dev_preview/cognitoidentity/src/bin/describe-identity-pool.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cognitoidentity::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_cognitoidentity::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/cognitoidentity/src/bin/describe-identity-pool.rs
+++ b/rust_dev_preview/cognitoidentity/src/bin/describe-identity-pool.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cognitoidentity::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/cognitoidentity/src/bin/list-identity-pools.rs
+++ b/rust_dev_preview/cognitoidentity/src/bin/list-identity-pools.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cognitoidentity::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_cognitoidentity::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/cognitoidentity/src/bin/list-identity-pools.rs
+++ b/rust_dev_preview/cognitoidentity/src/bin/list-identity-pools.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cognitoidentity::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/cognitoidentity/src/bin/list-pool-identities.rs
+++ b/rust_dev_preview/cognitoidentity/src/bin/list-pool-identities.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cognitoidentity::error::DisplayErrorContext;
 use aws_sdk_cognitoidentity::{config::Region, meta::PKG_VERSION, Client};

--- a/rust_dev_preview/cognitoidentity/src/bin/list-pool-identities.rs
+++ b/rust_dev_preview/cognitoidentity/src/bin/list-pool-identities.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cognitoidentity::types::DisplayErrorContext;
-use aws_sdk_cognitoidentity::{Client, Region, PKG_VERSION};
+use aws_sdk_cognitoidentity::error::DisplayErrorContext;
+use aws_sdk_cognitoidentity::{config::Region, meta::PKG_VERSION, Client};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use cognitoidentity_code_examples::Error;
 use std::process;

--- a/rust_dev_preview/cognitoidentity/src/lib.rs
+++ b/rust_dev_preview/cognitoidentity/src/lib.rs
@@ -20,11 +20,11 @@ impl From<aws_sdk_cognitoidentity::Error> for Error {
     }
 }
 
-impl<T> From<aws_sdk_cognitoidentity::types::SdkError<T>> for Error
+impl<T> From<aws_sdk_cognitoidentity::error::SdkError<T>> for Error
 where
     T: StdError + Send + Sync + 'static,
 {
-    fn from(source: aws_sdk_cognitoidentity::types::SdkError<T>) -> Self {
+    fn from(source: aws_sdk_cognitoidentity::error::SdkError<T>) -> Self {
         Self {
             source: source.into(),
         }

--- a/rust_dev_preview/cognitoidentityprovider/Cargo.toml
+++ b/rust_dev_preview/cognitoidentityprovider/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cognitoidentityprovider = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cognitoidentityprovider = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/cognitoidentityprovider/src/bin/list-user-pools.rs
+++ b/rust_dev_preview/cognitoidentityprovider/src/bin/list-user-pools.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cognitoidentityprovider::types::DisplayErrorContext;
-use aws_sdk_cognitoidentityprovider::{Client, Region, PKG_VERSION};
+use aws_sdk_cognitoidentityprovider::error::DisplayErrorContext;
+use aws_sdk_cognitoidentityprovider::{config::Region, meta::PKG_VERSION, Client};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use cognitoidentityprovider_code_examples::Error;
 use std::process;

--- a/rust_dev_preview/cognitoidentityprovider/src/bin/list-user-pools.rs
+++ b/rust_dev_preview/cognitoidentityprovider/src/bin/list-user-pools.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cognitoidentityprovider::error::DisplayErrorContext;
 use aws_sdk_cognitoidentityprovider::{config::Region, meta::PKG_VERSION, Client};

--- a/rust_dev_preview/cognitoidentityprovider/src/lib.rs
+++ b/rust_dev_preview/cognitoidentityprovider/src/lib.rs
@@ -26,11 +26,11 @@ impl From<aws_sdk_cognitoidentityprovider::Error> for Error {
     }
 }
 
-impl<T> From<aws_sdk_cognitoidentityprovider::types::SdkError<T>> for Error
+impl<T> From<aws_sdk_cognitoidentityprovider::error::SdkError<T>> for Error
 where
     T: StdError + Send + Sync + 'static,
 {
-    fn from(source: aws_sdk_cognitoidentityprovider::types::SdkError<T>) -> Self {
+    fn from(source: aws_sdk_cognitoidentityprovider::error::SdkError<T>) -> Self {
         Error::unhandled(source)
     }
 }

--- a/rust_dev_preview/cognitosync/Cargo.toml
+++ b/rust_dev_preview/cognitosync/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cognitosync = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cognitosync = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/cognitosync/src/bin/list-identity-pool-usage.rs
+++ b/rust_dev_preview/cognitosync/src/bin/list-identity-pool-usage.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cognitosync::error::DisplayErrorContext;
 use aws_sdk_cognitosync::{config::Region, meta::PKG_VERSION, Client};

--- a/rust_dev_preview/cognitosync/src/bin/list-identity-pool-usage.rs
+++ b/rust_dev_preview/cognitosync/src/bin/list-identity-pool-usage.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_cognitosync::types::DisplayErrorContext;
-use aws_sdk_cognitosync::{Client, Region, PKG_VERSION};
+use aws_sdk_cognitosync::error::DisplayErrorContext;
+use aws_sdk_cognitosync::{config::Region, meta::PKG_VERSION, Client};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use cognitosync_code_examples::Error;
 use std::process;

--- a/rust_dev_preview/cognitosync/src/lib.rs
+++ b/rust_dev_preview/cognitosync/src/lib.rs
@@ -26,11 +26,11 @@ impl From<aws_sdk_cognitosync::Error> for Error {
     }
 }
 
-impl<T> From<aws_sdk_cognitosync::types::SdkError<T>> for Error
+impl<T> From<aws_sdk_cognitosync::error::SdkError<T>> for Error
 where
     T: StdError + Send + Sync + 'static,
 {
-    fn from(source: aws_sdk_cognitosync::types::SdkError<T>) -> Self {
+    fn from(source: aws_sdk_cognitosync::error::SdkError<T>) -> Self {
         Error::unhandled(source)
     }
 }

--- a/rust_dev_preview/concurrency/Cargo.toml
+++ b/rust_dev_preview/concurrency/Cargo.toml
@@ -21,7 +21,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 
 [dev-dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 fastrand = "1.8.0"

--- a/rust_dev_preview/concurrency/examples/s3.rs
+++ b/rust_dev_preview/concurrency/examples/s3.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client;
 use clap::Parser;

--- a/rust_dev_preview/concurrency/examples/s3.rs
+++ b/rust_dev_preview/concurrency/examples/s3.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_sdk_s3::types::ByteStream;
+use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client;
 use clap::Parser;
 use concurrency::Runtime;

--- a/rust_dev_preview/concurrency/examples/sqs.rs
+++ b/rust_dev_preview/concurrency/examples/sqs.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_sqs::Client;
 use clap::Parser;
 use concurrency::Runtime;

--- a/rust_dev_preview/config/Cargo.toml
+++ b/rust_dev_preview/config/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/config/src/bin/config-helloworld.rs
+++ b/rust_dev_preview/config/src/bin/config-helloworld.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_config::model::ResourceType;
-use aws_sdk_config::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_config::types::ResourceType;
+use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/config/src/bin/config-helloworld.rs
+++ b/rust_dev_preview/config/src/bin/config-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_config::types::ResourceType;
 use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/config/src/bin/delete-configuration-recorder.rs
+++ b/rust_dev_preview/config/src/bin/delete-configuration-recorder.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/config/src/bin/delete-configuration-recorder.rs
+++ b/rust_dev_preview/config/src/bin/delete-configuration-recorder.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_config::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/config/src/bin/delete-delivery-channel.rs
+++ b/rust_dev_preview/config/src/bin/delete-delivery-channel.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/config/src/bin/delete-delivery-channel.rs
+++ b/rust_dev_preview/config/src/bin/delete-delivery-channel.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_config::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/config/src/bin/enable-config.rs
+++ b/rust_dev_preview/config/src/bin/enable-config.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_config::types::{
     ConfigSnapshotDeliveryProperties, ConfigurationRecorder, DeliveryChannel,

--- a/rust_dev_preview/config/src/bin/enable-config.rs
+++ b/rust_dev_preview/config/src/bin/enable-config.rs
@@ -4,11 +4,11 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_config::model::{
+use aws_sdk_config::types::{
     ConfigSnapshotDeliveryProperties, ConfigurationRecorder, DeliveryChannel,
     MaximumExecutionFrequency, RecordingGroup, ResourceType,
 };
-use aws_sdk_config::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::process;
 use structopt::StructOpt;
 

--- a/rust_dev_preview/config/src/bin/list-configuration-recorders.rs
+++ b/rust_dev_preview/config/src/bin/list-configuration-recorders.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/config/src/bin/list-configuration-recorders.rs
+++ b/rust_dev_preview/config/src/bin/list-configuration-recorders.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_config::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/config/src/bin/list-delivery-channels.rs
+++ b/rust_dev_preview/config/src/bin/list-delivery-channels.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/config/src/bin/list-delivery-channels.rs
+++ b/rust_dev_preview/config/src/bin/list-delivery-channels.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_config::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/config/src/bin/list-resources.rs
+++ b/rust_dev_preview/config/src/bin/list-resources.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_config::model::ResourceType;
-use aws_sdk_config::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_config::types::ResourceType;
+use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/config/src/bin/list-resources.rs
+++ b/rust_dev_preview/config/src/bin/list-resources.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_config::types::ResourceType;
 use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/config/src/bin/show-resource-history.rs
+++ b/rust_dev_preview/config/src/bin/show-resource-history.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_config::model::ResourceType;
-use aws_sdk_config::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_config::types::ResourceType;
+use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/config/src/bin/show-resource-history.rs
+++ b/rust_dev_preview/config/src/bin/show-resource-history.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_config::types::ResourceType;
 use aws_sdk_config::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/cross_service/detect_faces/Cargo.toml
+++ b/rust_dev_preview/cross_service/detect_faces/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/cross_service/detect_faces/src/main.rs
+++ b/rust_dev_preview/cross_service/detect_faces/src/main.rs
@@ -4,6 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_s3::config::Region;
 use std::error::Error;
 use std::path::Path;
 use structopt::StructOpt;
@@ -39,7 +40,7 @@ struct Opt {
 // snippet-start:[detect_faces-save_bucket.rust.main]
 async fn save_bucket(
     client: &aws_sdk_s3::Client,
-    body: aws_sdk_s3::types::ByteStream,
+    body: aws_sdk_s3::primitives::ByteStream,
     bucket: &str,
     content_type: &str,
     key: &str,
@@ -65,12 +66,12 @@ async fn save_bucket(
 async fn describe_faces(
     verbose: bool,
     client: &aws_sdk_rekognition::Client,
-    image: aws_sdk_rekognition::model::Image,
+    image: aws_sdk_rekognition::types::Image,
 ) -> Result<(), aws_sdk_rekognition::Error> {
     let resp = client
         .detect_faces()
         .image(image)
-        .attributes(aws_sdk_rekognition::model::Attribute::All)
+        .attributes(aws_sdk_rekognition::types::Attribute::All)
         .send()
         .await?;
 
@@ -175,22 +176,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let s3_region = region.clone();
     let rek_region = region.clone();
 
-    let rek_region_provider =
-        RegionProviderChain::first_try(rek_region.map(aws_sdk_rekognition::Region::new))
-            .or_default_provider()
-            .or_else(aws_sdk_rekognition::Region::new("us-west-2"));
-
-    let s3_region_provider = RegionProviderChain::first_try(s3_region.map(aws_sdk_s3::Region::new))
+    let rek_region_provider = RegionProviderChain::first_try(rek_region.map(Region::new))
         .or_default_provider()
-        .or_else(aws_sdk_s3::Region::new("us-west-2"));
+        .or_else(Region::new("us-west-2"));
+
+    let s3_region_provider = RegionProviderChain::first_try(s3_region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
     println!();
 
     if verbose {
         println!(
             "Rekognition client version: {}",
-            aws_sdk_rekognition::PKG_VERSION
+            aws_sdk_rekognition::meta::PKG_VERSION
         );
-        println!("S3 client version:          {}", aws_sdk_s3::PKG_VERSION);
+        println!(
+            "S3 client version:          {}",
+            aws_sdk_s3::meta::PKG_VERSION
+        );
         println!("Bucket:                     {}", bucket);
         println!("Filename:                   {}", filename);
 
@@ -214,19 +217,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await;
     let rek_client = aws_sdk_rekognition::Client::new(&rek_shared_config);
 
-    let body = aws_sdk_s3::types::ByteStream::from_path(path).await;
+    let body = aws_sdk_s3::primitives::ByteStream::from_path(path).await;
 
     let key: String = String::from("uploads/") + &filename;
 
     save_bucket(&s3_client, body.unwrap(), &bucket, &content_type, &filename)
         .await
         .unwrap();
-    let s3_obj = aws_sdk_rekognition::model::S3Object::builder()
+    let s3_obj = aws_sdk_rekognition::types::S3Object::builder()
         .bucket(bucket)
         .name(key)
         .build();
 
-    let s3_img = aws_sdk_rekognition::model::Image::builder()
+    let s3_img = aws_sdk_rekognition::types::Image::builder()
         .s3_object(s3_obj)
         .build();
 

--- a/rust_dev_preview/cross_service/detect_labels/Cargo.toml
+++ b/rust_dev_preview/cross_service/detect_labels/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/cross_service/detect_labels/src/main.rs
+++ b/rust_dev_preview/cross_service/detect_labels/src/main.rs
@@ -6,7 +6,8 @@
 extern crate exif;
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_dynamodb::model::AttributeValue;
+use aws_sdk_dynamodb::config::Region;
+use aws_sdk_dynamodb::types::AttributeValue;
 use std::process;
 use structopt::StructOpt;
 
@@ -48,7 +49,7 @@ struct Edata {
 
 // snippet-start:[detect_labels-add_file_to_bucket.rust.main]
 async fn add_file_to_bucket(client: &aws_sdk_s3::Client, bucket: &str, filename: &str) {
-    let body = aws_sdk_s3::types::ByteStream::from_path(std::path::Path::new(filename)).await;
+    let body = aws_sdk_s3::primitives::ByteStream::from_path(std::path::Path::new(filename)).await;
 
     match body {
         Ok(b) => {
@@ -175,12 +176,12 @@ async fn get_label_data(
     bucket: &str,
     key: &str,
 ) -> Vec<Litem> {
-    let s3_obj = aws_sdk_rekognition::model::S3Object::builder()
+    let s3_obj = aws_sdk_rekognition::types::S3Object::builder()
         .bucket(bucket)
         .name(key)
         .build();
 
-    let s3_img = aws_sdk_rekognition::model::Image::builder()
+    let s3_img = aws_sdk_rekognition::types::Image::builder()
         .s3_object(s3_obj)
         .build();
 
@@ -240,32 +241,33 @@ async fn main() -> Result<(), exif::Error> {
     let s3_region = region.clone();
     let rek_region = region.clone();
 
-    let dynamo_region_provider =
-        RegionProviderChain::first_try(dynamo_region.map(aws_sdk_dynamodb::Region::new))
-            .or_default_provider()
-            .or_else(aws_sdk_dynamodb::Region::new("us-west-2"));
-
-    let rek_region_provider =
-        RegionProviderChain::first_try(rek_region.map(aws_sdk_rekognition::Region::new))
-            .or_default_provider()
-            .or_else(aws_sdk_rekognition::Region::new("us-west-2"));
-
-    let s3_region_provider = RegionProviderChain::first_try(s3_region.map(aws_sdk_s3::Region::new))
+    let dynamo_region_provider = RegionProviderChain::first_try(dynamo_region.map(Region::new))
         .or_default_provider()
-        .or_else(aws_sdk_s3::Region::new("us-west-2"));
+        .or_else(Region::new("us-west-2"));
+
+    let rek_region_provider = RegionProviderChain::first_try(rek_region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
+
+    let s3_region_provider = RegionProviderChain::first_try(s3_region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
 
     println!();
 
     if verbose {
         println!(
             "DynamoDB client version:    {}",
-            aws_sdk_dynamodb::PKG_VERSION
+            aws_sdk_dynamodb::meta::PKG_VERSION
         );
         println!(
             "Rekognition client version: {}",
-            aws_sdk_dynamodb::PKG_VERSION
+            aws_sdk_dynamodb::meta::PKG_VERSION
         );
-        println!("S3 client version:          {}", aws_sdk_s3::PKG_VERSION);
+        println!(
+            "S3 client version:          {}",
+            aws_sdk_s3::meta::PKG_VERSION
+        );
         println!("Filename:                   {}", &filename);
         println!("Bucket:                     {}", &bucket);
         println!("Table:                      {}", &table);

--- a/rust_dev_preview/cross_service/rest_ses/Cargo.toml
+++ b/rust_dev_preview/cross_service/rest_ses/Cargo.toml
@@ -14,10 +14,10 @@ name = "rest_ses"
 [dependencies]
 actix-web = "4"
 actix-web-prom = "0.6.0"
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cloudwatchlogs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rdsdata = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ses = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cloudwatchlogs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rdsdata = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ses = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 chrono = { version = "0.4.22", default-features = false, features = [
     "clock",
     "serde",
@@ -45,8 +45,8 @@ uuid = { version = "1.2.1", features = ["v4", "serde"] }
 xlsxwriter = "0.3.1"
 
 [dev-dependencies]
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["test-util"] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["test-util"] }
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 fake = { version = "2.5.0", features = ["uuid"] }
 once_cell = "1.15.0"
 rand = "0.8.5"

--- a/rust_dev_preview/cross_service/rest_ses/src/client.rs
+++ b/rust_dev_preview/cross_service/rest_ses/src/client.rs
@@ -7,8 +7,8 @@
 //!
 //! These wrappers add default ARNs for SDK resources the application accesses to common calls.
 use aws_config::SdkConfig;
-use aws_sdk_rdsdata::client::fluent_builders::ExecuteStatement;
-use aws_sdk_ses::client::fluent_builders::SendRawEmail;
+use aws_sdk_rdsdata::operation::execute_statement::builders::ExecuteStatementFluentBuilder;
+use aws_sdk_ses::operation::send_raw_email::builders::SendRawEmailFluentBuilder;
 use mail_builder::headers::address::Address;
 use secrecy::{ExposeSecret, Secret};
 use serde::Deserialize;
@@ -53,7 +53,7 @@ impl RdsClient {
     ///     .unwrap();
     /// # }
     /// ```
-    pub fn execute_statement(&self) -> ExecuteStatement {
+    pub fn execute_statement(&self) -> ExecuteStatementFluentBuilder {
         self.client
             .execute_statement()
             .secret_arn(self.secret_arn.expose_secret())
@@ -141,7 +141,7 @@ impl SesClient {
     }
 
     /// Prepares a SendRawEmail Amazon SES request with the source email & ARN configured.
-    pub fn send_raw_email(&self) -> SendRawEmail {
+    pub fn send_raw_email(&self) -> SendRawEmailFluentBuilder {
         self.client
             .send_raw_email()
             .source(self.source.clone().0)
@@ -160,9 +160,9 @@ macro_rules! params {
         {
             Some(vec![
             $(
-                aws_sdk_rdsdata::model::SqlParameter::builder()
+                aws_sdk_rdsdata::types::SqlParameter::builder()
                     .name($name.to_string())
-                    .value(aws_sdk_rdsdata::model::Field::StringValue($value.to_string().clone()))
+                    .value(aws_sdk_rdsdata::types::Field::StringValue($value.to_string().clone()))
                     .build(),
             )*
             ])

--- a/rust_dev_preview/cross_service/rest_ses/src/lib.rs
+++ b/rust_dev_preview/cross_service/rest_ses/src/lib.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 pub mod client;
 pub mod configuration;
 pub mod healthz;

--- a/rust_dev_preview/cross_service/rest_ses/src/main.rs
+++ b/rust_dev_preview/cross_service/rest_ses/src/main.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 //! Main that loads environments & prepares clients, and hands them to `startup`.
 use std::net::TcpListener;
 

--- a/rust_dev_preview/cross_service/rest_ses/src/report.rs
+++ b/rust_dev_preview/cross_service/rest_ses/src/report.rs
@@ -14,7 +14,7 @@ use actix_web::{
     web::{Data, Json},
     HttpResponse, ResponseError,
 };
-use aws_sdk_ses::{model::RawMessage, types::Blob};
+use aws_sdk_ses::{primitives::Blob, types::RawMessage};
 use mail_builder::MessageBuilder;
 use serde::Deserialize;
 use serde_json::json;

--- a/rust_dev_preview/cross_service/rest_ses/src/work_item/repository.rs
+++ b/rust_dev_preview/cross_service/rest_ses/src/work_item/repository.rs
@@ -9,8 +9,9 @@
 //! RDS and data parsing errors behind the WorkItemError enum defined in the
 //! parent work_item mod.
 use aws_sdk_rdsdata::{
-    error::ExecuteStatementError, model::RecordsFormatType, output::ExecuteStatementOutput,
-    types::SdkError,
+    error::SdkError,
+    operation::execute_statement::{ExecuteStatementError, ExecuteStatementOutput},
+    types::RecordsFormatType,
 };
 use serde_json::from_str;
 

--- a/rust_dev_preview/cross_service/telephone/Cargo.toml
+++ b/rust_dev_preview/cross_service/telephone/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-polly = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-transcribe = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-polly = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-transcribe = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 bytes = "1"
 reqwest = "0.11.4"

--- a/rust_dev_preview/cross_service/telephone/src/main.rs
+++ b/rust_dev_preview/cross_service/telephone/src/main.rs
@@ -4,8 +4,9 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_polly::model::{OutputFormat, VoiceId};
-use aws_sdk_transcribe::model::{LanguageCode, Media, MediaFormat, TranscriptionJobStatus};
+use aws_sdk_polly::config::Region;
+use aws_sdk_polly::types::{OutputFormat, VoiceId};
+use aws_sdk_transcribe::types::{LanguageCode, Media, MediaFormat, TranscriptionJobStatus};
 use serde_json::{Result, Value};
 use std::fs;
 use std::path::Path;
@@ -92,7 +93,7 @@ async fn save_mp3_file(
         println!("Saving file {} to bucket {}", filename, bucket);
         println!();
     }
-    let body = aws_sdk_s3::types::ByteStream::from_path(Path::new(filename))
+    let body = aws_sdk_s3::primitives::ByteStream::from_path(Path::new(filename))
         .await
         .unwrap();
 
@@ -228,29 +229,33 @@ async fn main() -> Result<()> {
     let transcribe_region = region.clone();
 
     // Create region provider for each service client.
-    let polly_region_provider =
-        RegionProviderChain::first_try(polly_region.map(aws_sdk_polly::Region::new))
-            .or_default_provider()
-            .or_else(aws_sdk_polly::Region::new("us-west-2"));
+    let polly_region_provider = RegionProviderChain::first_try(polly_region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
 
-    let s3_region_provider =
-        RegionProviderChain::first_try(s3_region.map(aws_sdk_polly::Region::new))
-            .or_default_provider()
-            .or_else(aws_sdk_polly::Region::new("us-west-2"));
+    let s3_region_provider = RegionProviderChain::first_try(s3_region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
 
     let transcribe_region_provider =
-        RegionProviderChain::first_try(transcribe_region.map(aws_sdk_transcribe::Region::new))
+        RegionProviderChain::first_try(transcribe_region.map(Region::new))
             .or_default_provider()
-            .or_else(aws_sdk_transcribe::Region::new("us-west-2"));
+            .or_else(Region::new("us-west-2"));
 
     println!();
 
     if verbose {
-        println!("Polly client version:     {}", aws_sdk_polly::PKG_VERSION);
-        println!("S3 client version:        {}", aws_sdk_s3::PKG_VERSION);
+        println!(
+            "Polly client version:     {}",
+            aws_sdk_polly::meta::PKG_VERSION
+        );
+        println!(
+            "S3 client version:        {}",
+            aws_sdk_s3::meta::PKG_VERSION
+        );
         println!(
             "Transcribe client version {}",
-            aws_sdk_transcribe::PKG_VERSION
+            aws_sdk_transcribe::meta::PKG_VERSION
         );
         println!(
             "Region:                   {}",

--- a/rust_dev_preview/custom-root-certificates/Cargo.toml
+++ b/rust_dev_preview/custom-root-certificates/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 description = "An example demonstrating setting a custom root certificate with rustls"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 # bringing our own HTTPs so no need for the default features
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false }
 tokio = { version = "1.21.2", features = ["full"] }
 rustls = "0.20.7"
 hyper-rustls = { version = "0.23.0", features = ["http2"] }

--- a/rust_dev_preview/dynamodb/Cargo.toml
+++ b/rust_dev_preview/dynamodb/Cargo.toml
@@ -11,18 +11,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "client-hyper",
   "rustls",
   "rt-tokio",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "rt-tokio",
 ] }
-aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 axum = "0.5.16"
 http = "0.2.5"
 futures = "0.3"

--- a/rust_dev_preview/dynamodb/src/bin/add-item.rs
+++ b/rust_dev_preview/dynamodb/src/bin/add-item.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_dynamodb::{error::DisplayErrorContext, Client};
 use dynamodb_code_examples::{
     make_config,

--- a/rust_dev_preview/dynamodb/src/bin/add-item.rs
+++ b/rust_dev_preview/dynamodb/src/bin/add-item.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_dynamodb::{types::DisplayErrorContext, Client};
+use aws_sdk_dynamodb::{error::DisplayErrorContext, Client};
 use dynamodb_code_examples::{
     make_config,
     scenario::add::{add_item, Item},

--- a/rust_dev_preview/dynamodb/src/bin/are-more-tables.rs
+++ b/rust_dev_preview/dynamodb/src/bin/are-more-tables.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_dynamodb::{Client, Error};
 use dynamodb_code_examples::{make_config, scenario::list::list_tables_are_more, Opt};
 use structopt::StructOpt;

--- a/rust_dev_preview/dynamodb/src/bin/create-table.rs
+++ b/rust_dev_preview/dynamodb/src/bin/create-table.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_dynamodb::{error::DisplayErrorContext, Client};
 use dynamodb_code_examples::{
     make_config, scenario::create::create_table, scenario::error::Error, Opt as BaseOpt,

--- a/rust_dev_preview/dynamodb/src/bin/create-table.rs
+++ b/rust_dev_preview/dynamodb/src/bin/create-table.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_dynamodb::{types::DisplayErrorContext, Client};
+use aws_sdk_dynamodb::{error::DisplayErrorContext, Client};
 use dynamodb_code_examples::{
     make_config, scenario::create::create_table, scenario::error::Error, Opt as BaseOpt,
 };

--- a/rust_dev_preview/dynamodb/src/bin/crud.rs
+++ b/rust_dev_preview/dynamodb/src/bin/crud.rs
@@ -4,13 +4,15 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_dynamodb::model::{
+use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ProvisionedThroughput,
     ScalarAttributeType, Select, TableStatus,
 };
-use aws_sdk_dynamodb::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};
 use aws_smithy_http::result::SdkError;
 
+use aws_sdk_dynamodb::operation::create_table::CreateTableError;
+use aws_sdk_dynamodb::operation::put_item::PutItemError;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::io::{stdin, Read};
@@ -49,7 +51,7 @@ async fn make_table(
     client: &Client,
     table: &str,
     key: &str,
-) -> Result<(), SdkError<aws_sdk_dynamodb::error::CreateTableError>> {
+) -> Result<(), SdkError<CreateTableError>> {
     let ad = AttributeDefinition::builder()
         .attribute_name(key)
         .attribute_type(ScalarAttributeType::S)
@@ -94,10 +96,7 @@ struct Item {
 
 /// Add an item to the table.
 // snippet-start:[dynamodb.rust.crud-add_item]
-async fn add_item(
-    client: &Client,
-    item: Item,
-) -> Result<(), SdkError<aws_sdk_dynamodb::error::PutItemError>> {
+async fn add_item(client: &Client, item: Item) -> Result<(), SdkError<PutItemError>> {
     let user_av = AttributeValue::S(item.value);
     let type_av = AttributeValue::S(item.utype);
     let age_av = AttributeValue::S(item.age);

--- a/rust_dev_preview/dynamodb/src/bin/crud.rs
+++ b/rust_dev_preview/dynamodb/src/bin/crud.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ProvisionedThroughput,

--- a/rust_dev_preview/dynamodb/src/bin/delete-item.rs
+++ b/rust_dev_preview/dynamodb/src/bin/delete-item.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_dynamodb::{types::DisplayErrorContext, Client};
+use aws_sdk_dynamodb::{error::DisplayErrorContext, Client};
 use dynamodb_code_examples::{
     make_config, scenario::delete::delete_item, scenario::error::Error, Opt as BaseOpt,
 };

--- a/rust_dev_preview/dynamodb/src/bin/delete-item.rs
+++ b/rust_dev_preview/dynamodb/src/bin/delete-item.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_dynamodb::{error::DisplayErrorContext, Client};
 use dynamodb_code_examples::{
     make_config, scenario::delete::delete_item, scenario::error::Error, Opt as BaseOpt,

--- a/rust_dev_preview/dynamodb/src/bin/delete-table.rs
+++ b/rust_dev_preview/dynamodb/src/bin/delete-table.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_dynamodb::{types::DisplayErrorContext, Client};
+use aws_sdk_dynamodb::{error::DisplayErrorContext, Client};
 use dynamodb_code_examples::{
     make_config, scenario::delete::delete_table, scenario::error::Error, Opt as BaseOpt,
 };

--- a/rust_dev_preview/dynamodb/src/bin/delete-table.rs
+++ b/rust_dev_preview/dynamodb/src/bin/delete-table.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_dynamodb::{error::DisplayErrorContext, Client};
 use dynamodb_code_examples::{
     make_config, scenario::delete::delete_table, scenario::error::Error, Opt as BaseOpt,

--- a/rust_dev_preview/dynamodb/src/bin/dynamodb-helloworld.rs
+++ b/rust_dev_preview/dynamodb/src/bin/dynamodb-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, KeySchemaElement, KeyType, ProvisionedThroughput, ScalarAttributeType,

--- a/rust_dev_preview/dynamodb/src/bin/dynamodb-helloworld.rs
+++ b/rust_dev_preview/dynamodb/src/bin/dynamodb-helloworld.rs
@@ -4,10 +4,10 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_dynamodb::model::{
+use aws_sdk_dynamodb::types::{
     AttributeDefinition, KeySchemaElement, KeyType, ProvisionedThroughput, ScalarAttributeType,
 };
-use aws_sdk_dynamodb::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/dynamodb/src/bin/list-items.rs
+++ b/rust_dev_preview/dynamodb/src/bin/list-items.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_dynamodb::{Client, Error};
 use dynamodb_code_examples::{make_config, scenario::list::list_items, Opt as BaseOpt};
 use structopt::StructOpt;

--- a/rust_dev_preview/dynamodb/src/bin/list-more-tables.rs
+++ b/rust_dev_preview/dynamodb/src/bin/list-more-tables.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_dynamodb::{Client, Error};
 use dynamodb_code_examples::{make_config, scenario::list::list_tables_iterative, Opt};
 use structopt::StructOpt;

--- a/rust_dev_preview/dynamodb/src/bin/list-tables-local.rs
+++ b/rust_dev_preview/dynamodb/src/bin/list-tables-local.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 // snippet-start:[dynamodb.rust.list-tables-local]
 use aws_sdk_dynamodb::{Client, Error};
 use dynamodb_code_examples::{make_config, scenario::list::list_tables, Opt};

--- a/rust_dev_preview/dynamodb/src/bin/list-tables-main.rs
+++ b/rust_dev_preview/dynamodb/src/bin/list-tables-main.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 // snippet-start:[dynamodb.rust.list-tables-main]
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_dynamodb::{Client, Error};

--- a/rust_dev_preview/dynamodb/src/bin/list-tables.rs
+++ b/rust_dev_preview/dynamodb/src/bin/list-tables.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_dynamodb::{Client, Error};
 use dynamodb_code_examples::{make_config, scenario::list::list_tables, Opt};
 use structopt::StructOpt;

--- a/rust_dev_preview/dynamodb/src/bin/list10-tables.rs
+++ b/rust_dev_preview/dynamodb/src/bin/list10-tables.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_dynamodb::{Client, Error};
 use dynamodb_code_examples::{make_config, scenario::list::list_tables_limit_10, Opt};
 use structopt::StructOpt;

--- a/rust_dev_preview/dynamodb/src/bin/movies.rs
+++ b/rust_dev_preview/dynamodb/src/bin/movies.rs
@@ -5,7 +5,7 @@
 
 use std::net::{Ipv4Addr, SocketAddr};
 
-use aws_sdk_dynamodb::{types::DisplayErrorContext, Client};
+use aws_sdk_dynamodb::{error::DisplayErrorContext, Client};
 use axum::extract::Extension;
 use dynamodb_code_examples::scenario::error::Error;
 use dynamodb_code_examples::scenario::movies::server::{make_app, movies_in_year};

--- a/rust_dev_preview/dynamodb/src/bin/movies.rs
+++ b/rust_dev_preview/dynamodb/src/bin/movies.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use std::net::{Ipv4Addr, SocketAddr};
 
 use aws_sdk_dynamodb::{error::DisplayErrorContext, Client};

--- a/rust_dev_preview/dynamodb/src/bin/partiql.rs
+++ b/rust_dev_preview/dynamodb/src/bin/partiql.rs
@@ -4,13 +4,15 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_dynamodb::model::{
+use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ProvisionedThroughput,
     ScalarAttributeType, TableStatus,
 };
-use aws_sdk_dynamodb::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};
 use aws_smithy_http::result::SdkError;
 
+use aws_sdk_dynamodb::operation::create_table::CreateTableError;
+use aws_sdk_dynamodb::operation::execute_statement::ExecuteStatementError;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::io::{stdin, Read};
@@ -49,7 +51,7 @@ async fn make_table(
     client: &Client,
     table: &str,
     key: &str,
-) -> Result<(), SdkError<aws_sdk_dynamodb::error::CreateTableError>> {
+) -> Result<(), SdkError<CreateTableError>> {
     let ad = AttributeDefinition::builder()
         .attribute_name(key)
         .attribute_type(ScalarAttributeType::S)
@@ -94,10 +96,7 @@ struct Item {
 
 /// Add an item to the table.
 // snippet-start:[dynamodb.rust.partiql-add_item]
-async fn add_item(
-    client: &Client,
-    item: Item,
-) -> Result<(), SdkError<aws_sdk_dynamodb::error::ExecuteStatementError>> {
+async fn add_item(client: &Client, item: Item) -> Result<(), SdkError<ExecuteStatementError>> {
     match client
         .execute_statement()
         .statement(format!(

--- a/rust_dev_preview/dynamodb/src/bin/partiql.rs
+++ b/rust_dev_preview/dynamodb/src/bin/partiql.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ProvisionedThroughput,

--- a/rust_dev_preview/dynamodb/src/lib.rs
+++ b/rust_dev_preview/dynamodb/src/lib.rs
@@ -6,7 +6,7 @@
 pub mod scenario;
 
 use aws_config::{meta::region::RegionProviderChain, SdkConfig};
-use aws_sdk_dynamodb::{Error, Region, PKG_VERSION};
+use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/dynamodb/src/scenario/add.rs
+++ b/rust_dev_preview/dynamodb/src/scenario/add.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_dynamodb::model::AttributeValue;
+use aws_sdk_dynamodb::types::AttributeValue;
 use aws_sdk_dynamodb::{Client, Error};
 
 pub struct Item {
@@ -71,7 +71,7 @@ pub async fn add_item(client: &Client, item: Item, table: &String) -> Result<Ite
 // snippet-start:[dynamodb.rust.add-item.test]
 #[cfg(test)]
 mod test {
-    use aws_sdk_dynamodb::model::AttributeValue;
+    use aws_sdk_dynamodb::types::AttributeValue;
     use sdk_examples_test_utils::single_shot_client;
 
     use super::{add_item, Item, ItemOut};

--- a/rust_dev_preview/dynamodb/src/scenario/create.rs
+++ b/rust_dev_preview/dynamodb/src/scenario/create.rs
@@ -4,10 +4,10 @@
  */
 
 use crate::scenario::error::Error;
-use aws_sdk_dynamodb::model::{
+use aws_sdk_dynamodb::operation::create_table::CreateTableOutput;
+use aws_sdk_dynamodb::types::{
     AttributeDefinition, KeySchemaElement, KeyType, ProvisionedThroughput, ScalarAttributeType,
 };
-use aws_sdk_dynamodb::output::CreateTableOutput;
 use aws_sdk_dynamodb::Client;
 
 // Create a table.

--- a/rust_dev_preview/dynamodb/src/scenario/delete.rs
+++ b/rust_dev_preview/dynamodb/src/scenario/delete.rs
@@ -5,8 +5,8 @@
 
 use crate::scenario::error::Error;
 use aws_sdk_dynamodb::{
-    model::AttributeValue,
-    output::{DeleteItemOutput, DeleteTableOutput},
+    operation::{delete_item::DeleteItemOutput, delete_table::DeleteTableOutput},
+    types::AttributeValue,
     Client,
 };
 

--- a/rust_dev_preview/dynamodb/src/scenario/error.rs
+++ b/rust_dev_preview/dynamodb/src/scenario/error.rs
@@ -29,11 +29,11 @@ impl From<aws_sdk_dynamodb::Error> for Error {
     }
 }
 
-impl<T> From<aws_sdk_dynamodb::types::SdkError<T>> for Error
+impl<T> From<aws_sdk_dynamodb::error::SdkError<T>> for Error
 where
     T: StdError + Send + Sync + 'static,
 {
-    fn from(source: aws_sdk_dynamodb::types::SdkError<T>) -> Self {
+    fn from(source: aws_sdk_dynamodb::error::SdkError<T>) -> Self {
         Error::unhandled(source)
     }
 }

--- a/rust_dev_preview/dynamodb/src/scenario/movies/mod.rs
+++ b/rust_dev_preview/dynamodb/src/scenario/movies/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use aws_sdk_dynamodb::model::{AttributeValue, PutRequest};
+use aws_sdk_dynamodb::types::{AttributeValue, PutRequest};
 use aws_smithy_client::SdkError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -173,7 +173,7 @@ impl From<&Movie> for PutRequest {
 
 #[cfg(test)]
 mod test {
-    use aws_sdk_dynamodb::model::PutRequest;
+    use aws_sdk_dynamodb::types::PutRequest;
 
     use super::Movie;
 

--- a/rust_dev_preview/dynamodb/src/scenario/movies/server.rs
+++ b/rust_dev_preview/dynamodb/src/scenario/movies/server.rs
@@ -1,4 +1,4 @@
-use aws_sdk_dynamodb::{model::AttributeValue, Client};
+use aws_sdk_dynamodb::{types::AttributeValue, Client};
 use axum::{extract::Path, routing::get, Extension, Router};
 use tower_http::cors::{Any, CorsLayer};
 

--- a/rust_dev_preview/dynamodb/src/scenario/movies/startup.rs
+++ b/rust_dev_preview/dynamodb/src/scenario/movies/startup.rs
@@ -1,8 +1,8 @@
 use super::Movie;
 use crate::scenario::error::Error;
 use aws_sdk_dynamodb::{
-    client::fluent_builders::CreateTable,
-    model::{
+    operation::create_table::builders::CreateTableFluentBuilder,
+    types::{
         AttributeDefinition, KeySchemaElement, KeyType, ProvisionedThroughput, ScalarAttributeType,
         TableStatus, WriteRequest,
     },
@@ -54,7 +54,7 @@ pub fn create_table(
     primary_key: &str,
     sort_key: &str,
     capacity: i64,
-) -> CreateTable {
+) -> CreateTableFluentBuilder {
     info!("Creating table: {table_name} with capacity {capacity} and key structure {primary_key}:{sort_key}");
     client
         .create_table()

--- a/rust_dev_preview/ebs/Cargo.toml
+++ b/rust_dev_preview/ebs/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ebs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ebs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 base64 = "0.13.0"
 sha2 = "0.9.5"

--- a/rust_dev_preview/ebs/src/bin/create-snapshot.rs
+++ b/rust_dev_preview/ebs/src/bin/create-snapshot.rs
@@ -4,9 +4,9 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ebs::model::ChecksumAlgorithm;
-use aws_sdk_ebs::types::ByteStream;
-use aws_sdk_ebs::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ebs::primitives::ByteStream;
+use aws_sdk_ebs::types::ChecksumAlgorithm;
+use aws_sdk_ebs::{config::Region, meta::PKG_VERSION, Client, Error};
 use sha2::Digest;
 use structopt::StructOpt;
 

--- a/rust_dev_preview/ebs/src/bin/create-snapshot.rs
+++ b/rust_dev_preview/ebs/src/bin/create-snapshot.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ebs::primitives::ByteStream;
 use aws_sdk_ebs::types::ChecksumAlgorithm;

--- a/rust_dev_preview/ebs/src/bin/delete-snapshot.rs
+++ b/rust_dev_preview/ebs/src/bin/delete-snapshot.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ebs/src/bin/delete-snapshot.rs
+++ b/rust_dev_preview/ebs/src/bin/delete-snapshot.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ec2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ebs/src/bin/get-snapshot-state.rs
+++ b/rust_dev_preview/ebs/src/bin/get-snapshot-state.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ec2::model::Filter;
-use aws_sdk_ec2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::types::Filter;
+use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ebs/src/bin/get-snapshot-state.rs
+++ b/rust_dev_preview/ebs/src/bin/get-snapshot-state.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::types::Filter;
 use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/ebs/src/bin/list-snapshots.rs
+++ b/rust_dev_preview/ebs/src/bin/list-snapshots.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ebs/src/bin/list-snapshots.rs
+++ b/rust_dev_preview/ebs/src/bin/list-snapshots.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ec2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ec2/Cargo.toml
+++ b/rust_dev_preview/ec2/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/ec2/src/bin/describe-instances.rs
+++ b/rust_dev_preview/ec2/src/bin/describe-instances.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ec2/src/bin/describe-instances.rs
+++ b/rust_dev_preview/ec2/src/bin/describe-instances.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ec2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ec2/src/bin/ec2-helloworld.rs
+++ b/rust_dev_preview/ec2/src/bin/ec2-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ec2/src/bin/ec2-helloworld.rs
+++ b/rust_dev_preview/ec2/src/bin/ec2-helloworld.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ec2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ec2/src/bin/list-all-instance-events.rs
+++ b/rust_dev_preview/ec2/src/bin/list-all-instance-events.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ec2/src/bin/list-all-instance-events.rs
+++ b/rust_dev_preview/ec2/src/bin/list-all-instance-events.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ec2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ec2/src/bin/monitor-instance.rs
+++ b/rust_dev_preview/ec2/src/bin/monitor-instance.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ec2/src/bin/monitor-instance.rs
+++ b/rust_dev_preview/ec2/src/bin/monitor-instance.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ec2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ec2/src/bin/reboot-instance.rs
+++ b/rust_dev_preview/ec2/src/bin/reboot-instance.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ec2/src/bin/reboot-instance.rs
+++ b/rust_dev_preview/ec2/src/bin/reboot-instance.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ec2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ec2/src/bin/start-instance.rs
+++ b/rust_dev_preview/ec2/src/bin/start-instance.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ec2/src/bin/start-instance.rs
+++ b/rust_dev_preview/ec2/src/bin/start-instance.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ec2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ec2/src/bin/stop-instance.rs
+++ b/rust_dev_preview/ec2/src/bin/stop-instance.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ec2/src/bin/stop-instance.rs
+++ b/rust_dev_preview/ec2/src/bin/stop-instance.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ec2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ecr/Cargo.toml
+++ b/rust_dev_preview/ecr/Cargo.toml
@@ -8,9 +8,9 @@ authors = [
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ecr = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ecr = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/ecr/src/bin/describe-repos.rs
+++ b/rust_dev_preview/ecr/src/bin/describe-repos.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ecr::{Error, Region};
+use aws_sdk_ecr::{config::Region, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ecr/src/bin/describe-repos.rs
+++ b/rust_dev_preview/ecr/src/bin/describe-repos.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ecr::{config::Region, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ecr/src/bin/list-images.rs
+++ b/rust_dev_preview/ecr/src/bin/list-images.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ecr::{Error, Region, PKG_VERSION};
+use aws_sdk_ecr::{config::Region, meta::PKG_VERSION, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ecr/src/bin/list-images.rs
+++ b/rust_dev_preview/ecr/src/bin/list-images.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ecr::{config::Region, meta::PKG_VERSION, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ecs/Cargo.toml
+++ b/rust_dev_preview/ecs/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ecs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ecs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/ecs/src/bin/cluster.rs
+++ b/rust_dev_preview/ecs/src/bin/cluster.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ecs::{config::Region, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ecs/src/bin/cluster.rs
+++ b/rust_dev_preview/ecs/src/bin/cluster.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ecs::{Error, Region};
+use aws_sdk_ecs::{config::Region, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ecs/src/bin/describe-clusters.rs
+++ b/rust_dev_preview/ecs/src/bin/describe-clusters.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ecs::{Error, Region, PKG_VERSION};
+use aws_sdk_ecs::{config::Region, meta::PKG_VERSION, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ecs/src/bin/describe-clusters.rs
+++ b/rust_dev_preview/ecs/src/bin/describe-clusters.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ecs::{config::Region, meta::PKG_VERSION, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/eks/Cargo.toml
+++ b/rust_dev_preview/eks/Cargo.toml
@@ -8,9 +8,9 @@ authors = [
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-eks = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-eks = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/eks/src/bin/create-cluster.rs
+++ b/rust_dev_preview/eks/src/bin/create-cluster.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_eks::model::VpcConfigRequest;
-use aws_sdk_eks::Region;
+use aws_sdk_eks::config::Region;
+use aws_sdk_eks::types::VpcConfigRequest;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/eks/src/bin/create-cluster.rs
+++ b/rust_dev_preview/eks/src/bin/create-cluster.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_eks::config::Region;
 use aws_sdk_eks::types::VpcConfigRequest;

--- a/rust_dev_preview/eks/src/bin/create-delete-cluster.rs
+++ b/rust_dev_preview/eks/src/bin/create-delete-cluster.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_eks::model::VpcConfigRequest;
-use aws_sdk_eks::{Client, Region, PKG_VERSION};
+use aws_sdk_eks::types::VpcConfigRequest;
+use aws_sdk_eks::{config::Region, meta::PKG_VERSION, Client};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/eks/src/bin/create-delete-cluster.rs
+++ b/rust_dev_preview/eks/src/bin/create-delete-cluster.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_eks::types::VpcConfigRequest;
 use aws_sdk_eks::{config::Region, meta::PKG_VERSION, Client};

--- a/rust_dev_preview/eks/src/bin/list-clusters.rs
+++ b/rust_dev_preview/eks/src/bin/list-clusters.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_eks::{Client, Region, PKG_VERSION};
+use aws_sdk_eks::{config::Region, meta::PKG_VERSION, Client};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/eks/src/bin/list-clusters.rs
+++ b/rust_dev_preview/eks/src/bin/list-clusters.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_eks::{config::Region, meta::PKG_VERSION, Client};
 use structopt::StructOpt;

--- a/rust_dev_preview/firehose/Cargo.toml
+++ b/rust_dev_preview/firehose/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-firehose = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = {git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-firehose = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = {git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/firehose/src/bin/put-records-batch.rs
+++ b/rust_dev_preview/firehose/src/bin/put-records-batch.rs
@@ -4,11 +4,11 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_firehose::error::PutRecordBatchError;
-use aws_sdk_firehose::model::Record;
-use aws_sdk_firehose::output::PutRecordBatchOutput;
-use aws_sdk_firehose::types::{Blob, SdkError};
-use aws_sdk_firehose::{Client, Error, PKG_VERSION};
+use aws_sdk_firehose::error::SdkError;
+use aws_sdk_firehose::operation::put_record_batch::{PutRecordBatchError, PutRecordBatchOutput};
+use aws_sdk_firehose::primitives::Blob;
+use aws_sdk_firehose::types::Record;
+use aws_sdk_firehose::{meta::PKG_VERSION, Client, Error};
 use aws_types::region::Region;
 use structopt::StructOpt;
 

--- a/rust_dev_preview/firehose/src/bin/put-records-batch.rs
+++ b/rust_dev_preview/firehose/src/bin/put-records-batch.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_firehose::error::SdkError;
 use aws_sdk_firehose::operation::put_record_batch::{PutRecordBatchError, PutRecordBatchOutput};

--- a/rust_dev_preview/globalaccelerator/Cargo.toml
+++ b/rust_dev_preview/globalaccelerator/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-globalaccelerator = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-globalaccelerator = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = "0.1.8"
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/globalaccelerator/src/bin/globalaccelerator-helloworld.rs
+++ b/rust_dev_preview/globalaccelerator/src/bin/globalaccelerator-helloworld.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_globalaccelerator::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_globalaccelerator::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 use tokio_stream::StreamExt;
 

--- a/rust_dev_preview/globalaccelerator/src/bin/globalaccelerator-helloworld.rs
+++ b/rust_dev_preview/globalaccelerator/src/bin/globalaccelerator-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_globalaccelerator::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/glue/Cargo.toml
+++ b/rust_dev_preview/glue/Cargo.toml
@@ -13,20 +13,20 @@ name = "scenario"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-glue = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-glue = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "client-hyper",
   "rustls",
   "rt-tokio",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "rt-tokio",
 ] }
-aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing = "0.1.37"

--- a/rust_dev_preview/glue/src/bin/scenario.rs
+++ b/rust_dev_preview/glue/src/bin/scenario.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0.
 
+#![allow(clippy::result_large_err)]
+
 /// This scenario follows the [AWS Glue Tutorial](https://docs.aws.amazon.com/glue/latest/ug/tutorial-add-crawler.html).
 use glue_code_examples::{GlueMvpError, GlueScenario};
 use tracing::{error, warn};

--- a/rust_dev_preview/glue/src/cleanup.rs
+++ b/rust_dev_preview/glue/src/cleanup.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0.
 
-use aws_sdk_glue::model::CrawlerState;
+use aws_sdk_glue::types::CrawlerState;
 use tracing::{instrument, warn};
 
 use crate::{clients::GLUE_CLIENT, GlueMvpError, GlueScenario};
@@ -43,7 +43,7 @@ impl GlueScenario {
         let glue = GLUE_CLIENT.get().await;
 
         // Wait for crawler to finish.
-        let unknown_state = aws_sdk_glue::model::CrawlerState::from("unknown");
+        let unknown_state = aws_sdk_glue::types::CrawlerState::from("unknown");
         let crawler = glue
             .get_crawler()
             .name(self.crawler())

--- a/rust_dev_preview/glue/src/lib.rs
+++ b/rust_dev_preview/glue/src/lib.rs
@@ -6,7 +6,7 @@ pub mod clients;
 pub mod prepare;
 pub mod run;
 
-use aws_sdk_glue::model::Table;
+use aws_sdk_glue::types::Table;
 use clap::Parser;
 use secrecy::Secret;
 use std::time::Duration;

--- a/rust_dev_preview/glue/src/prepare.rs
+++ b/rust_dev_preview/glue/src/prepare.rs
@@ -5,10 +5,10 @@ use crate::{
     clients::{GLUE_CLIENT, S3_CLIENT},
     GlueMvpError, GlueScenario, CRAWLER_TARGET,
 };
-use aws_sdk_glue::model::{
+use aws_sdk_glue::types::{
     Crawler, CrawlerState, CrawlerTargets, DatabaseInput, Job, JobCommand, S3Target, Table,
 };
-use aws_sdk_s3::types::ByteStream;
+use aws_sdk_s3::primitives::ByteStream;
 use secrecy::ExposeSecret;
 use std::future::Future;
 use tracing::{info, instrument, warn};

--- a/rust_dev_preview/glue/src/run.rs
+++ b/rust_dev_preview/glue/src/run.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0.
 
-use aws_sdk_glue::model::{JobRun, JobRunState};
+use aws_sdk_glue::types::{JobRun, JobRunState};
 use futures::StreamExt;
 use tracing::{info, instrument, warn};
 
@@ -68,7 +68,7 @@ impl GlueScenario {
     #[instrument(skip(self))]
     pub async fn wait_for_job_run(&self, job_run_id: &str) -> Result<(), GlueMvpError> {
         let glue = GLUE_CLIENT.get().await;
-        let unknown_state = aws_sdk_glue::model::JobRunState::from("unknown");
+        let unknown_state = aws_sdk_glue::types::JobRunState::from("unknown");
 
         // snippet-start:[rust.glue.get_job_run]
         let get_job_run = || async {

--- a/rust_dev_preview/glue/tests/happy.rs
+++ b/rust_dev_preview/glue/tests/happy.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0.
 
-use aws_sdk_glue::model::JobRunState;
+use aws_sdk_glue::types::JobRunState;
 use glue_code_examples::{
     clients::{GLUE_CLIENT, S3_CLIENT},
     GlueScenario, GlueScenarioArgs,

--- a/rust_dev_preview/greengrassv2/Cargo.toml
+++ b/rust_dev_preview/greengrassv2/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Aaron Tsui <aaron.tsui@outlook.com>"]
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-greengrassv2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-greengrassv2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/rust_dev_preview/greengrassv2/src/bin/list-core-devices.rs
+++ b/rust_dev_preview/greengrassv2/src/bin/list-core-devices.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_greengrassv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/greengrassv2/src/bin/list-core-devices.rs
+++ b/rust_dev_preview/greengrassv2/src/bin/list-core-devices.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_greengrassv2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_greengrassv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/iam/Cargo.toml
+++ b/rust_dev_preview/iam/Cargo.toml
@@ -17,15 +17,15 @@ name = "iam_getting_started"
 path = "src/bin/iam-getting-started.rs"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["hardcoded-credentials"] }
-aws-hyper = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-iam = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["test-util"] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["hardcoded-credentials"] }
+aws-hyper = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-iam = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["test-util"] }
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 sdk-examples-test-utils = { path = "../test-utils" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/iam/src/bin/create-role.rs
+++ b/rust_dev_preview/iam/src/bin/create-role.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iam::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_iam::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::fs;
 use structopt::StructOpt;
 

--- a/rust_dev_preview/iam/src/bin/create-role.rs
+++ b/rust_dev_preview/iam/src/bin/create-role.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_iam::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::fs;

--- a/rust_dev_preview/iam/src/bin/iam-getting-started.rs
+++ b/rust_dev_preview/iam/src/bin/iam-getting-started.rs
@@ -19,6 +19,8 @@ To run the service class tests run:
 cargo test
 */
 
+#![allow(clippy::result_large_err)]
+
 // snippet-start:[rust.example_code.iam.iam_basics.scenario]
 
 use aws_config::meta::region::RegionProviderChain;

--- a/rust_dev_preview/iam/src/bin/iam-getting-started.rs
+++ b/rust_dev_preview/iam/src/bin/iam-getting-started.rs
@@ -23,7 +23,7 @@ cargo test
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_iam::Error as iamError;
-use aws_sdk_iam::{Client as iamClient, Credentials as iamCredentials, Region};
+use aws_sdk_iam::{config::Credentials as iamCredentials, config::Region, Client as iamClient};
 use aws_sdk_s3::Client as s3Client;
 use aws_sdk_sts::Client as stsClient;
 use std::borrow::Borrow;

--- a/rust_dev_preview/iam/src/iam-service-lib.rs
+++ b/rust_dev_preview/iam/src/iam-service-lib.rs
@@ -5,20 +5,14 @@
 
 // snippet-start:[rust.example_code.iam.scenario_getting_started.lib]
 
-use aws_sdk_iam::error::{
-    AttachRolePolicyError, CreateAccessKeyError, CreateServiceLinkedRoleError, DeleteUserError,
-    DeleteUserPolicyError, GetAccountPasswordPolicyError, GetRoleError,
-    ListAttachedRolePoliciesError, ListGroupsError, ListPoliciesError, ListRolePoliciesError,
-    ListRolesError, ListSAMLProvidersError, ListUsersError,
+use aws_sdk_iam::error::SdkError;
+use aws_sdk_iam::operation::{
+    attach_role_policy::*, create_access_key::*, create_role::*, create_service_linked_role::*,
+    delete_user::*, delete_user_policy::*, get_account_password_policy::*, get_role::*,
+    list_attached_role_policies::*, list_groups::*, list_policies::*, list_role_policies::*,
+    list_roles::*, list_saml_providers::*, list_users::*,
 };
-use aws_sdk_iam::model::{AccessKey, Policy, Role, User};
-use aws_sdk_iam::output::{
-    AttachRolePolicyOutput, CreateAccessKeyOutput, CreateRoleOutput, CreateServiceLinkedRoleOutput,
-    GetAccountPasswordPolicyOutput, GetRoleOutput, ListAttachedRolePoliciesOutput,
-    ListGroupsOutput, ListPoliciesOutput, ListRolePoliciesOutput, ListRolesOutput,
-    ListSamlProvidersOutput, ListUsersOutput,
-};
-use aws_sdk_iam::types::SdkError;
+use aws_sdk_iam::types::{AccessKey, Policy, Role, User};
 use aws_sdk_iam::Client as iamClient;
 use aws_sdk_iam::{Client, Error as iamError};
 use tokio::time::{sleep, Duration};

--- a/rust_dev_preview/iam/tests/test-iam-service-lib.rs
+++ b/rust_dev_preview/iam/tests/test-iam-service-lib.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iam::{Client as iamClient, Region};
+use aws_sdk_iam::{config::Region, Client as iamClient};
 use uuid::Uuid;
 
 #[ignore]

--- a/rust_dev_preview/iot/Cargo.toml
+++ b/rust_dev_preview/iot/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-iot = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-iot = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/iot/src/bin/describe-endpoint.rs
+++ b/rust_dev_preview/iot/src/bin/describe-endpoint.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_iot::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/iot/src/bin/describe-endpoint.rs
+++ b/rust_dev_preview/iot/src/bin/describe-endpoint.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iot::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_iot::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/iot/src/bin/list-things.rs
+++ b/rust_dev_preview/iot/src/bin/list-things.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_iot::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/iot/src/bin/list-things.rs
+++ b/rust_dev_preview/iot/src/bin/list-things.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iot::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_iot::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/kinesis/Cargo.toml
+++ b/rust_dev_preview/kinesis/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-kinesis = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-kinesis = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/kinesis/src/bin/create-stream.rs
+++ b/rust_dev_preview/kinesis/src/bin/create-stream.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kinesis::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kinesis::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/kinesis/src/bin/create-stream.rs
+++ b/rust_dev_preview/kinesis/src/bin/create-stream.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kinesis::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/kinesis/src/bin/delete-stream.rs
+++ b/rust_dev_preview/kinesis/src/bin/delete-stream.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kinesis::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kinesis::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/kinesis/src/bin/delete-stream.rs
+++ b/rust_dev_preview/kinesis/src/bin/delete-stream.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kinesis::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/kinesis/src/bin/describe-stream.rs
+++ b/rust_dev_preview/kinesis/src/bin/describe-stream.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kinesis::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kinesis::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/kinesis/src/bin/describe-stream.rs
+++ b/rust_dev_preview/kinesis/src/bin/describe-stream.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kinesis::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/kinesis/src/bin/list-streams.rs
+++ b/rust_dev_preview/kinesis/src/bin/list-streams.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kinesis::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kinesis::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/kinesis/src/bin/list-streams.rs
+++ b/rust_dev_preview/kinesis/src/bin/list-streams.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kinesis::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/kinesis/src/bin/put-record.rs
+++ b/rust_dev_preview/kinesis/src/bin/put-record.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kinesis::primitives::Blob;
 use aws_sdk_kinesis::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/kinesis/src/bin/put-record.rs
+++ b/rust_dev_preview/kinesis/src/bin/put-record.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kinesis::types::Blob;
-use aws_sdk_kinesis::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kinesis::primitives::Blob;
+use aws_sdk_kinesis::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/kms/Cargo.toml
+++ b/rust_dev_preview/kms/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 description = "Example usage of the KMS service"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-kms = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-kms = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "client-hyper",
   "rustls",
   "rt-tokio",

--- a/rust_dev_preview/kms/src/bin/create-key.rs
+++ b/rust_dev_preview/kms/src/bin/create-key.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/kms/src/bin/create-key.rs
+++ b/rust_dev_preview/kms/src/bin/create-key.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kms::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/kms/src/bin/decrypt.rs
+++ b/rust_dev_preview/kms/src/bin/decrypt.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kms::primitives::Blob;
 use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/kms/src/bin/decrypt.rs
+++ b/rust_dev_preview/kms/src/bin/decrypt.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kms::types::Blob;
-use aws_sdk_kms::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kms::primitives::Blob;
+use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::fs;
 use structopt::StructOpt;
 

--- a/rust_dev_preview/kms/src/bin/encrypt.rs
+++ b/rust_dev_preview/kms/src/bin/encrypt.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kms::types::Blob;
-use aws_sdk_kms::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kms::primitives::Blob;
+use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::fs::File;
 use std::io::Write;
 use structopt::StructOpt;

--- a/rust_dev_preview/kms/src/bin/encrypt.rs
+++ b/rust_dev_preview/kms/src/bin/encrypt.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kms::primitives::Blob;
 use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/kms/src/bin/generate-data-key-without-plaintext.rs
+++ b/rust_dev_preview/kms/src/bin/generate-data-key-without-plaintext.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kms::types::DataKeySpec;
 use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/kms/src/bin/generate-data-key-without-plaintext.rs
+++ b/rust_dev_preview/kms/src/bin/generate-data-key-without-plaintext.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kms::model::DataKeySpec;
-use aws_sdk_kms::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kms::types::DataKeySpec;
+use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/kms/src/bin/generate-data-key.rs
+++ b/rust_dev_preview/kms/src/bin/generate-data-key.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kms::types::DataKeySpec;
 use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/kms/src/bin/generate-data-key.rs
+++ b/rust_dev_preview/kms/src/bin/generate-data-key.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kms::model::DataKeySpec;
-use aws_sdk_kms::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kms::types::DataKeySpec;
+use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/kms/src/bin/generate-random.rs
+++ b/rust_dev_preview/kms/src/bin/generate-random.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kms::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::process;
 use structopt::StructOpt;
 

--- a/rust_dev_preview/kms/src/bin/generate-random.rs
+++ b/rust_dev_preview/kms/src/bin/generate-random.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::process;

--- a/rust_dev_preview/kms/src/bin/kms-helloworld.rs
+++ b/rust_dev_preview/kms/src/bin/kms-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_kms::{config::Region, Client};
 
 // snippet-start:[kms.rust.kms-helloworld]

--- a/rust_dev_preview/kms/src/bin/kms-helloworld.rs
+++ b/rust_dev_preview/kms/src/bin/kms-helloworld.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_kms::{Client, Region};
+use aws_sdk_kms::{config::Region, Client};
 
 // snippet-start:[kms.rust.kms-helloworld]
 /// Creates a random byte string that is cryptographically secure in __us-east-1__.

--- a/rust_dev_preview/kms/src/bin/list-keys.rs
+++ b/rust_dev_preview/kms/src/bin/list-keys.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/kms/src/bin/list-keys.rs
+++ b/rust_dev_preview/kms/src/bin/list-keys.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kms::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/kms/src/bin/reencrypt-data.rs
+++ b/rust_dev_preview/kms/src/bin/reencrypt-data.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kms::types::Blob;
-use aws_sdk_kms::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_kms::primitives::Blob;
+use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::fs;
 use std::fs::File;
 use std::io::Write;

--- a/rust_dev_preview/kms/src/bin/reencrypt-data.rs
+++ b/rust_dev_preview/kms/src/bin/reencrypt-data.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_kms::primitives::Blob;
 use aws_sdk_kms::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/lambda/Cargo.toml
+++ b/rust_dev_preview/lambda/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 lambda_runtime = "0.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }

--- a/rust_dev_preview/lambda/src/bin/change-java-runtime.rs
+++ b/rust_dev_preview/lambda/src/bin/change-java-runtime.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_lambda::model::Runtime;
+use aws_sdk_lambda::types::Runtime;
 use aws_sdk_lambda::{Client, Error};
 use lambda_code_examples::{make_client, ArnOpt};
 use structopt::StructOpt;

--- a/rust_dev_preview/lambda/src/bin/change-java-runtime.rs
+++ b/rust_dev_preview/lambda/src/bin/change-java-runtime.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_lambda::types::Runtime;
 use aws_sdk_lambda::{Client, Error};
 use lambda_code_examples::{make_client, ArnOpt};

--- a/rust_dev_preview/lambda/src/bin/invoke-function.rs
+++ b/rust_dev_preview/lambda/src/bin/invoke-function.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_lambda::{Client, Error};
 use lambda_code_examples::{make_client, ArnOpt};
 use structopt::StructOpt;

--- a/rust_dev_preview/lambda/src/bin/list-all-function-runtimes.rs
+++ b/rust_dev_preview/lambda/src/bin/list-all-function-runtimes.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_lambda::Error;
 use lambda_code_examples::{make_client, make_config, Opt as BaseOpt};
 use structopt::StructOpt;

--- a/rust_dev_preview/lambda/src/bin/list-functions.rs
+++ b/rust_dev_preview/lambda/src/bin/list-functions.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_lambda::{Client, Error};
 use lambda_code_examples::{make_client, Opt};
 use structopt::StructOpt;

--- a/rust_dev_preview/lambda/src/lib.rs
+++ b/rust_dev_preview/lambda/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::{meta::region::RegionProviderChain, SdkConfig};
-use aws_sdk_lambda::{Client, Region, PKG_VERSION};
+use aws_sdk_lambda::{config::Region, meta::PKG_VERSION, Client};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/localstack/Cargo.toml
+++ b/rust_dev_preview/localstack/Cargo.toml
@@ -6,9 +6,9 @@ authors = ["Doug Schwartz <dougsch@amazon.com>"]
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 http = "0.2"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/localstack/src/bin/use-localstack.rs
+++ b/rust_dev_preview/localstack/src/bin/use-localstack.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 // snippet-start:[localstack.rust.use-localstack]
 use std::error::Error;
 

--- a/rust_dev_preview/logging/logger/Cargo.toml
+++ b/rust_dev_preview/logging/logger/Cargo.toml
@@ -11,8 +11,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 # snippet-start:[logging.rust.logger-cargo.toml-env_logger]
 env_logger = "0.9.0"
 # snippet-end:[logging.rust.logger-cargo.toml-env_logger]

--- a/rust_dev_preview/logging/logger/src/main.rs
+++ b/rust_dev_preview/logging/logger/src/main.rs
@@ -4,7 +4,7 @@
  */
 // snippet-start:[logging.rust.main]
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_dynamodb::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/logging/logger/src/main.rs
+++ b/rust_dev_preview/logging/logger/src/main.rs
@@ -2,6 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+
+#![allow(clippy::result_large_err)]
+
 // snippet-start:[logging.rust.main]
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/logging/tracing/Cargo.toml
+++ b/rust_dev_preview/logging/tracing/Cargo.toml
@@ -11,8 +11,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1.20.1", features = ["full"] }
 # snippet-start:[logging.rust.tracing-cargo.toml-tracing_subscriber]

--- a/rust_dev_preview/logging/tracing/src/main.rs
+++ b/rust_dev_preview/logging/tracing/src/main.rs
@@ -4,7 +4,7 @@
  */
 // snippet-start:[tracing.rust.main]
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_dynamodb::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/logging/tracing/src/main.rs
+++ b/rust_dev_preview/logging/tracing/src/main.rs
@@ -2,6 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+
+#![allow(clippy::result_large_err)]
+
 // snippet-start:[tracing.rust.main]
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/medialive/Cargo.toml
+++ b/rust_dev_preview/medialive/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-medialive = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-medialive = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/medialive/src/bin/medialive-helloworld.rs
+++ b/rust_dev_preview/medialive/src/bin/medialive-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_medialive::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/medialive/src/bin/medialive-helloworld.rs
+++ b/rust_dev_preview/medialive/src/bin/medialive-helloworld.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_medialive::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_medialive::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/mediapackage/Cargo.toml
+++ b/rust_dev_preview/mediapackage/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-mediapackage = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-mediapackage = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/mediapackage/src/bin/list-endpoints.rs
+++ b/rust_dev_preview/mediapackage/src/bin/list-endpoints.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_mediapackage::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/mediapackage/src/bin/list-endpoints.rs
+++ b/rust_dev_preview/mediapackage/src/bin/list-endpoints.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_mediapackage::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_mediapackage::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/mediapackage/src/bin/mediapackage-helloworld.rs
+++ b/rust_dev_preview/mediapackage/src/bin/mediapackage-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_mediapackage::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/mediapackage/src/bin/mediapackage-helloworld.rs
+++ b/rust_dev_preview/mediapackage/src/bin/mediapackage-helloworld.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_mediapackage::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_mediapackage::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/polly/Cargo.toml
+++ b/rust_dev_preview/polly/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-polly = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-polly = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 bytes = "1"
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/polly/src/bin/describe-voices.rs
+++ b/rust_dev_preview/polly/src/bin/describe-voices.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_polly::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_polly::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/polly/src/bin/describe-voices.rs
+++ b/rust_dev_preview/polly/src/bin/describe-voices.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_polly::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/polly/src/bin/list-lexicons.rs
+++ b/rust_dev_preview/polly/src/bin/list-lexicons.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_polly::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_polly::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/polly/src/bin/list-lexicons.rs
+++ b/rust_dev_preview/polly/src/bin/list-lexicons.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_polly::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/polly/src/bin/polly-helloworld.rs
+++ b/rust_dev_preview/polly/src/bin/polly-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_polly::types::{Engine, Voice};
 use aws_sdk_polly::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/polly/src/bin/polly-helloworld.rs
+++ b/rust_dev_preview/polly/src/bin/polly-helloworld.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_polly::model::{Engine, Voice};
-use aws_sdk_polly::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_polly::types::{Engine, Voice};
+use aws_sdk_polly::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/polly/src/bin/put-lexicon.rs
+++ b/rust_dev_preview/polly/src/bin/put-lexicon.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_polly::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_polly::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/polly/src/bin/put-lexicon.rs
+++ b/rust_dev_preview/polly/src/bin/put-lexicon.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_polly::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/polly/src/bin/synthesize-speech-presigned.rs
+++ b/rust_dev_preview/polly/src/bin/synthesize-speech-presigned.rs
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_polly::model::{OutputFormat, VoiceId};
-use aws_sdk_polly::presigning::config::PresigningConfig;
-use aws_sdk_polly::{Client, Region, PKG_VERSION};
+use aws_sdk_polly::presigning::PresigningConfig;
+use aws_sdk_polly::types::{OutputFormat, VoiceId};
+use aws_sdk_polly::{config::Region, meta::PKG_VERSION, Client};
 use std::error::Error;
 use std::fs;
 use std::time::Duration;

--- a/rust_dev_preview/polly/src/bin/synthesize-speech-presigned.rs
+++ b/rust_dev_preview/polly/src/bin/synthesize-speech-presigned.rs
@@ -2,6 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_polly::presigning::PresigningConfig;
 use aws_sdk_polly::types::{OutputFormat, VoiceId};

--- a/rust_dev_preview/polly/src/bin/synthesize-speech.rs
+++ b/rust_dev_preview/polly/src/bin/synthesize-speech.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_polly::model::{OutputFormat, VoiceId};
-use aws_sdk_polly::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_polly::types::{OutputFormat, VoiceId};
+use aws_sdk_polly::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::fs;
 use structopt::StructOpt;
 use tokio::io::AsyncWriteExt;

--- a/rust_dev_preview/polly/src/bin/synthesize-speech.rs
+++ b/rust_dev_preview/polly/src/bin/synthesize-speech.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_polly::types::{OutputFormat, VoiceId};
 use aws_sdk_polly::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/qldb/Cargo.toml
+++ b/rust_dev_preview/qldb/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-qldb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-qldbsession = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-qldb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-qldbsession = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = { version = "0.1.9", features = ["default"] }
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/qldb/src/bin/create-ledger.rs
+++ b/rust_dev_preview/qldb/src/bin/create-ledger.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_qldb::model::PermissionsMode;
-use aws_sdk_qldb::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_qldb::types::PermissionsMode;
+use aws_sdk_qldb::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/qldb/src/bin/create-ledger.rs
+++ b/rust_dev_preview/qldb/src/bin/create-ledger.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_qldb::types::PermissionsMode;
 use aws_sdk_qldb::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/qldb/src/bin/list-ledgers.rs
+++ b/rust_dev_preview/qldb/src/bin/list-ledgers.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_qldb::{config::Region, meta::PKG_VERSION, Client as QLDBClient, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/qldb/src/bin/list-ledgers.rs
+++ b/rust_dev_preview/qldb/src/bin/list-ledgers.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_qldb::{Client as QLDBClient, Error, Region, PKG_VERSION};
+use aws_sdk_qldb::{config::Region, meta::PKG_VERSION, Client as QLDBClient, Error};
 use structopt::StructOpt;
 use tokio_stream::StreamExt;
 

--- a/rust_dev_preview/qldb/src/bin/qldb-helloworld.rs
+++ b/rust_dev_preview/qldb/src/bin/qldb-helloworld.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_qldbsession::model::StartSessionRequest;
-use aws_sdk_qldbsession::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_qldbsession::types::StartSessionRequest;
+use aws_sdk_qldbsession::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/qldb/src/bin/qldb-helloworld.rs
+++ b/rust_dev_preview/qldb/src/bin/qldb-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_qldbsession::types::StartSessionRequest;
 use aws_sdk_qldbsession::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/rds/Cargo.toml
+++ b/rust_dev_preview/rds/Cargo.toml
@@ -10,8 +10,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rds = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rds = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/rds/src/bin/rds-helloworld.rs
+++ b/rust_dev_preview/rds/src/bin/rds-helloworld.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_rds::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_rds::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/rds/src/bin/rds-helloworld.rs
+++ b/rust_dev_preview/rds/src/bin/rds-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_rds::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/rdsdata/Cargo.toml
+++ b/rust_dev_preview/rdsdata/Cargo.toml
@@ -10,8 +10,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rdsdata = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rdsdata = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/rdsdata/src/bin/rdsdata-helloworld.rs
+++ b/rust_dev_preview/rdsdata/src/bin/rdsdata-helloworld.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_rdsdata::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_rdsdata::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/rdsdata/src/bin/rdsdata-helloworld.rs
+++ b/rust_dev_preview/rdsdata/src/bin/rdsdata-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_rdsdata::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/route53/Cargo.toml
+++ b/rust_dev_preview/route53/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-route53 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-route53 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/route53/src/bin/route53-helloworld.rs
+++ b/rust_dev_preview/route53/src/bin/route53-helloworld.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_route53::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_route53::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/route53/src/bin/route53-helloworld.rs
+++ b/rust_dev_preview/route53/src/bin/route53-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_route53::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/s3/Cargo.toml
+++ b/rust_dev_preview/s3/Cargo.toml
@@ -21,16 +21,16 @@ assert_cmd = "2.0"
 predicates = "2.1"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 # snippet-start:[s3.rust.s3-object-lambda-cargo.toml]
-aws-endpoint = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-endpoint = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 # snippet-end:[s3.rust.s3-object-lambda-cargo.toml]
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "test-util",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["rt-tokio"] }
-aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["rt-tokio"] }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 sdk-examples-test-utils = { path = "../test-utils" }
 bytes = "0.4.12"
 futures-util = { version = "0.3.21", features = ["alloc"] }

--- a/rust_dev_preview/s3/src/bin/client.rs
+++ b/rust_dev_preview/s3/src/bin/client.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 // snippet-start:[s3.rust.client-use]
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::Client;

--- a/rust_dev_preview/s3/src/bin/copy-object.rs
+++ b/rust_dev_preview/s3/src/bin/copy-object.rs
@@ -5,8 +5,11 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::{
-    error::CopyObjectError, output::CopyObjectOutput, types::SdkError, Client, Error, Region,
-    PKG_VERSION,
+    config::Region,
+    error::SdkError,
+    meta::PKG_VERSION,
+    operation::copy_object::{CopyObjectError, CopyObjectOutput},
+    Client, Error,
 };
 use structopt::StructOpt;
 

--- a/rust_dev_preview/s3/src/bin/copy-object.rs
+++ b/rust_dev_preview/s3/src/bin/copy-object.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::{
     config::Region,

--- a/rust_dev_preview/s3/src/bin/create-bucket.rs
+++ b/rust_dev_preview/s3/src/bin/create-bucket.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::create_bucket::{CreateBucketError, CreateBucketOutput};

--- a/rust_dev_preview/s3/src/bin/create-bucket.rs
+++ b/rust_dev_preview/s3/src/bin/create-bucket.rs
@@ -4,11 +4,10 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::error::CreateBucketError;
-use aws_sdk_s3::model::{BucketLocationConstraint, CreateBucketConfiguration};
-use aws_sdk_s3::output::CreateBucketOutput;
-use aws_sdk_s3::types::SdkError;
-use aws_sdk_s3::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::operation::create_bucket::{CreateBucketError, CreateBucketOutput};
+use aws_sdk_s3::types::{BucketLocationConstraint, CreateBucketConfiguration};
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/s3/src/bin/delete-object.rs
+++ b/rust_dev_preview/s3/src/bin/delete-object.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/s3/src/bin/delete-object.rs
+++ b/rust_dev_preview/s3/src/bin/delete-object.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/s3/src/bin/delete-objects.rs
+++ b/rust_dev_preview/s3/src/bin/delete-objects.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::model::{Delete, ObjectIdentifier};
-use aws_sdk_s3::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_s3::types::{Delete, ObjectIdentifier};
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/s3/src/bin/delete-objects.rs
+++ b/rust_dev_preview/s3/src/bin/delete-objects.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::types::{Delete, ObjectIdentifier};
 use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/s3/src/bin/get-object-presigned.rs
+++ b/rust_dev_preview/s3/src/bin/get-object-presigned.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::presigning::config::PresigningConfig;
-use aws_sdk_s3::{Client, Region, PKG_VERSION};
+use aws_sdk_s3::presigning::PresigningConfig;
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client};
 use std::error::Error;
 use std::time::Duration;
 use structopt::StructOpt;

--- a/rust_dev_preview/s3/src/bin/get-object-presigned.rs
+++ b/rust_dev_preview/s3/src/bin/get-object-presigned.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::presigning::PresigningConfig;
 use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client};

--- a/rust_dev_preview/s3/src/bin/if-modified-since.rs
+++ b/rust_dev_preview/s3/src/bin/if-modified-since.rs
@@ -3,8 +3,9 @@
 
 // snippet-start:[s3.rust.if-modified-since]
 use aws_sdk_s3::{
-    error::HeadObjectError,
-    types::{ByteStream, DateTime, SdkError},
+    error::SdkError,
+    operation::head_object::HeadObjectError,
+    primitives::{ByteStream, DateTime},
     Client, Error,
 };
 use aws_smithy_types::date_time::Format;

--- a/rust_dev_preview/s3/src/bin/if-modified-since.rs
+++ b/rust_dev_preview/s3/src/bin/if-modified-since.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0.
 
+#![allow(clippy::result_large_err)]
+
 // snippet-start:[s3.rust.if-modified-since]
 use aws_sdk_s3::{
     error::SdkError,

--- a/rust_dev_preview/s3/src/bin/list-buckets.rs
+++ b/rust_dev_preview/s3/src/bin/list-buckets.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/s3/src/bin/list-buckets.rs
+++ b/rust_dev_preview/s3/src/bin/list-buckets.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/s3/src/bin/list-object-versions.rs
+++ b/rust_dev_preview/s3/src/bin/list-object-versions.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/s3/src/bin/list-object-versions.rs
+++ b/rust_dev_preview/s3/src/bin/list-object-versions.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/s3/src/bin/list-objects.rs
+++ b/rust_dev_preview/s3/src/bin/list-objects.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/s3/src/bin/list-objects.rs
+++ b/rust_dev_preview/s3/src/bin/list-objects.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/s3/src/bin/put-object-presigned.rs
+++ b/rust_dev_preview/s3/src/bin/put-object-presigned.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::presigning::config::PresigningConfig;
-use aws_sdk_s3::{Client, Region, PKG_VERSION};
+use aws_sdk_s3::presigning::PresigningConfig;
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client};
 use std::error::Error;
 use std::time::Duration;
 use structopt::StructOpt;

--- a/rust_dev_preview/s3/src/bin/put-object-presigned.rs
+++ b/rust_dev_preview/s3/src/bin/put-object-presigned.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::presigning::PresigningConfig;
 use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client};

--- a/rust_dev_preview/s3/src/bin/s3-getting-started.rs
+++ b/rust_dev_preview/s3/src/bin/s3-getting-started.rs
@@ -20,7 +20,7 @@ user guide.
 // snippet-start:[rust.example_code.s3.basics.imports]
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::{Client, Region};
+use aws_sdk_s3::{config::Region, Client};
 use s3_service::error::Error;
 use uuid::Uuid;
 

--- a/rust_dev_preview/s3/src/bin/s3-getting-started.rs
+++ b/rust_dev_preview/s3/src/bin/s3-getting-started.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 /*
 Purpose
 

--- a/rust_dev_preview/s3/src/bin/s3-helloworld.rs
+++ b/rust_dev_preview/s3/src/bin/s3-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/s3/src/bin/s3-helloworld.rs
+++ b/rust_dev_preview/s3/src/bin/s3-helloworld.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::types::ByteStream;
-use aws_sdk_s3::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::path::Path;
 use std::process;
 use structopt::StructOpt;

--- a/rust_dev_preview/s3/src/bin/s3-multipart-upload.rs
+++ b/rust_dev_preview/s3/src/bin/s3-multipart-upload.rs
@@ -5,16 +5,17 @@
 
 // snippet-start:[rust.example_code.s3.large_files.scenario]
 
-use std::convert::TryInto;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::model::{CompletedMultipartUpload, CompletedPart};
-use aws_sdk_s3::output::{CreateMultipartUploadOutput, GetObjectOutput};
-use aws_sdk_s3::types::DisplayErrorContext;
-use aws_sdk_s3::{Client as S3Client, Region};
+use aws_sdk_s3::error::DisplayErrorContext;
+use aws_sdk_s3::operation::{
+    create_multipart_upload::CreateMultipartUploadOutput, get_object::GetObjectOutput,
+};
+use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+use aws_sdk_s3::{config::Region, Client as S3Client};
 use aws_smithy_http::byte_stream::{ByteStream, Length};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};

--- a/rust_dev_preview/s3/src/bin/s3-multipart-upload.rs
+++ b/rust_dev_preview/s3/src/bin/s3-multipart-upload.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 // snippet-start:[rust.example_code.s3.large_files.scenario]
 
 use std::fs::File;

--- a/rust_dev_preview/s3/src/bin/select-object-content.rs
+++ b/rust_dev_preview/s3/src/bin/select-object-content.rs
@@ -4,11 +4,11 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::model::{
+use aws_sdk_s3::types::{
     CompressionType, CsvInput, CsvOutput, ExpressionType, FileHeaderInfo, InputSerialization,
     OutputSerialization, SelectObjectContentEventStream,
 };
-use aws_sdk_s3::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/s3/src/bin/select-object-content.rs
+++ b/rust_dev_preview/s3/src/bin/select-object-content.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::types::{
     CompressionType, CsvInput, CsvOutput, ExpressionType, FileHeaderInfo, InputSerialization,

--- a/rust_dev_preview/s3/src/error.rs
+++ b/rust_dev_preview/s3/src/error.rs
@@ -26,11 +26,11 @@ impl From<aws_sdk_s3::Error> for Error {
     }
 }
 
-impl<T> From<aws_sdk_s3::types::SdkError<T>> for Error
+impl<T> From<aws_sdk_s3::error::SdkError<T>> for Error
 where
     T: StdError + Send + Sync + 'static,
 {
-    fn from(source: aws_sdk_s3::types::SdkError<T>) -> Self {
+    fn from(source: aws_sdk_s3::error::SdkError<T>) -> Self {
         Self::unhandled(source)
     }
 }

--- a/rust_dev_preview/s3/src/s3-service-lib.rs
+++ b/rust_dev_preview/s3/src/s3-service-lib.rs
@@ -5,15 +5,17 @@
 
 // snippet-start:[rust.example_code.s3.scenario_getting_started.lib]
 
-use aws_sdk_s3::error::{CopyObjectError, CreateBucketError, GetObjectError, PutObjectError};
-use aws_sdk_s3::model::{
+use aws_sdk_s3::operation::{
+    copy_object::{CopyObjectError, CopyObjectOutput},
+    create_bucket::{CreateBucketError, CreateBucketOutput},
+    get_object::{GetObjectError, GetObjectOutput},
+    list_objects_v2::ListObjectsV2Output,
+    put_object::{PutObjectError, PutObjectOutput},
+};
+use aws_sdk_s3::types::{
     BucketLocationConstraint, CreateBucketConfiguration, Delete, ObjectIdentifier,
 };
-use aws_sdk_s3::output::{
-    CopyObjectOutput, CreateBucketOutput, GetObjectOutput, ListObjectsV2Output, PutObjectOutput,
-};
-use aws_sdk_s3::types::{ByteStream, SdkError};
-use aws_sdk_s3::Client;
+use aws_sdk_s3::{error::SdkError, primitives::ByteStream, Client};
 use error::Error;
 use std::path::Path;
 use std::str;

--- a/rust_dev_preview/s3/tests/test-s3-getting-started.rs
+++ b/rust_dev_preview/s3/tests/test-s3-getting-started.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::{Client, Region};
+use aws_sdk_s3::{config::Region, Client};
 use s3_service::error::Error;
 use uuid::Uuid;
 

--- a/rust_dev_preview/sagemaker/Cargo.toml
+++ b/rust_dev_preview/sagemaker/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sagemaker = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sagemaker = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/sagemaker/src/bin/list-training-jobs.rs
+++ b/rust_dev_preview/sagemaker/src/bin/list-training-jobs.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sagemaker::{Client, Region, PKG_VERSION};
+use aws_sdk_sagemaker::{config::Region, meta::PKG_VERSION, Client};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use sagemaker_code_examples::Error;
 use structopt::StructOpt;

--- a/rust_dev_preview/sagemaker/src/bin/list-training-jobs.rs
+++ b/rust_dev_preview/sagemaker/src/bin/list-training-jobs.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sagemaker::{config::Region, meta::PKG_VERSION, Client};
 use aws_smithy_types_convert::date_time::DateTimeExt;

--- a/rust_dev_preview/sagemaker/src/bin/sagemaker-helloworld.rs
+++ b/rust_dev_preview/sagemaker/src/bin/sagemaker-helloworld.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sagemaker::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sagemaker::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/sagemaker/src/bin/sagemaker-helloworld.rs
+++ b/rust_dev_preview/sagemaker/src/bin/sagemaker-helloworld.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sagemaker::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/sagemaker/src/lib.rs
+++ b/rust_dev_preview/sagemaker/src/lib.rs
@@ -20,11 +20,11 @@ impl From<aws_sdk_sagemaker::Error> for Error {
     }
 }
 
-impl<T> From<aws_sdk_sagemaker::types::SdkError<T>> for Error
+impl<T> From<aws_sdk_sagemaker::error::SdkError<T>> for Error
 where
     T: StdError + Send + Sync + 'static,
 {
-    fn from(source: aws_sdk_sagemaker::types::SdkError<T>) -> Self {
+    fn from(source: aws_sdk_sagemaker::error::SdkError<T>) -> Self {
         Self {
             source: source.into(),
         }

--- a/rust_dev_preview/sdk-config/Cargo.toml
+++ b/rust_dev_preview/sdk-config/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/sdk-config/src/bin/disable_retries.rs
+++ b/rust_dev_preview/sdk-config/src/bin/disable_retries.rs
@@ -5,7 +5,7 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::config::retry::RetryConfig;
-use aws_sdk_s3::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/sdk-config/src/bin/disable_retries.rs
+++ b/rust_dev_preview/sdk-config/src/bin/disable_retries.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::config::retry::RetryConfig;
 use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/sdk-config/src/bin/lazy_static.rs
+++ b/rust_dev_preview/sdk-config/src/bin/lazy_static.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 //! Use lazy_static and AsyncOnce to allow on demand access to a global config and client.
 //! Configs and clients are both cheap to clone (they are Tower stacks).
 //! This example will log "Initializing SdkConfig" and "Initializing S3 Client" once each.

--- a/rust_dev_preview/sdk-config/src/bin/set_retries.rs
+++ b/rust_dev_preview/sdk-config/src/bin/set_retries.rs
@@ -5,7 +5,7 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::config::retry::RetryConfig;
-use aws_sdk_s3::{config, Client, Error, Region, PKG_VERSION};
+use aws_sdk_s3::{config, config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/sdk-config/src/bin/set_retries.rs
+++ b/rust_dev_preview/sdk-config/src/bin/set_retries.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::config::retry::RetryConfig;
 use aws_sdk_s3::{config, config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/sdk-config/src/bin/timeouts.rs
+++ b/rust_dev_preview/sdk-config/src/bin/timeouts.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::timeout::TimeoutConfig;
 use std::time::Duration;
 

--- a/rust_dev_preview/secretsmanager/Cargo.toml
+++ b/rust_dev_preview/secretsmanager/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 description = "Example usage of the SecretManager service"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-secretsmanager = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-secretsmanager = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/secretsmanager/src/bin/create-secret.rs
+++ b/rust_dev_preview/secretsmanager/src/bin/create-secret.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_secretsmanager::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/secretsmanager/src/bin/create-secret.rs
+++ b/rust_dev_preview/secretsmanager/src/bin/create-secret.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_secretsmanager::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_secretsmanager::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/secretsmanager/src/bin/get-secret-value.rs
+++ b/rust_dev_preview/secretsmanager/src/bin/get-secret-value.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_secretsmanager::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/secretsmanager/src/bin/get-secret-value.rs
+++ b/rust_dev_preview/secretsmanager/src/bin/get-secret-value.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_secretsmanager::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_secretsmanager::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/secretsmanager/src/bin/list-secrets.rs
+++ b/rust_dev_preview/secretsmanager/src/bin/list-secrets.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_secretsmanager::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/secretsmanager/src/bin/list-secrets.rs
+++ b/rust_dev_preview/secretsmanager/src/bin/list-secrets.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_secretsmanager::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_secretsmanager::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/sending-presigned-requests/Cargo.toml
+++ b/rust_dev_preview/sending-presigned-requests/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 http = "0.2.6"
 hyper = "0.14"
 reqwest = "0.11"

--- a/rust_dev_preview/sending-presigned-requests/src/main.rs
+++ b/rust_dev_preview/sending-presigned-requests/src/main.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::presigning::{PresignedRequest, PresigningConfig};
 use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client};

--- a/rust_dev_preview/sending-presigned-requests/src/main.rs
+++ b/rust_dev_preview/sending-presigned-requests/src/main.rs
@@ -4,9 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::presigning::config::PresigningConfig;
-use aws_sdk_s3::presigning::request::PresignedRequest;
-use aws_sdk_s3::{Client, Region, PKG_VERSION};
+use aws_sdk_s3::presigning::{PresignedRequest, PresigningConfig};
+use aws_sdk_s3::{config::Region, meta::PKG_VERSION, Client};
 use std::error::Error;
 use std::time::Duration;
 use structopt::StructOpt;

--- a/rust_dev_preview/ses/Cargo.toml
+++ b/rust_dev_preview/ses/Cargo.toml
@@ -8,8 +8,8 @@ authors = [
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sesv2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sesv2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/ses/src/bin/create-contact-list.rs
+++ b/rust_dev_preview/ses/src/bin/create-contact-list.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sesv2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ses/src/bin/create-contact-list.rs
+++ b/rust_dev_preview/ses/src/bin/create-contact-list.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ses/src/bin/create-contact.rs
+++ b/rust_dev_preview/ses/src/bin/create-contact.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sesv2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ses/src/bin/create-contact.rs
+++ b/rust_dev_preview/ses/src/bin/create-contact.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ses/src/bin/is-email-verified.rs
+++ b/rust_dev_preview/ses/src/bin/is-email-verified.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sesv2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ses/src/bin/is-email-verified.rs
+++ b/rust_dev_preview/ses/src/bin/is-email-verified.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ses/src/bin/list-contact-lists.rs
+++ b/rust_dev_preview/ses/src/bin/list-contact-lists.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sesv2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ses/src/bin/list-contact-lists.rs
+++ b/rust_dev_preview/ses/src/bin/list-contact-lists.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ses/src/bin/list-contacts.rs
+++ b/rust_dev_preview/ses/src/bin/list-contacts.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sesv2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ses/src/bin/list-contacts.rs
+++ b/rust_dev_preview/ses/src/bin/list-contacts.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/ses/src/bin/send-email.rs
+++ b/rust_dev_preview/ses/src/bin/send-email.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sesv2::model::{Body, Content, Destination, EmailContent, Message};
-use aws_sdk_sesv2::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sesv2::types::{Body, Content, Destination, EmailContent, Message};
+use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ses/src/bin/send-email.rs
+++ b/rust_dev_preview/ses/src/bin/send-email.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sesv2::types::{Body, Content, Destination, EmailContent, Message};
 use aws_sdk_sesv2::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/sitewise/Cargo.toml
+++ b/rust_dev_preview/sitewise/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 # For more keys and their definitions, see https://doc.rust-lang.org/cargo/reference/manifest.html.
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-iotsitewise = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-iotsitewise = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 structopt = { version = "0.3", default-features = false }

--- a/rust_dev_preview/sitewise/src/bin/describe-asset.rs
+++ b/rust_dev_preview/sitewise/src/bin/describe-asset.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iotsitewise::types::DisplayErrorContext;
-use aws_sdk_iotsitewise::{Client, Region, PKG_VERSION};
+use aws_sdk_iotsitewise::error::DisplayErrorContext;
+use aws_sdk_iotsitewise::{config::Region, meta::PKG_VERSION, Client};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use sitewise_code_examples::Error;
 use std::process;

--- a/rust_dev_preview/sitewise/src/bin/describe-asset.rs
+++ b/rust_dev_preview/sitewise/src/bin/describe-asset.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_iotsitewise::error::DisplayErrorContext;
 use aws_sdk_iotsitewise::{config::Region, meta::PKG_VERSION, Client};

--- a/rust_dev_preview/sitewise/src/bin/list-asset-models.rs
+++ b/rust_dev_preview/sitewise/src/bin/list-asset-models.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iotsitewise::types::DisplayErrorContext;
-use aws_sdk_iotsitewise::{Client, Region, PKG_VERSION};
+use aws_sdk_iotsitewise::error::DisplayErrorContext;
+use aws_sdk_iotsitewise::{config::Region, meta::PKG_VERSION, Client};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use sitewise_code_examples::Error;
 use std::process;

--- a/rust_dev_preview/sitewise/src/bin/list-asset-models.rs
+++ b/rust_dev_preview/sitewise/src/bin/list-asset-models.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_iotsitewise::error::DisplayErrorContext;
 use aws_sdk_iotsitewise::{config::Region, meta::PKG_VERSION, Client};

--- a/rust_dev_preview/sitewise/src/bin/list-assets.rs
+++ b/rust_dev_preview/sitewise/src/bin/list-assets.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_iotsitewise::error::DisplayErrorContext;
 use aws_sdk_iotsitewise::{config::Region, meta::PKG_VERSION, types::ListAssetsFilter, Client};

--- a/rust_dev_preview/sitewise/src/bin/list-assets.rs
+++ b/rust_dev_preview/sitewise/src/bin/list-assets.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iotsitewise::types::DisplayErrorContext;
-use aws_sdk_iotsitewise::{model::ListAssetsFilter, Client, Region, PKG_VERSION};
+use aws_sdk_iotsitewise::error::DisplayErrorContext;
+use aws_sdk_iotsitewise::{config::Region, meta::PKG_VERSION, types::ListAssetsFilter, Client};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use sitewise_code_examples::Error;
 use std::process;

--- a/rust_dev_preview/sitewise/src/bin/list-portals.rs
+++ b/rust_dev_preview/sitewise/src/bin/list-portals.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_iotsitewise::types::DisplayErrorContext;
-use aws_sdk_iotsitewise::{Client, Region, PKG_VERSION};
+use aws_sdk_iotsitewise::error::DisplayErrorContext;
+use aws_sdk_iotsitewise::{config::Region, meta::PKG_VERSION, Client};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use sitewise_code_examples::Error;
 use std::process;

--- a/rust_dev_preview/sitewise/src/bin/list-portals.rs
+++ b/rust_dev_preview/sitewise/src/bin/list-portals.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_iotsitewise::error::DisplayErrorContext;
 use aws_sdk_iotsitewise::{config::Region, meta::PKG_VERSION, Client};

--- a/rust_dev_preview/sitewise/src/lib.rs
+++ b/rust_dev_preview/sitewise/src/lib.rs
@@ -26,11 +26,11 @@ impl From<aws_sdk_iotsitewise::Error> for Error {
     }
 }
 
-impl<T> From<aws_sdk_iotsitewise::types::SdkError<T>> for Error
+impl<T> From<aws_sdk_iotsitewise::error::SdkError<T>> for Error
 where
     T: StdError + Send + Sync + 'static,
 {
-    fn from(source: aws_sdk_iotsitewise::types::SdkError<T>) -> Self {
+    fn from(source: aws_sdk_iotsitewise::error::SdkError<T>) -> Self {
         Error::unhandled(source)
     }
 }

--- a/rust_dev_preview/snowball/Cargo.toml
+++ b/rust_dev_preview/snowball/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-snowball = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-snowball = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/snowball/src/bin/create-address.rs
+++ b/rust_dev_preview/snowball/src/bin/create-address.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_snowball::model::Address;
-use aws_sdk_snowball::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_snowball::types::Address;
+use aws_sdk_snowball::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/snowball/src/bin/create-address.rs
+++ b/rust_dev_preview/snowball/src/bin/create-address.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_snowball::types::Address;
 use aws_sdk_snowball::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/snowball/src/bin/describe-addresses.rs
+++ b/rust_dev_preview/snowball/src/bin/describe-addresses.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_snowball::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_snowball::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/snowball/src/bin/describe-addresses.rs
+++ b/rust_dev_preview/snowball/src/bin/describe-addresses.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_snowball::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/snowball/src/bin/list-jobs.rs
+++ b/rust_dev_preview/snowball/src/bin/list-jobs.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_snowball::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_snowball::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/snowball/src/bin/list-jobs.rs
+++ b/rust_dev_preview/snowball/src/bin/list-jobs.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_snowball::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/sns/Cargo.toml
+++ b/rust_dev_preview/sns/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sns = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sns = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/sns/src/bin/create-topic.rs
+++ b/rust_dev_preview/sns/src/bin/create-topic.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sns::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/sns/src/bin/create-topic.rs
+++ b/rust_dev_preview/sns/src/bin/create-topic.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sns::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sns::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/sns/src/bin/list-topics.rs
+++ b/rust_dev_preview/sns/src/bin/list-topics.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sns::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/sns/src/bin/list-topics.rs
+++ b/rust_dev_preview/sns/src/bin/list-topics.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sns::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sns::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/sns/src/bin/sns-hello-world.rs
+++ b/rust_dev_preview/sns/src/bin/sns-hello-world.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sns::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/sns/src/bin/sns-hello-world.rs
+++ b/rust_dev_preview/sns/src/bin/sns-hello-world.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sns::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sns::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/sqs/Cargo.toml
+++ b/rust_dev_preview/sqs/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/sqs/src/bin/sqs-hello-world.rs
+++ b/rust_dev_preview/sqs/src/bin/sqs-hello-world.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sqs::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/sqs/src/bin/sqs-hello-world.rs
+++ b/rust_dev_preview/sqs/src/bin/sqs-hello-world.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sqs::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sqs::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ssm/Cargo.toml
+++ b/rust_dev_preview/ssm/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ssm = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ssm = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/ssm/src/bin/create-parameter.rs
+++ b/rust_dev_preview/ssm/src/bin/create-parameter.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ssm::types::ParameterType;
 use aws_sdk_ssm::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rust_dev_preview/ssm/src/bin/create-parameter.rs
+++ b/rust_dev_preview/ssm/src/bin/create-parameter.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ssm::model::ParameterType;
-use aws_sdk_ssm::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ssm::types::ParameterType;
+use aws_sdk_ssm::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ssm/src/bin/describe-parameters.rs
+++ b/rust_dev_preview/ssm/src/bin/describe-parameters.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ssm::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_ssm::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rust_dev_preview/ssm/src/bin/describe-parameters.rs
+++ b/rust_dev_preview/ssm/src/bin/describe-parameters.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ssm::{config::Region, meta::PKG_VERSION, Client, Error};
 use structopt::StructOpt;

--- a/rust_dev_preview/stepfunction/Cargo.toml
+++ b/rust_dev_preview/stepfunction/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Daniele Frasca <https://github.com/ymwjbxxq/>"]
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sfn = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sfn = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/stepfunction/src/bin/start-execution.rs
+++ b/rust_dev_preview/stepfunction/src/bin/start-execution.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_sfn::{Client, Error};
 use structopt::StructOpt;
 

--- a/rust_dev_preview/stepfunction/src/bin/stop-execution.rs
+++ b/rust_dev_preview/stepfunction/src/bin/stop-execution.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#![allow(clippy::result_large_err)]
+
 use aws_sdk_sfn::{Client, Error};
 use structopt::StructOpt;
 

--- a/rust_dev_preview/sts/Cargo.toml
+++ b/rust_dev_preview/sts/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = {git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = {git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/sts/src/bin/assume-role.rs
+++ b/rust_dev_preview/sts/src/bin/assume-role.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sts::{Client, Error, PKG_VERSION};
+use aws_sdk_sts::{meta::PKG_VERSION, Client, Error};
 use aws_types::region::Region;
 use aws_types::sdk_config::SdkConfig;
 use structopt::StructOpt;

--- a/rust_dev_preview/sts/src/bin/assume-role.rs
+++ b/rust_dev_preview/sts/src/bin/assume-role.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sts::{meta::PKG_VERSION, Client, Error};
 use aws_types::region::Region;

--- a/rust_dev_preview/sts/src/bin/get-caller-identity.rs
+++ b/rust_dev_preview/sts/src/bin/get-caller-identity.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_sts::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::fmt::Debug;

--- a/rust_dev_preview/sts/src/bin/get-caller-identity.rs
+++ b/rust_dev_preview/sts/src/bin/get-caller-identity.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_sts::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_sts::{config::Region, meta::PKG_VERSION, Client, Error};
 use std::fmt::Debug;
 use structopt::StructOpt;
 

--- a/rust_dev_preview/test-utils/Cargo.toml
+++ b/rust_dev_preview/test-utils/Cargo.toml
@@ -7,12 +7,12 @@ authors = [
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "test-util",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main"}
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next"}
 http = "0.2"
 
 [lib]

--- a/rust_dev_preview/test-utils/src/macros.rs
+++ b/rust_dev_preview/test-utils/src/macros.rs
@@ -90,13 +90,13 @@ macro_rules! client_config {
     ) => {
         /// TODO: remove after https://github.com/awslabs/smithy-rs/pull/2145
         $sdk_crate::Config::builder()
-            .credentials_provider($sdk_crate::Credentials::new(
+            .credentials_provider($sdk_crate::config::Credentials::new(
                 "ATESTCLIENT",
                 "atestsecretkey",
                 Some("atestsessiontoken".to_string()),
                 None,
                 "",
             ))
-            .region($sdk_crate::Region::new("us-east-1"))
+            .region($sdk_crate::config::Region::new("us-east-1"))
     };
 }

--- a/rust_dev_preview/testing/Cargo.toml
+++ b/rust_dev_preview/testing/Cargo.toml
@@ -11,14 +11,14 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.51"
 # snippet-end:[testing.rust.Cargo.toml]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "test-util",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "hardcoded-credentials",
 ] }
 tokio = { version = "1.20.1", features = ["full"] }

--- a/rust_dev_preview/testing/src/enums.rs
+++ b/rust_dev_preview/testing/src/enums.rs
@@ -10,7 +10,7 @@ use std::error::Error;
 
 // snippet-start:[testing.rust.enums-struct]
 pub struct ListObjectsResult {
-    pub objects: Vec<s3::model::Object>,
+    pub objects: Vec<s3::types::Object>,
     pub continuation_token: Option<String>,
     pub has_more: bool,
 }
@@ -23,7 +23,7 @@ pub enum ListObjects {
     Test {
         expected_bucket: String,
         expected_prefix: String,
-        pages: Vec<Vec<s3::model::Object>>,
+        pages: Vec<Vec<s3::types::Object>>,
     },
 }
 // snippet-end:[testing.rust.enums-enum]
@@ -79,7 +79,7 @@ impl ListObjects {
     // snippet-start:[testing.rust.enums-test]
     #[cfg(test)]
     fn test_list_objects(
-        pages: &[Vec<s3::model::Object>],
+        pages: &[Vec<s3::types::Object>],
         continuation_token: Option<String>,
     ) -> Result<ListObjectsResult, Box<dyn Error + Send + Sync + 'static>> {
         use std::str::FromStr;
@@ -135,7 +135,7 @@ async fn determine_prefix_file_size(
 // snippet-start:[testing.rust.enums-tests]
 #[tokio::test]
 async fn test_single_page() {
-    use s3::model::Object;
+    use s3::types::Object;
 
     // Create a TestListObjects instance with just one page of two objects in it
     let fake = ListObjects::Test {
@@ -158,7 +158,7 @@ async fn test_single_page() {
 
 #[tokio::test]
 async fn test_multiple_pages() {
-    use s3::model::Object;
+    use s3::types::Object;
 
     // This time, we add a helper function for making pages
     fn make_page(sizes: &[i64]) -> Vec<Object> {

--- a/rust_dev_preview/testing/src/intro.rs
+++ b/rust_dev_preview/testing/src/intro.rs
@@ -80,14 +80,14 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         verbose,
     } = Opt::from_args();
 
-    let region_provider = RegionProviderChain::first_try(region.map(s3::Region::new))
+    let region_provider = RegionProviderChain::first_try(region.map(s3::config::Region::new))
         .or_default_provider()
-        .or_else(s3::Region::new("us-west-2"));
+        .or_else(s3::config::Region::new("us-west-2"));
 
     println!();
 
     if verbose {
-        println!("S3 client version: {}", s3::PKG_VERSION);
+        println!("S3 client version: {}", s3::meta::PKG_VERSION);
         println!(
             "Region:            {}",
             region_provider.region().await.unwrap().as_ref()

--- a/rust_dev_preview/testing/src/traits.rs
+++ b/rust_dev_preview/testing/src/traits.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 
 // snippet-start:[testing.rust.traits-trait]
 pub struct ListObjectsResult {
-    pub objects: Vec<s3::model::Object>,
+    pub objects: Vec<s3::types::Object>,
     pub continuation_token: Option<String>,
     pub has_more: bool,
 }
@@ -70,7 +70,7 @@ impl ListObjects for S3ListObjects {
 pub struct TestListObjects {
     expected_bucket: String,
     expected_prefix: String,
-    pages: Vec<Vec<s3::model::Object>>,
+    pages: Vec<Vec<s3::types::Object>>,
 }
 
 #[async_trait]
@@ -136,7 +136,7 @@ async fn determine_prefix_file_size(
 // snippet-start:[testing.rust.traits-tests]
 #[tokio::test]
 async fn test_single_page() {
-    use s3::model::Object;
+    use s3::types::Object;
 
     // Create a TestListObjects instance with just one page of two objects in it
     let fake = TestListObjects {
@@ -159,7 +159,7 @@ async fn test_single_page() {
 
 #[tokio::test]
 async fn test_multiple_pages() {
-    use s3::model::Object;
+    use s3::types::Object;
 
     // This time, we add a helper function for making pages
     fn make_page(sizes: &[i64]) -> Vec<Object> {

--- a/rust_dev_preview/tls/Cargo.toml
+++ b/rust_dev_preview/tls/Cargo.toml
@@ -12,9 +12,9 @@ name = "tls"
 path = "src/lib.rs"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-kms = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-kms = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false }
 webpki-roots = "0.22.4"
 tokio = { version = "1.20.1", features = ["full"] }
 rustls = "0.20.6"

--- a/rust_dev_preview/transcribestreaming/Cargo.toml
+++ b/rust_dev_preview/transcribestreaming/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-transcribestreaming = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-transcribestreaming = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 async-stream = "0.3"
 bytes = "1"
 hound = "3.4"

--- a/rust_dev_preview/transcribestreaming/src/main.rs
+++ b/rust_dev_preview/transcribestreaming/src/main.rs
@@ -5,11 +5,11 @@
 
 use async_stream::stream;
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_transcribestreaming::model::{
+use aws_sdk_transcribestreaming::primitives::Blob;
+use aws_sdk_transcribestreaming::types::{
     AudioEvent, AudioStream, LanguageCode, MediaEncoding, TranscriptResultStream,
 };
-use aws_sdk_transcribestreaming::types::Blob;
-use aws_sdk_transcribestreaming::{Client, Error, Region, PKG_VERSION};
+use aws_sdk_transcribestreaming::{config::Region, meta::PKG_VERSION, Client, Error};
 use bytes::BufMut;
 use std::time::Duration;
 use structopt::StructOpt;

--- a/rust_dev_preview/transcribestreaming/src/main.rs
+++ b/rust_dev_preview/transcribestreaming/src/main.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#![allow(clippy::result_large_err)]
+
 use async_stream::stream;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_transcribestreaming::primitives::Blob;

--- a/rust_dev_preview/webassembly/Cargo.toml
+++ b/rust_dev_preview/webassembly/Cargo.toml
@@ -10,13 +10,13 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
-aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["hardcoded-credentials"] }
-aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
-aws-smithy-async = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["event-stream"] }
-aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false }
+aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["hardcoded-credentials"] }
+aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false }
+aws-smithy-async = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false }
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["event-stream"] }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 async-trait = "0.1.63"
 console_error_panic_hook = "0.1.7"
 http = "0.2.8"

--- a/rust_dev_preview/webassembly/src/lib.rs
+++ b/rust_dev_preview/webassembly/src/lib.rs
@@ -5,7 +5,7 @@
 
 use async_trait::async_trait;
 use aws_credential_types::{cache::CredentialsCache, provider::ProvideCredentials, Credentials};
-use aws_sdk_lambda::{Client, Region, PKG_VERSION};
+use aws_sdk_lambda::{config::Region, meta::PKG_VERSION, Client};
 use aws_smithy_async::rt::sleep::{AsyncSleep, Sleep};
 use aws_smithy_client::erase::DynConnector;
 use aws_smithy_http::{body::SdkBody, result::ConnectorError};


### PR DESCRIPTION
## I'm resolving an issue with an existing code example

The Rust SDK is reorganizing modules in its crates. This PR updates the examples to compile against the latest.

Confirm you have met the following minimum requirements:

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [x] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
***

## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
