### PR TITLE
PAM: Update strategies.ts with missing empty code asset

### DIFF
--- a/resources/cdk/photo_asset_manager/lib/backend/strategies.ts
+++ b/resources/cdk/photo_asset_manager/lib/backend/strategies.ts
@@ -7,7 +7,7 @@ export const EMPTY_LAMBDAS_STRATEGY: PamLambdasStrategy = {
   timeout: Duration.seconds(10),
   memorySize: 128,
   codeAsset() {
-    return Code.fromAsset("");
+    return Code.fromAsset("./missing");
   },
   runtime: Runtime.NODEJS_18_X,
   handlers: {


### PR DESCRIPTION
The empty string causes a recursive expansion in CDK assets until the language code asset has been filled out. This makes the error much more obvious.
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request fixes a confusing error message when first deploying a new language for PAM

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
