### PR TITLE
Fix title of Personalize Events putItems example.

### DIFF
--- a/.doc_gen/metadata/personalize-events_metadata.yaml
+++ b/.doc_gen/metadata/personalize-events_metadata.yaml
@@ -25,9 +25,9 @@ personalize-events_putEvents:
   services:
     personalize-events: {PutEvents}
 personalize-events_putItems:
-  title: Incrementally import an item into &PERSE; using an &AWS; SDK
-  title_abbrev: Import real-time interaction event data
-  synopsis: import real-time interaction event data into &PERSE;.
+  title: Incrementally import items into &PERSE; using an &AWS; SDK
+  title_abbrev: Import items into a dataset
+  synopsis: incrementally import items into an &PERSE; dataset.
   category:
   languages:
     JavaScript:


### PR DESCRIPTION
Old cut 'n' paste error uncovered by snexii. Update the putItems example so it reflects what the example is doing and (more importantly) so the title_abbrev field is different than the putEvents example. When two examples have identical title_abbrev, only one is published to the guides.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
