### PR TITLE
Added warning about SNS breaking presigned URLs

### DIFF
--- a/applications/photo-asset-manager/DEVELOPMENT.md
+++ b/applications/photo-asset-manager/DEVELOPMENT.md
@@ -9,10 +9,11 @@ per-language AWS Lambda implementations.
 ## Add a new language
 
 To add a new supported implementation language:
+
 1. Create a new project in the appropriate language folder.
 1. Implement the Lambda functions.
 1. Edit [`./lib/backend/strategies.ts`](./cdk/lib/backend/strategies.ts) and add a new `PamLambdaStrategy` for the language.
-(Copy or refer to an existing instance.)
+   (Copy or refer to an existing instance.)
    1. Register this language in the `STRATEGIES` constant.
    1. Update the current languages in the README.
 
@@ -64,11 +65,11 @@ The Python handler specifies the entire module and function to execute.
 
 When implementing Lambda functions, application AWS resources are available in the following environment variables.
 
-| Variable              | Usage                                                         |
-| --------------------- | ------------------------------------------------------------- |
-| `LABELS_TABLE_NAME`   | Name for the Labels Table                                     |
-| `STORAGE_BUCKET_NAME` | Name for the Storage Bucket                                   |
-| `WORKING_BUCKET_NAME` | Name for the Working Bucket                                   |
+| Variable              | Usage                                                                                                                            |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `LABELS_TABLE_NAME`   | Name for the Labels Table                                                                                                        |
+| `STORAGE_BUCKET_NAME` | Name for the Storage Bucket                                                                                                      |
+| `WORKING_BUCKET_NAME` | Name for the Working Bucket                                                                                                      |
 | `NOTIFICATION_TOPIC`  | Amazon Resource Name (ARN) of the Amazon Simple Notification Service (Amazon SNS) topic to send download ready notifications to. |
 
 #### Upload
@@ -102,6 +103,7 @@ When implementing Lambda functions, application AWS resources are available in t
 1. Load all Images from the Labels Table that match the selected labels into a set (no duplicates).
 1. Read those images from the Storage Bucket, and write them to a single zip archive in the Working Bucket.
 1. Send a message to the SNS topic with a link to a presigned GET URL for that zip archive.
+   - WARNING: Presigned URLs are often longer than email client limits, and email clients may insert newlines or spaces for formatting that breaks the URL. This is a known limitation of using SNS, and the Code Examples team are looking for alternatives. However, SNS does not send rich html, and the design goals do not allow for PAM to handle PII directly.
 
 ## Deploy and test
 

--- a/applications/photo-asset-manager/SPECIFICATION.md
+++ b/applications/photo-asset-manager/SPECIFICATION.md
@@ -80,11 +80,11 @@ A GET request is made to `/labels`. The labels are displayed to the user who can
 
 API Gateway provides HTTP API routes for the Lambda integrations `LabelsFn`, `UploadFn`, and `PrepareDownloadFn`. Each endpoint is configured with a an Amazon Cognito authorizer. Parameters for all routes are provided in the body of the request in a JSON object. Each parameter is a top-level item in the request body JSON object.
 
-| Method | Route     | Parameters        | Example response                                            | Lambda            |
-| ------ | --------- | ----------------- | ----------------------------------------------------------- | ----------------- |
-| PUT    | /upload   | file_name: string | {"url": "presigned URL"}                                    | UploadFn          |
-| GET    | /labels   |                   | {"labels": {"maintain": {"count": 5}, "lake": {"count": 3}} | LabelsFn          |
-| POST   | /download | labels: string[]  | {} (event)                                                  | PrepareDownloadFn |
+| Method | Route     | Parameters        | Example response                                             | Lambda            |
+| ------ | --------- | ----------------- | ------------------------------------------------------------ | ----------------- |
+| PUT    | /upload   | file_name: string | {"url": "presigned URL"}                                     | UploadFn          |
+| GET    | /labels   |                   | {"labels": {"maintain": {"count": 5}, "lake": {"count": 3}}} | LabelsFn          |
+| POST   | /download | labels: string[]  | {} (event)                                                   | PrepareDownloadFn |
 
 ### ⭐ Amazon Cognito
 
@@ -161,6 +161,8 @@ This Lambda will be triggered by uploads to the Storage Bucket.
 4. Send an SNS message including this presigned URL.
 
 SNS topics are created using the AWS CDK. The `PrepareDownloadFn` Lambda publishes messages by calling the Amazon SNS service client’s publish().
+
+WARNING: Presigned URLs are often longer than email client limits, and email clients may insert newlines or spaces for formatting that breaks the URL. This is a known limitation of using SNS, and the Code Examples team are looking for alternatives. However, SNS does not send rich html, and the design goals do not allow for PAM to handle PII directly.
 
 # README
 


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request adds warnings about a known flaw in SNS email handling for PAM presigned URL notifications.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
