### PR TITLE
Revert "Allow &AWS-Region; entity"

### DIFF
--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -2162,7 +2162,7 @@ s3_Scenario_BatchObjectVersioning:
 s3_Scenario_PresignedUrl:
   title: Create a presigned URL for &S3; using an &AWS; SDK
   title_abbrev: Create a presigned URL
-  synopsis: create a presigned URL for &S3; and upload an object. For all &AWS-Regions; launched after March 20, 2019, you need to specify the endpoint-url and &AWS-Region; with the request.
+  synopsis: create a presigned URL for Amazon S3 and upload an object.
   category: Scenarios
   languages:
     .NET:

--- a/.doc_gen/validation/validate_doc_metadata.py
+++ b/.doc_gen/validation/validate_doc_metadata.py
@@ -109,9 +109,8 @@ class StringExtension(String):
             return True
         valid = True
         if self.check_aws:
-            # All occurrences of AWS must be entities or within a word (including hyphens).
-            # https://regex101.com/r/JoKjfE/1
-            valid = len(re.findall('(?<![&\\da-zA-Z])AWS|AWS(?![;\\da-zA-Z\\-])', value)) == 0
+            # All occurrences of AWS must be entities or within a word.
+            valid = len(re.findall('(?<![&\\da-zA-Z])AWS|AWS(?![;\\da-zA-Z])', value)) == 0
             if not valid:
                 self.last_err = 'valid string: it contains a non-entity usage of "AWS"'
         if valid and self.upper_start:


### PR DESCRIPTION
Reverts awsdocs/aws-doc-sdk-examples#4733 - there's a separate check in internal tooling that flags this as invalid.