### PR TITLE
Updates to use the constant values for DyanmoDB definitions

### DIFF
--- a/dotnetv3/Lambda/CreateDynamoDBTableExample/CreateDynamoDBTableExample/Function.cs
+++ b/dotnetv3/Lambda/CreateDynamoDBTableExample/CreateDynamoDBTableExample/Function.cs
@@ -74,12 +74,12 @@ namespace CreateDynamoDBTableExample
                     new AttributeDefinition
                     {
                         AttributeName = "ID",
-                        AttributeType = "S",
+                        AttributeType = ScalarAttributeType.S,
                     },
                     new AttributeDefinition
                     {
                         AttributeName = "Area",
-                        AttributeType = "S",
+                        AttributeType = ScalarAttributeType.S,
                     },
                 },
                 // The KeySchema describes how the attributes will used used
@@ -91,12 +91,12 @@ namespace CreateDynamoDBTableExample
                     new KeySchemaElement
                     {
                         AttributeName = "ID",
-                        KeyType = "HASH",
+                        KeyType = KeyType.HASH,
                     },
                     new KeySchemaElement
                     {
                         AttributeName = "Area",
-                        KeyType = "RANGE",
+                        KeyType = KeyType.RANGE,
                     },
                 },
                 ProvisionedThroughput = new ProvisionedThroughput

--- a/dotnetv3/dynamodb/CreateTablesLoadDataExample/CreateTablesLoadDataExample/CreateTablesLoadData.cs
+++ b/dotnetv3/dynamodb/CreateTablesLoadDataExample/CreateTablesLoadDataExample/CreateTablesLoadData.cs
@@ -77,7 +77,7 @@ namespace CreateTablesLoadDataExample
             new AttributeDefinition
             {
               AttributeName = "Id",
-              AttributeType = "N",
+              AttributeType = ScalarAttributeType.N,
             },
           },
                 KeySchema = new List<KeySchemaElement>()
@@ -85,7 +85,7 @@ namespace CreateTablesLoadDataExample
             new KeySchemaElement
             {
               AttributeName = "Id",
-              KeyType = "HASH",
+              KeyType = KeyType.HASH,
             },
           },
                 ProvisionedThroughput = new ProvisionedThroughput
@@ -118,7 +118,7 @@ namespace CreateTablesLoadDataExample
             new AttributeDefinition
             {
               AttributeName = "Name",
-              AttributeType = "S",
+              AttributeType = ScalarAttributeType.S,
             },
           },
                 KeySchema = new List<KeySchemaElement>()
@@ -126,7 +126,7 @@ namespace CreateTablesLoadDataExample
             new KeySchemaElement
             {
               AttributeName = "Name",
-              KeyType = "HASH",
+              KeyType = KeyType.HASH,
             },
           },
                 ProvisionedThroughput = new ProvisionedThroughput
@@ -160,12 +160,12 @@ namespace CreateTablesLoadDataExample
             new AttributeDefinition
             {
               AttributeName = "ForumName", // Hash attribute.
-              AttributeType = "S",
+              AttributeType = ScalarAttributeType.S,
             },
             new AttributeDefinition
             {
               AttributeName = "Subject",
-              AttributeType = "S",
+              AttributeType = ScalarAttributeType.S,
             },
           },
                 KeySchema = new List<KeySchemaElement>()
@@ -173,12 +173,12 @@ namespace CreateTablesLoadDataExample
             new KeySchemaElement
             {
               AttributeName = "ForumName", // Hash attribute
-              KeyType = "HASH",
+              KeyType = KeyType.HASH,
             },
             new KeySchemaElement
             {
               AttributeName = "Subject", // Range attribute
-              KeyType = "RANGE",
+              KeyType = KeyType.RANGE,
             },
           },
                 ProvisionedThroughput = new ProvisionedThroughput
@@ -210,17 +210,17 @@ namespace CreateTablesLoadDataExample
             new AttributeDefinition
             {
               AttributeName = "Id",
-              AttributeType = "S",
+              AttributeType = ScalarAttributeType.S,
             },
             new AttributeDefinition
             {
               AttributeName = "ReplyDateTime",
-              AttributeType = "S",
+              AttributeType = ScalarAttributeType.S,
             },
             new AttributeDefinition
             {
               AttributeName = "PostedBy",
-              AttributeType = "S",
+              AttributeType = ScalarAttributeType.S,
             },
           },
                 KeySchema = new List<KeySchemaElement>()
@@ -228,12 +228,12 @@ namespace CreateTablesLoadDataExample
             new KeySchemaElement()
             {
               AttributeName = "Id",
-              KeyType = "HASH",
+              KeyType = KeyType.HASH,
             },
             new KeySchemaElement()
             {
               AttributeName = "ReplyDateTime",
-              KeyType = "RANGE",
+              KeyType = KeyType.RANGE,
             },
           },
                 LocalSecondaryIndexes = new List<LocalSecondaryIndex>()
@@ -245,11 +245,11 @@ namespace CreateTablesLoadDataExample
               {
                 new KeySchemaElement()
                 {
-                  AttributeName = "Id", KeyType = "HASH",
+                  AttributeName = "Id", KeyType = KeyType.HASH,
                 },
                 new KeySchemaElement()
                 {
-                  AttributeName = "PostedBy", KeyType = "RANGE",
+                  AttributeName = "PostedBy", KeyType = KeyType.RANGE,
                 },
               },
               Projection = new Projection()

--- a/dotnetv3/dynamodb/low-level-api/LowLevelTableExample/LowLevelTableExample.cs
+++ b/dotnetv3/dynamodb/low-level-api/LowLevelTableExample/LowLevelTableExample.cs
@@ -187,7 +187,7 @@ static class LowLevelTableExample
     private static async Task WaitUntilTableReady(string tableName)
     {
         string? status = null;
-        // Let us wait until table is created. Call DescribeTable.
+        // Wait until table is created. Call DescribeTable.
         do
         {
             Thread.Sleep(5000); // Wait 5 seconds.

--- a/dotnetv3/dynamodb/low-level-api/LowLevelTableExample/LowLevelTableExample.cs
+++ b/dotnetv3/dynamodb/low-level-api/LowLevelTableExample/LowLevelTableExample.cs
@@ -4,222 +4,210 @@
 // snippet-start:[dynamodb.dotnetv3.LowLevelTableExample]
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
 
-namespace LowLevelTableExample
+namespace LowLevelTableExample;
+
+static class LowLevelTableExample
 {
-    public class LowLevelTableExample
+    private static readonly IAmazonDynamoDB Client = new AmazonDynamoDBClient();
+    private const string ExampleTableName = "ExampleTable";
+
+    static async Task Main()
     {
-        private static readonly string _tableName = "ExampleTable";
-
-        public static async Task<bool> CreateExampleTable(AmazonDynamoDBClient client)
+        try
         {
-            Console.WriteLine("\n*** Creating table ***");
-            var request = new CreateTableRequest
-            {
-                AttributeDefinitions = new List<AttributeDefinition>()
-            {
-                new AttributeDefinition
-                {
-                    AttributeName = "Id",
-                    AttributeType = "N"
-                },
-                new AttributeDefinition
-                {
-                    AttributeName = "ReplyDateTime",
-                    AttributeType = "N"
-                }
-            },
-                KeySchema = new List<KeySchemaElement>
-            {
-                new KeySchemaElement
-                {
-                    AttributeName = "Id",
-                    KeyType = "HASH" //Partition key
-                },
-                new KeySchemaElement
-                {
-                    AttributeName = "ReplyDateTime",
-                    KeyType = "RANGE" //Sort key
-                }
-            },
-                ProvisionedThroughput = new ProvisionedThroughput
-                {
-                    ReadCapacityUnits = 5,
-                    WriteCapacityUnits = 6
-                },
-                TableName = _tableName
-            };
-
-            var response = await client.CreateTableAsync(request);
-
-            var tableDescription = response.TableDescription;
-            Console.WriteLine("{1}: {0} \t ReadsPerSec: {2} \t WritesPerSec: {3}",
-                      tableDescription.TableStatus,
-                      tableDescription.TableName,
-                      tableDescription.ProvisionedThroughput.ReadCapacityUnits,
-                      tableDescription.ProvisionedThroughput.WriteCapacityUnits);
-
-            string status = tableDescription.TableStatus;
-            Console.WriteLine(_tableName + " - " + status);
-
-            WaitUntilTableReady(client);
-
-            return true;
+            await CreateExampleTable();
+            await ListMyTables();
+            await GetTableInformation();
+            await UpdateExampleTable();
         }
-
-        // snippet-start:[dynamodb.dotnetv3.ListTableExample]
-
-        public static async Task<bool> ListMyTables(AmazonDynamoDBClient client)
+        catch (AmazonDynamoDBException e)
         {
-            Console.WriteLine("\n*** Listing tables ***");
-            string lastTableNameEvaluated = null;
-            do
-            {
-                var request = new ListTablesRequest
-                {
-                    Limit = 2,
-                    ExclusiveStartTableName = lastTableNameEvaluated
-                };
-
-                var response = await client.ListTablesAsync(request);
-                foreach (string name in response.TableNames)
-                    Console.WriteLine(name);
-
-                lastTableNameEvaluated = response.LastEvaluatedTableName;
-            } while (lastTableNameEvaluated != null);
-
-            return true;
+            Console.WriteLine(e.Message);
         }
-        // snippet-end:[dynamodb.dotnetv3.ListTableExample]
-
-        // snippet-start:[dynamodb.dotnetv3.DescribeTableExample]
-        public static async Task<bool> GetTableInformation(AmazonDynamoDBClient client)
+        catch (AmazonServiceException e)
         {
-            Console.WriteLine("\n*** Retrieving table information ***");
-            var request = new DescribeTableRequest
-            {
-                TableName = _tableName
-            };
-
-            var response = await client.DescribeTableAsync(request);
-
-            TableDescription description = response.Table;
-            Console.WriteLine("Name: {0}", description.TableName);
-            Console.WriteLine("# of items: {0}", description.ItemCount);
-            Console.WriteLine("Provision Throughput (reads/sec): {0}",
-                      description.ProvisionedThroughput.ReadCapacityUnits);
-            Console.WriteLine("Provision Throughput (writes/sec): {0}",
-                      description.ProvisionedThroughput.WriteCapacityUnits);
-
-            return true;
+            Console.WriteLine(e.Message);
         }
-        // snippet-end:[dynamodb.dotnetv3.DescribeTableExample]
-
-        public static async Task<bool> UpdateExampleTable(AmazonDynamoDBClient client)
+        catch (Exception e)
         {
-            Console.WriteLine("\n*** Updating table ***");
-            var request = new UpdateTableRequest()
-            {
-                TableName = _tableName,
-                ProvisionedThroughput = new ProvisionedThroughput()
-                {
-                    ReadCapacityUnits = 6,
-                    WriteCapacityUnits = 7
-                }
-            };
-
-            await client.UpdateTableAsync(request);
-
-            WaitUntilTableReady(client);
-
-            return true;
+            Console.WriteLine(e.Message);
         }
-
-        public static async Task<bool> DeleteExampleTable(AmazonDynamoDBClient client)
+        finally
         {
-            Console.WriteLine("\n*** Deleting table ***");
-            var request = new DeleteTableRequest
-            {
-                TableName = _tableName
-            };
+            Console.WriteLine("To continue, press Enter");
+            Console.ReadLine();
 
-            await client.DeleteTableAsync(request);
-
-            Console.WriteLine("Table is being deleted...");
-
-            return true;
-        }
-
-        private static async void WaitUntilTableReady(AmazonDynamoDBClient client)
-        {
-            string status;
-            // Let us wait until table is created. Call DescribeTable.
-            do
-            {
-                System.Threading.Thread.Sleep(5000); // Wait 5 seconds.
-                var res = await client.DescribeTableAsync(new DescribeTableRequest
-                {
-                    TableName = _tableName
-                });
-
-                Console.WriteLine("Table name: {0}, status: {1}",
-                          res.Table.TableName,
-                          res.Table.TableStatus);
-                status = res.Table.TableStatus;
-
-            } while (status != "ACTIVE");
-        }
-
-        static void Main()
-        {
-            var client = new AmazonDynamoDBClient();
-
-            var result = CreateExampleTable(client);
-
-            if (!result.Result)
-            {
-                Console.WriteLine("Could not create example table.");
-                return;
-            }
-
-            result = ListMyTables(client);
-
-            if (!result.Result)
-            {
-                Console.WriteLine("Could not list tables.");
-                Console.WriteLine("You must delete the " + _tableName + " table yourself.");
-                return;
-            }
-
-            result = GetTableInformation(client);
-
-            if (!result.Result)
-            {
-                Console.WriteLine("Could not get table information.");
-                Console.WriteLine("You must delete the " + _tableName + " table yourself.");
-                return;
-            }
-
-            result = UpdateExampleTable(client);
-
-            if (!result.Result)
-            {
-                Console.WriteLine("Could not update example table.");
-                Console.WriteLine("You must delete the " + _tableName + " table yourself");
-                return;
-            }
-
-            result = DeleteExampleTable(client);
-
-            if (!result.Result)
-            {
-                Console.WriteLine("Could not delete example table.");
-                Console.WriteLine("You must delete the " + _tableName + " table yourself.");
-            }
+            await DeleteExampleTable();
         }
     }
+
+    // snippet-start:[dynamodb.dotnetv3.CreateExampleTable]
+    private static async Task CreateExampleTable()
+    {
+        Console.WriteLine("\n*** Creating table ***");
+
+        var response = await Client.CreateTableAsync(new CreateTableRequest
+        {
+            AttributeDefinitions = new List<AttributeDefinition>
+            {
+                new AttributeDefinition
+                {
+                    AttributeName = "Id",
+                    AttributeType = ScalarAttributeType.N
+                },
+                new AttributeDefinition
+                {
+                    AttributeName = "ReplyDateTime",
+                    AttributeType = ScalarAttributeType.N
+                }
+            },
+            KeySchema = new List<KeySchemaElement>
+            {
+                new KeySchemaElement
+                {
+                    AttributeName = "Id",
+                    KeyType = KeyType.HASH //Partition key
+                },
+                new KeySchemaElement
+                {
+                    AttributeName = "ReplyDateTime",
+                    KeyType = KeyType.RANGE //Sort key
+                }
+            },
+            ProvisionedThroughput = new ProvisionedThroughput
+            {
+                ReadCapacityUnits = 5,
+                WriteCapacityUnits = 6
+            },
+            TableName = ExampleTableName
+        });
+
+        var tableDescription = response.TableDescription;
+        Console.WriteLine($"{tableDescription.TableName}: {tableDescription.TableStatus} \t " +
+                          $"ReadsPerSec: {tableDescription.ProvisionedThroughput.ReadCapacityUnits} \t " +
+                          $"WritesPerSec: {tableDescription.ProvisionedThroughput.WriteCapacityUnits}");
+
+        Console.WriteLine($"{ExampleTableName} - {tableDescription.TableStatus}");
+
+        await WaitUntilTableReady(ExampleTableName);
+    }
+    // snippet-end:[dynamodb.dotnetv3.CreateExampleTable]
+
+    // snippet-start:[dynamodb.dotnetv3.ListTableExample]
+    private static async Task ListMyTables()
+    {
+        Console.WriteLine("\n*** Listing tables ***");
+
+        string? lastTableNameEvaluated = null;
+        do
+        {
+            var response = await Client.ListTablesAsync(new ListTablesRequest
+            {
+                Limit = 2,
+                ExclusiveStartTableName = lastTableNameEvaluated
+            });
+
+            foreach (var name in response.TableNames)
+            {
+                Console.WriteLine(name);
+            }
+
+            lastTableNameEvaluated = response.LastEvaluatedTableName;
+        } while (lastTableNameEvaluated != null);
+    }
+    // snippet-end:[dynamodb.dotnetv3.ListTableExample]
+
+    // snippet-start:[dynamodb.dotnetv3.DescribeTableExample]
+    private static async Task GetTableInformation()
+    {
+        Console.WriteLine("\n*** Retrieving table information ***");
+
+        var response = await Client.DescribeTableAsync(new DescribeTableRequest
+        {
+            TableName = ExampleTableName
+        });
+
+        var table = response.Table;
+        Console.WriteLine($"Name: {table.TableName}");
+        Console.WriteLine($"# of items: {table.ItemCount}");
+        Console.WriteLine($"Provision Throughput (reads/sec): " +
+                          $"{table.ProvisionedThroughput.ReadCapacityUnits}");
+        Console.WriteLine($"Provision Throughput (writes/sec): " +
+                          $"{table.ProvisionedThroughput.WriteCapacityUnits}");
+    }
+    // snippet-end:[dynamodb.dotnetv3.DescribeTableExample]
+
+    // snippet-start:[dynamodb.dotnetv3.UpdateExampleTable]
+    private static async Task UpdateExampleTable()
+    {
+        Console.WriteLine("\n*** Updating table ***");
+
+        await Client.UpdateTableAsync(new UpdateTableRequest
+        {
+            TableName = ExampleTableName,
+            ProvisionedThroughput = new ProvisionedThroughput
+            {
+                ReadCapacityUnits = 6,
+                WriteCapacityUnits = 7
+            }
+        });
+
+        await WaitUntilTableReady(ExampleTableName);
+    }
+    // snippet-end:[dynamodb.dotnetv3.UpdateExampleTable]
+
+    // snippet-start:[dynamodb.dotnetv3.DeleteExampleTable]
+    private static async Task DeleteExampleTable()
+    {
+        Console.WriteLine("\n*** Deleting table ***");
+
+        try
+        {
+            await Client.DeleteTableAsync(new DeleteTableRequest
+            {
+                TableName = ExampleTableName
+            });
+
+            Console.WriteLine("Table is being deleted...");
+        }
+        catch (ResourceNotFoundException)
+        {
+            // something went wrong during CreateTable
+        }
+    }
+    // snippet-end:[dynamodb.dotnetv3.DeleteExampleTable]
+
+    // snippet-start:[dynamodb.dotnetv3.WaitUntilTableReady]
+    private static async Task WaitUntilTableReady(string tableName)
+    {
+        string? status = null;
+        // Let us wait until table is created. Call DescribeTable.
+        do
+        {
+            Thread.Sleep(5000); // Wait 5 seconds.
+            try
+            {
+                var res = await Client.DescribeTableAsync(new DescribeTableRequest
+                {
+                    TableName = tableName
+                });
+
+                Console.WriteLine($"Table name: {res.Table.TableName}, status: {res.Table.TableStatus}");
+                status = res.Table.TableStatus;
+            }
+            catch (ResourceNotFoundException)
+            {
+                // DescribeTable is eventually consistent. So you might
+                // get resource not found. So we handle the potential exception.
+            }
+        } while (status != "ACTIVE");
+    }
+    // snippet-end:[dynamodb.dotnetv3.WaitUntilTableReady]
 }
 // snippet-end:[dynamodb.dotnetv3.LowLevelTableExample]

--- a/dotnetv3/dynamodb/low-level-api/LowLevelTableExample/LowLevelTableExample.cs
+++ b/dotnetv3/dynamodb/low-level-api/LowLevelTableExample/LowLevelTableExample.cs
@@ -178,7 +178,7 @@ static class LowLevelTableExample
         }
         catch (ResourceNotFoundException)
         {
-            // something went wrong during CreateTable
+            // Something went wrong during CreateTable.
         }
     }
     // snippet-end:[dynamodb.dotnetv3.DeleteExampleTable]

--- a/dotnetv3/dynamodb/low-level-api/LowLevelTableExample/LowLevelTableExample.cs
+++ b/dotnetv3/dynamodb/low-level-api/LowLevelTableExample/LowLevelTableExample.cs
@@ -204,7 +204,7 @@ static class LowLevelTableExample
             catch (ResourceNotFoundException)
             {
                 // DescribeTable is eventually consistent. So you might
-                // get resource not found. So we handle the potential exception.
+                // get resource not found. We handle the potential exception.
             }
         } while (status != "ACTIVE");
     }

--- a/dotnetv3/dynamodb/low-level-api/LowLevelTableExample/LowLevelTableExample.csproj
+++ b/dotnetv3/dynamodb/low-level-api/LowLevelTableExample/LowLevelTableExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnetv3/dynamodb/scenarios/DynamoDB_Basics/DynamoDB_Basics_Scenario/DynamoDbMethods.cs
+++ b/dotnetv3/dynamodb/scenarios/DynamoDB_Basics/DynamoDB_Basics_Scenario/DynamoDbMethods.cs
@@ -24,12 +24,12 @@ namespace DynamoDB_Basics_Scenario
                     new AttributeDefinition
                     {
                         AttributeName = "title",
-                        AttributeType = "S",
+                        AttributeType = ScalarAttributeType.S,
                     },
                     new AttributeDefinition
                     {
                         AttributeName = "year",
-                        AttributeType = "N",
+                        AttributeType = ScalarAttributeType.N,
                     },
                 },
                 KeySchema = new List<KeySchemaElement>()
@@ -37,12 +37,12 @@ namespace DynamoDB_Basics_Scenario
                     new KeySchemaElement
                     {
                         AttributeName = "year",
-                        KeyType = "HASH",
+                        KeyType = KeyType.HASH,
                     },
                     new KeySchemaElement
                     {
                         AttributeName = "title",
-                        KeyType = "RANGE",
+                        KeyType = KeyType.RANGE,
                     },
                 },
                 ProvisionedThroughput = new ProvisionedThroughput

--- a/dotnetv3/dynamodb/scenarios/PartiQL_Basics_Scenario/PartiQL_Basics_Scenario/DynamoDBMethods.cs
+++ b/dotnetv3/dynamodb/scenarios/PartiQL_Basics_Scenario/PartiQL_Basics_Scenario/DynamoDBMethods.cs
@@ -28,12 +28,12 @@ namespace PartiQL_Basics_Scenario
                     new AttributeDefinition
                     {
                         AttributeName = "title",
-                        AttributeType = "S",
+                        AttributeType = ScalarAttributeType.S,
                     },
                     new AttributeDefinition
                     {
                         AttributeName = "year",
-                        AttributeType = "N",
+                        AttributeType = ScalarAttributeType.N,
                     },
                 },
                 KeySchema = new List<KeySchemaElement>()
@@ -41,12 +41,12 @@ namespace PartiQL_Basics_Scenario
                     new KeySchemaElement
                     {
                         AttributeName = "year",
-                        KeyType = "HASH",
+                        KeyType = KeyType.HASH,
                     },
                     new KeySchemaElement
                     {
                         AttributeName = "title",
-                        KeyType = "RANGE",
+                        KeyType = KeyType.RANGE,
                     },
                 },
                 ProvisionedThroughput = new ProvisionedThroughput

--- a/dotnetv3/dynamodb/scenarios/PartiQL_Batch_Scenario/PartiQL_Batch_Scenario/DynamoDBMethods.cs
+++ b/dotnetv3/dynamodb/scenarios/PartiQL_Batch_Scenario/PartiQL_Batch_Scenario/DynamoDBMethods.cs
@@ -28,12 +28,12 @@ namespace PartiQL_Batch_Scenario
                     new AttributeDefinition
                     {
                         AttributeName = "title",
-                        AttributeType = "S",
+                        AttributeType = ScalarAttributeType.S,
                     },
                     new AttributeDefinition
                     {
                         AttributeName = "year",
-                        AttributeType = "N",
+                        AttributeType = ScalarAttributeType.N,
                     },
                 },
                 KeySchema = new List<KeySchemaElement>()
@@ -41,12 +41,12 @@ namespace PartiQL_Batch_Scenario
                     new KeySchemaElement
                     {
                         AttributeName = "year",
-                        KeyType = "HASH",
+                        KeyType = KeyType.HASH,
                     },
                     new KeySchemaElement
                     {
                         AttributeName = "title",
-                        KeyType = "RANGE",
+                        KeyType = KeyType.RANGE,
                     },
                 },
                 ProvisionedThroughput = new ProvisionedThroughput


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

Thank you for making a submission to the *aws-doc-sdk-examples* repository. For more information about submitting pull requests to this repository, see [Guidelines for contributing](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/CONTRIBUTING.md).

*NOTE:* This pull request (PR) template contains two sections. Use the section that applies to your submission, and remove the section which doesn't apply.
***

***
## I'm resolving an issue with an existing code example

Describe the changes you have made here, including any issue numbers.

This update fixes a reported issue with some of the DynamoDB examples, where strings were used instead of the provided constant classes. It also adds snippet tags that they can be used in various documentation that has the same issue.

Confirm you have met the following minimum requirements:

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [x] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
***
## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
