### PR TITLE
Updating C# run instructions for WriteMe.

### DIFF
--- a/.doc_gen/readmes/includes/run_instructions.jinja2
+++ b/.doc_gen/readmes/includes/run_instructions.jinja2
@@ -72,8 +72,7 @@ ruby {{scenario['file']}}
 ```
 {% elif lang_config['name'] == '.NET' and lang_config['sdk_ver'] == 3 %}
 Before you compile the .NET application, you can optionally set configuration values
-in the settings.json file. These settings include your account and topic settings for
-sending an email from your alarm. Alternatively, add a settings.local.json file with
+in the settings.json file. Alternatively, add a settings.local.json file with
 your local settings, which will be loaded automatically when the application runs.
 
 After the example compiles, you can run it from the command line. To do so, navigate to


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

## I'm resolving an issue with an existing code example

The only modification is an update to the run_instructions.jinja2 file for running .NET examples.

The changes needs only text review.

***
## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
