### PR TITLE
Update all Swift example package files

### DIFF
--- a/swift/example_code/cognito-identity/FindOrCreateIdentityPool/Package.swift
+++ b/swift/example_code/cognito-identity/FindOrCreateIdentityPool/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 /*
    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -23,9 +23,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(
-            name: "AWSSwiftSDK",
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.2.0"
+            from: "0.20.0"
         )
     ],
     // snippet-end:[cognitoidentity.swift.package-dependencies]
@@ -36,7 +35,7 @@ let package = Package(
         .target(
             name: "CognitoIdentityHandler",
             dependencies: [
-                .product(name: "AWSCognitoIdentity", package: "AWSSwiftSDK"),
+                .product(name: "AWSCognitoIdentity", package: "aws-sdk-swift"),
             ],
             path: "./Sources/CognitoIdentityHandler"
         ),
@@ -47,7 +46,7 @@ let package = Package(
             name: "CognitoIdentityHandlerTests",
             dependencies: [
                 "FindOrCreateIdentityPool",
-                .product(name: "AWSCognitoIdentity", package: "AWSSwiftSDK"),
+                .product(name: "AWSCognitoIdentity", package: "aws-sdk-swift"),
             ],
             path: "./Tests/CognitoIdentityHandlerTests"
         ),

--- a/swift/example_code/ddb/BatchGetItem/Package.swift
+++ b/swift/example_code/ddb/BatchGetItem/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.10.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",

--- a/swift/example_code/ddb/basics/Package.swift
+++ b/swift/example_code/ddb/basics/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.10.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -47,10 +47,7 @@ let package = Package(
                 "SwiftUtilities",
                 "MovieList",
             ],
-            path: "./Sources",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources"
         ),
 // snippet-end:[ddb.swift.basics.package.target.executable]
 // snippet-start:[ddb.swift.basics.package.target.handler]
@@ -59,10 +56,7 @@ let package = Package(
             dependencies: [
                 .product(name: "AWSDynamoDB", package: "aws-sdk-swift"),
             ],
-            path: "./MovieList",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./MovieList"
         ),
 // snippet-end:[ddb.swift.basics.package.target.handler]
 // snippet-start:[ddb.swift.basics.package.target.tests]
@@ -74,10 +68,7 @@ let package = Package(
                 "MovieList",
                 "SwiftUtilities"
             ],
-            path: "./Tests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests"
         )
 // snippet-end:[ddb.swift.basics.package.target.tests]
     ]

--- a/swift/example_code/iam/AttachRolePolicy/Package.swift
+++ b/swift/example_code/iam/AttachRolePolicy/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.9.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -50,10 +50,7 @@ let package = Package(
                 "SwiftyTextTable",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/AttachRolePolicy",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/AttachRolePolicy"
         ),
 // snippet-end:[iam.swift.attachrolepolicy.package.target.executable]
 // snippet-start:[iam.swift.attachrolepolicy.package.target.handler]
@@ -73,10 +70,7 @@ let package = Package(
                 "SwiftUtilities",
                 "SwiftyTextTable",
             ],
-            path: "./Tests/AttachRolePolicyTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/AttachRolePolicyTests"
         )
 // snippet-end:[iam.swift.attachrolepolicy.package.target.tests]
     ]

--- a/swift/example_code/iam/CreateRole/Package.swift
+++ b/swift/example_code/iam/CreateRole/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.3.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -45,10 +45,7 @@ let package = Package(
                 "ServiceHandler",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/CreateRole",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/CreateRole"
         ),
 // snippet-end:[iam.swift.createrole.package.target.executable]
 // snippet-start:[iam.swift.createrole.package.target.handler]
@@ -67,10 +64,7 @@ let package = Package(
                 "createrole",
                 "SwiftUtilities"
             ],
-            path: "./Tests/CreateRoleTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/CreateRoleTests"
         )
 // snippet-end:[iam.swift.createrole.package.target.tests]
     ]

--- a/swift/example_code/iam/CreateServiceLinkedRole/Package.swift
+++ b/swift/example_code/iam/CreateServiceLinkedRole/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.
 //
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.3.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -45,10 +45,7 @@ let package = Package(
                 "ServiceHandler",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/CreateServiceLinkedRole",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/CreateServiceLinkedRole"
         ),
 // snippet-end:[iam.swift.createservicelinkedrole.package.target.executable]
 // snippet-start:[iam.swift.createservicelinkedrole.package.target.handler]
@@ -67,10 +64,7 @@ let package = Package(
                 "createservicelinkedrole",
                 "SwiftUtilities"
             ],
-            path: "./Tests/CreateServiceLinkedRoleTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/CreateServiceLinkedRoleTests"
         )
 // snippet-end:[iam.swift.createservicelinkedrole.package.target.tests]
     ]

--- a/swift/example_code/iam/CreateUser/Package.swift
+++ b/swift/example_code/iam/CreateUser/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.3.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -45,10 +45,7 @@ let package = Package(
                 "ServiceHandler",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/CreateUser",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/CreateUser"
         ),
 // snippet-end:[iam.swift.createuser.package.target.executable]
 // snippet-start:[iam.swift.createuser.package.target.handler]
@@ -67,10 +64,7 @@ let package = Package(
                 "createuser",
                 "SwiftUtilities"
             ],
-            path: "./Tests/CreateUserTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/CreateUserTests"
         )
 // snippet-end:[iam.swift.createuser.package.target.tests]
     ]

--- a/swift/example_code/iam/GetPolicy/Package.swift
+++ b/swift/example_code/iam/GetPolicy/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.3.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -45,10 +45,7 @@ let package = Package(
                 "ServiceHandler",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/GetPolicy",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/GetPolicy"
         ),
 // snippet-end:[iam.swift.getpolicy.package.target.executable]
 // snippet-start:[iam.swift.getpolicy.package.target.handler]
@@ -67,10 +64,7 @@ let package = Package(
                 "getpolicy",
                 "SwiftUtilities",
             ],
-            path: "./Tests/GetPolicyTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/GetPolicyTests"
         )
 // snippet-end:[iam.swift.getpolicy.package.target.tests]
     ]

--- a/swift/example_code/iam/GetRole/Package.swift
+++ b/swift/example_code/iam/GetRole/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.3.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -45,10 +45,7 @@ let package = Package(
                 "ServiceHandler",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/GetRole",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/GetRole"
         ),
 // snippet-end:[iam.swift.getrole.package.target.executable]
 // snippet-start:[iam.swift.getrole.package.target.handler]
@@ -67,10 +64,7 @@ let package = Package(
                 "getrole",
                 "SwiftUtilities"
             ],
-            path: "./Tests/GetRoleTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/GetRoleTests"
         )
 // snippet-end:[iam.swift.getrole.package.target.tests]
     ]

--- a/swift/example_code/iam/ListAttachedRolePolicies/Package.swift
+++ b/swift/example_code/iam/ListAttachedRolePolicies/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.3.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -44,10 +44,7 @@ let package = Package(
                 "ServiceHandler",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/ListAttachedRolePolicies",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/ListAttachedRolePolicies"
         ),
 // snippet-end:[iam.swift.listattachedrolepolicies.package.target.executable]
 // snippet-start:[iam.swift.listattachedrolepolicies.package.target.handler]
@@ -66,10 +63,7 @@ let package = Package(
                 "listattachedrolepolicies",
                 "SwiftUtilities",
             ],
-            path: "./Tests/ListAttachedRolePoliciesTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/ListAttachedRolePoliciesTests"
         )
 // snippet-end:[iam.swift.listattachedrolepolicies.package.target.tests]
     ]

--- a/swift/example_code/iam/ListGroups/Package.swift
+++ b/swift/example_code/iam/ListGroups/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.
 //
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.9.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -46,10 +46,7 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "AWSIAM", package: "aws-sdk-swift"),
             ],
-            path: "./Sources/ListGroups",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/ListGroups"
         ),
 // snippet-end:[iam.swift.listgroups.package.target.executable]
 // snippet-start:[iam.swift.listgroups.package.target.handler]
@@ -68,10 +65,7 @@ let package = Package(
                 "listgroups",
                 "SwiftUtilities"
             ],
-            path: "./Tests/ListGroupsTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/ListGroupsTests"
         )
 // snippet-end:[iam.swift.listgroups.package.target.tests]
     ]

--- a/swift/example_code/iam/ListPolicies/Package.swift
+++ b/swift/example_code/iam/ListPolicies/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.3.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -50,10 +50,7 @@ let package = Package(
                 "SwiftyTextTable",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/ListPolicies",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/ListPolicies"
         ),
 // snippet-end:[iam.swift.listpolicies.package.target.executable]
 // snippet-start:[iam.swift.listpolicies.package.target.handler]
@@ -73,10 +70,7 @@ let package = Package(
                 "SwiftUtilities",
                 "SwiftyTextTable",
             ],
-            path: "./Tests/ListPoliciesTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/ListPoliciesTests"
         )
 // snippet-end:[iam.swift.listpolicies.package.target.tests]
     ]

--- a/swift/example_code/iam/ListRolePolicies/Package.swift
+++ b/swift/example_code/iam/ListRolePolicies/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.3.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -50,10 +50,7 @@ let package = Package(
                 "SwiftyTextTable",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/ListRolePolicies",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/ListRolePolicies"
         ),
 // snippet-end:[iam.swift.listrolepolicies.package.target.executable]
 // snippet-start:[iam.swift.listrolepolicies.package.target.handler]
@@ -73,10 +70,7 @@ let package = Package(
                 "SwiftUtilities",
                 "SwiftyTextTable",
             ],
-            path: "./Tests/ListRolePoliciesTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/ListRolePoliciesTests"
         )
 // snippet-end:[iam.swift.listrolepolicies.package.target.tests]
     ]

--- a/swift/example_code/iam/ListRoles/Package.swift
+++ b/swift/example_code/iam/ListRoles/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.3.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -45,10 +45,7 @@ let package = Package(
                 "ServiceHandler",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/ListRoles",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/ListRoles"
         ),
 // snippet-end:[iam.swift.listroles.package.target.executable]
 // snippet-start:[iam.swift.listroles.package.target.handler]
@@ -67,10 +64,7 @@ let package = Package(
                 "listroles",
                 "SwiftUtilities"
             ],
-            path: "./Tests/ListRolesTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/ListRolesTests"
         )
 // snippet-end:[iam.swift.listroles.package.target.tests]
     ]

--- a/swift/example_code/iam/ListUsers/Package.swift
+++ b/swift/example_code/iam/ListUsers/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.3.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -45,10 +45,7 @@ let package = Package(
                 "ServiceHandler",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/ListUsers",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/ListUsers"
         ),
 // snippet-end:[iam.swift.listusers.package.target.executable]
 // snippet-start:[iam.swift.listusers.package.target.handler]
@@ -67,10 +64,7 @@ let package = Package(
                 "listusers",
                 "SwiftUtilities"
             ],
-            path: "./Tests/ListUsersTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/ListUsersTests"
         )
 // snippet-end:[iam.swift.listusers.package.target.tests]
     ]

--- a/swift/example_code/iam/basics/Package.swift
+++ b/swift/example_code/iam/basics/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.10.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
@@ -49,10 +49,7 @@ let package = Package(
                 "SwiftUtilities",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            path: "./Sources/Basics",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Sources/Basics"
         ),
 // snippet-end:[iam.swift.basics.package.target.executable]
 // snippet-start:[iam.swift.basics.package.target.handler]
@@ -62,7 +59,7 @@ let package = Package(
                 .product(name: "AWSIAM", package: "aws-sdk-swift"),
                 .product(name: "AWSS3", package: "aws-sdk-swift"),
                 .product(name: "AWSSTS", package: "aws-sdk-swift"),
-                "SwiftUtilities",
+                "SwiftUtilities"
             ],
             path: "./Sources/ServiceHandler"
         ),
@@ -78,10 +75,7 @@ let package = Package(
                 "basics",
                 "SwiftUtilities"
             ],
-            path: "./Tests/BasicsTests",
-            linkerSettings: [
-                .linkedLibrary("rt")    // Include librt for Dispatch to work.
-            ]
+            path: "./Tests/BasicsTests"
         )
 // snippet-end:[iam.swift.basics.package.target.tests]
     ]

--- a/swift/example_code/iam/basics/Sources/Basics/Basics.swift
+++ b/swift/example_code/iam/basics/Sources/Basics/Basics.swift
@@ -30,7 +30,6 @@ import AWSIAM
 import AWSSTS
 import AWSS3
 import ClientRuntime
-import AWSClientRuntime
 // snippet-end:[iam.swift.basics.main.imports]
 
 @testable import ServiceHandler

--- a/swift/example_code/iam/basics/Sources/ServiceHandler/ServiceHandlerIAM.swift
+++ b/swift/example_code/iam/basics/Sources/ServiceHandler/ServiceHandlerIAM.swift
@@ -45,9 +45,10 @@ public class ServiceHandlerIAM {
                 guard   let keyId = accessKeyId,
                         let secretKey = secretAccessKey else {
                             throw ServiceHandlerError.authError
-                        }
-                let credentialsProvider = try AWSCredentialsProvider.fromStatic(
-                    AWSCredentialsProviderStaticConfig(
+                }
+
+                let credentialsProvider = try AWSClientRuntime.StaticCredentialsProvider(
+                    AWSClientRuntime.Credentials(
                         accessKey: keyId,
                         secret: secretKey,
                         sessionToken: sessionToken
@@ -58,7 +59,7 @@ public class ServiceHandlerIAM {
                 // provider. Then create a new `IAMClient` using those
                 // permissions.
 
-                let iamConfig = try IAMClient.IAMClientConfiguration(
+                let iamConfig = try await IAMClient.IAMClientConfiguration(
                     credentialsProvider: credentialsProvider,
                     region: self.region
                 )
@@ -86,8 +87,8 @@ public class ServiceHandlerIAM {
             // token to generate a static credentials provider suitable for
             // use when initializing an IAM client.
 
-            let credentialsProvider = try AWSCredentialsProvider.fromStatic(
-                AWSCredentialsProviderStaticConfig(
+            let credentialsProvider = try AWSClientRuntime.StaticCredentialsProvider(
+                AWSClientRuntime.Credentials(
                     accessKey: accessKeyId,
                     secret: secretAccessKey,
                     sessionToken: sessionToken
@@ -96,7 +97,7 @@ public class ServiceHandlerIAM {
 
             // Create a new IAM client with the specified access credentials.
 
-            let iamConfig = try IAMClient.IAMClientConfiguration(
+            let iamConfig = try await IAMClient.IAMClientConfiguration(
                 credentialsProvider: credentialsProvider,
                 region: self.region
             )

--- a/swift/example_code/iam/basics/Sources/ServiceHandler/ServiceHandlerIAM_Ext.swift
+++ b/swift/example_code/iam/basics/Sources/ServiceHandler/ServiceHandlerIAM_Ext.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import AWSIAM
-import AWSClientRuntime
 import ClientRuntime
 import SwiftUtilities
 

--- a/swift/example_code/iam/basics/Sources/ServiceHandler/ServiceHandlerS3.swift
+++ b/swift/example_code/iam/basics/Sources/ServiceHandler/ServiceHandlerS3.swift
@@ -11,8 +11,8 @@
 import Foundation
 import AWSS3
 import ClientRuntime
-import AWSClientRuntime
 import SwiftUtilities
+import AWSClientRuntime
 // snippet-end:[iam.swift.basics.s3.imports]
 
 public class ServiceHandlerS3 {
@@ -53,9 +53,10 @@ public class ServiceHandlerS3 {
                 guard   let keyId = accessKeyId,
                         let secretKey = secretAccessKey else {
                             throw ServiceHandlerError.authError
-                        }
-                let credentialsProvider = try AWSCredentialsProvider.fromStatic(
-                    AWSCredentialsProviderStaticConfig(
+                }
+
+                let credentialsProvider = try AWSClientRuntime.StaticCredentialsProvider(
+                    AWSClientRuntime.Credentials(
                         accessKey: keyId,
                         secret: secretKey,
                         sessionToken: sessionToken
@@ -65,7 +66,7 @@ public class ServiceHandlerS3 {
                 // Create an Amazon S3 configuration specifying the credentials
                 // provider. Then create a new `S3Client` using those permissions.
 
-                let s3Config = try S3Client.S3ClientConfiguration(
+                let s3Config = try await S3Client.S3ClientConfiguration(
                     credentialsProvider: credentialsProvider,
                     region: self.region
                 )
@@ -94,8 +95,8 @@ public class ServiceHandlerS3 {
             // to generate a static credentials provider suitable for use when
             // initializing an Amazon S3 client.
 
-            let credentialsProvider = try AWSCredentialsProvider.fromStatic(
-                AWSCredentialsProviderStaticConfig(
+            let credentialsProvider = try AWSClientRuntime.StaticCredentialsProvider(
+                AWSClientRuntime.Credentials(
                     accessKey: accessKeyId,
                     secret: secretAccessKey,
                     sessionToken: sessionToken
@@ -105,7 +106,7 @@ public class ServiceHandlerS3 {
             // Create a new Amazon S3 client with the specified access
             // credentials.
 
-            let s3Config = try S3Client.S3ClientConfiguration(
+            let s3Config = try await S3Client.S3ClientConfiguration(
                 credentialsProvider: credentialsProvider,
                 region: self.region
             )

--- a/swift/example_code/iam/basics/Sources/ServiceHandler/ServiceHandlerSTS.swift
+++ b/swift/example_code/iam/basics/Sources/ServiceHandler/ServiceHandlerSTS.swift
@@ -12,8 +12,8 @@ import Foundation
 import AWSIAM
 import AWSSTS
 import ClientRuntime
-import AWSClientRuntime
 import SwiftUtilities
+import AWSClientRuntime
 // snippet-end:[iam.swift.basics.sts.imports]
 
 /// A class providing functions for interacting with the AWS Security Token
@@ -55,9 +55,10 @@ public class ServiceHandlerSTS {
                 guard   let keyId = accessKeyId,
                         let secretKey = secretAccessKey else {
                             throw ServiceHandlerError.authError
-                        }
-                let credentialsProvider = try AWSCredentialsProvider.fromStatic(
-                    AWSCredentialsProviderStaticConfig(
+                }
+                
+                let credentialsProvider = try AWSClientRuntime.StaticCredentialsProvider(
+                    AWSClientRuntime.Credentials(
                         accessKey: keyId,
                         secret: secretKey,
                         sessionToken: sessionToken
@@ -67,7 +68,7 @@ public class ServiceHandlerSTS {
                 // Create an AWS STS configuration specifying the credentials
                 // provider. Then create a new `STSClient` using those permissions.
 
-                let s3Config = try STSClient.STSClientConfiguration(
+                let s3Config = try await STSClient.STSClientConfiguration(
                     credentialsProvider: credentialsProvider,
                     region: self.region
                 )
@@ -96,17 +97,17 @@ public class ServiceHandlerSTS {
             // to generate a static credentials provider suitable for use when
             // initializing an AWS STS client.
 
-            let credentialsProvider = try AWSCredentialsProvider.fromStatic(
-                AWSCredentialsProviderStaticConfig(
-                    accessKey: accessKeyId,
-                    secret: secretAccessKey,
-                    sessionToken: sessionToken
+                let credentialsProvider = try AWSClientRuntime.StaticCredentialsProvider(
+                    AWSClientRuntime.Credentials(
+                        accessKey: accessKeyId,
+                        secret: secretAccessKey,
+                        sessionToken: sessionToken
+                    )
                 )
-            )
 
             // Create a new AWS STS client with the specified access credentials.
 
-            let stsConfig = try STSClient.STSClientConfiguration(
+            let stsConfig = try await STSClient.STSClientConfiguration(
                 credentialsProvider: credentialsProvider,
                 region: self.region
             )

--- a/swift/example_code/iam/basics/Sources/ServiceHandler/ServiceHandlerSTS_Ext.swift
+++ b/swift/example_code/iam/basics/Sources/ServiceHandler/ServiceHandlerSTS_Ext.swift
@@ -9,7 +9,6 @@
 import Foundation
 import AWSSTS
 import AWSIAM
-import AWSClientRuntime
 import ClientRuntime
 import SwiftUtilities
 

--- a/swift/example_code/s3/DeleteObjects/Package.swift
+++ b/swift/example_code/s3/DeleteObjects/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.
 //
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.10.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",

--- a/swift/example_code/s3/DeleteObjects/Sources/ServiceHandler/ServiceHandler.swift
+++ b/swift/example_code/s3/DeleteObjects/Sources/ServiceHandler/ServiceHandler.swift
@@ -10,7 +10,6 @@
 import Foundation
 import AWSS3
 import ClientRuntime
-import AWSClientRuntime
 // snippet-end:[s3.swift.deleteobjects.handler.imports]
 
 /// Errors returned by `ServiceHandler` functions.

--- a/swift/example_code/s3/ListBuckets/Package.swift
+++ b/swift/example_code/s3/ListBuckets/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.17.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",

--- a/swift/example_code/s3/basics/Package.swift
+++ b/swift/example_code/s3/basics/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.
 //
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.18.0"
+            from: "0.20.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",


### PR DESCRIPTION
All Swift SDK examples' Package.swift files have now been updated to request a minimum SDK version of 0.20.0, to use the Swift tools' version 5.5 syntax, and to remove the unneeded `rt` library from the libraries linked in.

There are no changes to any source code files; only the package files have been updated. None of the effected files are presented in-content. All changed projects have been built and both run and tested to confirm the changes work.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
