### PR TITLE
4757 test fixes for c++

### DIFF
--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -16,7 +16,7 @@ RUN \
 
 # Build only the services needed for example code.
 ENV SERVICES="acm;autoscaling;cloudtrail;codebuild;codecommit;cognito-idp;dynamodb;ec2;elasticache;elasticbeanstalk"
-ENV SERVICES=${SERVICES}";elasticfilesystem;email;events;glacier;glue;guardduty;iam;kinesis;lambda;logs;monitoring"
+ENV SERVICES=${SERVICES}";elasticfilesystem;email;events;glacier;glue;guardduty;iam;kinesis;lambda;logs;mediaconvert;monitoring"
 ENV SERVICES=${SERVICES}";monitoring;neptune;rds;rds-data;redshift;s3;s3-crt;s3-encryption;secretsmanager;sesv2;sns;sqs"
 ENV SERVICES=${SERVICES}";storagegateway;sts;transfer;transcribe;transcribestreaming"
 

--- a/cpp/example_code/aurora/tests/aurora_gtests.h
+++ b/cpp/example_code/aurora/tests/aurora_gtests.h
@@ -43,7 +43,7 @@ namespace AwsDocTest {
 
     private:
 
-        bool suppressStdOut();
+        static bool suppressStdOut();
 
         static Aws::SDKOptions s_options;
 

--- a/cpp/example_code/aurora/tests/gtest_getting_started_with_db_clusters.cpp
+++ b/cpp/example_code/aurora/tests/gtest_getting_started_with_db_clusters.cpp
@@ -9,6 +9,7 @@
  * _2_ Requires credentials and permissions.
  * _3_ Does not require credentials.
  *
+ * -*L_ Designates a test with a long execution time.
  */
 
 #include <gtest/gtest.h>
@@ -22,8 +23,9 @@ namespace AwsDocTest {
 
     bool addHttpResponses(MockHTTP &mockHttp);
 
+    // Only run the un-mocked test in special cases because of its long execution time.
     // NOLINTNEXTLINE(readability-named-parameter)
-    TEST_F(Aurora_GTests, gettingStartedWithDBClusters_2_) {
+    TEST_F(Aurora_GTests, gettingStartedWithDBClusters_2L_) {
         AddCommandLineResponses(RESPONSES);
 
         bool result = AwsDoc::Aurora::gettingStartedWithDBClusters(*s_clientConfig);

--- a/cpp/example_code/mediaconvert/create_job.cpp
+++ b/cpp/example_code/mediaconvert/create_job.cpp
@@ -17,8 +17,8 @@
 #include <aws/core/Aws.h>
 #include <aws/core/utils/json/JsonSerializer.h>
 #include <aws/mediaconvert/MediaConvertClient.h>
-#include <aws/mediaconvert/Model/DescribeEndpointsRequest.h>
-#include <aws/mediaconvert/Model/CreateJobRequest.h>
+#include <aws/mediaconvert/model/DescribeEndpointsRequest.h>
+#include <aws/mediaconvert/model/CreateJobRequest.h>
 #include "mediaconvert_samples.h"
 #include <fstream>
 

--- a/cpp/example_code/mediaconvert/describe_endpoints.cpp
+++ b/cpp/example_code/mediaconvert/describe_endpoints.cpp
@@ -19,7 +19,7 @@
 #include "mediaconvert_samples.h"
 #include <aws/core/Aws.h>
 #include <aws/mediaconvert/MediaConvertClient.h>
-#include <aws/mediaconvert/Model/DescribeEndpointsRequest.h>
+#include <aws/mediaconvert/model/DescribeEndpointsRequest.h>
 
 //! Retrieve the account API endpoint.
 /*!

--- a/cpp/example_code/mediaconvert/get_job.cpp
+++ b/cpp/example_code/mediaconvert/get_job.cpp
@@ -16,7 +16,7 @@
 
 #include <aws/core/Aws.h>
 #include <aws/mediaconvert/MediaConvertClient.h>
-#include <aws/mediaconvert/Model/GetJobRequest.h>
+#include <aws/mediaconvert/model/GetJobRequest.h>
 #include "mediaconvert_samples.h"
 
 // snippet-start:[cpp.example_code.mediaconvert.GetJob]

--- a/cpp/example_code/mediaconvert/list_jobs.cpp
+++ b/cpp/example_code/mediaconvert/list_jobs.cpp
@@ -16,7 +16,7 @@
 
 #include <aws/core/Aws.h>
 #include <aws/mediaconvert/MediaConvertClient.h>
-#include <aws/mediaconvert/Model/ListJobsRequest.h>
+#include <aws/mediaconvert/model/ListJobsRequest.h>
 #include "mediaconvert_samples.h"
 
 // snippet-start:[cpp.example_code.mediaconvert.ListJobs]

--- a/cpp/example_code/mediaconvert/tests/MediaConvert_gtests.cpp
+++ b/cpp/example_code/mediaconvert/tests/MediaConvert_gtests.cpp
@@ -7,7 +7,7 @@
 #include <fstream>
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/mediaconvert/MediaConvertClient.h>
-#include <aws/mediaconvert/Model/DescribeEndpointsRequest.h>
+#include <aws/mediaconvert/model/DescribeEndpointsRequest.h>
 #include <aws/testing/mocks/http/MockHttpClient.h>
 #include "mediaconvert_samples.h"
 

--- a/cpp/example_code/mediaconvert/utils.cpp
+++ b/cpp/example_code/mediaconvert/utils.cpp
@@ -17,7 +17,7 @@
 
 #include <aws/core/Aws.h>
 #include <aws/mediaconvert/MediaConvertClient.h>
-#include <aws/mediaconvert/Model/DescribeEndpointsRequest.h>
+#include <aws/mediaconvert/model/DescribeEndpointsRequest.h>
 #include <fstream>
 #include "mediaconvert_samples.h"
 

--- a/cpp/example_code/rds/tests/gtest_getting_started_with_db_instances.cpp
+++ b/cpp/example_code/rds/tests/gtest_getting_started_with_db_instances.cpp
@@ -8,6 +8,8 @@
  * _1_ Requires credentials, permissions, and AWS resources.
  * _2_ Requires credentials and permissions.
  * _3_ Does not require credentials.
+*
+ * -*L_ Designates a test with a long execution time.
  *
  */
 
@@ -22,8 +24,9 @@ namespace AwsDocTest {
 
     bool addHttpResponses(MockHTTP &mockHttp);
 
+    // Only run the un-mocked test in special cases because of its long execution time.
     // NOLINTNEXTLINE(readability-named-parameter)
-    TEST_F(RDS_GTests, gettingStartedWithDBInstances_2_) {
+    TEST_F(RDS_GTests, gettingStartedWithDBInstances_2L_) {
         AddCommandLineResponses(RESPONSES);
 
         bool result = AwsDoc::RDS::gettingStartedWithDBInstances(*s_clientConfig);

--- a/cpp/example_code/s3/tests/S3_GTests.cpp
+++ b/cpp/example_code/s3/tests/S3_GTests.cpp
@@ -185,6 +185,7 @@ bool AwsDocTest::S3_GTests::CreateBucket(const Aws::String &bucketName) {
     Aws::S3::S3Client client(*s_clientConfig);
     Aws::S3::Model::CreateBucketRequest request;
     request.SetBucket(bucketName);
+    request.SetObjectOwnership(Aws::S3::Model::ObjectOwnership::BucketOwnerPreferred); // Needed for the ACL tests.
     if (s_clientConfig->region != Aws::Region::US_EAST_1) {
         Aws::S3::Model::CreateBucketConfiguration createBucketConfiguration;
         createBucketConfiguration.WithLocationConstraint(

--- a/cpp/run_automated_tests.py
+++ b/cpp/run_automated_tests.py
@@ -26,6 +26,7 @@ import sys
 import getopt
 import glob
 import re
+import datetime
 
 
 def build_tests(service="*"):
@@ -150,10 +151,13 @@ def main(argv):
         elif opt in ("-s"):
             service = arg
 
+    start_time = datetime.datetime.now()
     [err_code, run_files] = build_tests(service=service)
 
     if err_code == 0 :
         err_code = run_tests(run_files = run_files, type1=type1, type2=type2, type3=type3)
+
+    print(f"Execution duration - {datetime.datetime.now() - start_time}")
 
     return err_code
 


### PR DESCRIPTION
New defaults for S3 bucket creation required changes to support ACL tests.
Added tags to long running tests (> 10 minutes) to allow them to be excluded.
Fixed path errors for case-sensitive systems.
Added missing service to SDK install.
Added execution time logging.