### PR TITLE
fix(go/s3): url.QueryEscape for URL encoding of CopySource

### DIFF
--- a/go/example_code/s3/s3_copy_object.go
+++ b/go/example_code/s3/s3_copy_object.go
@@ -62,7 +62,7 @@ func main() {
 
     // Copy the item
     _, err = svc.CopyObject(&s3.CopyObjectInput{Bucket: aws.String(other),
-        CopySource: aws.String(url.PathEscape(source)), Key: aws.String(item)})
+        CopySource: aws.String(url.QueryEscape(source)), Key: aws.String(item)})
     if err != nil {
         exitErrorf("Unable to copy item from bucket %q to bucket %q, %v", bucket, other, err)
     }

--- a/go/s3/CopyObject/CopyObject.go
+++ b/go/s3/CopyObject/CopyObject.go
@@ -43,7 +43,7 @@ func CopyItem(sess *session.Session, sourceBucket *string, targetBucket *string,
     // Copy the item
     _, err := svc.CopyObject(&s3.CopyObjectInput{
         Bucket:     targetBucket,
-        CopySource: aws.String(url.PathEscape(source)),
+        CopySource: aws.String(url.QueryEscape(source)),
         Key:        item,
     })
     // snippet-end:[s3.go.copy_object.call]


### PR DESCRIPTION
# aws-doc-sdk-examples Pull Request

Thank you for making a submission to the *aws-doc-sdk-examples* repository. For more information about submitting pull requests to this repository, see [Guidelines for contributing](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/CONTRIBUTING.md).
## I'm resolving an issue with an existing code example

Per bug #4780, `url.PathEscape()` does not escape `+` characters in keys for S3 copy object requests. Using the resulting code results in a 404 as the `+` is treated as a space, so the source object is not found (or at worst the wrong object is copied if it does contain a space...)

Instead, use `url.QueryEscape()` which does encode `+` characters, see examples here: 
https://pkg.go.dev/net/url#PathEscape
https://pkg.go.dev/net/url#QueryEscape

Confirm you have met the following minimum requirements:

- [ ] Test the changed code. For recommendations, see [How we test code examples](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#how-we-test-code-examples).
- [ ] Run a linter against the changed code and implement the resulting suggestions. For recommendations, see [Linters run on check in](https://github.com/awsdocs/aws-doc-sdk-examples/wiki/Code-quality-guidelines---testing-and-linting#linters-run-on-check-in).
***
## Open source license adherence

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
