### PR TITLE
Add more IGNORE_FOLDERS

### DIFF
--- a/.github/pre_validate/pre_validate.py
+++ b/.github/pre_validate/pre_validate.py
@@ -51,10 +51,14 @@ EXT_LOOKUP = {
 
 # folders to skip
 IGNORE_FOLDERS = {
-    'venv',
-    '__pycache__',
+    '.doc_gen',
     '.pytest_cache',
-    '.doc_gen'
+    '__pycache__',
+    'cdk.out',
+    'node_modules',
+    'dist',
+    'target',
+    'venv'
 }
 
 # files to skip


### PR DESCRIPTION
To make pre_validate easier to run locally, adding more output folders to the ignore list.