### PR TITLE
SOS: Treat Bash as an SDK in metdata

### DIFF
--- a/.doc_gen/cross-content/phrases-code-examples.ent
+++ b/.doc_gen/cross-content/phrases-code-examples.ent
@@ -29,8 +29,6 @@
 
 <!ENTITY Bashlong '&CLIlong; with Bash script'>
 <!ENTITY Bash '&CLI; with Bash script'>
-<!ENTITY guide-rust-dev '&guide-cli-ug;'>
-<!ENTITY guide-rust-api '&guide-cli-ref;'>
 
 <!-- API Gateway Management API -->
 

--- a/.doc_gen/cross-content/phrases-code-examples.ent
+++ b/.doc_gen/cross-content/phrases-code-examples.ent
@@ -25,6 +25,13 @@
 <!ENTITY guide-rust-dev '&Rustlong; developer guide'>
 <!ENTITY guide-rust-api '&Rustlong; API reference'>
 
+<!-- SDK for Bash (a virtual SDK that uses the CLI) -->
+
+<!ENTITY Bashlong '&CLIlong; with Bash script'>
+<!ENTITY Bash '&CLI; with Bash script'>
+<!ENTITY guide-rust-dev '&guide-cli-ug;'>
+<!ENTITY guide-rust-api '&guide-cli-ref;'>
+
 <!-- API Gateway Management API -->
 
 <!ENTITY ABPMA '&ABP; Management API'>

--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -137,9 +137,9 @@ s3_CreateBucket:
             - description:
               snippet_tags:
                 - s3.swift.basics.handler.createbucket
-    CLI:
+    Bash:
       versions:
-        - sdk_version: 1
+        - sdk_version: 2
           github: aws-cli/bash-linux/s3
           sdkguide:
           excerpts:
@@ -269,9 +269,9 @@ s3_CopyObject:
             - description:
               snippet_tags:
                 - s3.swift.basics.handler.copyfile
-    CLI:
+    Bash:
       versions:
-        - sdk_version: 1
+        - sdk_version: 2
           github: aws-cli/bash-linux/s3
           sdkguide:
           excerpts:
@@ -426,9 +426,9 @@ s3_DeleteObject:
             - description:
               snippet_tags:
                 - s3.swift.basics.handler.deletefile
-    CLI:
+    Bash:
       versions:
-        - sdk_version: 1
+        - sdk_version: 2
           github: aws-cli/bash-linux/s3
           sdkguide:
           excerpts:
@@ -552,9 +552,9 @@ s3_DeleteObjects:
             - description:
               snippet_tags:
                 - cpp.example_code.s3.delete_objects
-    CLI:
+    Bash:
       versions:
-        - sdk_version: 1
+        - sdk_version: 2
           github: aws-cli/bash-linux/s3
           sdkguide:
           excerpts:
@@ -861,9 +861,9 @@ s3_GetObject:
             - description: Read an object into a Swift Data object.
               snippet_tags:
                 - s3.swift.basics.handler.readfile
-    CLI:
+    Bash:
       versions:
-        - sdk_version: 1
+        - sdk_version: 2
           github: aws-cli/bash-linux/s3
           sdkguide:
           excerpts:
@@ -1178,9 +1178,9 @@ s3_ListObjects:
             - description:
               snippet_tags:
                 - s3.swift.basics.handler.listbucketfiles
-    CLI:
+    Bash:
       versions:
-        - sdk_version: 1
+        - sdk_version: 2
           github: aws-cli/bash-linux/s3
           sdkguide:
           excerpts:
@@ -1354,9 +1354,9 @@ s3_PutObject:
             - description: Upload the contents of a Swift Data object to a bucket.
               snippet_tags:
                 - s3.swift.basics.handler.createfile
-    CLI:
+    Bash:
       versions:
-        - sdk_version: 1
+        - sdk_version: 2
           github: aws-cli/bash-linux/s3
           sdkguide:
           excerpts:
@@ -1493,9 +1493,9 @@ s3_DeleteBucket:
             - description:
               snippet_tags:
                 - s3.swift.basics.handler.deletebucket
-    CLI:
+    Bash:
       versions:
-        - sdk_version: 1
+        - sdk_version: 2
           github: aws-cli/bash-linux/s3
           sdkguide:
           excerpts:
@@ -1925,9 +1925,9 @@ s3_HeadBucket:
               snippet_tags:
                 - python.example_code.s3.helper.BucketWrapper
                 - python.example_code.s3.HeadBucket
-    CLI:
+    Bash:
       versions:
-        - sdk_version: 1
+        - sdk_version: 2
           github: aws-cli/bash-linux/s3
           sdkguide:
           excerpts:
@@ -2577,9 +2577,9 @@ s3_Scenario_GettingStarted:
             - description: A Swift command-line program to manage the SDK calls.
               snippet_tags:
                 - s3.swift.basics.example
-    CLI:
+    Bash:
       versions:
-        - sdk_version: 1
+        - sdk_version: 2
           github: aws-cli/bash-linux/s3
           sdkguide:
           excerpts:

--- a/.doc_gen/metadata/sdks.yaml
+++ b/.doc_gen/metadata/sdks.yaml
@@ -205,19 +205,30 @@ Swift:
         link_template: "https://awslabs.github.io/aws-sdk-swift/reference/0.x"
   guide: "&guide-swift-dev;"
 CLI:
-  property: cli
+  property: sh
   sdk:
-    1:
+    2:
       long: "&CLIlong;"
       short: "&CLI;"
       expanded:
         long: "AWS Command Line Interface"
         short: "Command Line Interface"
-      guide: "cli"
+      guide: "cli/latest/userguide/cli-chap-welcome.html"
       api_ref:
         uid: "aws-cli"
         name: "&guide-cli-ref;"
-      title_override:
-        title: "Additional code examples for the &CLIlong;"
-        title_abbrev: "Additional code examples"
+  guide: "&guide-cli-ug;"
+Bash:
+  property: bash
+  sdk:
+    2:
+      long: "&Bashlong;"
+      short: "&Bash;"
+      expanded:
+        long: "AWS Command Line Interface with Bash script"
+        short: "Command Line Interface with Bash script"
+      guide: "cli/latest/userguide/cli-chap-welcome.html"
+      api_ref:
+        uid: "aws-cli"
+        name: "&guide-cli-ref;"
   guide: "&guide-cli-ug;"

--- a/.doc_gen/validation/example_schema.yaml
+++ b/.doc_gen/validation/example_schema.yaml
@@ -10,7 +10,7 @@ example:
   synopsis_list: list(str(upper_start=True, end_punc=True), required=False)
   category: str(required=False, upper_start=True, no_end_punc=True)
   guide_topic: include('guide_topic', required=False)
-  languages: map(include('language'), key=enum('C++', 'CLI', 'Go', 'Java', 'JavaScript', 'Kotlin', '.NET', 'PHP', 'Python', 'Ruby', 'Rust', 'SAP ABAP', 'Swift'))
+  languages: map(include('language'), key=enum('Bash', 'C++', 'CLI', 'Go', 'Java', 'JavaScript', 'Kotlin', '.NET', 'PHP', 'Python', 'Ruby', 'Rust', 'SAP ABAP', 'Swift'))
   service_main: service_name(required=False)
   services: map(map(key=str(), required=False), key=service_name())
 

--- a/.doc_gen/validation/sdks_schema.yaml
+++ b/.doc_gen/validation/sdks_schema.yaml
@@ -1,6 +1,6 @@
 # Yamale Schema for SDK metadata, which is the sdks.yaml file in the metadata folder.
 
-map(include('sdk'), key=enum('C++', 'CLI', 'Go', 'Java', 'JavaScript', 'Kotlin', '.NET', 'PHP', 'Python', 'Ruby', 'Rust', 'SAP ABAP', 'Swift'))
+map(include('sdk'), key=enum('Bash', 'C++', 'CLI', 'Go', 'Java', 'JavaScript', 'Kotlin', '.NET', 'PHP', 'Python', 'Ruby', 'Rust', 'SAP ABAP', 'Swift'))
 ---
 sdk:
   property: include('syntax_enum')
@@ -28,6 +28,6 @@ title_override:
   title: str()
   title_abbrev: str()
 
-syntax_enum: enum('cpp', 'cli', 'go', 'java', 'javascript', 'kotlin', 'csharp', 'php', 'python', 'ruby', 'rust', 'sap-abap', 'swift')
+syntax_enum: enum('bash', 'cpp', 'go', 'java', 'javascript', 'kotlin', 'csharp', 'php', 'python', 'ruby', 'rust', 'sap-abap', 'sh', 'swift')
 entity_regex: regex('^[&]([\dA-Za-z-_])+[;]$', name='valid entity')
 entity_with_version_regex: regex('^[&]([\dA-Za-z-_])+;', name='valid entity with version')


### PR DESCRIPTION
We need to differentiate Bash examples from CLI examples in the code example output. The simplest way to do this is to treat "CLI with Bash" as a separate SDK from "CLI". This gives each its own tab in the service output, and each its own chapter in the SDK output.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
