### PR TITLE
Update PAM headers

### DIFF
--- a/resources/clients/react/elros-pam/src/pam-api.ts
+++ b/resources/clients/react/elros-pam/src/pam-api.ts
@@ -24,7 +24,12 @@ const request: typeof fetch = async (input, init) => {
 };
 
 const getHeaders = (config: PamApiConfig): { Authorization: string } | {} =>
-  config.token ? { Authorization: `Bearer ${config.token}` } : {};
+  config.token
+    ? {
+        Authorization: `Bearer ${config.token}`,
+        "Content-Type": "application/json",
+      }
+    : {};
 
 export const getLabels = async (config: PamApiConfig): Promise<Label[]> => {
   const response = await request(


### PR DESCRIPTION
PAM client was leaving the content-type header blank, implying text when we need json.