### PR TITLE
Modify Java tests to only run Comprehend

### DIFF
--- a/javav2/example_code/comprehend/src/test/java/AmazonComprehendTest.java
+++ b/javav2/example_code/comprehend/src/test/java/AmazonComprehendTest.java
@@ -71,6 +71,7 @@ public class AmazonComprehendTest {
     }
 
     @Test
+    @Tag("weathertop")
     @Tag("IntegrationTest")
     @Order(1)
     public void DetectEntities() {
@@ -79,6 +80,7 @@ public class AmazonComprehendTest {
     }
 
     @Test
+    @Tag("weathertop")
     @Tag("IntegrationTest")
     @Order(2)
     public void DetectKeyPhrases() {
@@ -87,6 +89,7 @@ public class AmazonComprehendTest {
     }
 
     @Test
+    @Tag("weathertop")
     @Tag("IntegrationTest")
     @Order(3)
     public void DetectLanguage() {
@@ -95,6 +98,7 @@ public class AmazonComprehendTest {
     }
 
     @Test
+    @Tag("weathertop")
     @Tag("IntegrationTest")
     @Order(4)
     public void DetectSentiment() {
@@ -103,6 +107,7 @@ public class AmazonComprehendTest {
     }
 
     @Test
+    @Tag("weathertop")
     @Tag("IntegrationTest")
     @Order(5)
     public void DetectSyntax() {

--- a/javav2/run_test.sh
+++ b/javav2/run_test.sh
@@ -5,7 +5,7 @@ run_mvn_tests() {
   for dir in "$1"/*/; do
     if [[ -f "$dir/pom.xml" ]]; then
       echo "Running mvn test in $dir"
-      (cd "$dir" && mvn test)
+      (cd "$dir" && mvn test -Dgroups=weathertop -DexcludedGroups=quarantine)
     fi
     if [[ -d "$dir" ]]; then
       run_mvn_tests "$dir"  # Recursively call function for sub-directories


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request limits Java tests running in AWS to only those within the Comprehend service directory, per @scmacdon request.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
