### PR TITLE
Add page_size to limit DynamoDB list items

### DIFF
--- a/rust_dev_preview/examples/dynamodb/src/bin/list-items.rs
+++ b/rust_dev_preview/examples/dynamodb/src/bin/list-items.rs
@@ -10,10 +10,13 @@ use clap::Parser;
 use dynamodb_code_examples::{make_config, scenario::list::list_items, Opt as BaseOpt};
 
 #[derive(Debug, Parser)]
-struct Opt {
+struct ListItemsOpt {
     /// The name of the table.
     #[structopt(short, long)]
     table: String,
+
+    #[structopt(default_value = "10", long)]
+    page_size: Option<i32>,
 
     #[structopt(flatten)]
     base: BaseOpt,
@@ -31,10 +34,14 @@ struct Opt {
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt::init();
 
-    let Opt { table, base } = Opt::parse();
+    let ListItemsOpt {
+        table,
+        base,
+        page_size,
+    } = ListItemsOpt::parse();
 
     let shared_config = make_config(base).await?;
     let client = Client::new(&shared_config);
 
-    list_items(&client, &table).await
+    list_items(&client, &table, page_size).await
 }

--- a/rust_dev_preview/examples/dynamodb/src/scenario/list.rs
+++ b/rust_dev_preview/examples/dynamodb/src/scenario/list.rs
@@ -179,17 +179,19 @@ pub async fn list_tables_are_more(client: &Client) -> Result<(), Error> {
 
 // Lists the items in a table.
 // snippet-start:[dynamodb.rust.list-items]
-pub async fn list_items(client: &Client, table: &str) -> Result<(), Error> {
+pub async fn list_items(client: &Client, table: &str, page_size: Option<i32>) -> Result<(), Error> {
+    let page_size = page_size.unwrap_or(10);
     let items: Result<Vec<_>, _> = client
         .scan()
         .table_name(table)
+        .limit(page_size)
         .into_paginator()
         .items()
         .send()
         .collect()
         .await;
 
-    println!("Items in table:");
+    println!("Items in table (up to {page_size}):");
     for item in items? {
         println!("   {:?}", item);
     }


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request adds page_size to limit how many DynamoDB items are returned when listing items in a DDB Scan action.

Closes #4969 

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
