### PR TITLE
Add 'encoding=utf-8' to file open in pre_validate.py so it can read emojis on Windows

### DIFF
--- a/.github/pre_validate/pre_validate.py
+++ b/.github/pre_validate/pre_validate.py
@@ -186,7 +186,7 @@ def check_files(root, quiet):
                 file_count += 1
                 if not quiet:
                     print("\nChecking File: " + file_path)
-                with open(file_path) as f:
+                with open(file_path, encoding='utf-8') as f:
                     file_contents = f.read()
 
                 error_count += verify_no_deny_list_words(file_contents, file_path)


### PR DESCRIPTION
Python uses cp1252 by default on Windows, which can't read various unicode. Specifying 'utf-8' encoding on read solves this problem.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
