### PR TITLE
JavaScript (v3): Use @smithy namespace for internal packages.

### DIFF
--- a/javascriptv3/example_code/eventbridge/src/package.json
+++ b/javascriptv3/example_code/eventbridge/src/package.json
@@ -5,8 +5,8 @@
   "repository": "git@github.com/awsdocs/aws-doc-sdk-examples/tree/master/javascriptv3/example_code/eventbridge.git",
   "author": "Brian Murray <brmur@amazon.com>",
   "license": "Apache 2.0",
+  "type": "module",
   "dependencies": {
-    "@aws-sdk/eventbridge": "^3.32.0"
-  },
-  "type": "module"
+    "@aws-sdk/client-eventbridge": "^3.387.0"
+  }
 }

--- a/javascriptv3/example_code/eventbridge/tests/package.json
+++ b/javascriptv3/example_code/eventbridge/tests/package.json
@@ -6,8 +6,7 @@
   "author": "Brian Murray <brmur@amazon.com>, Alex Forsyth <alex-git@amazon.com>",
   "license": "Apache 2.0",
   "dependencies": {
-    "@aws-sdk/eventbridge": "^3.32.0",
-    "@aws-sdk/node-http-handler": "^3.32.0"
+    "@aws-sdk/client-eventbridge": "^3.387.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.14.4",

--- a/javascriptv3/example_code/glacier/package.json
+++ b/javascriptv3/example_code/glacier/package.json
@@ -7,7 +7,6 @@
   "license": "Apache 2.0",
   "dependencies": {
     "@aws-sdk/client-glacier": "^3.32.0",
-    "@aws-sdk/node-http-handler": "^3.32.0",
     "@aws-sdk/types": "^3.32.0"
   },
   "devDependencies": {

--- a/javascriptv3/example_code/kinesis/package.json
+++ b/javascriptv3/example_code/kinesis/package.json
@@ -11,16 +11,15 @@
   "license": "Apache 2.0",
   "dependencies": {
     "@aws-sdk/client-cognito-identity": "^3.32.0",
-    "@aws-sdk/credential-provider-cognito-identity": "^3.32.0",
     "@aws-sdk/client-kinesis": "^3.32.0",
-    "@aws-sdk/node-http-handler": "^3.32.0",
+    "@aws-sdk/credential-provider-cognito-identity": "^3.32.0",
     "@aws-sdk/types": "^3.32.0"
   },
   "devDependencies": {
-    "webpack": "^4.42.0",
-    "webpack-cli": "^3.3.11",
     "@aws-sdk/types": "^3.32.0",
-    "@types/node": "^14.0.23"
+    "@types/node": "^14.0.23",
+    "webpack": "^4.42.0",
+    "webpack-cli": "^3.3.11"
   },
   "module": "type"
 }

--- a/javascriptv3/example_code/mediaconvert/package.json
+++ b/javascriptv3/example_code/mediaconvert/package.json
@@ -7,10 +7,9 @@
   "license": "Apache 2.0",
   "dependencies": {
     "@aws-sdk/client-mediaconvert": "^3.32.0",
-    "@aws-sdk/node-http-handler": "^3.32.0",
     "@aws-sdk/types": "^3.32.0",
-    "node-fetch": "^2.6",
-    "jest": "^26.6.3"
+    "jest": "^26.6.3",
+    "node-fetch": "^2.6"
   },
   "devDependencies": {
     "@types/node": "^14.0.23",

--- a/javascriptv3/example_code/nodegetstarted/package.json
+++ b/javascriptv3/example_code/nodegetstarted/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.32.0",
-    "@aws-sdk/node-http-handler": "^3.32.0",
     "@aws-sdk/types": "^3.32.0"
   },
   "devDependencies": {

--- a/javascriptv3/example_code/personalize/tests/package.json
+++ b/javascriptv3/example_code/personalize/tests/package.json
@@ -11,8 +11,7 @@
     "@aws-sdk/client-personalize-events": "^3.51.0",
     "@aws-sdk/client-personalize-runtime": "^3.51.0",
     "dotenv": "^16.0.0",
-    "fs": "^0.0.1-security",
-    "@aws-sdk/node-http-handler": "^3.32.0"
+    "fs": "^0.0.1-security"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.14.4",

--- a/javascriptv3/example_code/polly/general-examples/src/package.json
+++ b/javascriptv3/example_code/polly/general-examples/src/package.json
@@ -6,7 +6,6 @@
   "license": "Apache 2.0",
   "dependencies": {
     "@aws-sdk/client-polly": "^3.32.0",
-    "@aws-sdk/node-http-handler": "^3.32.0",
     "@aws-sdk/types": "^3.32.0"
   },
   "devDependencies": {

--- a/javascriptv3/example_code/polly/package.json
+++ b/javascriptv3/example_code/polly/package.json
@@ -6,14 +6,13 @@
   "author": "Brian Murray <brmur@amazon.com>, Alex Forsyth <alex-git@amazon.com>",
   "license": "Apache 2.0",
   "scripts": {
-    "run":"webpack src/polly.js --mode development --libraryTarget commonjs2 --target web --devtool false -o src/dist/main.js"
+    "run": "webpack src/polly.js --mode development --libraryTarget commonjs2 --target web --devtool false -o src/dist/main.js"
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity": "^3.32.0",
-    "@aws-sdk/credential-provider-cognito-identity": "^3.32.0",
     "@aws-sdk/client-polly": "^3.32.0",
-    "@aws-sdk/polly-request-presigner": "^3.32.0",
-    "@aws-sdk/node-http-handler": "^3.32.0"
+    "@aws-sdk/credential-provider-cognito-identity": "^3.32.0",
+    "@aws-sdk/polly-request-presigner": "^3.32.0"
   },
   "devDependencies": {
     "webpack": "^4.42.0",

--- a/javascriptv3/example_code/redshift/package.json
+++ b/javascriptv3/example_code/redshift/package.json
@@ -7,7 +7,6 @@
   "license": "Apache 2.0",
   "dependencies": {
     "@aws-sdk/client-redshift": "^3.32.0",
-    "@aws-sdk/node-http-handler": "^3.32.0",
     "@aws-sdk/types": "^3.32.0"
   },
   "devDependencies": {

--- a/javascriptv3/example_code/rekognition/estimate-age-example/src/package.json
+++ b/javascriptv3/example_code/rekognition/estimate-age-example/src/package.json
@@ -10,10 +10,9 @@
   "author": "Brian Murray <brmur@amazon.com>",
   "license": "Apache 2.0",
   "dependencies": {
-    "@aws-sdk/client-rekognition": "^3.32.0",
-    "@aws-sdk/node-http-handler": "^3.32.0",
-    "@aws-sdk/credential-provider-cognito-identity": "^3.32.0",
     "@aws-sdk/client-cognito-identity": "^3.32.0",
+    "@aws-sdk/client-rekognition": "^3.32.0",
+    "@aws-sdk/credential-provider-cognito-identity": "^3.32.0",
     "uuid": "^8.3.2",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11"

--- a/javascriptv3/example_code/s3/package.json
+++ b/javascriptv3/example_code/s3/package.json
@@ -12,11 +12,11 @@
     "@aws-crypto/sha256-browser": "^4.0.0",
     "@aws-sdk/client-s3": "^3.272.0",
     "@aws-sdk/credential-providers": "^3.276.0",
-    "@aws-sdk/hash-node": "^3.272.0",
-    "@aws-sdk/protocol-http": "^3.272.0",
     "@aws-sdk/s3-request-presigner": "^3.276.0",
-    "@aws-sdk/url-parser": "^3.272.0",
     "@aws-sdk/util-format-url": "^3.272.0",
+    "@smithy/hash-node": "^2.0.2",
+    "@smithy/protocol-http": "^2.0.2",
+    "@smithy/url-parser": "^2.0.2",
     "libs": "*"
   },
   "devDependencies": {

--- a/javascriptv3/example_code/s3/scenarios/presigned-url-download.js
+++ b/javascriptv3/example_code/s3/scenarios/presigned-url-download.js
@@ -3,21 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fileURLToPath } from "url";
+import {fileURLToPath} from "url";
 
 // snippet-start:[s3.JavaScript.buckets.getpresignedurlv3]
-import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import { fromIni } from "@aws-sdk/credential-providers";
-import { HttpRequest } from "@aws-sdk/protocol-http";
-import {
-  getSignedUrl,
-  S3RequestPresigner,
-} from "@aws-sdk/s3-request-presigner";
-import { parseUrl } from "@aws-sdk/url-parser";
-import { formatUrl } from "@aws-sdk/util-format-url";
-import { Hash } from "@aws-sdk/hash-node";
+import {GetObjectCommand, S3Client} from "@aws-sdk/client-s3";
+import {fromIni} from "@aws-sdk/credential-providers";
+import {HttpRequest} from "@smithy/protocol-http";
+import {getSignedUrl, S3RequestPresigner} from "@aws-sdk/s3-request-presigner";
+import {parseUrl} from "@smithy/url-parser";
+import {formatUrl} from "@aws-sdk/util-format-url";
+import {Hash} from "@smithy/hash-node";
 
-const createPresignedUrlWithoutClient = async ({ region, bucket, key }) => {
+const createPresignedUrlWithoutClient = async ({region, bucket, key}) => {
   const url = parseUrl(`https://${bucket}.s3.${region}.amazonaws.com/${key}`);
   const presigner = new S3RequestPresigner({
     credentials: fromIni(),
@@ -29,10 +26,10 @@ const createPresignedUrlWithoutClient = async ({ region, bucket, key }) => {
   return formatUrl(signedUrlObject);
 };
 
-const createPresignedUrlWithClient = ({ region, bucket, key }) => {
-  const client = new S3Client({ region });
-  const command = new GetObjectCommand({ Bucket: bucket, Key: key });
-  return getSignedUrl(client, command, { expiresIn: 3600 });
+const createPresignedUrlWithClient = ({region, bucket, key}) => {
+  const client = new S3Client({region});
+  const command = new GetObjectCommand({Bucket: bucket, Key: key});
+  return getSignedUrl(client, command, {expiresIn: 3600});
 };
 
 export const main = async () => {

--- a/javascriptv3/example_code/s3/scenarios/presigned-url-upload.js
+++ b/javascriptv3/example_code/s3/scenarios/presigned-url-upload.js
@@ -3,22 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fileURLToPath } from "url";
+import {fileURLToPath} from "url";
 
 // snippet-start:[s3.JavaScript.buckets.presignedurlv3]
 import https from "https";
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import { fromIni } from "@aws-sdk/credential-providers";
-import { HttpRequest } from "@aws-sdk/protocol-http";
-import {
-  getSignedUrl,
-  S3RequestPresigner,
-} from "@aws-sdk/s3-request-presigner";
-import { parseUrl } from "@aws-sdk/url-parser";
-import { formatUrl } from "@aws-sdk/util-format-url";
-import { Hash } from "@aws-sdk/hash-node";
+import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
+import {fromIni} from "@aws-sdk/credential-providers";
+import {HttpRequest} from "@smithy/protocol-http";
+import {getSignedUrl, S3RequestPresigner} from "@aws-sdk/s3-request-presigner";
+import {parseUrl} from "@smithy/url-parser";
+import {formatUrl} from "@aws-sdk/util-format-url";
+import {Hash} from "@smithy/hash-node";
 
-const createPresignedUrlWithoutClient = async ({ region, bucket, key }) => {
+const createPresignedUrlWithoutClient = async ({region, bucket, key}) => {
   const url = parseUrl(`https://${bucket}.s3.${region}.amazonaws.com/${key}`);
   const presigner = new S3RequestPresigner({
     credentials: fromIni(),
@@ -27,22 +24,22 @@ const createPresignedUrlWithoutClient = async ({ region, bucket, key }) => {
   });
 
   const signedUrlObject = await presigner.presign(
-    new HttpRequest({ ...url, method: "PUT" })
+    new HttpRequest({...url, method: "PUT"})
   );
   return formatUrl(signedUrlObject);
 };
 
-const createPresignedUrlWithClient = ({ region, bucket, key }) => {
-  const client = new S3Client({ region });
-  const command = new PutObjectCommand({ Bucket: bucket, Key: key });
-  return getSignedUrl(client, command, { expiresIn: 3600 });
+const createPresignedUrlWithClient = ({region, bucket, key}) => {
+  const client = new S3Client({region});
+  const command = new PutObjectCommand({Bucket: bucket, Key: key});
+  return getSignedUrl(client, command, {expiresIn: 3600});
 };
 
 function put(url, data) {
   return new Promise((resolve, reject) => {
     const req = https.request(
       url,
-      { method: "PUT", headers: { "Content-Length": new Blob([data]).size } },
+      {method: "PUT", headers: {"Content-Length": new Blob([data]).size}},
       (res) => {
         let responseBody = "";
         res.on("data", (chunk) => {

--- a/javascriptv3/package-lock.json
+++ b/javascriptv3/package-lock.json
@@ -2014,11 +2014,11 @@
         "@aws-crypto/sha256-browser": "^4.0.0",
         "@aws-sdk/client-s3": "^3.272.0",
         "@aws-sdk/credential-providers": "^3.276.0",
-        "@aws-sdk/hash-node": "^3.272.0",
-        "@aws-sdk/protocol-http": "^3.272.0",
         "@aws-sdk/s3-request-presigner": "^3.276.0",
-        "@aws-sdk/url-parser": "^3.272.0",
         "@aws-sdk/util-format-url": "^3.272.0",
+        "@smithy/hash-node": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/url-parser": "^2.0.2",
         "libs": "*"
       },
       "devDependencies": {
@@ -2090,6 +2090,100 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "example_code/s3/node_modules/@smithy/hash-node": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.2.tgz",
+      "integrity": "sha512-JKDzZ1YVR7JzOBaJoWy3ToJCE86OQE6D4kOBvvVsu93a3lcF9kv6KYTKBYEWAjwOn/CpK4NH7mKB01OQ8H+aiA==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "example_code/s3/node_modules/@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "example_code/s3/node_modules/@smithy/protocol-http": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+      "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "example_code/s3/node_modules/@smithy/querystring-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.2.tgz",
+      "integrity": "sha512-L4VtKQ8O4/aWPQJbiFymbhAmxdfLnEaROh/Vs0OstJ7jtOZeBl2QJmuWY2V7hjt64W7V+tEn2sv6vVvnxkm/xQ==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "example_code/s3/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "example_code/s3/node_modules/@smithy/url-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.2.tgz",
+      "integrity": "sha512-X1mHCzrSVDlhVy7d3S7Vq+dTfYzwh4n7xGHhyJumu77nJqIss0lazVug85Pwo0DKIoO314wAOvMnBxNYDa+7wA==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "example_code/s3/node_modules/@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "example_code/s3/node_modules/@smithy/util-utf8": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "example_code/s3/node_modules/pathe": {
       "version": "1.1.0",
@@ -69634,11 +69728,11 @@
         "@aws-crypto/sha256-browser": "^4.0.0",
         "@aws-sdk/client-s3": "^3.272.0",
         "@aws-sdk/credential-providers": "^3.276.0",
-        "@aws-sdk/hash-node": "^3.272.0",
-        "@aws-sdk/protocol-http": "^3.272.0",
         "@aws-sdk/s3-request-presigner": "^3.276.0",
-        "@aws-sdk/url-parser": "^3.272.0",
         "@aws-sdk/util-format-url": "^3.272.0",
+        "@smithy/hash-node": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/url-parser": "^2.0.2",
         "libs": "*",
         "vitest": "^0.28.5"
       },
@@ -69713,6 +69807,79 @@
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
             }
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.2.tgz",
+          "integrity": "sha512-JKDzZ1YVR7JzOBaJoWy3ToJCE86OQE6D4kOBvvVsu93a3lcF9kv6KYTKBYEWAjwOn/CpK4NH7mKB01OQ8H+aiA==",
+          "requires": {
+            "@smithy/types": "^2.1.0",
+            "@smithy/util-buffer-from": "^2.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+          "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+          "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+          "requires": {
+            "@smithy/types": "^2.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.2.tgz",
+          "integrity": "sha512-L4VtKQ8O4/aWPQJbiFymbhAmxdfLnEaROh/Vs0OstJ7jtOZeBl2QJmuWY2V7hjt64W7V+tEn2sv6vVvnxkm/xQ==",
+          "requires": {
+            "@smithy/types": "^2.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.2.tgz",
+          "integrity": "sha512-X1mHCzrSVDlhVy7d3S7Vq+dTfYzwh4n7xGHhyJumu77nJqIss0lazVug85Pwo0DKIoO314wAOvMnBxNYDa+7wA==",
+          "requires": {
+            "@smithy/querystring-parser": "^2.0.2",
+            "@smithy/types": "^2.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+          "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+          "requires": {
+            "@smithy/is-array-buffer": "^2.0.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+          "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^2.0.0",
+            "tslib": "^2.5.0"
           }
         },
         "pathe": {


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

The JS SDK deprecated some packages and moved them under the @smithy namespace. This addresses the handful of places where those packages were being used.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
