### PR TITLE
Add MediaConvert examples to metadata and other metadata miscellany

### DIFF
--- a/.doc_gen/cross-content/cross_SQSMessage_Java_block.xml
+++ b/.doc_gen/cross-content/cross_SQSMessage_Java_block.xml
@@ -5,7 +5,7 @@
 ]>
 <block>
     <para>
-        Shows how to use the &SQSlong; API to 
+        Shows how to use the &SQS; API to
         develop a Spring REST API that sends and retrieves messages. 
     </para>
     <para>

--- a/.doc_gen/cross-content/cross_SQSMessage_Kotlin_block.xml
+++ b/.doc_gen/cross-content/cross_SQSMessage_Kotlin_block.xml
@@ -5,7 +5,7 @@
 ]>
 <block>
     <para>
-        Shows how to use the &SQSlong; API to 
+        Shows how to use the &SQS; API to
         develop a Spring REST API that sends and retrieves messages. 
     </para>
     <para>

--- a/.doc_gen/cross-content/cross_detect_faces_rust_block.xml
+++ b/.doc_gen/cross-content/cross_detect_faces_rust_block.xml
@@ -5,7 +5,7 @@
 ]>
 <block>
   <para>
-    Save the image in an &S3long; bucket with an <emphasis role="bold">uploads</emphasis> prefix,
+    Save the image in an &S3; bucket with an <emphasis role="bold">uploads</emphasis> prefix,
     use &REKlong; to detect facial details, such as age range, gender, and emotion (smiling, etc.),
     and display those details.
   </para>

--- a/.doc_gen/cross-content/cross_detect_labels_rust_block.xml
+++ b/.doc_gen/cross-content/cross_detect_labels_rust_block.xml
@@ -6,7 +6,7 @@
 <block>
   <para>
     Get EXIF information from a JPG, JPEG, or PNG file,
-    upload the image file to an &S3long; bucket,
+    upload the image file to an &S3; bucket,
     use &REKlong; to identify the three top attributes (<emphasis>labels</emphasis> in &REK;) in the file,
     and add the EXIF and label information to a &DDBlong; table in the Region.
   </para>

--- a/.doc_gen/cross-content/cross_telephone_rust_block.xml
+++ b/.doc_gen/cross-content/cross_telephone_rust_block.xml
@@ -6,7 +6,7 @@
 <block>
   <para>
     Use &POLlong; to synthesize a plain text (UTF-8) input file to an audio file,
-    upload the audio file to an &S3long; bucket,
+    upload the audio file to an &S3; bucket,
     use &TSClong; to convert that audio file to text,
     and display the text.
   </para>

--- a/.doc_gen/metadata/aurora_metadata.yaml
+++ b/.doc_gen/metadata/aurora_metadata.yaml
@@ -2,7 +2,7 @@
 aurora_Hello:
   title: Hello &AUR;
   title_abbrev: Hello &AUR;
-  synopsis: get started using &AURlong;.
+  synopsis: get started using &AUR;.
   category: Hello
   languages:
     .NET:

--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -16,9 +16,9 @@ cross_RedshiftDataTracker:
     redshift:
     ses:
 cross_SQSMessageApp:
-  title: Create a web application that sends and retrieves messages by using the &SQSlong; API
+  title: Create a web application that sends and retrieves messages by using &SQS;
   title_abbrev: Create a messaging application
-  synopsis: create a messaging application by using the &SQSlong; API.
+  synopsis: create a messaging application by using &SQS;.
   languages:
     Kotlin:
       versions:
@@ -442,8 +442,8 @@ cross_DetectFaces:
   title: Detect faces in an image using an &AWS; SDK
   title_abbrev: Detect faces in an image
   synopsis_list:
-    - Save an image in an &S3long; &S3;) bucket.
-    - Use &REKlong; (&REK;) to detect facial details, such as age range, gender, and emotion (smiling, etc.).
+    - Save an image in an &S3; bucket.
+    - Use &REKlong; to detect facial details, such as age range, gender, and emotion (smiling, etc.).
     - Display those details.
   languages:
     Rust:
@@ -459,8 +459,8 @@ cross_DetectLabels:
   synopsis_list:
     - Get EXIF information from a a JPG, JPEG, or PNG file.
     - Upload the image file to an &S3long; (&S3;) bucket.
-    - Use &REKlong; (&REK;) to identify the three top attributes (labels in &REK;) in the file.
-    - Add the EXIF and label information to a &DDBlong; (&DDB;) table in the Region.
+    - Use &REKlong; to identify the three top attributes (labels in &REK;) in the file.
+    - Add the EXIF and label information to a &DDBlong; table in the Region.
   languages:
     Rust:
       versions:

--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -443,7 +443,7 @@ cross_DetectFaces:
   title_abbrev: Detect faces in an image
   synopsis_list:
     - Save an image in an &S3; bucket.
-    - Use &REKlong; to detect facial details, such as age range, gender, and emotion (smiling, etc.).
+    - Use &REKlong; to detect facial details, such as age range, gender, and emotion (such as smiling).
     - Display those details.
   languages:
     Rust:

--- a/.doc_gen/metadata/ec2_metadata.yaml
+++ b/.doc_gen/metadata/ec2_metadata.yaml
@@ -1,7 +1,7 @@
 ec2_Hello:
   title: Hello &EC2;
   title_abbrev: Hello &EC2;
-  synopsis: get started using &EC2long; (&EC2;).
+  synopsis: get started using &EC2;.
   category: Hello
   languages:
     .NET:

--- a/.doc_gen/metadata/glue_metadata.yaml
+++ b/.doc_gen/metadata/glue_metadata.yaml
@@ -2,7 +2,7 @@
 glue_Hello:
   title: Hello &GLU;
   title_abbrev: Hello &GLU;
-  synopsis: get started using &GLUlong; (&GLU;).
+  synopsis: get started using &GLU;.
   category: Hello
   languages:
     .NET:

--- a/.doc_gen/metadata/iam_metadata.yaml
+++ b/.doc_gen/metadata/iam_metadata.yaml
@@ -1,7 +1,7 @@
 iam_Hello:
   title: Hello &IAM;
   title_abbrev: Hello &IAM;
-  synopsis: get started using &IAMlong; (&IAM;).
+  synopsis: get started using &IAM;.
   category: Hello
   languages:
     .NET:

--- a/.doc_gen/metadata/keyspaces_metadata.yaml
+++ b/.doc_gen/metadata/keyspaces_metadata.yaml
@@ -1,7 +1,7 @@
 keyspaces_Hello:
   title: Hello &KEY;
   title_abbrev: Hello &KEY;
-  synopsis: get started using &KEYlong;.
+  synopsis: get started using &KEY;.
   category: Hello
   languages:
     .NET:

--- a/.doc_gen/metadata/lookoutvision_metadata.yaml
+++ b/.doc_gen/metadata/lookoutvision_metadata.yaml
@@ -354,7 +354,7 @@ lookoutvision_ListProjects:
 lookoutvision_Hello:
   title: Hello &LYRA;
   title_abbrev: Hello &LYRA;
-  synopsis: get started using &LYRAlong;.
+  synopsis: get started using &LYRA;.
   category: Hello
   languages:
     Python:

--- a/.doc_gen/metadata/mediaconvert_metadata.yaml
+++ b/.doc_gen/metadata/mediaconvert_metadata.yaml
@@ -1,0 +1,75 @@
+mediaconvert_CreateJob:
+  title: Create a &EMC; transcoding job using an &AWS; SDK
+  title_abbrev: Create a transcoding job
+  synopsis: create a &EMC; transcoding job.
+  category:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/mediaconvert
+          excerpts:
+            - description:
+              snippet_tags:
+                - mediaconvert.java.createjob.complete
+    Kotlin:
+      versions:
+        - sdk_version: 1
+          github: kotlin/services/mediaconvert
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - mediaconvert.kotlin.createjob.main
+  services:
+    mediaconvert: {CreateJob}
+mediaconvert_ListJobs:
+  title: List &EMC; transcoding jobs using an &AWS; SDK
+  title_abbrev: List transcoding jobs
+  synopsis: list &EMC; transcoding jobs.
+  category:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/mediaconvert
+          excerpts:
+            - description:
+              snippet_tags:
+                - mediaconvert.java.list_jobs.main
+    Kotlin:
+      versions:
+        - sdk_version: 1
+          github: kotlin/services/mediaconvert
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - mediaconvert.kotlin.list_jobs.main
+  services:
+    mediaconvert: {ListJobs}
+mediaconvert_GetJob:
+  title: Get a &EMC; transcoding job using an &AWS; SDK
+  title_abbrev: Get a transcoding job
+  synopsis: get a &EMC; transcoding job.
+  category:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/mediaconvert
+          excerpts:
+            - description:
+              snippet_tags:
+                - mediaconvert.java.get_job.main
+    Kotlin:
+      versions:
+        - sdk_version: 1
+          github: kotlin/services/mediaconvert
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - mediaconvert.kotlin.get_job.main
+  services:
+    mediaconvert: {GetJob}

--- a/.doc_gen/metadata/route53domains_metadata.yaml
+++ b/.doc_gen/metadata/route53domains_metadata.yaml
@@ -2,7 +2,7 @@
 route-53_Hello:
   title: Hello &R53DR;
   title_abbrev: Hello &R53DR;
-  synopsis: get started using &R53DRlong;.
+  synopsis: get started using &R53DR;.
   category: Hello
   languages:
     Kotlin:

--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -2,7 +2,7 @@
 s3_Hello:
   title: Hello &S3;
   title_abbrev: Hello &S3;
-  synopsis: get started using &S3long; (&S3;).
+  synopsis: get started using &S3;.
   category: Hello
   languages:
     Python:

--- a/.doc_gen/metadata/services.yaml
+++ b/.doc_gen/metadata/services.yaml
@@ -85,7 +85,7 @@ aurora:
     subtitle: User Guide
     url: AmazonRDS/latest/AuroraUserGuide/CHAP_AuroraOverview.html
   tags:
-    product_categories: {'Database'}
+    product_categories: {'Databases'}
   version: rds-2014-10-31
   api_ref: AmazonRDS/latest/APIReference/Welcome.html
 auto-scaling:
@@ -255,7 +255,7 @@ comprehend:
     url: comprehend/latest/dg/what-is.html
   api_ref: comprehend/latest/APIReference/welcome.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: comprehend-2017-11-27
 config-service:
   long: '&CClong;'
@@ -301,7 +301,7 @@ dynamodb:
     url: amazondynamodb/latest/developerguide/Introduction.html
   api_ref: amazondynamodb/latest/APIReference/Welcome.html
   tags:
-    product_categories: {'Database'}
+    product_categories: {'Databases'}
   version: dynamodb-2012-08-10
 ebs:
   long: '&EBSlong; (&EBS;)'
@@ -487,7 +487,7 @@ iot:
     url: iot/latest/developerguide/what-is-aws-iot.html
   api_ref: iot/latest/apireference/Welcome.html
   tags:
-    product_categories: {'Internet of Things (IoT)'}
+    product_categories: {'IoT'}
   version: iot-2015-05-28
 keyspaces:
   long: '&KEYlong;'
@@ -502,7 +502,7 @@ keyspaces:
     url: keyspaces/latest/devguide/what-is-keyspaces.html
   api_ref: keyspaces/latest/APIReference/Welcome.html
   tags:
-    product_categories: {'Database'}
+    product_categories: {'Databases'}
   version: keyspaces-2022-02-10
 kinesis:
   long: '&AKlong;'
@@ -547,7 +547,7 @@ kms:
     url: kms/latest/developerguide/overview.html
   api_ref: kms/latest/APIReference/Welcome.html
   tags:
-    product_categories: {'Cryptography &amp; PKI'}
+    product_categories: {'Security, Identity, &amp; Compliance'}
   version: kms-2014-11-01
 lambda:
   long: '&LAMlong;'
@@ -577,7 +577,7 @@ lex:
     url: lexv2/latest/dg/what-is.html
   api_ref: lexv2/latest/APIReference/welcome.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: runtime.lex.v2-2020-08-07
 lookoutvision:
   long: '&LYRAlong;'
@@ -592,8 +592,23 @@ lookoutvision:
     url: lookout-for-vision/latest/developer-guide/what-is.html
   api_ref: lookout-for-vision/latest/APIReference/Welcome.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: lookoutvision-2020-11-20
+mediaconvert:
+  long: '&EMClong;'
+  short: '&EMC;'
+  sort: MediaConvert
+  expanded:
+    long: AWS Elemental MediaConvert
+    short: MediaConvert
+  blurb: is a service that formats and compresses offline video content for delivery to televisions or connected devices.
+  guide:
+    subtitle: User Guide
+    url: mediaconvert/latest/ug/what-is.html
+  api_ref: mediaconvert/latest/apireference/custom-endpoints.html
+  tags:
+    product_categories: {'Media Services'}
+  version: mediaconvert-2017-08-29
 medialive:
   long: '&EMLlong;'
   short: '&EML;'
@@ -652,7 +667,7 @@ personalize:
     url: personalize/latest/dg/what-is-personalize.html
   api_ref: personalize/latest/dg/API_Reference.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: personalize-2018-05-22
 personalize-runtime:
   long: "&PERSRlong;"
@@ -667,7 +682,7 @@ personalize-runtime:
     url: personalize/latest/dg/what-is-personalize.html
   api_ref: personalize/latest/dg/API_Operations_Amazon_Personalize_Runtime.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: personalize-runtime-2018-05-22
 personalize-events:
   long: "&PERSElong;"
@@ -682,7 +697,7 @@ personalize-events:
     url: personalize/latest/dg/what-is-personalize.html
   api_ref: personalize/latest/dg/API_Operations_Amazon_Personalize_Events.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: personalize-events-2018-03-22
 pinpoint:
   bundle: pinpoint
@@ -744,7 +759,7 @@ polly:
     url: polly/latest/dg/what-is.html
   api_ref: polly/latest/dg/API_Reference.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: polly-2016-06-10
 qldb:
   long: '&QLDBlong; (&QLDB;)'
@@ -759,7 +774,7 @@ qldb:
     url: qldb/latest/developerguide/what-is.html
   api_ref: qldb/latest/developerguide/api-reference.html
   tags:
-    product_categories: {'Database'}
+    product_categories: {'Databases'}
   version: qldb-2019-01-02
 rds:
   long: '&RDSlong; (&RDS;)'
@@ -774,7 +789,7 @@ rds:
     url: AmazonRDS/latest/UserGuide/Welcome.html
   api_ref: AmazonRDS/latest/APIReference/Welcome.html
   tags:
-    product_categories: {'Database'}
+    product_categories: {'Databases'}
   version: rds-2014-10-31
 rds-data:
   long: '&RDSDataServicelong;'
@@ -789,7 +804,7 @@ rds-data:
     url: AmazonRDS/latest/UserGuide/Welcome.html
   api_ref: rdsdataservice/latest/APIReference/Welcome.html
   tags:
-    product_categories: {'Database'}
+    product_categories: {'Databases'}
   version: rds-data-2018-08-01
 redshift:
   long: '&RSlong;'
@@ -805,7 +820,7 @@ redshift:
     url: redshift/latest/mgmt/welcome.html
   api_ref: redshift/latest/APIReference/Welcome.html
   tags:
-    product_categories: {'Database'}
+    product_categories: {'Databases'}
   version: redshift-2012-12-01
 rekognition:
   caveat: The code examples in this chapter are intended to supplement the code examples
@@ -822,7 +837,7 @@ rekognition:
     url: rekognition/latest/dg/what-is.html
   api_ref: rekognition/latest/APIReference/Welcome.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: rekognition-2016-06-27
 route-53:
   bundle: route-53
@@ -899,7 +914,7 @@ sagemaker:
     url: sagemaker/latest/dg/whatis.html
   api_ref: sagemaker/latest/APIReference/Welcome.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: sagemaker-2017-07-24
 secrets-manager:
   long: '&ASMlong;'
@@ -1053,7 +1068,7 @@ support:
     url: awssupport/latest/user/getting-started.html
   api_ref: support/latest/APIReference/welcome.html
   tags:
-    product_categories: {'Customer Enablement Services'}
+    product_categories: {'Contact Center'}
   version: support-2013-04-15
 textract:
   long: '&TEXTRACTlong;'
@@ -1068,7 +1083,7 @@ textract:
     url: textract/latest/dg/what-is.html
   api_ref: textract/latest/dg/API_Reference.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: textract-2018-06-27
 transcribe:
   long: '&TSClong;'
@@ -1083,7 +1098,7 @@ transcribe:
     url: transcribe/latest/dg/what-is.html
   api_ref: transcribe/latest/APIReference/Welcome.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: transcribe-2017-10-26
 transcribe-medical:
   long: '&TSClong;'
@@ -1099,7 +1114,7 @@ transcribe-medical:
     url: transcribe/latest/dg/transcribe-medical.html
   api_ref: transcribe/latest/APIReference/Welcome.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: transcribe-2017-10-26
 translate:
   long: '&TSLlong;'
@@ -1114,5 +1129,5 @@ translate:
     url: translate/latest/dg/what-is.html
   api_ref: translate/latest/APIReference/welcome.html
   tags:
-    product_categories: {'Machine Learning'}
+    product_categories: {'Machine Learning &amp; AI'}
   version: translate-2017-07-01


### PR DESCRIPTION
* Added Java and Kotlin MediaConvert examples to metadata.
* Update service categories to match Directories fields. 
* Other minor metadata miscellany.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
