### PR TITLE
PHP Fix deleteObjects example; 'Key' is not a valid parameter for the deleteObjects method

### DIFF
--- a/php/example_code/s3/s3_basics/GettingStartedWithS3.php
+++ b/php/example_code/s3/s3_basics/GettingStartedWithS3.php
@@ -135,7 +135,6 @@ try {
     }
     $s3client->deleteObjects([
         'Bucket' => $bucket_name,
-        'Key' => $file_name,
         'Delete' => [
             'Objects' => $objects,
         ],


### PR DESCRIPTION
This pull request fixes the [deleteObjects example](https://docs.aws.amazon.com/en_us/sdk-for-php/v3/developer-guide/php_s3_code_examples.html#actions); 'Key' is not a valid parameter for the [deleteObjects method](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#deleteobjects).

fixes: https://issues.amazon.com/issues/awsdocs-35485

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
