### PR TITLE
Java V2 Add Java examples for Polly

### DIFF
--- a/.doc_gen/metadata/polly_metadata.yaml
+++ b/.doc_gen/metadata/polly_metadata.yaml
@@ -5,6 +5,15 @@ polly_DescribeVoices:
   synopsis: get &POL; voices available for synthesis.
   category:
   languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/polly
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - polly.java2.describe_voice.main
     .NET:
       versions:
         - sdk_version: 3
@@ -66,6 +75,15 @@ polly_ListLexicons:
   synopsis: list &POL; pronunciation lexicons.
   category:
   languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/polly
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - polly.java2.list_icons.main
     .NET:
       versions:
         - sdk_version: 3
@@ -135,6 +153,15 @@ polly_SynthesizeSpeech:
   synopsis: synthesize speech from text with &POL;.
   category:
   languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/polly
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - polly.java2.demo.main
     .NET:
       versions:
         - sdk_version: 3


### PR DESCRIPTION
This pull request adds Java V2 examples to Polly. 

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
