### PR TITLE
SAP ABAP: Replace ABAP listobjects example with listobjectsv2 in S3

### DIFF
--- a/.abapgit.xml
+++ b/.abapgit.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
  <asx:values>
   <DATA>

--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -1169,7 +1169,7 @@ s3_ListObjects:
           excerpts:
             - description:
               snippet_tags:
-                - s3.abapv1.list_objects
+                - s3.abapv1.list_objects_v2
     Swift:
       versions:
         - sdk_version: 1

--- a/sap-abap/package.devc.xml
+++ b/sap-abap/package.devc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/cloudwatch/package.devc.xml
+++ b/sap-abap/services/cloudwatch/package.devc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.xml
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.xml
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/ec2/package.devc.xml
+++ b/sap-abap/services/ec2/package.devc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.xml
+++ b/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/kinesis/package.devc.xml
+++ b/sap-abap/services/kinesis/package.devc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.xml
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.xml
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/package.devc.xml
+++ b/sap-abap/services/package.devc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/s3/package.devc.xml
+++ b/sap-abap/services/s3/package.devc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/s3/zcl_aws1_s3_actions.clas.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_actions.clas.abap
@@ -3,51 +3,51 @@
 " "  Reserved.
 " "  SPDX-License-Identifier: MIT-0
 " """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-class ZCL_AWS1_S3_ACTIONS definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_s3_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods CREATE_BUCKET
-    importing
-      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME .
-  methods PUT_OBJECT
-    importing
-      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME
-      !IV_FILE_NAME type /AWS1/S3_OBJECTKEY .
-  methods GET_OBJECT
-    importing
-      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME
-      !IV_OBJECT_KEY type /AWS1/S3_OBJECTKEY
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_S3_GETOBJECTOUTPUT .
-  methods COPY_OBJECT
-    importing
-      !IV_DEST_BUCKET type /AWS1/S3_BUCKETNAME
-      !IV_DEST_OBJECT type /AWS1/S3_OBJECTKEY
-      !IV_SRC_BUCKET type /AWS1/S3_BUCKETNAME
-      !IV_SRC_OBJECT type /AWS1/S3_OBJECTKEY .
-  methods LIST_OBJECTS
-    importing
-      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_S3_LISTOBJECTSOUTPUT .
-  methods DELETE_OBJECT
-    importing
-      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME
-      !IV_OBJECT_KEY type /AWS1/S3_OBJECTKEY .
-  methods DELETE_BUCKET
-    importing
-      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME .
-  methods LIST_OBJECTS_V2
-    importing
-      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_S3_LISTOBJSV2OUTPUT .
-protected section.
-private section.
+    METHODS create_bucket
+      IMPORTING
+        !iv_bucket_name TYPE /aws1/s3_bucketname .
+    METHODS put_object
+      IMPORTING
+        !iv_bucket_name TYPE /aws1/s3_bucketname
+        !iv_file_name   TYPE /aws1/s3_objectkey .
+    METHODS get_object
+      IMPORTING
+        !iv_bucket_name TYPE /aws1/s3_bucketname
+        !iv_object_key  TYPE /aws1/s3_objectkey
+      EXPORTING
+        !oo_result      TYPE REF TO /aws1/cl_s3_getobjectoutput .
+    METHODS copy_object
+      IMPORTING
+        !iv_dest_bucket TYPE /aws1/s3_bucketname
+        !iv_dest_object TYPE /aws1/s3_objectkey
+        !iv_src_bucket  TYPE /aws1/s3_bucketname
+        !iv_src_object  TYPE /aws1/s3_objectkey .
+    METHODS list_objects
+      IMPORTING
+        !iv_bucket_name TYPE /aws1/s3_bucketname
+      EXPORTING
+        !oo_result      TYPE REF TO /aws1/cl_s3_listobjectsoutput .
+    METHODS delete_object
+      IMPORTING
+        !iv_bucket_name TYPE /aws1/s3_bucketname
+        !iv_object_key  TYPE /aws1/s3_objectkey .
+    METHODS delete_bucket
+      IMPORTING
+        !iv_bucket_name TYPE /aws1/s3_bucketname .
+    METHODS list_objects_v2
+      IMPORTING
+        !iv_bucket_name TYPE /aws1/s3_bucketname
+      EXPORTING
+        !oo_result      TYPE REF TO /aws1/cl_s3_listobjsv2output .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -185,7 +185,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD LIST_OBJECTS_V2.
+  METHOD list_objects_v2.
     CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).

--- a/sap-abap/services/s3/zcl_aws1_s3_actions.clas.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_actions.clas.abap
@@ -3,45 +3,49 @@
 " "  Reserved.
 " "  SPDX-License-Identifier: MIT-0
 " """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+class ZCL_AWS1_S3_ACTIONS definition
+  public
+  final
+  create public .
 
-CLASS zcl_aws1_s3_actions DEFINITION
-  PUBLIC
-  FINAL
-  CREATE PUBLIC .
+public section.
 
-  PUBLIC SECTION.
-
-    METHODS create_bucket
-      IMPORTING
-        !iv_bucket_name TYPE /aws1/s3_bucketname .
-    METHODS put_object
-      IMPORTING
-        !iv_bucket_name TYPE /aws1/s3_bucketname
-        !iv_file_name   TYPE /aws1/s3_objectkey .
-    METHODS get_object
-      IMPORTING
-        !iv_bucket_name TYPE /aws1/s3_bucketname
-        !iv_object_key  TYPE /aws1/s3_objectkey
-      EXPORTING
-        !oo_result      TYPE REF TO /aws1/cl_s3_getobjectoutput .
-    METHODS copy_object
-      IMPORTING
-        !iv_dest_bucket TYPE /aws1/s3_bucketname
-        !iv_dest_object TYPE /aws1/s3_objectkey
-        !iv_src_bucket  TYPE /aws1/s3_bucketname
-        !iv_src_object  TYPE /aws1/s3_objectkey .
-    METHODS list_objects
-      IMPORTING
-        !iv_bucket_name TYPE /aws1/s3_bucketname
-      EXPORTING
-        !oo_result      TYPE REF TO /aws1/cl_s3_listobjectsoutput .
-    METHODS delete_object
-      IMPORTING
-        !iv_bucket_name TYPE /aws1/s3_bucketname
-        !iv_object_key  TYPE /aws1/s3_objectkey .
-    METHODS delete_bucket
-      IMPORTING
-        !iv_bucket_name TYPE /aws1/s3_bucketname .
+  methods CREATE_BUCKET
+    importing
+      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME .
+  methods PUT_OBJECT
+    importing
+      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME
+      !IV_FILE_NAME type /AWS1/S3_OBJECTKEY .
+  methods GET_OBJECT
+    importing
+      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME
+      !IV_OBJECT_KEY type /AWS1/S3_OBJECTKEY
+    exporting
+      !OO_RESULT type ref to /AWS1/CL_S3_GETOBJECTOUTPUT .
+  methods COPY_OBJECT
+    importing
+      !IV_DEST_BUCKET type /AWS1/S3_BUCKETNAME
+      !IV_DEST_OBJECT type /AWS1/S3_OBJECTKEY
+      !IV_SRC_BUCKET type /AWS1/S3_BUCKETNAME
+      !IV_SRC_OBJECT type /AWS1/S3_OBJECTKEY .
+  methods LIST_OBJECTS
+    importing
+      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME
+    exporting
+      !OO_RESULT type ref to /AWS1/CL_S3_LISTOBJECTSOUTPUT .
+  methods DELETE_OBJECT
+    importing
+      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME
+      !IV_OBJECT_KEY type /AWS1/S3_OBJECTKEY .
+  methods DELETE_BUCKET
+    importing
+      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME .
+  methods LIST_OBJECTS_V2
+    importing
+      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME
+    exporting
+      !OO_RESULT type ref to /AWS1/CL_S3_LISTOBJSV2OUTPUT .
 protected section.
 private section.
 ENDCLASS.
@@ -178,6 +182,25 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[s3.abapv1.list_objects]
+  ENDMETHOD.
+
+
+  METHOD LIST_OBJECTS_V2.
+    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_s3) = /aws1/cl_s3_factory=>create( lo_session ).
+
+    "snippet-start:[s3.abapv1.list_objects_v2]
+    TRY.
+        oo_result = lo_s3->listobjectsv2(         " oo_result is returned for testing purposes. "
+          iv_bucket = iv_bucket_name
+        ).
+        MESSAGE 'Retrieved list of objects in S3 bucket.' TYPE 'I'.
+      CATCH /aws1/cx_s3_nosuchbucket.
+        MESSAGE 'Bucket does not exist.' TYPE 'E'.
+    ENDTRY.
+    "snippet-end:[s3.abapv1.list_objects_v2]
   ENDMETHOD.
 
 

--- a/sap-abap/services/s3/zcl_aws1_s3_actions.clas.xml
+++ b/sap-abap/services/s3/zcl_aws1_s3_actions.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
@@ -48,6 +48,12 @@
      <CMPNAME>LIST_OBJECTS</CMPNAME>
      <LANGU>E</LANGU>
      <DESCRIPT>List objects in the bucket.</DESCRIPT>
+    </SEOCOMPOTX>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCL_AWS1_S3_ACTIONS</CLSNAME>
+     <CMPNAME>LIST_OBJECTS_V2</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>List objects in the bucket with V2 method.</DESCRIPT>
     </SEOCOMPOTX>
     <SEOCOMPOTX>
      <CLSNAME>ZCL_AWS1_S3_ACTIONS</CLSNAME>

--- a/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.xml
+++ b/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/sagemaker/package.devc.xml
+++ b/sap-abap/services/sagemaker/package.devc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.xml
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.xml
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/sns/package.devc.xml
+++ b/sap-abap/services/sns/package.devc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/sns/zcl_aws1_sns_actions.clas.xml
+++ b/sap-abap/services/sns/zcl_aws1_sns_actions.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.xml
+++ b/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/sqs/package.devc.xml
+++ b/sap-abap/services/sqs/package.devc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.xml
+++ b/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/textract/package.devc.xml
+++ b/sap-abap/services/textract/package.devc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/textract/zcl_aws1_tex_actions.clas.xml
+++ b/sap-abap/services/textract/zcl_aws1_tex_actions.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
@@ -17,7 +17,7 @@
      <CLSNAME>ZCL_AWS1_TEX_ACTIONS</CLSNAME>
      <CMPNAME>ANALYZE_DOCUMENT</CMPNAME>
      <LANGU>E</LANGU>
-     <DESCRIPT>Analyzes an input document for relationships between detects.</DESCRIPT>
+     <DESCRIPT>Analyzes an input document for relationships between detects</DESCRIPT>
     </SEOCOMPOTX>
     <SEOCOMPOTX>
      <CLSNAME>ZCL_AWS1_TEX_ACTIONS</CLSNAME>

--- a/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.xml
+++ b/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.xml
+++ b/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.xml
@@ -35,13 +35,13 @@
      <CLSNAME>ZCL_AWS1_XL8_ACTIONS</CLSNAME>
      <CMPNAME>STOP_TEXT_TRANSLATION_JOB</CMPNAME>
      <LANGU>E</LANGU>
-     <DESCRIPT>Stops an asynchronous batch translation job that is in progress.</DESCRIPT>
+     <DESCRIPT>Stops an asynchronous batch translation job that is in progr</DESCRIPT>
     </SEOCOMPOTX>
     <SEOCOMPOTX>
      <CLSNAME>ZCL_AWS1_XL8_ACTIONS</CLSNAME>
      <CMPNAME>TRANSLATE_TEXT</CMPNAME>
      <LANGU>E</LANGU>
-     <DESCRIPT>Translates input text from the source language to the target.</DESCRIPT>
+     <DESCRIPT>Translates input text from the source language to the target</DESCRIPT>
     </SEOCOMPOTX>
    </DESCRIPTIONS>
   </asx:values>


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request is in response to a user suggestion, that we replace our S3 `listobjects` example (which invokes a deprecated method) with `listobjectsv2`.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
