### PR TITLE
Require SSL for textract explorer bucket.

### DIFF
--- a/python/cross_service/textract_explorer/setup.yaml
+++ b/python/cross_service/textract_explorer/setup.yaml
@@ -12,6 +12,23 @@ Resources:
         Ref: textractdemobucket1D185E28
       PolicyDocument:
         Statement:
+          - Action: s3:*
+            Condition:
+              Bool:
+                aws:SecureTransport: "false"
+            Effect: Deny
+            Principal:
+              AWS: "*"
+            Resource:
+              - Fn::GetAtt:
+                  - textractdemobucket1D185E28
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - textractdemobucket1D185E28
+                        - Arn
+                    - /*
           - Action:
               - s3:GetObject*
               - s3:GetBucket*

--- a/resources/cdk/textract_example_s3_sns_sqs/package.json
+++ b/resources/cdk/textract_example_s3_sns_sqs/package.json
@@ -11,23 +11,23 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "^1.91.0",
+    "@aws-cdk/assert": "^1.203.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "^1.91.0",
+    "aws-cdk": "^1.203.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-iam": "^1.91.0",
-    "@aws-cdk/core": "^1.91.0",
-    "@aws-cdk/aws-kms": "^1.91.0",
-    "@aws-cdk/aws-s3": "^1.91.0",
-    "@aws-cdk/aws-sns": "^1.91.0",
-    "@aws-cdk/aws-sns-subscriptions": "^1.91.0",
-    "@aws-cdk/aws-sqs": "^1.91.0",
+    "@aws-cdk/aws-iam": "^1.203.0",
+    "@aws-cdk/core": "^1.203.0",
+    "@aws-cdk/aws-kms": "^1.203.0",
+    "@aws-cdk/aws-s3": "^1.203.0",
+    "@aws-cdk/aws-sns": "^1.203.0",
+    "@aws-cdk/aws-sns-subscriptions": "^1.203.0",
+    "@aws-cdk/aws-sqs": "^1.203.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/resources/cdk/textract_example_s3_sns_sqs/setup.ts
+++ b/resources/cdk/textract_example_s3_sns_sqs/setup.ts
@@ -38,6 +38,7 @@ export class SetupStack extends cdk.Stack {
     let textract = new ServicePrincipal('textract.amazonaws.com');
 
     let bucket = new Bucket(this, 'textract-demo-bucket', {
+      enforceSSL: true,
       removalPolicy: cdk.RemovalPolicy.DESTROY
     });
     bucket.grantReadWrite(textract);


### PR DESCRIPTION
Best practice is to require SSL for buckets so that the transport is encrypted.
* Update the underlying CDK script with `enforceSSL: true` for the bucket policy.
* Update the aws-cdk version to one that includes `enforceSSL`.
* Update the CFN setup.yaml for the textract explorer example.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
