### PR TITLE
Removed title override for .NET content.

### DIFF
--- a/.doc_gen/metadata/sdks.yaml
+++ b/.doc_gen/metadata/sdks.yaml
@@ -130,9 +130,6 @@ Kotlin:
       api_ref:
         uid: "DotNetSDKV3"
         name: "&guide-net-api;"
-      title_override:
-        title: "Additional code examples for the &NET;"
-        title_abbrev: "Additional code examples"
   guide: "&guide-net-dev;"
 PHP:
   property: php


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request removes the title override that was created a while ago for the .NET developer guide. We are changing our approach to the inclusion of the code examples, and the default name is preferred.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
