### PR TITLE
Javascriptv3: fix Polly Example failure.

### DIFF
--- a/javascriptv3/example_code/polly/general-examples/src/setup.yaml
+++ b/javascriptv3/example_code/polly/general-examples/src/setup.yaml
@@ -36,6 +36,9 @@ Resources:
           - Action: polly:SynthesizeSpeech
             Effect: Allow
             Resource: "*"
+          - Action: polly:StartSpeechSynthesisTask
+            Effect: Allow
+            Resource: "*"
         Version: "2012-10-17"
       PolicyName: CognitoDefaultUnauthenticatedRoleDefaultPolicy2B700C08
       Roles:
@@ -126,4 +129,3 @@ Conditions:
           - Fn::Equals:
               - Ref: AWS::Region
               - us-west-2
-


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request adds a policy that allows "polly:StartSpeechSynthesisTask" to successfully run `polly_synthesize_to_s3.js` example. See issue https://github.com/awsdocs/aws-doc-sdk-examples/issues/4896

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
