### PR TITLE
Update metadata to better support developer center output

### DIFF
--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -8,6 +8,7 @@ cross_PAM:
       versions:
         - sdk_version: 2
           block_content: cross_PAM_Java_block.xml
+  service_main: rekognition
   services:
     sns:
     s3:
@@ -27,6 +28,7 @@ cross_RedshiftDataTracker:
       versions:
         - sdk_version: 1
           block_content: cross_RedshiftDataTracker_Kotlin_block.xml
+  service_main: redshift
   services:
     redshift:
     ses:
@@ -43,6 +45,7 @@ cross_SQSMessageApp:
       versions:
         - sdk_version: 2
           block_content: cross_SQSMessage_Java_block.xml
+  service_main: sqs
   services:
     sqs:
     comprehend:
@@ -82,6 +85,7 @@ cross_RDSDataTracker:
       versions:
         - sdk_version: 1
           block_content: cross_RDSDataTracker_cpp_block.xml
+  service_main: aurora
   services:
     aurora:
     rds:
@@ -105,6 +109,7 @@ cross_SnsPublishSubscription:
       versions:
         - sdk_version: 2
           block_content: cross_SNSSubPub_Java_block.xml
+  service_main: translate
   services:
     sns:
     translate:
@@ -121,6 +126,7 @@ cross_LexChatbotLanguages:
       versions:
         - sdk_version: 3
           block_content: cross_Lex_JavaScript_block.xml
+  service_main: lex
   services:
     lex:
     translate:
@@ -153,6 +159,7 @@ cross_DynamoDBDataTracker:
       versions:
         - sdk_version: 3
           block_content: cross_DynamoDBDataTracker_JavaScript_block.xml
+  service_main: dynamodb
   services:
     dynamodb:
     ses:
@@ -167,6 +174,7 @@ cross_ApiGatewayDataTracker:
         - sdk_version: 3
           github: python/cross_service/apigateway_covid-19_tracker
           block_content: cross_ApiGatewayDataTracker_Python_block.xml
+  service_main: api-gateway
   services:
     api-gateway:
     cloudformation:
@@ -182,6 +190,7 @@ cross_ApiGatewayWebsocketChat:
         - sdk_version: 3
           github: python/cross_service/apigateway_websocket_chat
           block_content: cross_ApiGatewayWebsocketChat_Python_block.xml
+  service_main: api-gateway
   services:
     api-gateway:
     dynamodb:
@@ -197,10 +206,11 @@ cross_AuroraRestLendingLibrary:
         - sdk_version: 3
           github: python/cross_service/aurora_rest_lending_library
           block_content: cross_AuroraRestLendingLibrary_Python_block.xml
+  service_main: aurora
   services:
     api-gateway:
+    aurora:
     lambda:
-    rds:
     secrets-manager:
 cross_StepFunctionsMessenger:
   title: Create a messenger application with &SFN;
@@ -212,6 +222,7 @@ cross_StepFunctionsMessenger:
         - sdk_version: 3
           github: python/cross_service/stepfunctions_messenger
           block_content: cross_StepFunctionsMessenger_Python_block.xml
+  service_main: sfn
   services:
     dynamodb:
     lambda:
@@ -233,6 +244,7 @@ cross_TextractExplorer:
         - sdk_version: 3
           github: python/cross_service/textract_explorer
           block_content: cross_TextractExplorer_Python_block.xml
+  service_main: textract
   services:
     s3:
     sns:
@@ -250,6 +262,7 @@ cross_TextractComprehendDetectEntities:
         - sdk_version: 3
           github: python/cross_service/textract_comprehend_notebook
           block_content: cross_TextractComprehendDetectEntities_Python_block.xml
+  service_main: textract
   services:
     comprehend:
     s3:
@@ -272,6 +285,7 @@ cross_SubmitDataApp:
       versions:
         - sdk_version: 3
           block_content: cross_SubmitDataApp_JavaScript_block.xml
+  service_main: dynamodb
   services:
     dynamodb:
     sns:
@@ -298,6 +312,7 @@ cross_LambdaAPIGateway:
       versions:
         - sdk_version: 3
           block_content: cross_LambdaAPIGateway_Python_block.xml
+  service_main: lambda
   services:
     api-gateway:
     lambda:
@@ -326,6 +341,7 @@ cross_LambdaScheduledEvents:
           block_content: cross_LambdaScheduledEvents_Python_block.xml
           add_services:
             cloudwatch-logs:
+  service_main: lambda
   services:
     eventbridge:
     lambda:
@@ -342,6 +358,7 @@ cross_ServerlessWorkflows:
       versions:
         - sdk_version: 3
           block_content: cross_ServerlessWorkflows_JavaScript_block.xml
+  service_main: sfn
   services:
     dynamodb:
     lambda:
@@ -356,6 +373,7 @@ cross_TranscriptionApp:
       versions:
         - sdk_version: 3
           block_content: cross_TranscriptionApp_JavaScript_block.xml
+  service_main: transcribe
   services:
     cognito-identity:
     s3:
@@ -370,6 +388,7 @@ cross_TranscriptionStreamingApp:
       versions:
         - sdk_version: 3
           block_content: cross_TranscriptionStreamingApp_JavaScript_block.xml
+  service_main: transcribe
   services:
     translate:
     comprehend:
@@ -388,6 +407,7 @@ cross_RekognitionPhotoAnalyzerPPE:
       versions:
         - sdk_version: 3
           block_content: cross_RekognitionPhotoAnalyzerPPE_JavaScript_block.xml
+  service_main: rekognition
   services:
     rekognition:
     s3:
@@ -420,6 +440,7 @@ cross_RekognitionPhotoAnalyzer:
         - sdk_version: 3
           github: python/cross_service/photo_analyzer
           block_content: cross_RekognitionPhotoAnalyzer_Python_block.xml
+  service_main: rekognition
   services:
     rekognition:
     s3:
@@ -451,6 +472,7 @@ cross_RekognitionVideoDetection:
           add_services:
             sns:
             sqs:
+  service_main: rekognition
   services:
     rekognition:
 cross_DetectFaces:
@@ -465,6 +487,7 @@ cross_DetectFaces:
       versions:
         - sdk_version: 1
           block_content: cross_detect_faces_rust_block.xml
+  service_main: rekognition
   services:
     rekognition: {}
     s3: {}
@@ -481,6 +504,7 @@ cross_DetectLabels:
       versions:
         - sdk_version: 1
           block_content: cross_detect_labels_rust_block.xml
+  service_main: rekognition
   services:
     dynamodb: {}
     rekognition: {}
@@ -498,6 +522,7 @@ cross_Telephone:
       versions:
         - sdk_version: 1
           block_content: cross_telephone_rust_block.xml
+  service_main: polly
   services:
     polly: {}
     s3: {}
@@ -513,6 +538,7 @@ cross_LambdaForBrowser:
           block_content: cross_LambdaForBrowser_JavaScript_block.xml
         - sdk_version: 3
           block_content: cross_LambdaForBrowser_JavaScriptV3_block.xml
+  service_main: lambda
   services:
     lambda:
     dynamodb:

--- a/.doc_gen/metadata/services.yaml
+++ b/.doc_gen/metadata/services.yaml
@@ -713,7 +713,7 @@ pinpoint:
     url: pinpoint/latest/developerguide/welcome.html
   api_ref: pinpoint/latest/apireference/welcome.html
   tags:
-    product_categories: {'Front-End Web &amp; Mobile', 'Business Applications'}
+    product_categories: {'Business Applications'}
   version: pinpoint-2016-12-01
 pinpoint-email:
   long: '&PIN-Email-API;'
@@ -728,7 +728,7 @@ pinpoint-email:
     url: pinpoint/latest/developerguide/welcome.html
   api_ref: pinpoint/latest/apireference/welcome.html
   tags:
-    product_categories: {'Front-End Web &amp; Mobile', 'Business Applications'}
+    product_categories: {'Business Applications'}
   version: pinpoint-email-2018-07-26
 pinpoint-sms-voice:
   bundle: pinpoint
@@ -744,7 +744,7 @@ pinpoint-sms-voice:
     url: pinpoint/latest/developerguide/welcome.html
   api_ref: pinpoint-sms-voice/latest/APIReference/welcome.html
   tags:
-    product_categories: {'Front-End Web &amp; Mobile', 'Business Applications'}
+    product_categories: {'Business Applications'}
   version: pinpoint-sms-voice-2018-09-05
 polly:
   long: '&POLlong;'
@@ -1007,7 +1007,7 @@ sns:
     url: sns/latest/dg/welcome.html
   api_ref: sns/latest/api/welcome.html
   tags:
-    product_categories: {'Application Integration', 'Front-End Web &amp; Mobile'}
+    product_categories: {'Application Integration'}
   version: sns-2010-03-31
 sqs:
   long: '&SQSlong; (&SQS;)'
@@ -1101,8 +1101,8 @@ transcribe:
     product_categories: {'Machine Learning &amp; AI'}
   version: transcribe-2017-10-26
 transcribe-medical:
-  long: '&TSClong;'
-  short: '&TSC;'
+  long: '&TSCMlong;'
+  short: '&TSCM;'
   sort: Transcribe Medical
   expanded:
     long: Amazon Transcribe Medical

--- a/.doc_gen/validation/example_schema.yaml
+++ b/.doc_gen/validation/example_schema.yaml
@@ -11,6 +11,7 @@ example:
   category: str(required=False, upper_start=True, no_end_punc=True)
   guide_topic: include('guide_topic', required=False)
   languages: map(include('language'), key=enum('C++', 'Go', 'Java', 'JavaScript', 'Kotlin', '.NET', 'PHP', 'Python', 'Ruby', 'Rust', 'SAP ABAP', 'Swift'))
+  service_main: service_name(required=False)
   services: map(map(key=str(), required=False), key=service_name())
 
 guide_topic:


### PR DESCRIPTION
Small metadata updates for dev center output:

* Add service_main to cross meta. Dev center needs a single service for category and URL. For examples that encompass multiple services, this field specifies the "main" service for the example.
* Fix TSC to TSCM. Comprehend Medical was mistakenly using Comprehend's entity.
* Remove second product category from two-category services. A few services had more than one product category, but dev center uses a single product category. Cutting to one category is the most expedient solution for now.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
