### PR TITLE
Remove sos label from label ruleset

### DIFF
--- a/.github/label-ruleset.yml
+++ b/.github/label-ruleset.yml
@@ -36,5 +36,3 @@ tool/cloudformation:
   - cloudformation/**/*
 type/github-settings:
   - .github/**/*
-type/sos:
-  - .doc_gen/metadata/**/*


### PR DESCRIPTION
We no longer use the SoS label, so this should be removed from our auto-labeler.