### PR TITLE
make example keys and bucket names more generic

### DIFF
--- a/javascriptv3/example_code/s3/scenarios/presigned-url-download.js
+++ b/javascriptv3/example_code/s3/scenarios/presigned-url-download.js
@@ -29,7 +29,7 @@ const createPresignedUrlWithoutClient = async ({ region, bucket, key }) => {
   return formatUrl(signedUrlObject);
 };
 
-const createPresignedUrlWithClient = async ({ region, bucket, key }) => {
+const createPresignedUrlWithClient = ({ region, bucket, key }) => {
   const client = new S3Client({ region });
   const command = new GetObjectCommand({ Bucket: bucket, Key: key });
   return getSignedUrl(client, command, { expiresIn: 3600 });
@@ -37,8 +37,8 @@ const createPresignedUrlWithClient = async ({ region, bucket, key }) => {
 
 export const main = async () => {
   const REGION = "us-east-1";
-  const BUCKET = "coreys-default-bucket";
-  const KEY = "corey_mug.jpg";
+  const BUCKET = "example_bucket";
+  const KEY = "example_file.jpg";
 
   try {
     const noClientUrl = await createPresignedUrlWithoutClient({

--- a/javascriptv3/example_code/s3/scenarios/presigned-url-upload.js
+++ b/javascriptv3/example_code/s3/scenarios/presigned-url-upload.js
@@ -32,7 +32,7 @@ const createPresignedUrlWithoutClient = async ({ region, bucket, key }) => {
   return formatUrl(signedUrlObject);
 };
 
-const createPresignedUrlWithClient = async ({ region, bucket, key }) => {
+const createPresignedUrlWithClient = ({ region, bucket, key }) => {
   const client = new S3Client({ region });
   const command = new PutObjectCommand({ Bucket: bucket, Key: key });
   return getSignedUrl(client, command, { expiresIn: 3600 });
@@ -63,8 +63,8 @@ function put(url, data) {
 
 export const main = async () => {
   const REGION = "us-east-1";
-  const BUCKET = "coreys-default-bucket";
-  const KEY = "corey_test.txt";
+  const BUCKET = "example_bucket";
+  const KEY = "example_file.txt";
 
   // There are two ways to generate a presigned URL.
   // 1. Use createPresignedUrl without the S3 client.


### PR DESCRIPTION
Looks like the S3 guide took down their 'delete' section. I fixed the strings, but didn't add the delete functionality. It would be nearly identity to the download example and seems unnecessary.