### PR TITLE
Removed inconsistencies in cli arguments and doc comments

### DIFF
--- a/rust_dev_preview/config/src/bin/config-helloworld.rs
+++ b/rust_dev_preview/config/src/bin/config-helloworld.rs
@@ -54,8 +54,8 @@ async fn get_history(client: &Client, id: &str, res: ResourceType) -> Result<(),
 /// NOTE: AWS Config must be enabled to discover resources
 /// # Arguments
 ///
-/// * `-resource_id RESOURCE-ID` - The ID of the resource.
-/// * `-resource_type RESOURCE-TYPE` - The type of resource, such as **AWS::EC2::SecurityGroup**.
+/// * `[--resource_id RESOURCE-ID]` - The ID of the resource.
+/// * `[--resource_type RESOURCE-TYPE]` - The type of resource, such as **AWS::EC2::SecurityGroup**.
 /// * `[-r REGION]` - The AWS Region in which the client is created.
 ///   If not supplied, uses the value of the **AWS_REGION** environment variable.
 ///   If the environment variable is not set, defaults to **us-west-2**.

--- a/rust_dev_preview/config/src/bin/show-resource-history.rs
+++ b/rust_dev_preview/config/src/bin/show-resource-history.rs
@@ -52,8 +52,8 @@ async fn show_history(client: &Client, id: &str, res: ResourceType) -> Result<()
 /// NOTE: AWS Config must be enabled to discover resources.
 /// # Arguments
 ///
-/// * `-i ID` - The ID of the resource.
-/// * `--resource-type RESOURCE-TYPE` - The resource type, such as `AWS::EC2::SecurityGroup`.
+/// * `[-i ID]` - The ID of the resource.
+/// * `[--resource-type RESOURCE-TYPE]` - The resource type, such as `AWS::EC2::SecurityGroup`.
 /// * `[-r REGION]` - The Region in which the client is created.
 ///   If not supplied, uses the value of the **AWS_REGION** environment variable.
 ///   If the environment variable is not set, defaults to **us-west-2**.

--- a/rust_dev_preview/ecr/src/bin/list-images.rs
+++ b/rust_dev_preview/ecr/src/bin/list-images.rs
@@ -55,7 +55,7 @@ async fn show_images(
 /// Lists the images in an Amazon Elastic Container Registry repository.
 /// # Arguments
 ///
-/// * `[-repository REPOSITORY]` - The ECR repository containing images.
+/// * `[--repository REPOSITORY]` - The ECR repository containing images.
 /// * `[-r REGION]` - The Region in which the client is created.
 ///   If not supplied, uses the value of the **AWS_REGION** environment variable.
 ///   If the environment variable is not set, defaults to **us-west-2**.

--- a/rust_dev_preview/eks/src/bin/create-delete-cluster.rs
+++ b/rust_dev_preview/eks/src/bin/create-delete-cluster.rs
@@ -22,7 +22,7 @@ struct Opt {
 
     /// The Amazon Resource Name (ARN) of the IAM role that provides permissions
     /// for the Kubernetes control plane to make calls to AWS API operations on your behalf.
-    #[structopt(long)]
+    #[structopt(short, long)]
     arn: String,
 
     /// The subnet IDs for your Amazon EKS nodes.
@@ -75,9 +75,9 @@ async fn remove_cluster(
 /// Creates and deletes an Amazon Elastic Kubernetes Service cluster.
 /// # Arguments
 ///
-/// * `-a ARN]` - The ARN of the role for the cluster.
-/// * `-c CLUSTER-NAME` - The name of the cluster.
-/// * `-s SUBNET-IDS` - The subnet IDs of the cluster.
+/// * `[-a ARN]` - The ARN of the role for the cluster.
+/// * `[-c CLUSTER-NAME]` - The name of the cluster.
+/// * `[-s SUBNET-IDS]` - The subnet IDs of the cluster.
 ///   You must specify at least two subnet IDs in separate AZs.
 /// * `[-r REGION]` - The Region in which the client is created.
 ///   If not supplied, uses the value of the **AWS_REGION** environment variable.

--- a/rust_dev_preview/firehose/src/bin/put-records-batch.rs
+++ b/rust_dev_preview/firehose/src/bin/put-records-batch.rs
@@ -17,11 +17,11 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 struct Opt {
     /// The AWS Region.
-    #[structopt(long)]
+    #[structopt(short, long)]
     region: Option<String>,
 
     /// Whether to display additional information.
-    #[structopt(long)]
+    #[structopt(short, long)]
     verbose: bool,
 
     /// Whether to display additional information.

--- a/rust_dev_preview/snowball/src/bin/create-address.rs
+++ b/rust_dev_preview/snowball/src/bin/create-address.rs
@@ -76,16 +76,16 @@ async fn add_address(client: &Client, address: Address) -> Result<(), Error> {
 /// * `[-r REGION]` - The Region in which the client is created.
 ///    If not supplied, uses the value of the **AWS_REGION** environment variable.
 ///    If the environment variable is not set, defaults to **us-west-2**.
-/// * `--city CITY` - The required city portion of the address.
+/// * `[--city CITY]` - The required city portion of the address.
 /// * `[--company COMPANY]` - The company portion of the address.
-/// * `--country COUNTRY` - The required country portion of the address.
+/// * `[--country COUNTRY]` - The required country portion of the address.
 /// * `[--landmark LANDMARK]` - The landmark portion of the address.
-/// * `--name NAME` - The required name portion of the address.
-/// * `--phone-number PHONE-NUMBER` - The required phone number portion of the address.
-/// * `--postal-code POSTAL-CODE` - The required postal code (zip in USA) portion of the address.
+/// * `[--name NAME]` - The required name portion of the address.
+/// * `[--phone-number PHONE-NUMBER]` - The required phone number portion of the address.
+/// * `[--postal-code POSTAL-CODE]` - The required postal code (zip in USA) portion of the address.
 /// * `[--prefecture-or-district PREFECTURE-OR-DISTRICT]` - The prefecture or district portion of the address.
-/// * `--state STATE` - The required state portion of the address. It must be (two is best) upper-case letters.
-/// * `--street1 STREET1` - The required first street portion of the address.
+/// * `[--state STATE]` - The required state portion of the address. It must be (two is best) upper-case letters.
+/// * `[--street1 STREET1]` - The required first street portion of the address.
 /// * `[--street2 STREET2]` - The second street portion of the address.
 /// * `[--street3 STREET3]` - The third street portion of the address.
 /// * `[-v]` - Whether to display additional information.

--- a/rust_dev_preview/sts/src/bin/assume-role.rs
+++ b/rust_dev_preview/sts/src/bin/assume-role.rs
@@ -14,11 +14,11 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 struct Opt {
     /// The AWS Region.
-    #[structopt(long)]
+    #[structopt(short, long)]
     region: Option<String>,
 
     /// Whether to display additional information.
-    #[structopt(long)]
+    #[structopt(short, long)]
     verbose: bool,
 
     /// Whether to display additional information.

--- a/rust_dev_preview/sts/src/bin/get-caller-identity.rs
+++ b/rust_dev_preview/sts/src/bin/get-caller-identity.rs
@@ -13,11 +13,11 @@ use std::fmt::Debug;
 #[derive(Debug, Parser)]
 struct Opt {
     /// The AWS Region.
-    #[structopt(long)]
+    #[structopt(short, long)]
     region: Option<String>,
 
     /// Whether to display additional information.
-    #[structopt(long)]
+    #[structopt(short, long)]
     verbose: bool,
 }
 


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

Thank you for making a submission to the *aws-doc-sdk-examples* repository. For more information about submitting pull requests to this repository, see [Guidelines for contributing](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/CONTRIBUTING.md).

*NOTE:* This pull request (PR) template contains two sections. Use the section that applies to your submission, and remove the section which doesn't apply.

## I'm resolving an issue with an existing code example

There were inconsistencies between doc comments and cli arguments. Even in doc comments there were inconsistencies in format of expressing cli arguments.

Confirm you have met the following minimum requirements:

- [x] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [x] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).

## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
