### PR TITLE
Add related example list to template.

### DIFF
--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -916,23 +916,6 @@ s3_GetBucketLifecycleConfiguration:
                 - python.example_code.s3.GetBucketLifecycleConfiguration
   services:
     s3: {GetBucketLifecycleConfiguration}
-s3_SetBucketNotification:
-  title: Enable notifications of specified events on an &S3; bucket using an &AWS; SDK
-  title_abbrev: Enable notifications
-  synopsis: enable notifications on an S3 bucket.
-  category:
-  languages:
-    Java:
-      versions:
-        - sdk_version: 2
-          github: javav2/example_code/s3
-          sdkguide:
-          excerpts:
-            - description: 
-              snippet_tags:
-                - s3.java2.s3_enable_notifications.main    
-  services:
-    s3: {PutBucketLogging}
 s3_ServiceAccessLogging:
   title: Enable logging on an &S3; bucket using an &AWS; SDK
   title_abbrev: Enable logging
@@ -2082,6 +2065,15 @@ s3_PutBucketNotification:
             - description:
               snippet_tags:
                 - S3.dotnetv3.EnableNotificationsExample
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/s3
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - s3.java2.s3_enable_notifications.main
   services:
     s3: {PutBucketNotificationConfiguration}
 s3_TransferAcceleration:

--- a/.doc_gen/templates/zonbook/utility/notes.xml
+++ b/.doc_gen/templates/zonbook/utility/notes.xml
@@ -3,9 +3,7 @@
 {{- $scenarios := index . 1}}
 {{- $crosses := index . 2}}
 {{- if $actions}}
-<para><emphasis>Actions</emphasis> are code excerpts that show you how to call individual service functions and
-    are not designed to be run in isolation. You can see actions in context in related scenarios and
-    cross-service examples.</para>
+<para><emphasis>Actions</emphasis> are code excerpts from larger programs and must be run in context. While actions show you how to call individual service functions, you can see actions in context in their related scenarios and cross-service examples.</para>
 {{- end}}
 {{- if $scenarios}}
 <para><emphasis>Scenarios</emphasis> are code examples that show you how to accomplish a specific task by

--- a/.doc_gen/templates/zonbook/utility/notes.xml
+++ b/.doc_gen/templates/zonbook/utility/notes.xml
@@ -3,7 +3,9 @@
 {{- $scenarios := index . 1}}
 {{- $crosses := index . 2}}
 {{- if $actions}}
-<para><emphasis>Actions</emphasis> are code excerpts that show you how to call individual service functions.</para>
+<para><emphasis>Actions</emphasis> are code excerpts that show you how to call individual service functions and
+    are not designed to be run in isolation. You can see actions in context in related scenarios and
+    cross-service examples.</para>
 {{- end}}
 {{- if $scenarios}}
 <para><emphasis>Scenarios</emphasis> are code examples that show you how to accomplish a specific task by

--- a/.doc_gen/templates/zonbook/utility/service_examples.xml
+++ b/.doc_gen/templates/zonbook/utility/service_examples.xml
@@ -43,6 +43,27 @@
     {{- if .GuideTopic.Url}}
     <para>For more information, see <ulink {{.GuideTopic.DocType}} url="{{.GuideTopic.Url}}">{{.GuideTopic.Text}}</ulink>.</para>
     {{- end}}
+    {{- if eq $examples.CategoryName "Actions"}}
+        {{- if .RelatedExamples}}
+            {{- $codex_text := "code examples"}}
+            {{- if eq 1 (len .RelatedExamples)}}
+                {{- $codex_text = "code example"}}
+            {{- end}}
+            <para>Action examples are code excerpts that are not designed to be run in isolation. You can see this action in
+            context in the following {{$codex_text}}:
+            </para>
+            <itemizedlist>
+            {{- range $rel_example := .RelatedExamples}}
+                <listitem>
+                    <para>
+                        <xref linkend="{{$svc_prefix}}example_{{$rel_example}}_section"
+                              endterm="example_{{$rel_example}}_section.titleabbrev"/>
+                    </para>
+                </listitem>
+            {{- end}}
+            </itemizedlist>
+        {{- end}}
+    {{- end}}
     <xi:include href="{{$include_docs}}{{.ExampleId}}{{$addSvc}}_tablist.xml"></xi:include>
     {{- if not $is_library}}
     {{- template "note_complete_list"}}

--- a/.doc_gen/templates/zonbook/utility/service_examples.xml
+++ b/.doc_gen/templates/zonbook/utility/service_examples.xml
@@ -49,7 +49,7 @@
             {{- if eq 1 (len .RelatedExamples)}}
                 {{- $codex_text = "code example"}}
             {{- end}}
-            <para>Action examples are code excerpts that are not designed to be run in isolation. You can see this action in
+            <para>Action examples are code excerpts from larger programs and must be run in context. You can see this action in
             context in the following {{$codex_text}}:
             </para>
             <itemizedlist>


### PR DESCRIPTION
* Add related example list to action examples. This is a list of links to scenarios or other examples that demonstrate the action in context instead of in isolation.
* Expand the description of an action to help reduce confusion.
* Fix a miscategorized Java example (uncovered by this update).

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
