### PR TITLE
Update to pycognito instead of warrant

### DIFF
--- a/python/example_code/cognito/cognito_idp_actions.py
+++ b/python/example_code/cognito/cognito_idp_actions.py
@@ -313,7 +313,7 @@ class CognitoIdentityProviderWrapper:
         device_and_pw_hash = aws_srp.hash_sha256(device_and_pw.encode('utf-8'))
         salt = aws_srp.pad_hex(aws_srp.get_random(16))
         x_value = aws_srp.hex_to_long(aws_srp.hex_hash(salt + device_and_pw_hash))
-        verifier = aws_srp.pad_hex(pow(srp_helper.g, x_value, srp_helper.big_n))
+        verifier = aws_srp.pad_hex(pow(srp_helper.val_g, x_value, srp_helper.big_n))
         device_secret_verifier_config = {
             "PasswordVerifier": base64.standard_b64encode(bytearray.fromhex(verifier)).decode('utf-8'),
             "Salt": base64.standard_b64encode(bytearray.fromhex(salt)).decode('utf-8')
@@ -386,7 +386,7 @@ class CognitoIdentityProviderWrapper:
 
             challenge_params = response_auth['ChallengeParameters']
             challenge_params['USER_ID_FOR_SRP'] = device_group_key + device_key
-            cr = srp_helper.process_challenge(challenge_params)
+            cr = srp_helper.process_challenge(challenge_params, {'USERNAME': user_name})
             cr['USERNAME'] = user_name
             cr['DEVICE_KEY'] = device_key
             response_verifier = self.cognito_idp_client.respond_to_auth_challenge(

--- a/python/example_code/cognito/requirements.txt
+++ b/python/example_code/cognito/requirements.txt
@@ -1,4 +1,4 @@
 boto3>=1.26.79
 pytest>=7.2.1
 qrcode>=7.4.2
-warrant>=0.6.1
+pycognito>=2022.12.0

--- a/python/example_code/cognito/scenario_signup_user_with_mfa.py
+++ b/python/example_code/cognito/scenario_signup_user_with_mfa.py
@@ -31,7 +31,7 @@ import webbrowser
 
 import boto3
 import qrcode
-from warrant import aws_srp
+from pycognito import aws_srp
 
 from cognito_idp_actions import CognitoIdentityProviderWrapper
 

--- a/python/example_code/cognito/test/test_cognito_idp_actions.py
+++ b/python/example_code/cognito/test/test_cognito_idp_actions.py
@@ -268,7 +268,7 @@ def test_sign_in_with_tracked_device(make_stubber, stub_runner, error_code, stop
     aws_srp.AWSSRP.get_auth_params = lambda s: {
         'USERNAME': user_name, 'SRP_A': 'test-srp-a', 'DEVICE_KEY': device_key}
     tstamp = str(datetime.utcnow())
-    aws_srp.AWSSRP.process_challenge = lambda s, x: {
+    aws_srp.AWSSRP.process_challenge = lambda s, x, r: {
         'TIMESTAMP': tstamp, 'USERNAME': user_name,
         'PASSWORD_CLAIM_SECRET_BLOCK': 'test-secret-block',
         'PASSWORD_CLAIM_SIGNATURE': 'test-signature',
@@ -284,7 +284,7 @@ def test_sign_in_with_tracked_device(make_stubber, stub_runner, error_code, stop
             {})
         runner.add(
             cognito_idp_stubber.stub_respond_to_auth_challenge, client_id,
-            'DEVICE_PASSWORD_VERIFIER', aws_srp.AWSSRP.process_challenge('s', True),
+            'DEVICE_PASSWORD_VERIFIER', aws_srp.AWSSRP.process_challenge('s', True, True),
             '', access_token=access_token)
     if error_code is None:
         got_access_token = wrapper.sign_in_with_tracked_device(

--- a/python/example_code/cognito/test/test_scenario_signup_user_with_mfa.py
+++ b/python/example_code/cognito/test/test_scenario_signup_user_with_mfa.py
@@ -60,7 +60,7 @@ def test_scenario(make_stubber, stub_runner, monkeypatch, error_code, stop_on_me
     aws_srp.AWSSRP.get_auth_params = lambda s: {
         'USERNAME': user_name, 'SRP_A': 'test-srp-a', 'DEVICE_KEY': device_key}
     tstamp = str(datetime.utcnow())
-    aws_srp.AWSSRP.process_challenge = lambda s, x: {
+    aws_srp.AWSSRP.process_challenge = lambda s, x, r: {
         'TIMESTAMP': tstamp, 'USERNAME': user_name,
         'PASSWORD_CLAIM_SECRET_BLOCK': 'test-secret-block',
         'PASSWORD_CLAIM_SIGNATURE': 'test-signature',
@@ -109,7 +109,7 @@ def test_scenario(make_stubber, stub_runner, monkeypatch, error_code, stop_on_me
             {})
         runner.add(
             cognito_idp_stubber.stub_respond_to_auth_challenge, client_id,
-            'DEVICE_PASSWORD_VERIFIER', aws_srp.AWSSRP.process_challenge('s', True),
+            'DEVICE_PASSWORD_VERIFIER', aws_srp.AWSSRP.process_challenge('s', True, True),
             '', access_token=access_token)
 
     if error_code is None:

--- a/python/test_tools/requirements.txt
+++ b/python/test_tools/requirements.txt
@@ -13,6 +13,6 @@ playsound==1.2.2
 pytest>=7.2.1
 qrcode>=7.4.2
 requests>=2.28.2
-warrant>=0.6.1
+pycognito>=2022.12.0
 webargs>=8.2.0
 websockets>=10.4


### PR DESCRIPTION
An audit found that the latest version of warrant used by Python Cognito examples uses an outdated and potentially vulnerable version of pycryptodome. This PR updates the example to use pycognito, which is much more recent (and appears to be actively maintained, where warrant hasn't been touched in quite some time).

* All Python cognito unit and integ tests pass.
* Ran pip-audit on the installed packages and no vulnerabilities were found.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
