### PR TITLE
Update allowed-labels.yml

### DIFF
--- a/.github/allowed-labels.yml
+++ b/.github/allowed-labels.yml
@@ -130,3 +130,6 @@
 - name: size/large
   color: "adb5bd"
   description: "A large amount of effort/complexity"
+- name: cross-service-team
+  color: "e0cdff"
+  description: "PRs for the Cross Service Cloud Sherpas"

--- a/.github/workflows/label-checker.yml
+++ b/.github/workflows/label-checker.yml
@@ -2,6 +2,8 @@
 name: Label Checker
 on:
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - synchronize


### PR DESCRIPTION
Adds label for cross-service team PRs. To be ignored by the on-call flow and managed/shepherded by the Cross Service team.
