### PR TITLE
SOS: Honor absolute GitHub URL for tributary examples.

### DIFF
--- a/.doc_gen/templates/zonbook/example_language_template.xml
+++ b/.doc_gen/templates/zonbook/example_language_template.xml
@@ -26,7 +26,11 @@
             <note>
                 <para>
                     There's more on GitHub. Find the complete example and learn how to set up and run in the
+                    {{- if hasPrefix $version.GitHubUrl "https:"}}
+                    <ulink url="{{$version.GitHubUrl}}">{{$version.Category}}</ulink> repository.
+                    {{- else}}
                     <ulink url="https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/{{$version.GitHubUrl}}">&AWS; Code Examples Repository</ulink>.
+                    {{- end}}
                 </para>
             </note>
             {{- end}}


### PR DESCRIPTION
The current behavior is to treat all GitHub URLs as relative and prefix them with this repo's root.
This update adds the prefix only if they truly are relative, otherwise it keeps them as is (needed for tributaries, which are external to this repo).

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
