### PR TITLE
C++: Add hello world documentation to language level README

### DIFF
--- a/cpp/README.rst
+++ b/cpp/README.rst
@@ -29,27 +29,27 @@ applicable to utilizing the code examples in this repository.
 Building and running the code examples
 =============
  
-The example code is organized in sub-folders by AWS service.
+The example code is organized in subfolders by AWS service.
 For example "example_code/s3" contains the Amazon Simple Storage Service (Amazon S3) code examples.
 
 Examples that use multiple services are located in the [example_code/cross-service](example_code/cross-service) folder.
 
-The examples use the CMake build system. Every service sub-folder contains a CMakeLists.txt file which will build all the examples for that service. 
+The examples use the CMake build system. Every service subfolder contains a CMakeLists.txt file that builds all the examples for that service. 
 
-Additional information geared specifically to understanding the example applications is at
+To understand more about the example applications, see
 [Get started with the AWS SDK for C++ code examples](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/getting-started-code-examples.html).
 
 Hello Service
 -----------
 
 Many of the services have a "Hello Service" folder with a starter project and README documentation. 
-For example, the AmazonS S3 Hello project is located at [example_code/s3/hello_s3](example_code/s3/hello_s3).
+For example, the Amazon S3 Hello project is located at [example_code/s3/hello_s3](example_code/s3/hello_s3).
 
 Docker image (Beta)
 ===================
 
 This example code will soon be available in a container image
-hosted on [Amazon Elastic Container Registry (ECR)](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html). This image will be pre-loaded
+hosted on [Amazon Elastic Container Registry (ECR)](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html). This image will be preloaded
 with all C++ examples with dependencies pre-resolved, allowing you to explore
 these examples in an isolated environment.
 

--- a/cpp/README.rst
+++ b/cpp/README.rst
@@ -29,9 +29,21 @@ applicable to utilizing the code examples in this repository.
 Building and running the code examples
 =============
  
-Additional information geared specifically to understanding the example applications is at
-`AWS SDK for C++ Code Examples <https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/programming-services.html>`_.
+The example code is organized in sub-folders by AWS service.
+For example "example_code/s3" contains the Amazon Simple Storage Service (Amazon S3) code examples.
 
+Examples that use multiple services are located in the [example_code/cross-service](example_code/cross-service) folder.
+
+The examples use the CMake build system. Every service sub-folder contains a CMakeLists.txt file which will build all the examples for that service. 
+
+Additional information geared specifically to understanding the example applications is at
+[Get started with the AWS SDK for C++ code examples](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/getting-started-code-examples.html).
+
+Hello Service
+-----------
+
+Many of the services have a "Hello Service" folder with a starter project and README documentation. 
+For example, the AmazonS S3 Hello project is located at [example_code/s3/hello_s3](example_code/s3/hello_s3).
 
 Docker image (Beta)
 ===================

--- a/cpp/example_code/aurora/hello_aurora/hello_aurora.cpp
+++ b/cpp/example_code/aurora/hello_aurora/hello_aurora.cpp
@@ -28,7 +28,9 @@
  */
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
     int result = 0;
     {
         Aws::Client::ClientConfiguration clientConfig;
@@ -65,7 +67,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return 0;
 }
 // snippet-end:[cpp.example_code.aurora.hello_aurora]

--- a/cpp/example_code/autoscaling/hello_autoscaling/hello_autoscaling.cpp
+++ b/cpp/example_code/autoscaling/hello_autoscaling/hello_autoscaling.cpp
@@ -29,7 +29,9 @@
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
     int result = 0;
     {
         Aws::Client::ClientConfiguration clientConfig;
@@ -75,7 +77,7 @@ int main(int argc, char **argv) {
     }
 
 
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return result;
 }
 // snippet-end:[cpp.example_code.autoscaling.hello_autoscaling]

--- a/cpp/example_code/cognito/hello_cognito/hello_cognito.cpp
+++ b/cpp/example_code/cognito/hello_cognito/hello_cognito.cpp
@@ -29,7 +29,9 @@
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
     int result = 0;
     {
         Aws::Client::ClientConfiguration clientConfig;
@@ -71,7 +73,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return result;
 }
 // snippet-end:[cpp.example_code.cognito.hello_cognito]

--- a/cpp/example_code/dynamodb/hello_dynamodb/hello_dynamodb.cpp
+++ b/cpp/example_code/dynamodb/hello_dynamodb/hello_dynamodb.cpp
@@ -29,7 +29,9 @@
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
 
     int result = 0;
     {
@@ -60,7 +62,7 @@ int main(int argc, char **argv) {
     }
 
 
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return result;
 }
 // snippet-end:[cpp.example_code.dynamodb.hello_dynamodb]

--- a/cpp/example_code/ec2/hello_ec2/hello_ec2.cpp
+++ b/cpp/example_code/ec2/hello_ec2/hello_ec2.cpp
@@ -30,7 +30,9 @@
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
     int result = 0;
     {
         Aws::Client::ClientConfiguration clientConfig;
@@ -108,7 +110,7 @@ int main(int argc, char **argv) {
     }
 
 
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return result;
 }
 // snippet-end:[cpp.example_code.ec2.hello_ec2]

--- a/cpp/example_code/glue/hello_glue/hello_glue.cpp
+++ b/cpp/example_code/glue/hello_glue/hello_glue.cpp
@@ -29,7 +29,9 @@
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
     int result = 0;
     {
         Aws::Client::ClientConfiguration clientConfig;
@@ -70,7 +72,7 @@ int main(int argc, char **argv) {
             std::cout << "   " << i + 1 << ". " << jobs[i] << std::endl;
         }
     }
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return result;
 }
 // snippet-end:[cpp.example_code.glue.hello_glue]

--- a/cpp/example_code/iam/hello_iam/hello_iam.cpp
+++ b/cpp/example_code/iam/hello_iam/hello_iam.cpp
@@ -30,7 +30,9 @@
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
     int result = 0;
     {
         const Aws::String DATE_FORMAT("%Y-%m-%d");
@@ -79,7 +81,7 @@ int main(int argc, char **argv) {
     }
 
 
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return result;
 }
 // snippet-end:[cpp.example_code.iam.hello_iam]

--- a/cpp/example_code/lambda/hello_lambda/hello_lambda.cpp
+++ b/cpp/example_code/lambda/hello_lambda/hello_lambda.cpp
@@ -28,7 +28,9 @@
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
     int result = 0;
     {
         Aws::Client::ClientConfiguration clientConfig;
@@ -75,7 +77,7 @@ int main(int argc, char **argv) {
     }
 
 
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return result;
 }
 // snippet-end:[cpp.example_code.lambda.hello_lambda]

--- a/cpp/example_code/rds/hello_rds/hello_rds.cpp
+++ b/cpp/example_code/rds/hello_rds/hello_rds.cpp
@@ -29,7 +29,9 @@
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
     int result = 0;
     {
         Aws::Client::ClientConfiguration clientConfig;
@@ -70,7 +72,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return result;
 }
 // snippet-end:[cpp.example_code.rds.hello_rds]

--- a/cpp/example_code/s3/hello_s3/hello_s3.cpp
+++ b/cpp/example_code/s3/hello_s3/hello_s3.cpp
@@ -28,7 +28,9 @@
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
     int result = 0;
     {
         Aws::Client::ClientConfiguration clientConfig;
@@ -50,7 +52,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return result;
 }
 // snippet-end:[cpp.example_code.s3.hello_s3]

--- a/cpp/example_code/sns/hello_sns/hello_sns.cpp
+++ b/cpp/example_code/sns/hello_sns/hello_sns.cpp
@@ -29,7 +29,9 @@
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
     {
         Aws::Client::ClientConfiguration clientConfig;
         // Optional: Set to the AWS Region (overrides config file).
@@ -79,7 +81,7 @@ int main(int argc, char **argv) {
     }
 
 
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return 0;
 }
 // snippet-end:[cpp.example_code.sns.hello_sns]

--- a/cpp/example_code/sqs/hello_sqs/hello_sqs.cpp
+++ b/cpp/example_code/sqs/hello_sqs/hello_sqs.cpp
@@ -29,7 +29,9 @@
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    Aws::InitAPI(options);
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
     {
         Aws::Client::ClientConfiguration clientConfig;
         // Optional: Set to the AWS Region (overrides config file).
@@ -73,7 +75,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    Aws::ShutdownAPI(options);
+    Aws::ShutdownAPI(options); // Should only be called once.
     return 0;
 }
 // snippet-end:[cpp.example_code.sqs.hello_sqs]


### PR DESCRIPTION
Add hello world documentation to language level README.
For 12 existing hello worlds.
Add logging information to cpp file.
Add documentation about sdk init shutdown.