### PR TITLE
Rearranging snippet comments of DynamoDBMapper examples

### DIFF
--- a/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/datamodeling/DynamoDBMapperBatchWriteExample.java
+++ b/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/datamodeling/DynamoDBMapperBatchWriteExample.java
@@ -8,7 +8,6 @@
 // snippet-sourcetype:[full-example]
 // snippet-sourcedate:[ ]
 // snippet-sourceauthor:[AWS]
-// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperBatchWriteExample] 
 /**
  * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -26,6 +25,7 @@
 
 package com.amazonaws.codesamples.datamodeling;
 
+// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperBatchWriteExample.import]
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,7 +41,9 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+// snippet-end:[dynamodb.java.codeexample.DynamoDBMapperBatchWriteExample.import]
 
+// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperBatchWriteExample]
 public class DynamoDBMapperBatchWriteExample {
 
     static AmazonDynamoDB client = AmazonDynamoDBClientBuilder.standard().build();

--- a/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/datamodeling/DynamoDBMapperCRUDExample.java
+++ b/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/datamodeling/DynamoDBMapperCRUDExample.java
@@ -8,7 +8,6 @@
 // snippet-sourcetype:[full-example]
 // snippet-sourcedate:[ ]
 // snippet-sourceauthor:[AWS]
-// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperCRUDExample] 
 /**
  * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -26,6 +25,7 @@
 
 package com.amazonaws.codesamples.datamodeling;
 
+// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperCRUDExample.import]
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -38,7 +38,9 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+// snippet-end:[dynamodb.java.codeexample.DynamoDBMapperCRUDExample.import]
 
+// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperCRUDExample]
 public class DynamoDBMapperCRUDExample {
 
     static AmazonDynamoDB client = AmazonDynamoDBClientBuilder.standard().build();

--- a/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/datamodeling/DynamoDBMapperExample.java
+++ b/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/datamodeling/DynamoDBMapperExample.java
@@ -8,7 +8,6 @@
 // snippet-sourcetype:[full-example]
 // snippet-sourcedate:[ ]
 // snippet-sourceauthor:[AWS]
-// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperExample] 
 /**
  * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -24,6 +23,7 @@
 */
 package com.amazonaws.codesamples.datamodeling;
 
+// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperExample.import]
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -38,7 +38,9 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverted;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverter;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+// snippet-end:[dynamodb.java.codeexample.DynamoDBMapperExample.import]
 
+// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperExample]
 public class DynamoDBMapperExample {
 
     static AmazonDynamoDB client;

--- a/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/datamodeling/DynamoDBMapperQueryScanExample.java
+++ b/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/datamodeling/DynamoDBMapperQueryScanExample.java
@@ -8,7 +8,6 @@
 // snippet-sourcetype:[full-example]
 // snippet-sourcedate:[ ]
 // snippet-sourceauthor:[AWS]
-// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperQueryScanExample] 
 /**
  * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -26,6 +25,7 @@
 
 package com.amazonaws.codesamples.datamodeling;
 
+// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperQueryScanExample.import]
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -44,7 +44,9 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+// snippet-end:[dynamodb.java.codeexample.DynamoDBMapperQueryScanExample.import]
 
+// snippet-start:[dynamodb.java.codeexample.DynamoDBMapperQueryScanExample]
 public class DynamoDBMapperQueryScanExample {
 
     static AmazonDynamoDB client = AmazonDynamoDBClientBuilder.standard().build();


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

Thank you for making a submission to the *aws-doc-sdk-examples* repository. For more information about submitting pull requests to this repository, see [Guidelines for contributing](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/CONTRIBUTING.md).

*NOTE:* This pull request (PR) template contains two sections. Use the section that applies to your submission, and remove the section which doesn't apply.

## I'm resolving an issue with an existing code example

Describe the changes you have made here, including any issue numbers.

I'm working on reviewing the current examples of DynamoDB Mapper in the DynamoDB Developer Guide ([link](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBMapper.html)), and identified 4 examples that can be improved. 

Th samples are:
- Example: CRUD operations
- Example: Batch write operations
- Example: Query and scan
- Mapping arbitrary data

The changes are:
- Move the original main "snippet-start" comment to the top of the class name (because I don't want the "Copyright" words to appear in the documentation page, they are not helpful in code samples)
- Add new "snippet-start" and "snippet-end" to wrap the import list


Confirm you have met the following minimum requirements:

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [ ] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
***
## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
