### PR TITLE
Update allowed-labels.yml

### DIFF
--- a/.github/allowed-labels.yml
+++ b/.github/allowed-labels.yml
@@ -61,45 +61,18 @@
 - name: tool/integration-testing
   description: "Relates to integration testing"
   color: "663399"
-- name: status/on-call-review-needed
+- name: incomplete/on-call-review
   color: "AD1C21"
   description: "This work needs an on-call review"
-- name: status/on-call-review-complete
+- name: complete/on-call-review
   color: "1FC058"
   description: "Code review complete"
-- name: status/text-review-needed
+- name: incomplete/text-review
   color: "AD1C21"
   description: "This work needs editorial (text) review"
-- name: status/text-review-complete
+- name: complete/text-review
   color: "1FC058"
   description: "Text review complete"
-- name: status/no-text-review-needed
-  color: "5E2824"
-  description: "No text which needs review"
-- name: status/ready-to-merge
-  color: "7FFF00"
-  description: "This work is READY TO MERGE"
-- name: status/in-progress
-  color: "008080"
-  description: "This work is currently in progress"
-- name: status/back-to-author
-  color: "00FFFF"
-  description: "This work needs further work (other)"
-- name: status/needs-input
-  color: "00FFFF"
-  description: "This work needs input from the reporter"
-- name: research-spike
-  color: "00FFFF"
-  description: "This work needs research by the resolver"
-- name: status/on-hold
-  color: "000000"
-  description: "On Hold. Do not merge until released by author."
-- name: status/future-release
-  color: "000000"
-  description: "Hold for merge until after release"
-- name: status/stale
-  color: "00FFFF"
-  description: "This is stale"
 - name: type/bug
   color: "d8bfd8"
   description: "A bug in an existing code sample"

--- a/.github/allowed-labels.yml
+++ b/.github/allowed-labels.yml
@@ -61,16 +61,16 @@
 - name: tool/integration-testing
   description: "Relates to integration testing"
   color: "663399"
-- name: incomplete/on-call-review
+ name: status/on-call-review-needed
   color: "AD1C21"
   description: "This work needs an on-call review"
-- name: complete/on-call-review
+- name: status/on-call-review-complete
   color: "1FC058"
   description: "Code review complete"
-- name: incomplete/text-review
+- name: status/text-review-needed
   color: "AD1C21"
   description: "This work needs editorial (text) review"
-- name: complete/text-review
+- name: status/text-review-complete
   color: "1FC058"
   description: "Text review complete"
 - name: type/bug

--- a/.github/allowed-labels.yml
+++ b/.github/allowed-labels.yml
@@ -103,3 +103,6 @@
 - name: type/tracking
   color: "5aa9f9"
   description: "Similar to an Epic, but used to track a single individual's multi-part issues."
+- name: type/spike
+  color: "00FFFF"
+  description: "This work needs research by the resolver"

--- a/.github/allowed-labels.yml
+++ b/.github/allowed-labels.yml
@@ -61,7 +61,7 @@
 - name: tool/integration-testing
   description: "Relates to integration testing"
   color: "663399"
- name: status/on-call-review-needed
+- name: status/on-call-review-needed
   color: "AD1C21"
   description: "This work needs an on-call review"
 - name: status/on-call-review-complete


### PR DESCRIPTION
# This PR...
Deletes a bunch of labels that we're not using anymore.

| label                        | reason to delete                                                                                                                                                                                                                                                    |
|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| status/no-text-review-needed | Text review by Liz is left up to   the judgement of the team, but we always should be reviewing text even if Liz   isn't going to. In this case, because all PR's get reviewed for text by   either Liz or the reviewer/author, this label doesn't reflect reality. |
| status/ready-to-merge        | If you want to see which PR's are "ready to merge",   just search in GitHub for ones that have approvals and required labels. Label   is redundant.                                                                                                                 |
| status/in-progress           | Nobody is going to be reviewing your PR anyways unless you   ask. But in general, if it's still in progress it shouldn't be a PR.                                                                                                                                   |
| status/back-to-author        | Just assign it back to the author and leave a comment. No   label needed.                                                                                                                                                                                           |
| status/needs-input           | Needs input from who? I'm not understanding what reality this   is supposed to reflect.                                                                                                                                                                             |
| status/on-hold               | If it's truly "on-hold", simply close the PR.                                                                                                                                                                                                                       |
| status/future-release        | Everything is in a future release.                                                                                                                                                                                                                                  |
