### PR TITLE
Rust: Fix wrong service name in output

### DIFF
--- a/rust_dev_preview/ssm/src/bin/create-parameter.rs
+++ b/rust_dev_preview/ssm/src/bin/create-parameter.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Error> {
     println!();
 
     if verbose {
-        println!("SQS client version:   {}", PKG_VERSION);
+        println!("SSM client version:   {}", PKG_VERSION);
         println!(
             "Region:               {}",
             region_provider.region().await.unwrap().as_ref()

--- a/rust_dev_preview/ssm/src/bin/describe-parameters.rs
+++ b/rust_dev_preview/ssm/src/bin/describe-parameters.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Error> {
     println!();
 
     if verbose {
-        println!("SQS client version: {}", PKG_VERSION);
+        println!("SSM client version: {}", PKG_VERSION);
         println!(
             "Region:             {}",
             region_provider.region().await.unwrap().as_ref()


### PR DESCRIPTION
This pull request fixes the wrong service name in the SSM example docs of Rust.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
