### PR TITLE
gov2: made changes to return non nil error for UploadFile method, s3

### DIFF
--- a/gov2/s3/actions/bucket_basics.go
+++ b/gov2/s3/actions/bucket_basics.go
@@ -104,9 +104,9 @@ func (basics BucketBasics) UploadFile(bucketName string, objectKey string, fileN
 	file, err := os.Open(fileName)
 	if err != nil {
 		log.Printf("Couldn't open file %v to upload. Here's why: %v\n", fileName, err)
-	} else {
+	} 
 		defer file.Close()
-		_, err := basics.S3Client.PutObject(context.TODO(), &s3.PutObjectInput{
+		_, err = basics.S3Client.PutObject(context.TODO(), &s3.PutObjectInput{
 			Bucket: aws.String(bucketName),
 			Key:    aws.String(objectKey),
 			Body:   file,
@@ -115,7 +115,7 @@ func (basics BucketBasics) UploadFile(bucketName string, objectKey string, fileN
 			log.Printf("Couldn't upload file %v to %v:%v. Here's why: %v\n",
 				fileName, bucketName, objectKey, err)
 		}
-	}
+	
 	return err
 }
 

--- a/gov2/s3/actions/bucket_basics.go
+++ b/gov2/s3/actions/bucket_basics.go
@@ -104,7 +104,7 @@ func (basics BucketBasics) UploadFile(bucketName string, objectKey string, fileN
 	file, err := os.Open(fileName)
 	if err != nil {
 		log.Printf("Couldn't open file %v to upload. Here's why: %v\n", fileName, err)
-	} 
+	} else {
 		defer file.Close()
 		_, err = basics.S3Client.PutObject(context.TODO(), &s3.PutObjectInput{
 			Bucket: aws.String(bucketName),
@@ -115,7 +115,7 @@ func (basics BucketBasics) UploadFile(bucketName string, objectKey string, fileN
 			log.Printf("Couldn't upload file %v to %v:%v. Here's why: %v\n",
 				fileName, bucketName, objectKey, err)
 		}
-	
+	}
 	return err
 }
 


### PR DESCRIPTION
[[aws-doc-sdk-examples](https://github.com/awsdocs/aws-doc-sdk-examples/tree/main)/[gov2](https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/gov2)/[s3](https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/gov2/s3)/[actions](https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/gov2/s3/actions)
/bucket_basics.go ](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/gov2/s3/actions/bucket_basics.go#L103)

#5203 UploadFile should not return nil error if the file is existed and bucket is not existed
i made this method to return non nil errors in for different conditions like file existed and bucket is not existed

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
