### PR TITLE
JavaScript: Change v2 status

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Code examples for each language's SDK can be found within the following subdirec
 | Java       | [javav2/](javav2)                     | 2           | ![[]](https://img.shields.io/badge/-GA-blue) (Recommended version) |
 | Java       | [java/](java)                         | 1           | ![[]](https://img.shields.io/badge/-GA-blue) (Not Recommended)     |
 | JavaScript | [javascriptv3/](javascriptv3)         | 3           | ![[]](https://img.shields.io/badge/-GA-blue)                       |
-| JavaScript | [javascript/](javascript)             | 2           | ![[]](https://img.shields.io/badge/-deprecated-red)                |
+| JavaScript | [javascript/](javascript)             | 2           | ![[]](https://img.shields.io/badge/-GA-blue) (Not Recommended)     |
 | Kotlin     | [kotlin/](kotlin)                     |             | ![[]](https://img.shields.io/badge/-preview-brightgreen)           |
 | PHP        | [php/](php)                           | 3           | ![[]](https://img.shields.io/badge/-GA-blue)                       |
 | Python     | [python/](python)                     | 3           | ![[]](https://img.shields.io/badge/-GA-blue)                       |


### PR DESCRIPTION
V2 is not deprecated. In fact, it has not entered maintenance mode yet, and is considered GA.

Maintenance mode announcement will probably be made later this year.