### PR TITLE
Rust: Updated cs in send-email.rs, SES

### DIFF
--- a/rust_dev_preview/examples/ses/src/bin/send-email.rs
+++ b/rust_dev_preview/examples/ses/src/bin/send-email.rs
@@ -57,7 +57,7 @@ async fn send_message(
 
     let cs: String = contacts
         .iter()
-        .map(|i| i.email_address().unwrap_or_default())
+        .map(|i| format!("{},",i.email_address().unwrap_or_default()))
         .collect();
 
     let dest = Destination::builder().to_addresses(cs).build();


### PR DESCRIPTION
cs is being returned without a comma between emails. eg:
user@example.comuser2@example.comexample.comuser3@example.com ...

Causes Exception:
Error: BadRequestException(BadRequestException { message: Some("Illegal address"), meta: ErrorMetadata { code: Some("BadRequestException"), message: Some("Illegal address"), extras: Some({"aws_request_id": "da0bf20a-52b3-4acc-bb22-eec27cf68322"}) } })

If the contact list has more that one contact it will fail.