### PR TITLE
Swift: Simplified example for Swift guide intro

### DIFF
--- a/swift/example_code/s3/ListBuckets-Simple/.gitignore
+++ b/swift/example_code/s3/ListBuckets-Simple/.gitignore
@@ -1,9 +1,0 @@
-.DS_Store
-/.build
-/Packages
-/*.xcodeproj
-xcuserdata/
-DerivedData/
-.swiftpm/config/registries.json
-.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
-.netrc

--- a/swift/example_code/s3/ListBuckets-Simple/.gitignore
+++ b/swift/example_code/s3/ListBuckets-Simple/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/swift/example_code/s3/ListBuckets-Simple/Package.swift
+++ b/swift/example_code/s3/ListBuckets-Simple/Package.swift
@@ -1,9 +1,10 @@
 // swift-tools-version: 5.5
-// The swift-tools-version declares the minimum version of Swift required to
-// build this package.
 //
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+//
+// The swift-tools-version declares the minimum version of Swift required to
+// build this package.
 
 import PackageDescription
 

--- a/swift/example_code/s3/ListBuckets-Simple/Package.swift
+++ b/swift/example_code/s3/ListBuckets-Simple/Package.swift
@@ -25,7 +25,8 @@ let package = Package(
         .executableTarget(
             name: "ListBuckets-Simple",
             dependencies: [
-                .product(name: "AWSS3", package: "aws-sdk-swift")            ],
+                .product(name: "AWSS3", package: "aws-sdk-swift")
+            ],
             path: "Sources")
     ]
     // snippet-end:[s3.swift.intro.package-targets]

--- a/swift/example_code/s3/ListBuckets-Simple/Package.swift
+++ b/swift/example_code/s3/ListBuckets-Simple/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.5
+// The swift-tools-version declares the minimum version of Swift required to
+// build this package.
+//
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import PackageDescription
+
+let package = Package(
+    name: "ListBuckets-Simple",
+    // snippet-start:[s3.swift.intro.package-dependencies]
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(
+            url: "https://github.com/awslabs/aws-sdk-swift",
+            from: "0.17.0"
+        )
+    ],
+    // snippet-end:[s3.swift.intro.package-dependencies]
+    // snippet-start:[s3.swift.intro.package-targets]
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "ListBuckets-Simple",
+            dependencies: [
+                .product(name: "AWSS3", package: "aws-sdk-swift")            ],
+            path: "Sources")
+    ]
+    // snippet-end:[s3.swift.intro.package-targets]
+)

--- a/swift/example_code/s3/ListBuckets-Simple/Sources/main.swift
+++ b/swift/example_code/s3/ListBuckets-Simple/Sources/main.swift
@@ -11,9 +11,9 @@ import AWSS3
 // snippet-end:[s3.swift.intro.imports]
 
 // snippet-start:[s3.swift.intro.getbucketnames]
-// Return an array containing the names of every available bucket.
+// Return an array containing the names of all available buckets.
 //
-// - Returns: An array of strings listing the available buckets.
+// - Returns: An array of strings listing the buckets.
 func getBucketNames() async throws -> [String] {
     // Get an S3Client with which to access Amazon S3.
     // snippet-start:[s3.swift.intro.client-init]
@@ -52,8 +52,10 @@ struct Main {
             for name in names {
                 print("  \(name)")
             }
+        } catch let error as ServiceError {
+            print("An unexpected Amazon S3 service error occurred: \(error.message ?? "No details available")")
         } catch {
-            dump(error, name: "Error getting the bucket list.")
+            print("An unknown error occurred: \(dump(error))")
         }
     }
 }

--- a/swift/example_code/s3/ListBuckets-Simple/Sources/main.swift
+++ b/swift/example_code/s3/ListBuckets-Simple/Sources/main.swift
@@ -1,8 +1,8 @@
-/// A simple example that shows how to use the AWS SDK for Swift with the
-/// Amazon Simple Storage Service (Amazon S3) function `ListBuckets`.
-///
 /// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /// SPDX-License-Identifier: Apache-2.0
+///
+/// A simple example that shows how to use the AWS SDK for Swift with the
+/// Amazon Simple Storage Service (Amazon S3) function `ListBuckets`.
 
 // snippet-start:[s3.swift.intro.imports]
 import Foundation

--- a/swift/example_code/s3/ListBuckets-Simple/Sources/main.swift
+++ b/swift/example_code/s3/ListBuckets-Simple/Sources/main.swift
@@ -18,7 +18,6 @@ func getBucketNames() async throws -> [String] {
     // Get an S3Client with which to access Amazon S3.
     // snippet-start:[s3.swift.intro.client-init]
     let client = try S3Client(region: "us-east-1")
-    try S3Client(config: S3Client.S3ClientConfiguration)
     // snippet-end:[s3.swift.intro.client-init]
 
     // snippet-start:[s3.swift.intro.listbuckets]

--- a/swift/example_code/s3/ListBuckets-Simple/Sources/main.swift
+++ b/swift/example_code/s3/ListBuckets-Simple/Sources/main.swift
@@ -1,0 +1,61 @@
+/// A simple example that shows how to use the AWS SDK for Swift with the
+/// Amazon Simple Storage Service (Amazon S3) function `ListBuckets`.
+///
+/// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+/// SPDX-License-Identifier: Apache-2.0
+
+// snippet-start:[s3.swift.intro.imports]
+import Foundation
+import ClientRuntime
+import AWSS3
+// snippet-end:[s3.swift.intro.imports]
+
+// snippet-start:[s3.swift.intro.getbucketnames]
+// Return an array containing the names of every available bucket.
+//
+// - Returns: An array of strings listing the available buckets.
+func getBucketNames() async throws -> [String] {
+    // Get an S3Client with which to access Amazon S3.
+    // snippet-start:[s3.swift.intro.client-init]
+    let client = try S3Client(region: "us-east-1")
+    try S3Client(config: S3Client.S3ClientConfiguration)
+    // snippet-end:[s3.swift.intro.client-init]
+
+    // snippet-start:[s3.swift.intro.listbuckets]
+    let output = try await client.listBuckets(
+        input: ListBucketsInput()
+    )
+    // snippet-end:[s3.swift.intro.listbuckets]
+    
+    // Get the bucket names.
+    var bucketNames: [String] = []
+
+    guard let buckets = output.buckets else {
+        return bucketNames
+    }
+    for bucket in buckets {
+        bucketNames.append(bucket.name ?? "<unknown>")
+    }
+
+    return bucketNames
+}
+// snippet-end:[s3.swift.intro.getbucketnames]
+
+// snippet-start:[s3.swift.intro.main]
+/// The program's asynchronous entry point.
+@main
+struct Main {
+    static func main() async {
+        do {
+            let names = try await getBucketNames()
+
+            print("Found \(names.count) buckets:")
+            for name in names {
+                print("  \(name)")
+            }
+        } catch {
+            dump(error, name: "Error getting the bucket list.")
+        }
+    }
+}
+// snippet-end:[s3.swift.intro.main]

--- a/swift/example_code/s3/ListBuckets-Simple/Sources/main.swift
+++ b/swift/example_code/s3/ListBuckets-Simple/Sources/main.swift
@@ -53,7 +53,7 @@ struct Main {
                 print("  \(name)")
             }
         } catch let error as ServiceError {
-            print("An unexpected Amazon S3 service error occurred: \(error.message ?? "No details available")")
+            print("An Amazon S3 service error occurred: \(error.message ?? "No details available")")
         } catch {
             print("An unknown error occurred: \(dump(error))")
         }


### PR DESCRIPTION
This is a simplified Amazon S3 "ListBuckets" example for the AWS SDK for Swift. There is no mocking support, no test suite, and no command line parsing or other "extra" features. All the code does is use your default credentials to dump a list of your Amazon S3 buckets to the screen.

Code was taken from the previously-approved sample for listBuckets.

To test, build it and run. You should see a list of your Amazon S3 buckets. That's all there is to it.

<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
