### PR TITLE
Fix metadata validator check for non-entity uses of AWS.

### DIFF
--- a/.doc_gen/validation/validate_doc_metadata.py
+++ b/.doc_gen/validation/validate_doc_metadata.py
@@ -110,7 +110,7 @@ class StringExtension(String):
         valid = True
         if self.check_aws:
             # All occurrences of AWS must be entities or within a word.
-            valid = len(re.findall('(?<![&\\da-zA-Z])AWS|AWS(?![;\\da-zA-Z])', value)) == 0
+            valid = len(re.findall('(?<![&\da-zA-Z])AWS(?![;\da-zA-Z])', value)) == 0
             if not valid:
                 self.last_err = 'valid string: it contains a non-entity usage of "AWS"'
         if valid and self.upper_start:


### PR DESCRIPTION
Update the metadata check for uses of "AWS" that aren't entities or within a word so that it works as intended.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
