### PR TITLE
Java V2 Update RDS/Redshift examples to use AWS Secrets Manager to store database creds

### DIFF
--- a/javav2/example_code/rds/pom.xml
+++ b/javav2/example_code/rds/pom.xml
@@ -52,6 +52,15 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>rdsdata</artifactId>
         </dependency>
         <dependency>

--- a/javav2/example_code/rds/src/main/java/com/example/rds/AuroraScenario.java
+++ b/javav2/example_code/rds/src/main/java/com/example/rds/AuroraScenario.java
@@ -9,6 +9,8 @@
 
 package com.example.rds;
 
+import com.google.gson.Gson;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -47,6 +49,9 @@ import software.amazon.awssdk.services.rds.model.RdsException;
 import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.DescribeOrderableDbInstanceOptionsRequest;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,6 +62,11 @@ import java.util.List;
  * For more information, see the following documentation topic:
  *
  * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ *
+ * This example requires an AWS Secrets Manager secret that contains the database credentials. If you do not create a
+ * secret, this example will not work. For details, see:
+ *
+ * https://docs.aws.amazon.com/secretsmanager/latest/userguide/integrating_how-services-use-secrets_RS.html
  *
  * This Java example performs the following tasks:
  *
@@ -82,10 +92,9 @@ public class AuroraScenario {
     public static long sleepTime = 20;
     public static final String DASHES = new String(new char[80]).replace("\0", "-");
     public static void main(String[] args) throws InterruptedException {
-
         final String usage = "\n" +
             "Usage:\n" +
-            "    <dbClusterGroupName> <dbParameterGroupFamily> <dbInstanceClusterIdentifier> <dbInstanceIdentifier> <dbName> <dbSnapshotIdentifier> <username> <userPassword>" +
+            "    <dbClusterGroupName> <dbParameterGroupFamily> <dbInstanceClusterIdentifier> <dbInstanceIdentifier> <dbName> <dbSnapshotIdentifier><secretName>" +
             "Where:\n" +
             "    dbClusterGroupName - The name of the DB cluster parameter group. \n"+
             "    dbParameterGroupFamily - The DB cluster parameter group family name (for example, aurora-mysql5.7). \n"+
@@ -93,10 +102,9 @@ public class AuroraScenario {
             "    dbInstanceIdentifier - The database instance identifier.\n"+
             "    dbName  The database name.\n"+
             "    dbSnapshotIdentifier - The snapshot identifier.\n"+
-            "    username - The database user name.\n" +
-            "    userPassword - The database user name password.\n" ;
+            "    secretName - The name of the AWS Secrets Manager secret that contains the database credentials\"\n" ;;
 
-        if (args.length != 8) {
+       if (args.length != 7) {
             System.out.println(usage);
             System.exit(1);
         }
@@ -107,8 +115,13 @@ public class AuroraScenario {
         String dbInstanceIdentifier = args[3];
         String dbName = args[4];
         String dbSnapshotIdentifier = args[5];
-        String username = args[6];
-        String userPassword = args[7];
+        String secretName = args[6];
+
+        // Retrieve the database credentials using AWS Secrets Manager.
+        Gson gson = new Gson();
+        User user = gson.fromJson(String.valueOf(getSecretValues(secretName)), User.class);
+        String username = user.getUsername();
+        String userPassword = user.getPassword();
 
         Region region = Region.US_WEST_2;
         RdsClient rdsClient = RdsClient.builder()
@@ -213,6 +226,24 @@ public class AuroraScenario {
         rdsClient.close();
     }
 
+    private static SecretsManagerClient getSecretClient() {
+        Region region = Region.US_WEST_2;
+        return SecretsManagerClient.builder()
+            .region(region)
+            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+            .build();
+    }
+
+    private static String getSecretValues(String secretName) {
+        SecretsManagerClient secretClient = getSecretClient();
+        GetSecretValueRequest valueRequest = GetSecretValueRequest.builder()
+            .secretId(secretName)
+            .build();
+
+        GetSecretValueResponse valueResponse = secretClient.getSecretValue(valueRequest);
+        return valueResponse.secretString();
+    }
+
     // snippet-start:[rds.java2.scenario.cluster.del_paragroup.main]
     public static void deleteDBClusterGroup( RdsClient rdsClient, String dbClusterGroupName, String clusterDBARN) throws InterruptedException {
         try {
@@ -225,7 +256,6 @@ public class AuroraScenario {
                 DescribeDbInstancesResponse response = rdsClient.describeDBInstances();
                 List<DBInstance> instanceList = response.dbInstances();
                 int listSize = instanceList.size();
-                isDataDel = false ;
                 didFind = false;
                 int index = 1;
                 for (DBInstance instance: instanceList) {
@@ -294,7 +324,6 @@ public class AuroraScenario {
     }
     // snippet-end:[rds.java2.scenario.cluster.del.instance.main]
 
-
     // snippet-start:[rds.java2.scenario.cluster.wait.snapshot.main]
     public static void waitForSnapshotReady(RdsClient rdsClient, String dbSnapshotIdentifier, String dbInstanceClusterIdentifier) {
         try {
@@ -353,7 +382,6 @@ public class AuroraScenario {
         boolean instanceReady = false;
         String instanceReadyStr;
         System.out.println("Waiting for instance to become available.");
-
         try {
             DescribeDbInstancesRequest instanceRequest = DescribeDbInstancesRequest.builder()
                 .dbInstanceIdentifier(dbInstanceIdentifier)
@@ -383,13 +411,11 @@ public class AuroraScenario {
     }
     // snippet-end:[rds.java2.scenario.cluster.wait.db.main]
 
-
     // snippet-start:[rds.java2.scenario.cluster.create.instance.main]
     public static String createDBInstanceCluster(RdsClient rdsClient,
                                                  String dbInstanceIdentifier,
                                                  String dbInstanceClusterIdentifier,
                                                  String instanceClass){
-
         try {
             CreateDbInstanceRequest instanceRequest = CreateDbInstanceRequest.builder()
                 .dbInstanceIdentifier(dbInstanceIdentifier)
@@ -442,7 +468,6 @@ public class AuroraScenario {
         boolean instanceReady = false;
         String instanceReadyStr;
         System.out.println("Waiting for instance to become available.");
-
         try {
             DescribeDbClustersRequest instanceRequest = DescribeDbClustersRequest.builder()
                 .dbClusterIdentifier(dbClusterIdentifier)
@@ -469,7 +494,6 @@ public class AuroraScenario {
         }
     }
     // snippet-end:[rds.java2.scenario.cluster.wait.instances.main]
-
 
     // snippet-start:[rds.java2.scenario.cluster.create.main]
     public static String createDBCluster(RdsClient rdsClient, String dbParameterGroupFamily, String dbName, String dbClusterIdentifier, String userName, String password) {

--- a/javav2/example_code/rds/src/main/java/com/example/rds/CreateDBInstance.java
+++ b/javav2/example_code/rds/src/main/java/com/example/rds/CreateDBInstance.java
@@ -10,6 +10,8 @@
 package com.example.rds;
 
 // snippet-start:[rds.java2.create_instance.import]
+import com.google.gson.Gson;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -19,6 +21,10 @@ import software.amazon.awssdk.services.rds.model.CreateDbInstanceResponse;
 import software.amazon.awssdk.services.rds.model.RdsException;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+
 import java.util.List;
 // snippet-end:[rds.java2.create_instance.import]
 
@@ -28,48 +34,70 @@ import java.util.List;
  * For more information, see the following documentation topic:
  *
  * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ *
+ *  This example requires an AWS Secrets Manager secret that contains the database credentials. If you do not create a
+ *  secret, this example will not work. For details, see:
+ *
+ *  https://docs.aws.amazon.com/secretsmanager/latest/userguide/integrating_how-services-use-secrets_RS.html
+ *
+ *
  */
+// snippet-start:[rds.java2.create_instance.main]
 public class CreateDBInstance {
-        public static long sleepTime = 20;
+    public static long sleepTime = 20;
+    public static void main(String[] args) {
+        final String usage = "\n" +
+            "Usage:\n" +
+            "    <dbInstanceIdentifier> <dbName> <secretName>\n\n" +
+            "Where:\n" +
+            "    dbInstanceIdentifier - The database instance identifier. \n" +
+            "    dbName - The database name. \n" +
+            "    secretName - The name of the AWS Secrets Manager secret that contains the database credentials\"\n" ;
 
-        public static void main(String[] args) {
+     //   if (args.length != 4) {
+     //       System.out.println(usage);
+     //       System.exit(1);
+     //   }
 
-            final String usage = "\n" +
-                "Usage:\n" +
-                "    <dbInstanceIdentifier> <dbName> <masterUsername> <masterUserPassword> \n\n" +
-                "Where:\n" +
-                "    dbInstanceIdentifier - The database instance identifier. \n" +
-                "    dbName - The database name. \n" +
-                "    masterUsername - The master user name. \n" +
-                "    masterUserPassword - The password that corresponds to the master user name. \n";
+        String dbInstanceIdentifier = "formit9939433e";  //args[0];
+        String dbName = "formit4883844e";  //args[1];
+        String secretName = "redshift/work" ; //args[0];
+        Gson gson = new Gson();
+        User user = gson.fromJson(String.valueOf(getSecretValues(secretName)), User.class);
+        Region region = Region.US_WEST_2;
+        RdsClient rdsClient = RdsClient.builder()
+            .region(region)
+            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+            .build();
 
-            if (args.length != 4) {
-                System.out.println(usage);
-                System.exit(1);
-            }
+        createDatabaseInstance(rdsClient, dbInstanceIdentifier, dbName, user.getUsername(), user.getPassword()) ;
+        waitForInstanceReady(rdsClient, dbInstanceIdentifier) ;
+        rdsClient.close();
+    }
 
-            String dbInstanceIdentifier = args[0];
-            String dbName = args[1];
-            String masterUsername = args[2];
-            String masterUserPassword = args[3];
+    private static SecretsManagerClient getSecretClient() {
+        Region region = Region.US_WEST_2;
+        return SecretsManagerClient.builder()
+            .region(region)
+            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+            .build();
+    }
 
-            Region region = Region.US_WEST_2;
-            RdsClient rdsClient = RdsClient.builder()
-                .region(region)
-                .credentialsProvider(ProfileCredentialsProvider.create())
-                .build();
+    private static String getSecretValues(String secretName) {
+        SecretsManagerClient secretClient = getSecretClient();
+        GetSecretValueRequest valueRequest = GetSecretValueRequest.builder()
+            .secretId(secretName)
+            .build();
 
-            createDatabaseInstance(rdsClient, dbInstanceIdentifier, dbName, masterUsername, masterUserPassword) ;
-            waitForInstanceReady(rdsClient, dbInstanceIdentifier) ;
-            rdsClient.close();
-        }
+        GetSecretValueResponse valueResponse = secretClient.getSecretValue(valueRequest);
+        return valueResponse.secretString();
+    }
 
-    // snippet-start:[rds.java2.create_instance.main]
     public static void createDatabaseInstance(RdsClient rdsClient,
                                                   String dbInstanceIdentifier,
                                                   String dbName,
-                                                  String masterUsername,
-                                                  String masterUserPassword) {
+                                                  String userName,
+                                                  String userPassword) {
 
         try {
             CreateDbInstanceRequest instanceRequest = CreateDbInstanceRequest.builder()
@@ -78,10 +106,10 @@ public class CreateDBInstance {
                 .dbName(dbName)
                 .engine("mysql")
                 .dbInstanceClass("db.m4.large")
-                .engineVersion("8.0.15")
+                .engineVersion("8.0")
                 .storageType("standard")
-                .masterUsername(masterUsername)
-                .masterUserPassword(masterUserPassword)
+                .masterUsername(userName)
+                .masterUserPassword(userPassword)
                 .build();
 
             CreateDbInstanceResponse response = rdsClient.createDBInstance(instanceRequest);
@@ -93,21 +121,18 @@ public class CreateDBInstance {
         }
     }
 
-    // Waits until the database instance is available
+    // Waits until the database instance is available.
     public static void waitForInstanceReady(RdsClient rdsClient, String dbInstanceIdentifier) {
-
-        Boolean instanceReady = false;
-        String instanceReadyStr = "";
+        boolean instanceReady = false;
+        String instanceReadyStr;
         System.out.println("Waiting for instance to become available.");
-
         try {
             DescribeDbInstancesRequest instanceRequest = DescribeDbInstancesRequest.builder()
                 .dbInstanceIdentifier(dbInstanceIdentifier)
                 .build();
 
-            // Loop until the cluster is ready
+            // Loop until the cluster is ready.
             while (!instanceReady) {
-
                 DescribeDbInstancesResponse response = rdsClient.describeDBInstances(instanceRequest);
                 List<DBInstance> instanceList = response.dbInstances();
                 for (DBInstance instance : instanceList) {

--- a/javav2/example_code/rds/src/main/java/com/example/rds/CreateDBInstance.java
+++ b/javav2/example_code/rds/src/main/java/com/example/rds/CreateDBInstance.java
@@ -54,14 +54,14 @@ public class CreateDBInstance {
             "    dbName - The database name. \n" +
             "    secretName - The name of the AWS Secrets Manager secret that contains the database credentials\"\n" ;
 
-     //   if (args.length != 4) {
-     //       System.out.println(usage);
-     //       System.exit(1);
-     //   }
+        if (args.length != 4) {
+            System.out.println(usage);
+            System.exit(1);
+        }
 
-        String dbInstanceIdentifier = "formit9939433e";  //args[0];
-        String dbName = "formit4883844e";  //args[1];
-        String secretName = "redshift/work" ; //args[0];
+        String dbInstanceIdentifier = args[0];
+        String dbName = args[1];
+        String secretName = args[2];
         Gson gson = new Gson();
         User user = gson.fromJson(String.valueOf(getSecretValues(secretName)), User.class);
         Region region = Region.US_WEST_2;

--- a/javav2/example_code/rds/src/main/java/com/example/rds/RDSScenario.java
+++ b/javav2/example_code/rds/src/main/java/com/example/rds/RDSScenario.java
@@ -99,17 +99,17 @@ public class RDSScenario {
             "    dbSnapshotIdentifier - The snapshot identifier. \n" +
             "    secretName - The name of the AWS Secrets Manager secret that contains the database credentials\"\n" ;
 
-      //  if (args.length != 6) {
-      //      System.out.println(usage);
-      //      System.exit(1);
-      //  }
+        if (args.length != 6) {
+            System.out.println(usage);
+            System.exit(1);
+        }
 
-        String dbGroupName = "tes99tgroup555236w022" ;  //args[0];
-        String dbParameterGroupFamily = "mysql8.0" ; //args[1];
-        String dbInstanceIdentifier = "formit1993ww55" ; //args[2];
-        String dbName = "formit88023" ; //args[3];
-        String dbSnapshotIdentifier =  "formiSnapshot5" ; // args[4];
-        String secretName = "redshift/work" ; //args[5];
+        String dbGroupName = args[0];
+        String dbParameterGroupFamily = args[1];
+        String dbInstanceIdentifier = args[2];
+        String dbName = args[3];
+        String dbSnapshotIdentifier = args[4];
+        String secretName = args[5];
 
         Gson gson = new Gson();
         User user = gson.fromJson(String.valueOf(getSecretValues(secretName)), User.class);

--- a/javav2/example_code/rds/src/main/java/com/example/rds/RDSScenario.java
+++ b/javav2/example_code/rds/src/main/java/com/example/rds/RDSScenario.java
@@ -10,6 +10,8 @@
 package com.example.rds;
 
 // snippet-start:[rds.java2.scenario.import]
+import com.google.gson.Gson;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -43,6 +45,9 @@ import software.amazon.awssdk.services.rds.model.DescribeDbParametersRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbParameterGroupRequest;
 import software.amazon.awssdk.services.rds.model.DescribeOrderableDbInstanceOptionsRequest;
 import software.amazon.awssdk.services.rds.model.DeleteDbParameterGroupRequest;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 import java.util.ArrayList;
 import java.util.List;
 // snippet-end:[rds.java2.scenario.import]
@@ -55,6 +60,11 @@ import java.util.List;
  * For more information, see the following documentation topic:
  *
  * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ *
+ * This example requires an AWS Secrets Manager secret that contains the database credentials. If you do not create a
+ * secret, this example will not work. For details, see:
+ *
+ * https://docs.aws.amazon.com/secretsmanager/latest/userguide/integrating_how-services-use-secrets_RS.html
  *
  * This Java example performs the following tasks:
  *
@@ -78,31 +88,33 @@ public class RDSScenario {
     public static long sleepTime = 20;
     public static final String DASHES = new String(new char[80]).replace("\0", "-");
     public static void main(String[] args) throws InterruptedException {
-
         final String usage = "\n" +
             "Usage:\n" +
-            "    <dbGroupName> <dbParameterGroupFamily> <dbInstanceIdentifier> <dbName> <masterUsername> <masterUserPassword> <dbSnapshotIdentifier>\n\n" +
+            "    <dbGroupName> <dbParameterGroupFamily> <dbInstanceIdentifier> <dbName> <dbSnapshotIdentifier> <secretName>\n\n" +
             "Where:\n" +
             "    dbGroupName - The database group name. \n"+
             "    dbParameterGroupFamily - The database parameter group name (for example, mysql8.0).\n"+
             "    dbInstanceIdentifier - The database instance identifier \n"+
             "    dbName - The database name. \n"+
-            "    masterUsername - The master user name. \n"+
-            "    masterUserPassword - The password that corresponds to the master user name. \n"+
-            "    dbSnapshotIdentifier - The snapshot identifier. \n" ;
+            "    dbSnapshotIdentifier - The snapshot identifier. \n" +
+            "    secretName - The name of the AWS Secrets Manager secret that contains the database credentials\"\n" ;
 
-        if (args.length != 7) {
-            System.out.println(usage);
-            System.exit(1);
-        }
+      //  if (args.length != 6) {
+      //      System.out.println(usage);
+      //      System.exit(1);
+      //  }
 
-        String dbGroupName = args[0];
-        String dbParameterGroupFamily = args[1];
-        String dbInstanceIdentifier = args[2];
-        String dbName = args[3];
-        String masterUsername = args[4];
-        String masterUserPassword = args[5];
-        String dbSnapshotIdentifier = args[6];
+        String dbGroupName = "tes99tgroup555236w022" ;  //args[0];
+        String dbParameterGroupFamily = "mysql8.0" ; //args[1];
+        String dbInstanceIdentifier = "formit1993ww55" ; //args[2];
+        String dbName = "formit88023" ; //args[3];
+        String dbSnapshotIdentifier =  "formiSnapshot5" ; // args[4];
+        String secretName = "redshift/work" ; //args[5];
+
+        Gson gson = new Gson();
+        User user = gson.fromJson(String.valueOf(getSecretValues(secretName)), User.class);
+        String masterUsername = user.getUsername();
+        String masterUserPassword = user.getPassword();
 
         Region region = Region.US_WEST_2;
         RdsClient rdsClient = RdsClient.builder()
@@ -191,6 +203,24 @@ public class RDSScenario {
         rdsClient.close();
     }
 
+    private static SecretsManagerClient getSecretClient() {
+        Region region = Region.US_WEST_2;
+        return SecretsManagerClient.builder()
+            .region(region)
+            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+            .build();
+    }
+
+    public static String getSecretValues(String secretName) {
+        SecretsManagerClient secretClient = getSecretClient();
+        GetSecretValueRequest valueRequest = GetSecretValueRequest.builder()
+            .secretId(secretName)
+            .build();
+
+        GetSecretValueResponse valueResponse = secretClient.getSecretValue(valueRequest);
+        return valueResponse.secretString();
+    }
+
     // snippet-start:[rds.java2.scenario.del_paragroup.main]
     // Delete the parameter group after database has been deleted.
     // An exception is thrown if you attempt to delete the para group while database exists.
@@ -205,7 +235,6 @@ public class RDSScenario {
                 DescribeDbInstancesResponse response = rdsClient.describeDBInstances();
                 List<DBInstance> instanceList = response.dbInstances();
                 int listSize = instanceList.size();
-                isDataDel = false ;
                 didFind = false;
                 int index = 1;
                 for (DBInstance instance: instanceList) {
@@ -318,7 +347,6 @@ public class RDSScenario {
         boolean instanceReady = false;
         String instanceReadyStr;
         System.out.println("Waiting for instance to become available.");
-
         try {
             DescribeDbInstancesRequest instanceRequest = DescribeDbInstancesRequest.builder()
                 .dbInstanceIdentifier(dbInstanceIdentifier)

--- a/javav2/example_code/rds/src/main/java/com/example/rds/User.java
+++ b/javav2/example_code/rds/src/main/java/com/example/rds/User.java
@@ -1,0 +1,24 @@
+package com.example.rds;
+
+public class User {
+
+    private String username;
+    private String  password;
+
+    private String host;
+
+
+    //getter
+    public String getUsername(){
+        return this.username;
+    }
+
+    public String getPassword(){
+        return this.password;
+    }
+
+    String getHost(){
+        return this.host;
+    }
+
+}

--- a/javav2/example_code/rds/src/main/resources/config.properties
+++ b/javav2/example_code/rds/src/main/resources/config.properties
@@ -1,13 +1,14 @@
-dbInstanceIdentifier = <enter dbInstanceIdentifier value>
-dbSnapshotIdentifier = <enter dbSnapshotIdentifier value>
-dbName = <enter dbName value>
-masterUsername = <enter masterUsername value>
-masterUserPassword = <enter masterUserPassword value>
-newMasterUserPassword = <enter newMasterUserPassword value>
-dbGroupNameSc = <enter value>
-dbParameterGroupFamilySc =<enter value>
-dbInstanceIdentifierSc = <enter value>
-dbNameSc = <enter value>
-masterUsernameSc = <enter value>
-masterUserPasswordSc = <enter value>
-dbSnapshotIdentifierSc = <enter value>
+dbInstanceIdentifier = formit9939433
+dbSnapshotIdentifier = formit889936Snapshot
+dbName = formit4883844
+masterUsername = root
+masterUserPassword = root4321
+newMasterUserPassword = root1234
+dbGroupNameSc = tes99tgroup555236w022
+dbParameterGroupFamilySc = mysql8.0
+dbInstanceIdentifierSc = formit1993ww55
+dbNameSc = formit88023
+secretName = "redshift/work"
+dbSnapshotIdentifierSc = formiSnapshot5
+
+

--- a/javav2/example_code/rds/src/test/java/AmazonRDSTest.java
+++ b/javav2/example_code/rds/src/test/java/AmazonRDSTest.java
@@ -3,47 +3,80 @@
    SPDX-License-Identifier: Apache-2.0
 */
 import com.example.rds.*;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import com.google.gson.Gson;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.services.rds.RdsClient;
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 import java.io.*;
 import java.util.*;
+
+/**
+ * To run these Amazon Simple Notification Service integration tests, you need to either set the required values
+ * (for example, topicName) in the config.properties file or AWS Secret Manager.
+ */
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class AmazonRDSTest {
 
     private static  RdsClient rdsClient ;
-    private static Region region;
+
     private static String dbInstanceIdentifier = "" ;
     private static String dbSnapshotIdentifier = "" ;
     private static String dbName = "" ;
-    private static String masterUsername = "" ;
-    private static String masterUserPassword = "" ;
+
     private static String newMasterUserPassword = "" ;
 
     // Set data members required for the Scenario test.
     private static String  dbGroupNameSc = "" ;
     private static String  dbParameterGroupFamilySc = "" ;
-    private static String  dbInstanceIdentifierSc = "" ;
-    private static String  masterUsernameSc = "" ;
-    private static String  masterUserPasswordSc = "" ;
+    private  static String  dbInstanceIdentifierSc = "" ;
+    private static String secretDBName = "" ;
     private static String  dbSnapshotIdentifierSc = "" ;
     private static String  dbNameSc = "" ;
 
+    private static String dbClusterGroupName;
+
+    private static String dbParameterGroupFamily;
+
+    private static String dbInstanceClusterIdentifier;
+
     @BeforeAll
     public static void setUp() throws IOException {
-        region = Region.US_WEST_2;
         rdsClient = RdsClient.builder()
-            .region(region)
-            .credentialsProvider(ProfileCredentialsProvider.create())
+            .region(Region.US_WEST_2)
+            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
             .build();
 
+        Random rand = new Random();
+        int randomNum = rand.nextInt((10000 - 1) + 1) + 1;
+
+        // Get the values to run these tests from AWS Secrets Manager.
+        Gson gson = new Gson();
+        String json = getSecretValues();
+        SecretValues values = gson.fromJson(json, SecretValues.class);
+        dbInstanceIdentifier = values.getDbInstanceIdentifier()+ java.util.UUID.randomUUID();
+        dbSnapshotIdentifier = values.getDbSnapshotIdentifier()+ java.util.UUID.randomUUID();
+        dbName = values.getDbName()+ randomNum;
+        newMasterUserPassword = values.getNewMasterUserPassword();
+        dbGroupNameSc = values.getDbGroupNameSc()+ java.util.UUID.randomUUID();
+        dbParameterGroupFamilySc = values.getDbParameterGroupFamilySc();
+        dbInstanceIdentifierSc = values.getDbInstanceIdentifierSc()+ java.util.UUID.randomUUID();
+        dbSnapshotIdentifierSc = values.getDbSnapshotIdentifierSc()+ java.util.UUID.randomUUID();
+        dbNameSc = values.getDbNameSc()+ randomNum ;
+        dbClusterGroupName = values.getDbClusterGroupName()+randomNum;
+        dbParameterGroupFamily = values.getDbParameterGroupFamily();
+        dbInstanceClusterIdentifier = values.getDbInstanceClusterIdentifier();
+        secretDBName = values.getSecretName();
+
+        // Uncomment this code block if you prefer using a config.properties file to retrieve AWS values required for these tests.
+       /*
         try (InputStream input = AmazonRDSTest.class.getClassLoader().getResourceAsStream("config.properties")) {
             Properties prop = new Properties();
             if (input == null) {
@@ -52,84 +85,89 @@ public class AmazonRDSTest {
             }
 
             prop.load(input);
-            dbInstanceIdentifier = prop.getProperty("dbInstanceIdentifier");
-            dbSnapshotIdentifier = prop.getProperty("dbSnapshotIdentifier");
-            dbName = prop.getProperty("dbName");
+            dbInstanceIdentifier = prop.getProperty("dbInstanceIdentifier")+ java.util.UUID.randomUUID();
+            dbSnapshotIdentifier = prop.getProperty("dbSnapshotIdentifier")+ java.util.UUID.randomUUID();
+            dbName = prop.getProperty("dbName")+ randomNum;
             masterUsername = prop.getProperty("masterUsername");
             masterUserPassword = prop.getProperty("masterUserPassword");
             newMasterUserPassword = prop.getProperty("newMasterUserPassword");
-            dbGroupNameSc = prop.getProperty("dbGroupNameSc");
+            dbGroupNameSc = prop.getProperty("dbGroupNameSc")+ java.util.UUID.randomUUID();;
             dbParameterGroupFamilySc = prop.getProperty("dbParameterGroupFamilySc");
-            dbInstanceIdentifierSc = prop.getProperty("dbInstanceIdentifierSc");
+            dbInstanceIdentifierSc = prop.getProperty("dbInstanceIdentifierSc")+ java.util.UUID.randomUUID();;
             masterUsernameSc = prop.getProperty("masterUsernameSc");
             masterUserPasswordSc = prop.getProperty("masterUserPasswordSc");
-            dbSnapshotIdentifierSc = prop.getProperty("dbSnapshotIdentifierSc");
-            dbNameSc = prop.getProperty("dbNameSc");
+            dbSnapshotIdentifierSc = prop.getProperty("dbSnapshotIdentifierSc")+ java.util.UUID.randomUUID();;
+            dbNameSc = prop.getProperty("dbNameSc")+ randomNum ;
 
         } catch (IOException ex) {
             ex.printStackTrace();
         }
+        */
     }
 
     @Test
+    @Tag("IntegrationTest")
     @Order(1)
-    public void whenInitializingAWSRdsService_thenNotNull() {
-        assertNotNull(rdsClient);
-        System.out.println("Test 1 passed");
-    }
-
-    @Test
-    @Order(2)
     public void CreateDBInstance() {
-        assertDoesNotThrow(() ->CreateDBInstance.createDatabaseInstance(rdsClient, dbInstanceIdentifier, dbName, masterUsername, masterUserPassword));
-        System.out.println("Test 2 passed");
+        Gson gson = new Gson();
+        User user = gson.fromJson(String.valueOf(RDSScenario.getSecretValues(secretDBName)), User.class);
+        assertDoesNotThrow(() ->CreateDBInstance.createDatabaseInstance(rdsClient, dbInstanceIdentifier, dbName, user.getUsername(), user.getPassword()));
+        System.out.println("CreateDBInstance test passed");
     }
 
     @Test
-    @Order(3)
+    @Tag("IntegrationTest")
+    @Order(2)
     public void waitForInstanceReady() {
         assertDoesNotThrow(() ->CreateDBInstance.waitForInstanceReady(rdsClient, dbInstanceIdentifier));
-        System.out.println("Test 3 passed");
+        System.out.println("waitForInstanceReady test passed");
     }
 
     @Test
-    @Order(4)
+    @Tag("IntegrationTest")
+    @Order(3)
     public void DescribeAccountAttributes() {
         assertDoesNotThrow(() ->DescribeAccountAttributes.getAccountAttributes(rdsClient));
-        System.out.println("Test 4 passed");
+        System.out.println("DescribeAccountAttributes test passed");
     }
 
     @Test
-    @Order(5)
+    @Tag("IntegrationTest")
+    @Order(4)
     public void DescribeDBInstances() {
         assertDoesNotThrow(() ->DescribeDBInstances.describeInstances(rdsClient));
-        System.out.println("Test 5 passed");
+        System.out.println("DescribeDBInstances test passed");
+    }
+
+    @Test
+    @Tag("IntegrationTest")
+    @Order(5)
+    public void ModifyDBInstance() {
+        assertDoesNotThrow(() ->ModifyDBInstance.updateIntance(rdsClient, dbInstanceIdentifier, newMasterUserPassword));
+        System.out.println("ModifyDBInstance test passed");
     }
 
     @Test
     @Order(6)
-    public void ModifyDBInstance() {
-        assertDoesNotThrow(() ->ModifyDBInstance.updateIntance(rdsClient, dbInstanceIdentifier, newMasterUserPassword));
-        System.out.println("Test 6 passed");
-    }
-
-    @Test
-    @Order(7)
     public void CreateDBSnapshot() {
         assertDoesNotThrow(() ->CreateDBSnapshot.createSnapshot(rdsClient, dbInstanceIdentifier, dbSnapshotIdentifier));
-        System.out.println("Test 7 passed");
+        System.out.println("CreateDBSnapshot test passed");
     }
 
     @Test
-    @Order(8)
+    @Tag("IntegrationTest")
+    @Order(7)
     public void DeleteDBInstance() {
         assertDoesNotThrow(() ->DeleteDBInstance.deleteDatabaseInstance(rdsClient, dbInstanceIdentifier));
-        System.out.println("Test 8 passed");
+        System.out.println("DeleteDBInstance test passed");
     }
 
     @Test
-    @Order(9)
+    @Tag("IntegrationTest")
+    @Order(8)
     public void TestRDSScenario() throws InterruptedException {
+        Gson gson = new Gson();
+        User user = gson.fromJson(String.valueOf(RDSScenario.getSecretValues(secretDBName)), User.class);
         assertDoesNotThrow(() ->RDSScenario.describeDBEngines(rdsClient));
         assertDoesNotThrow(() ->RDSScenario.createDBParameterGroup(rdsClient, dbGroupNameSc, dbParameterGroupFamilySc));
         assertDoesNotThrow(() ->RDSScenario.describeDbParameterGroups(rdsClient, dbGroupNameSc));
@@ -138,16 +176,185 @@ public class AmazonRDSTest {
         assertDoesNotThrow(() ->RDSScenario.describeDbParameters(rdsClient, dbGroupNameSc, -1));
         assertDoesNotThrow(() ->RDSScenario.getAllowedEngines(rdsClient, dbParameterGroupFamilySc));
         assertDoesNotThrow(() ->RDSScenario.getMicroInstances(rdsClient));
-        String dbARN = RDSScenario.createDatabaseInstance(rdsClient, dbGroupNameSc, dbInstanceIdentifierSc, dbNameSc, masterUsernameSc, masterUserPasswordSc);
+        String dbARN = RDSScenario.createDatabaseInstance(rdsClient, dbGroupNameSc, dbInstanceIdentifierSc, dbNameSc, user.getUsername(), user.getPassword());
         assertFalse(dbARN.isEmpty());
         assertDoesNotThrow(() ->RDSScenario.waitForInstanceReady(rdsClient, dbInstanceIdentifierSc));
         assertDoesNotThrow(() ->RDSScenario.createSnapshot(rdsClient, dbInstanceIdentifierSc, dbSnapshotIdentifierSc));
         assertDoesNotThrow(() ->RDSScenario.waitForSnapshotReady(rdsClient, dbInstanceIdentifierSc, dbSnapshotIdentifierSc));
         assertDoesNotThrow(() ->RDSScenario.deleteDatabaseInstance(rdsClient, dbInstanceIdentifierSc));
         assertDoesNotThrow(() ->RDSScenario.deleteParaGroup(rdsClient, dbGroupNameSc, dbARN));
-        System.out.println("Test 9 passed");
+        System.out.println("TestRDSScenario test passed");
+    }
+
+    @Test
+    @Tag("IntegrationTest")
+    @Order(9)
+    public void TestAuroraScenario() throws InterruptedException {
+        Gson gson = new Gson();
+        User user = gson.fromJson(String.valueOf(RDSScenario.getSecretValues(secretDBName)), User.class);
+        System.out.println("1. Return a list of the available DB engines");
+        assertDoesNotThrow(() ->AuroraScenario.describeDBEngines(rdsClient));
+        System.out.println("2. Create a custom parameter group");
+        assertDoesNotThrow(() ->AuroraScenario.createDBClusterParameterGroup(rdsClient, dbClusterGroupName, dbParameterGroupFamily));
+        System.out.println("3. Get the parameter group");
+        assertDoesNotThrow(() ->AuroraScenario.describeDbClusterParameterGroups(rdsClient, dbClusterGroupName));
+        System.out.println("4. Get the parameters in the group");
+        assertDoesNotThrow(() ->AuroraScenario.describeDbClusterParameters(rdsClient, dbClusterGroupName, 0));
+        System.out.println("5. Modify the auto_increment_offset parameter");
+        assertDoesNotThrow(() ->AuroraScenario.modifyDBClusterParas(rdsClient, dbClusterGroupName));
+        System.out.println("6. Display the updated parameter value");
+        assertDoesNotThrow(() -> AuroraScenario.describeDbClusterParameters(rdsClient, dbClusterGroupName, -1));
+        System.out.println("7. Get a list of allowed engine versions");
+        assertDoesNotThrow(() ->AuroraScenario.getAllowedEngines(rdsClient, dbParameterGroupFamily));
+        System.out.println("8. Create an Aurora DB cluster database");
+        String arnClusterVal = AuroraScenario.createDBCluster(rdsClient, dbClusterGroupName, dbName, dbInstanceClusterIdentifier, user.getUsername(), user.getPassword()) ;
+        System.out.println("The ARN of the cluster is "+arnClusterVal);
+        System.out.println("9. Wait for DB instance to be ready" );
+        assertDoesNotThrow(() ->AuroraScenario.waitForInstanceReady(rdsClient, dbInstanceClusterIdentifier));
+        System.out.println("10. Get a list of instance classes available for the selected engine");
+        String instanceClass = AuroraScenario.getListInstanceClasses(rdsClient);
+        System.out.println("11. Create a database instance in the cluster.");
+        String clusterDBARN = AuroraScenario.createDBInstanceCluster(rdsClient, dbInstanceIdentifier, dbInstanceClusterIdentifier, instanceClass);
+        System.out.println("The ARN of the database is "+clusterDBARN);
+        System.out.println("12. Wait for DB instance to be ready" );
+        assertDoesNotThrow(() ->AuroraScenario.waitDBInstanceReady(rdsClient, dbInstanceIdentifier));
+        System.out.println("13. Create a snapshot");
+        assertDoesNotThrow(() ->AuroraScenario.createDBClusterSnapshot(rdsClient, dbInstanceClusterIdentifier, dbSnapshotIdentifier));
+        System.out.println("14. Wait for DB snapshot to be ready" );
+        assertDoesNotThrow(() ->AuroraScenario.waitForSnapshotReady(rdsClient, dbSnapshotIdentifier, dbInstanceClusterIdentifier));
+        System.out.println("14. Delete the DB instance" );
+        assertDoesNotThrow(() ->AuroraScenario.deleteDatabaseInstance(rdsClient, dbInstanceIdentifier));
+        System.out.println("15. Delete the DB cluster");
+        assertDoesNotThrow(() -> AuroraScenario.deleteCluster(rdsClient, dbInstanceClusterIdentifier));
+        System.out.println("16. Delete the DB cluster group");
+        assertDoesNotThrow(() -> AuroraScenario.deleteDBClusterGroup(rdsClient, dbClusterGroupName, clusterDBARN));
+        System.out.println("TestAuroraScenario test passed");
+    }
+
+    public static String getSecretValues() {
+        // Get the Amazon RDS creds from Secrets Manager.
+        SecretsManagerClient secretClient = SecretsManagerClient.builder()
+            .region(Region.US_EAST_1)
+            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+            .build();
+        String secretName = "test/rds";
+
+        GetSecretValueRequest valueRequest = GetSecretValueRequest.builder()
+            .secretId(secretName)
+            .build();
+
+        GetSecretValueResponse valueResponse = secretClient.getSecretValue(valueRequest);
+        return valueResponse.secretString();
+    }
+
+    @Nested
+    @DisplayName("A class used to get test values from test/rds (an AWS Secrets Manager secret)")
+    class SecretValues {
+        private String dbInstanceIdentifier;
+        private String dbSnapshotIdentifier;
+        private String dbName;
+
+        private String masterUsername;
+
+        private String masterUserPassword;
+
+        private String newMasterUserPassword;
+
+        private String dbGroupNameSc;
+
+        private String dbParameterGroupFamilySc;
+
+        private String dbInstanceIdentifierSc;
+
+        private String dbNameSc;
+
+        private String masterUsernameSc;
+
+        private String masterUserPasswordSc;
+
+        private String dbSnapshotIdentifierSc;
+
+        private String dbClusterGroupName;
+
+        private String dbParameterGroupFamily;
+
+        private String dbInstanceClusterIdentifier;
+
+        private String secretName;
+
+
+        public String getSecretName() {
+            return secretName;
+        }
+        public String getDbInstanceClusterIdentifier() {
+            return dbInstanceClusterIdentifier;
+        }
+
+        public String getDbParameterGroupFamily() {
+            return dbParameterGroupFamily;
+        }
+
+        public String getDbClusterGroupName() {
+            return dbClusterGroupName;
+        }
+
+        public String getDbInstanceIdentifier() {
+            return dbInstanceIdentifier;
+        }
+
+        public String getDbSnapshotIdentifier() {
+            return dbSnapshotIdentifier;
+        }
+
+        public String getDbName() {
+            return dbName;
+        }
+
+        public String getMasterUsername() {
+            return masterUsername;
+        }
+
+        public String getMasterUserPassword() {
+            return masterUserPassword;
+        }
+
+        public String getNewMasterUserPassword() {
+            return newMasterUserPassword;
+        }
+
+        public String getDbGroupNameSc() {
+            return dbGroupNameSc;
+        }
+
+        public String getDbParameterGroupFamilySc() {
+            return dbParameterGroupFamilySc;
+        }
+
+        public String getDbInstanceIdentifierSc() {
+            return dbInstanceIdentifierSc;
+        }
+
+        public String getDbNameSc() {
+            return dbNameSc;
+        }
+
+        public String getMasterUsernameSc() {
+            return masterUsernameSc;
+        }
+
+        public String getMasterUserPasswordSc() {
+            return masterUserPasswordSc;
+        }
+
+        public String getDbSnapshotIdentifierSc() {
+            return dbSnapshotIdentifierSc;
+        }
+
+
+
     }
 }
+
 
 
 

--- a/javav2/example_code/redshift/pom.xml
+++ b/javav2/example_code/redshift/pom.xml
@@ -31,6 +31,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
+                <configuration>
+                    <groups>IntegrationTest</groups>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -57,6 +60,15 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.9.2</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>

--- a/javav2/example_code/redshift/src/main/java/com/example/redshift/ConnectToCluster.java
+++ b/javav2/example_code/redshift/src/main/java/com/example/redshift/ConnectToCluster.java
@@ -52,13 +52,13 @@ public class ConnectToCluster {
             "Where:\n" +
             "    secretName - The name of the AWS Secrets Manager secret that contains the database credentials" ;
 
-     //   if (args.length != 1) {
-     //       System.out.println(usage);
-     //       System.exit(1);
-     //  }
+        if (args.length != 1) {
+            System.out.println(usage);
+            System.exit(1);
+       }
 
         // Get the Amazon RDS credentials from AWS Secrets Manager.
-        String secretName = "redshift/work" ; //args[0];
+        String secretName = args[0];
         Gson gson = new Gson();
         User user = gson.fromJson(String.valueOf(getSecretValues(secretName)), User.class);
         connectCluster(user) ;

--- a/javav2/example_code/redshift/src/main/java/com/example/redshift/ConnectToCluster.java
+++ b/javav2/example_code/redshift/src/main/java/com/example/redshift/ConnectToCluster.java
@@ -52,13 +52,13 @@ public class ConnectToCluster {
             "Where:\n" +
             "    secretName - The name of the AWS Secrets Manager secret that contains the database credentials" ;
 
-        if (args.length != 1) {
-            System.out.println(usage);
-            System.exit(1);
-       }
+     //   if (args.length != 1) {
+     //       System.out.println(usage);
+     //       System.exit(1);
+     //  }
 
         // Get the Amazon RDS credentials from AWS Secrets Manager.
-        String secretName = args[0];
+        String secretName = "redshift/work" ; //args[0];
         Gson gson = new Gson();
         User user = gson.fromJson(String.valueOf(getSecretValues(secretName)), User.class);
         connectCluster(user) ;

--- a/javav2/example_code/redshift/src/main/java/com/example/redshift/CreateAndModifyCluster.java
+++ b/javav2/example_code/redshift/src/main/java/com/example/redshift/CreateAndModifyCluster.java
@@ -60,8 +60,8 @@ public class CreateAndModifyCluster {
             System.exit(1);
         }
 
-        String clusterId = "redshift-cluster-1070" ; //args[0];
-        String secretName = "redshift/work" ; //args[0];
+        String clusterId = args[0];
+        String secretName = args[1];
         Gson gson = new Gson();
         User user = gson.fromJson(String.valueOf(getSecretValues(secretName)), User.class);
         Region region = Region.US_WEST_2;

--- a/javav2/example_code/redshift/src/main/java/com/example/redshift/CreateAndModifyCluster.java
+++ b/javav2/example_code/redshift/src/main/java/com/example/redshift/CreateAndModifyCluster.java
@@ -9,6 +9,8 @@
 package com.example.redshift;
 
 // snippet-start:[redshift.java2.create_cluster.import]
+import com.google.gson.Gson;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.redshift.RedshiftClient;
@@ -20,6 +22,10 @@ import software.amazon.awssdk.services.redshift.model.DescribeClustersResponse;
 import software.amazon.awssdk.services.redshift.model.Cluster;
 import software.amazon.awssdk.services.redshift.model.ModifyClusterResponse;
 import software.amazon.awssdk.services.redshift.model.ModifyClusterRequest;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+
 import java.util.List;
 // snippet-end:[redshift.java2.create_cluster.import]
 
@@ -29,6 +35,11 @@ import java.util.List;
  * For more information, see the following documentation topic:
  *
  * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ *
+ * This example requires an AWS Secrets Manager secret that contains the database credentials. If you do not create a
+ * secret, this example will not work. For details, see:
+ *
+ * https://docs.aws.amazon.com/secretsmanager/latest/userguide/integrating_how-services-use-secrets_RS.html
  */
 
 public class CreateAndModifyCluster {
@@ -42,39 +53,54 @@ public class CreateAndModifyCluster {
             "    <clusterId> <masterUsername> <masterUserPassword> \n\n" +
             "Where:\n" +
             "    clusterId - The id of the cluster to create. \n" +
-            "    masterUsername - The master user name. \n" +
-            "    masterUserPassword - The password that corresponds to the master user name. \n" ;
+            "    secretName - The name of the AWS Secrets Manager secret that contains the database credentials" ;
 
         if (args.length != 3) {
             System.out.println(usage);
             System.exit(1);
         }
 
-        String clusterId = args[0];
-        String masterUsername = args[1];
-        String masterUserPassword = args[2];
-
+        String clusterId = "redshift-cluster-1070" ; //args[0];
+        String secretName = "redshift/work" ; //args[0];
+        Gson gson = new Gson();
+        User user = gson.fromJson(String.valueOf(getSecretValues(secretName)), User.class);
         Region region = Region.US_WEST_2;
         RedshiftClient redshiftClient = RedshiftClient.builder()
             .region(region)
             .credentialsProvider(ProfileCredentialsProvider.create())
             .build();
 
-        createCluster(redshiftClient,clusterId, masterUsername, masterUserPassword );
+        createCluster(redshiftClient,clusterId, user.getMasterUsername(), user.getMasterUserPassword() );
         waitForClusterReady(redshiftClient, clusterId);
         modifyCluster(redshiftClient, clusterId);
         redshiftClient.close();
     }
 
+    public static String getSecretValues(String secretName) {
+        SecretsManagerClient secretClient = getSecretClient();
+        GetSecretValueRequest valueRequest = GetSecretValueRequest.builder()
+            .secretId(secretName)
+            .build();
+
+        GetSecretValueResponse valueResponse = secretClient.getSecretValue(valueRequest);
+        return valueResponse.secretString();
+    }
+    private static SecretsManagerClient getSecretClient() {
+        Region region = Region.US_WEST_2;
+        return SecretsManagerClient.builder()
+            .region(region)
+            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+            .build();
+    }
+
     // snippet-start:[redshift.java2.create_cluster.main]
     public static void createCluster(RedshiftClient redshiftClient, String clusterId, String masterUsername, String masterUserPassword ) {
-
         try {
             CreateClusterRequest clusterRequest = CreateClusterRequest.builder()
                 .clusterIdentifier(clusterId)
                 .masterUsername(masterUsername) // set the user name here
                 .masterUserPassword(masterUserPassword) // set the user password here
-                .nodeType("ds2.xlarge")
+                .nodeType("dc2.large")
                 .publiclyAccessible(true)
                 .numberOfNodes(2)
                 .build();

--- a/javav2/example_code/redshift/src/main/java/com/example/redshift/User.java
+++ b/javav2/example_code/redshift/src/main/java/com/example/redshift/User.java
@@ -1,0 +1,35 @@
+package com.example.redshift;
+
+public class User {
+
+    private String username;
+    private String  password;
+
+    private String masterUsername;
+
+    private String masterUserPassword;
+
+    private String host;
+
+
+    //getter
+    String getUsername(){
+        return this.username;
+    }
+
+    String getPassword(){
+        return this.password;
+    }
+
+    String getHost(){
+        return this.host;
+    }
+
+    public String getMasterUsername(){
+        return this.masterUsername;
+    }
+
+    public String getMasterUserPassword(){
+        return this.masterUserPassword;
+    }
+}

--- a/javav2/example_code/redshift/src/main/java/com/example/redshiftdata/ListDatabases.java
+++ b/javav2/example_code/redshift/src/main/java/com/example/redshiftdata/ListDatabases.java
@@ -8,6 +8,7 @@
 
 package com.example.redshiftdata;
 
+// snippet-start:[redshift.java2.data_list.import]
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.redshiftdata.model.ListDatabasesRequest;
@@ -18,6 +19,7 @@ import software.amazon.awssdk.services.redshiftdata.model.ListTablesResponse;
 import software.amazon.awssdk.services.redshiftdata.model.RedshiftDataException;
 import software.amazon.awssdk.services.redshiftdata.model.TableMember;
 import java.util.List;
+// snippet-end:[redshift.java2.data_list.import]
 
 
  /**
@@ -27,6 +29,7 @@ import java.util.List;
   *
   * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
   */
+ // snippet-start:[redshift.java2.data_list.main]
 public class ListDatabases {
 
     public static void main(String[] args) {
@@ -100,3 +103,4 @@ public class ListDatabases {
         }
     }
 }
+ // snippet-end:[redshift.java2.data_list.main]

--- a/javav2/example_code/redshift/src/main/java/com/example/redshiftdata/RetrieveData.java
+++ b/javav2/example_code/redshift/src/main/java/com/example/redshiftdata/RetrieveData.java
@@ -9,6 +9,7 @@
 
 package com.example.redshiftdata;
 
+// snippet-start:[redshift.java2.get_data.import]
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementResponse;
@@ -21,6 +22,7 @@ import software.amazon.awssdk.services.redshiftdata.model.RedshiftDataException;
 import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient;
 import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementRequest;
 import java.util.List;
+// snippet-end:[redshift.java2.get_data.import]
 
 
 /**
@@ -30,6 +32,7 @@ import java.util.List;
  *
  * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
  */
+// snippet-start:[redshift.java2.get_data.main]
 public class RetrieveData {
 
     public static void main(String[] args) {
@@ -145,3 +148,4 @@ public class RetrieveData {
         }
     }
 }
+// snippet-end:[redshift.java2.get_data.main]

--- a/javav2/example_code/redshift/src/main/resources/config.properties
+++ b/javav2/example_code/redshift/src/main/resources/config.properties
@@ -1,4 +1,3 @@
-clusterId = <enter a cluster id value>
-masterUsername = <enter a master user name>
-masterUserPassword = <enter corresponding password value>
+clusterId = redshift-cluster-1070
+secretName = redshift/work
 eventSourceType = cluster

--- a/javav2/example_code/redshift/src/test/java/AmazonRedshiftTest.java
+++ b/javav2/example_code/redshift/src/test/java/AmazonRedshiftTest.java
@@ -1,33 +1,50 @@
 import com.example.redshift.*;
+import com.google.gson.Gson;
 import org.junit.jupiter.api.*;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.redshift.RedshiftClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
+/**
+ * To run these Amazon Simple Notification Service integration tests, you need to either set the required values
+ * (for example, topicName) in the config.properties file or AWS Secret Manager.
+ */
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class AmazonRedshiftTest {
-
     private static RedshiftClient redshiftClient;
-    private static Region region;
     private static String clusterId = "";
-    private static String masterUsername = "";
-    private static String masterUserPassword = "";
+    private static String secretName = "";
     private static String eventSourceType = "";
 
     @BeforeAll
     public static void setUp() throws IOException {
-
-        // Run tests on Real AWS Resources
-        region = Region.US_WEST_2;
         redshiftClient = RedshiftClient.builder()
-                .region(region)
-                .credentialsProvider(ProfileCredentialsProvider.create())
-                .build();
-        try (InputStream input = AmazonRedshiftTest.class.getClassLoader().getResourceAsStream("config.properties")) {
+            .region(Region.US_EAST_1)
+            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+            .build();
 
+        Random rand = new Random();
+        int randomNum = rand.nextInt((10000 - 1) + 1) + 1;
+
+        // Get the values to run these tests from AWS Secrets Manager.
+        Gson gson = new Gson();
+        String json = getSecretValues();
+        SecretValues values = gson.fromJson(json, SecretValues.class);
+        clusterId = values.getClusterId() +randomNum;
+        secretName = values.getSecretName();
+        eventSourceType = values.getEventSourceType();
+
+        // Uncomment this code block if you prefer using a config.properties file to retrieve AWS values required for these tests.
+       /*
+        try (InputStream input = AmazonRedshiftTest.class.getClassLoader().getResourceAsStream("config.properties")) {
             Properties prop = new Properties();
 
             if (input == null) {
@@ -35,11 +52,9 @@ public class AmazonRedshiftTest {
                 return;
             }
 
-            //load a properties file from class path, inside static method
+            // Populate the data members required for all tests.
             prop.load(input);
-
-            // Populate the data members required for all tests
-            clusterId = prop.getProperty("clusterId");
+            clusterId = prop.getProperty("clusterId")+randomNum;
             masterUsername = prop.getProperty("masterUsername");
             masterUserPassword = prop.getProperty("masterUserPassword");
             eventSourceType = prop.getProperty("eventSourceType");
@@ -47,68 +62,102 @@ public class AmazonRedshiftTest {
         } catch (IOException ex) {
             ex.printStackTrace();
         }
+        */
     }
-
     @Test
+    @Tag("IntegrationTest")
     @Order(1)
-    public void whenInitializingAWSRedshiftService_thenNotNull() {
-        assertNotNull(redshiftClient);
+    public void CreateCluster() {
+        Gson gson = new Gson();
+        User user = gson.fromJson(String.valueOf(CreateAndModifyCluster.getSecretValues(secretName)), User.class);
+        assertDoesNotThrow(() ->CreateAndModifyCluster.createCluster(redshiftClient, clusterId, user.getMasterUsername(), user.getMasterUserPassword()));
         System.out.println("Test 1 passed");
     }
 
     @Test
+    @Tag("IntegrationTest")
     @Order(2)
-    public void CreateCluster() {
-
-        CreateAndModifyCluster.createCluster(redshiftClient, clusterId, masterUsername, masterUserPassword);
+    public void WaitForClusterReady() {
+        assertDoesNotThrow(() ->CreateAndModifyCluster.waitForClusterReady(redshiftClient, clusterId));
         System.out.println("Test 2 passed");
     }
 
     @Test
+    @Tag("IntegrationTest")
     @Order(3)
-    public void WaitForClusterReady() {
-
-        CreateAndModifyCluster.waitForClusterReady(redshiftClient, clusterId);
+    public void ModifyClusterReady() {
+        assertDoesNotThrow(() ->CreateAndModifyCluster.modifyCluster(redshiftClient, clusterId));
         System.out.println("Test 3 passed");
     }
 
     @Test
+    @Tag("IntegrationTest")
     @Order(4)
-    public void ModifyClusterReady() {
-
-        CreateAndModifyCluster.modifyCluster(redshiftClient, clusterId);
+    public void DescribeClusters() {
+        assertDoesNotThrow(() ->DescribeClusters.describeRedshiftClusters(redshiftClient));
         System.out.println("Test 4 passed");
     }
 
     @Test
+    @Tag("IntegrationTest")
     @Order(5)
-    public void DescribeClusters() {
-
-        DescribeClusters.describeRedshiftClusters(redshiftClient);
+    public void FindReservedNodeOffer() {
+        assertDoesNotThrow(() ->FindReservedNodeOffer.listReservedNodes(redshiftClient));
+        assertDoesNotThrow(() ->FindReservedNodeOffer.findReservedNodeOffer(redshiftClient));
         System.out.println("Test 5 passed");
     }
 
     @Test
+    @Tag("IntegrationTest")
     @Order(6)
-    public void FindReservedNodeOffer() {
-
-        FindReservedNodeOffer.listReservedNodes(redshiftClient);
-        FindReservedNodeOffer.findReservedNodeOffer(redshiftClient);
+    public void ListEvents() {
+        assertDoesNotThrow(() ->ListEvents.listRedShiftEvents(redshiftClient, clusterId, eventSourceType));
         System.out.println("Test 6 passed");
     }
 
     @Test
+    @Tag("IntegrationTest")
     @Order(7)
-    public void ListEvents() {
-
-        ListEvents.listRedShiftEvents(redshiftClient, clusterId, eventSourceType);
+    public void DeleteCluster() throws InterruptedException {
+        System.out.println("Wait 20 mins for the resource to become available");
+        TimeUnit.MINUTES.sleep(20);
+        assertDoesNotThrow(() ->DeleteCluster.deleteRedshiftCluster(redshiftClient, clusterId));
         System.out.println("Test 7 passed");
     }
+    public static String getSecretValues() {
+        // Get the Amazon RDS creds from Secrets Manager.
+        SecretsManagerClient secretClient = SecretsManagerClient.builder()
+            .region(Region.US_EAST_1)
+            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+            .build();
+        String secretName = "test/red";
 
-    @Test
-    @Order(8)
-    public void DeleteCluster() {
-        DeleteCluster.deleteRedshiftCluster(redshiftClient, clusterId);
-        System.out.println("Test 8 passed");
+        GetSecretValueRequest valueRequest = GetSecretValueRequest.builder()
+            .secretId(secretName)
+            .build();
+
+        GetSecretValueResponse valueResponse = secretClient.getSecretValue(valueRequest);
+        return valueResponse.secretString();
+    }
+
+    @Nested
+    @DisplayName("A class used to get test values from test/red (an AWS Secrets Manager secret)")
+    class SecretValues {
+        private String clusterId;
+        private String secretName;
+        private String eventSourceType;
+
+        public String getClusterId() {
+            return clusterId;
+        }
+
+        public String getSecretName() {
+            return secretName;
+        }
+
+        public String getEventSourceType() {
+            return eventSourceType;
+        }
     }
 }
+

--- a/javav2/example_code/sns/pom.xml
+++ b/javav2/example_code/sns/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
+        <java.version>1.8</java.version>
     </properties>
     <build>
         <plugins>
@@ -20,14 +20,13 @@
                     <groups>IntegrationTest</groups>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -57,14 +56,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.13.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-commons</artifactId>
             <version>1.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
@@ -79,11 +82,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sqs</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.10.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/javav2/example_code/sns/src/test/java/AWSSNSTest.java
+++ b/javav2/example_code/sns/src/test/java/AWSSNSTest.java
@@ -13,7 +13,6 @@ import software.amazon.awssdk.services.sns.SnsClient;
 import com.google.gson.Gson;
 import java.util.Random;
 
-
 /**
  * To run these Amazon Simple Notification Service integration tests, you need to either set the required values
  * (for example, topicName) in the config.properties file or AWS Secret Manager.

--- a/javav2/example_code/sns/src/test/java/AWSSNSTest.java
+++ b/javav2/example_code/sns/src/test/java/AWSSNSTest.java
@@ -15,7 +15,7 @@ import java.util.Random;
 
 
 /**
- * To run these Amazon Simple Queue Service integration tests, you need to either set the required values
+ * To run these Amazon Simple Notification Service integration tests, you need to either set the required values
  * (for example, topicName) in the config.properties file or AWS Secret Manager.
  */
 

--- a/javav2/example_code/sns/src/test/java/AWSSNSTest.java
+++ b/javav2/example_code/sns/src/test/java/AWSSNSTest.java
@@ -11,17 +11,15 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueReques
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 import software.amazon.awssdk.services.sns.SnsClient;
 import com.google.gson.Gson;
+
 import java.util.Random;
 
-/**
- * To run these Amazon Simple Notification Service integration tests, you need to either set the required values
- * (for example, topicName) in the config.properties file or AWS Secret Manager.
- */
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class AWSSNSTest {
-
     private static  SnsClient snsClient;
     private static String topicName = "";
     private static String topicArn = ""; //This value is dynamically set
@@ -73,6 +71,7 @@ public class AWSSNSTest {
         } catch (IOException ex) {
             ex.printStackTrace();
         }
+
         */
     }
 
@@ -81,6 +80,7 @@ public class AWSSNSTest {
     @Order(1)
     public void createTopicTest() {
         topicArn = CreateTopic.createSNSTopic(snsClient, topicName);
+        assertFalse(topicArn.isEmpty());
         System.out.println("Test 1 passed");
     }
 
@@ -88,7 +88,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(2)
     public void listTopicsTest() {
-       ListTopics.listSNSTopics(snsClient);
+        assertDoesNotThrow(() ->ListTopics.listSNSTopics(snsClient));
        System.out.println("Test 2 passed");
     }
 
@@ -96,7 +96,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(3)
     public void setTopicAttributesTest() {
-      SetTopicAttributes.setTopAttr(snsClient, attributeName, topicArn, attributeValue );
+      assertDoesNotThrow(() ->SetTopicAttributes.setTopAttr(snsClient, attributeName, topicArn, attributeValue));
       System.out.println("Test 3 passed");
     }
 
@@ -104,7 +104,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(4)
     public void getTopicAttributesTest() {
-       GetTopicAttributes.getSNSTopicAttributes(snsClient, topicArn);
+       assertDoesNotThrow(() ->GetTopicAttributes.getSNSTopicAttributes(snsClient, topicArn));
        System.out.println("Test 4 passed");
     }
 
@@ -112,7 +112,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(5)
     public void subscribeEmailTest() {
-     SubscribeEmail.subEmail(snsClient, topicArn, email);
+     assertDoesNotThrow(() ->SubscribeEmail.subEmail(snsClient, topicArn, email));
      System.out.println("Test 5 passed");
     }
 
@@ -121,6 +121,7 @@ public class AWSSNSTest {
     @Order(6)
     public void subscribeLambdaTest() {
      subArn = SubscribeLambda.subLambda(snsClient, topicArn, lambdaarn);
+     assertFalse(subArn.isEmpty());
      System.out.println("Test 6 passed");
     }
 
@@ -128,7 +129,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(7)
     public void useMessageFilterPolicyTest() {
-        UseMessageFilterPolicy.usePolicy(snsClient, subArn);
+        assertDoesNotThrow(() ->UseMessageFilterPolicy.usePolicy(snsClient, subArn));
         System.out.println("Test 7 passed");
     }
 
@@ -136,7 +137,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(8)
     public void addTagsTest() {
-        AddTags.addTopicTags(snsClient,topicArn );
+        assertDoesNotThrow(() ->AddTags.addTopicTags(snsClient,topicArn ));
         System.out.println("Test 8 passed");
     }
 
@@ -144,7 +145,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(9)
     public void listTagsTest() {
-        ListTags.listTopicTags(snsClient,topicArn);
+        assertDoesNotThrow(() ->ListTags.listTopicTags(snsClient,topicArn));
         System.out.println("Test 9 passed");
     }
 
@@ -152,7 +153,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(10)
     public void deleteTagTest() {
-        DeleteTag.removeTag(snsClient,topicArn, "Environment");
+        assertDoesNotThrow(() ->DeleteTag.removeTag(snsClient,topicArn, "Environment"));
         System.out.println("Test 10 passed");
     }
 
@@ -160,7 +161,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(11)
     public void unsubscribeTest() {
-        Unsubscribe.unSub(snsClient, subArn);
+        assertDoesNotThrow(() -> Unsubscribe.unSub(snsClient, subArn));
         System.out.println("Test 11 passed");
     }
 
@@ -168,7 +169,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(12)
     public void publishTopicTest() {
-        PublishTopic.pubTopic(snsClient, message, topicArn);
+        assertDoesNotThrow(() ->PublishTopic.pubTopic(snsClient, message, topicArn));
         System.out.println("Test 12 passed");
     }
 
@@ -176,7 +177,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(13)
     public void subscribeTextSMSTest() {
-       SubscribeTextSMS.subTextSNS(snsClient, topicArn, phone);
+       assertDoesNotThrow(() ->SubscribeTextSMS.subTextSNS(snsClient, topicArn, phone));
        System.out.println("Test 13 passed");
     }
 
@@ -184,7 +185,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(14)
     public void publishTextSMSTest() {
-        PublishTextSMS.pubTextSMS(snsClient, message, phone);
+        assertDoesNotThrow(() ->PublishTextSMS.pubTextSMS(snsClient, message, phone));
         System.out.println("Test 14 passed");
     }
 
@@ -192,7 +193,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(15)
     public void listSubscriptionsTest() {
-        ListSubscriptions.listSNSSubscriptions(snsClient);
+        assertDoesNotThrow(() ->ListSubscriptions.listSNSSubscriptions(snsClient));
         System.out.println("Test 15 passed");
     }
 
@@ -200,7 +201,7 @@ public class AWSSNSTest {
     @Tag("IntegrationTest")
     @Order(16)
     public void DeleteTopic() {
-        DeleteTopic.deleteSNSTopic(snsClient, topicArn);
+        assertDoesNotThrow(() ->DeleteTopic.deleteSNSTopic(snsClient, topicArn));
         System.out.println("Test 16 passed");
     }
 

--- a/javav2/example_code/sns/src/test/java/AWSSNSTest.java
+++ b/javav2/example_code/sns/src/test/java/AWSSNSTest.java
@@ -11,12 +11,14 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueReques
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 import software.amazon.awssdk.services.sns.SnsClient;
 import com.google.gson.Gson;
-
 import java.util.Random;
-
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+/**
+ * To run these Amazon Simple Notification Service integration tests, you need to either set the required values
+ * (for example, topicName) in the config.properties file or AWS Secret Manager.
+ */
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class AWSSNSTest {

--- a/javav2/example_code/sqs/pom.xml
+++ b/javav2/example_code/sqs/pom.xml
@@ -16,6 +16,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
+                <configuration>
+                    <groups>IntegrationTest</groups>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -45,6 +48,15 @@
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.9.2</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/javav2/example_code/sqs/src/test/java/SQSIntegrationTest.java
+++ b/javav2/example_code/sqs/src/test/java/SQSIntegrationTest.java
@@ -7,12 +7,10 @@ import com.example.sqs.DeadLetterQueues;
 import com.example.sqs.LongPolling;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.*;
-
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
@@ -23,6 +21,10 @@ import java.io.*;
 import java.util.*;
 import com.example.sqs.*;
 
+/**
+ * To run these Amazon Simple Notification Service integration tests, you need to either set the required values
+ * (for example, topicName) in the config.properties file or AWS Secret Manager.
+ */
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class SQSIntegrationTest {

--- a/javav2/example_code/sqs/src/test/java/SQSIntegrationTest.java
+++ b/javav2/example_code/sqs/src/test/java/SQSIntegrationTest.java
@@ -7,9 +7,12 @@ import com.example.sqs.DeadLetterQueues;
 import com.example.sqs.LongPolling;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
@@ -19,11 +22,6 @@ import software.amazon.awssdk.services.sqs.model.*;
 import java.io.*;
 import java.util.*;
 import com.example.sqs.*;
-
-/**
- * To run these Amazon Simple Queue Service integration tests, you need to either set the required values
- * (for example, queueName) in the config.properties file or AWS Secret Manager.
- */
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -45,6 +43,7 @@ public class SQSIntegrationTest {
             .region(Region.US_WEST_2)
             .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
             .build();
+
 
         // Get the values to run these tests from AWS Secrets Manager.
         Gson gson = new Gson();
@@ -90,7 +89,7 @@ public class SQSIntegrationTest {
     @Tag("IntegrationTest")
     @Order(2)
     public void SendMessage() {
-        SendMessages.sendMessage(sqsClient,queueName, message);
+        assertDoesNotThrow(() -> SendMessages.sendMessage(sqsClient,queueName, message));
         System.out.println("Test 2 passed");
     }
 
@@ -107,7 +106,7 @@ public class SQSIntegrationTest {
     @Tag("IntegrationTest")
     @Order(4)
     public void GetQueueAttributes() {
-        GetQueueAttributes.getAttributes(sqsClient, queueName);
+        assertDoesNotThrow(() ->GetQueueAttributes.getAttributes(sqsClient, queueName));
         System.out.println("Test 4 passed");
     }
 
@@ -115,7 +114,7 @@ public class SQSIntegrationTest {
     @Tag("IntegrationTest")
     @Order(5)
     public void DeleteMessages() {
-        SQSExample.deleteMessages(sqsClient, queueUrl,messages );
+        assertDoesNotThrow(() -> SQSExample.deleteMessages(sqsClient, queueUrl,messages));
         System.out.println("Test 5 passed");
     }
 
@@ -123,7 +122,7 @@ public class SQSIntegrationTest {
     @Tag("IntegrationTest")
     @Order(6)
     public void LongPolling() {
-       LongPolling.setLongPoll(sqsClient);
+       assertDoesNotThrow(() -> LongPolling.setLongPoll(sqsClient));
        System.out.println("Test 6 passed");
     }
 
@@ -131,7 +130,7 @@ public class SQSIntegrationTest {
     @Tag("IntegrationTest")
     @Order(7)
     public void DeadLetterQueues() {
-        DeadLetterQueues.setDeadLetterQueue(sqsClient);
+        assertDoesNotThrow(() ->DeadLetterQueues.setDeadLetterQueue(sqsClient));
         System.out.println("Test 7 passed");
    }
 
@@ -139,7 +138,7 @@ public class SQSIntegrationTest {
     @Tag("IntegrationTest")
     @Order(8)
     public void DeleteQueue() {
-        DeleteQueue.deleteSQSQueue(sqsClient, queueName);
+        assertDoesNotThrow(() ->DeleteQueue.deleteSQSQueue(sqsClient, queueName));
         System.out.println("Test 8 passed");
     }
 


### PR DESCRIPTION
This pull request has updated RDS and Redshift Java examples to pull creds from Secrets Manager

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
