### PR TITLE
cpp; Update minimum cmake, all services

### DIFF
--- a/cpp/example_code/acm/CMakeLists.txt
+++ b/cpp/example_code/acm/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set this project's name.
 project("acm-examples")

--- a/cpp/example_code/aurora/CMakeLists.txt
+++ b/cpp/example_code/aurora/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME aurora)
 set(SERVICE_COMPONENTS rds)

--- a/cpp/example_code/aurora/hello_aurora/CMakeLists.txt
+++ b/cpp/example_code/aurora/hello_aurora/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.aurora.hello_aurora.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS rds)

--- a/cpp/example_code/autoscaling/CMakeLists.txt
+++ b/cpp/example_code/autoscaling/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME auto_scaling)
 set(SERVICE_COMPONENTS autoscaling ec2 monitoring)

--- a/cpp/example_code/autoscaling/hello_autoscaling/CMakeLists.txt
+++ b/cpp/example_code/autoscaling/hello_autoscaling/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.autoscaling.hello_autoscaling.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS autoscaling)

--- a/cpp/example_code/cloudtrail/CMakeLists.txt
+++ b/cpp/example_code/cloudtrail/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(cloudtrail-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/cloudwatch/CMakeLists.txt
+++ b/cpp/example_code/cloudwatch/CMakeLists.txt
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME cloudwatch)
 set(SERVICE_COMPONENTS monitoring events logs)

--- a/cpp/example_code/codebuild/CMakeLists.txt
+++ b/cpp/example_code/codebuild/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(codebuild-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/codecommit/CMakeLists.txt
+++ b/cpp/example_code/codecommit/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(codecommit-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/cognito/CMakeLists.txt
+++ b/cpp/example_code/cognito/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME cognito)
 set(SERVICE_COMPONENTS cognito-idp)

--- a/cpp/example_code/cognito/hello_cognito/CMakeLists.txt
+++ b/cpp/example_code/cognito/hello_cognito/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.cognito.hello_cognito.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS cognito-idp)

--- a/cpp/example_code/cross-service/photo_asset_manager/CMakeLists.txt
+++ b/cpp/example_code/cross-service/photo_asset_manager/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 set(CMAKE_CXX_STANDARD 11)
 project(cpp_pam_lambdas LANGUAGES CXX)
 

--- a/cpp/example_code/cross-service/serverless-aurora/CMakeLists.txt
+++ b/cpp/example_code/cross-service/serverless-aurora/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_COMPONENTS sesv2 rds-data)
 

--- a/cpp/example_code/cross-service/topics_and_queues/CMakeLists.txt
+++ b/cpp/example_code/cross-service/topics_and_queues/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_COMPONENTS sns sqs)
 

--- a/cpp/example_code/dynamodb/CMakeLists.txt
+++ b/cpp/example_code/dynamodb/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME dynamodb)
 set(SERVICE_COMPONENTS dynamodb s3) # s3 is required for tests, and it must be included here because of caching.

--- a/cpp/example_code/dynamodb/hello_dynamodb/CMakeLists.txt
+++ b/cpp/example_code/dynamodb/hello_dynamodb/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.dynamodb.hello_dynamodb.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS dynamodb)

--- a/cpp/example_code/ebs/CMakeLists.txt
+++ b/cpp/example_code/ebs/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(ebs-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/ec2/CMakeLists.txt
+++ b/cpp/example_code/ec2/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME ec2)
 set(SERVICE_COMPONENTS ec2)

--- a/cpp/example_code/ec2/hello_ec2/CMakeLists.txt
+++ b/cpp/example_code/ec2/hello_ec2/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.ec2.hello_ec2.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS ec2)

--- a/cpp/example_code/efs/CMakeLists.txt
+++ b/cpp/example_code/efs/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(efs-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/elasticache/CMakeLists.txt
+++ b/cpp/example_code/elasticache/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(elasticache-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/elasticfilesystem/CMakeLists.txt
+++ b/cpp/example_code/elasticfilesystem/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(elasticfilesystem-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/general/CMakeLists.txt
+++ b/cpp/example_code/general/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[general.cpp.starter.cmakelists]
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.13)
 set(CMAKE_CXX_STANDARD 11)
 project(app LANGUAGES CXX)
 

--- a/cpp/example_code/glacier/CMakeLists.txt
+++ b/cpp/example_code/glacier/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(glacier-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/glue/CMakeLists.txt
+++ b/cpp/example_code/glue/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME glue)
 set(SERVICE_COMPONENTS glue s3 iam)

--- a/cpp/example_code/glue/hello_glue/CMakeLists.txt
+++ b/cpp/example_code/glue/hello_glue/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.glue.hello_glue.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS glue)

--- a/cpp/example_code/guardduty/CMakeLists.txt
+++ b/cpp/example_code/guardduty/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(guardduty-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/iam/CMakeLists.txt
+++ b/cpp/example_code/iam/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME iam)
 set(SERVICE_COMPONENTS  iam s3 sts)

--- a/cpp/example_code/iam/hello_iam/CMakeLists.txt
+++ b/cpp/example_code/iam/hello_iam/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.iam.hello_iam.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS iam)

--- a/cpp/example_code/kinesis/CMakeLists.txt
+++ b/cpp/example_code/kinesis/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(kinesis-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/lambda/CMakeLists.txt
+++ b/cpp/example_code/lambda/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME lambda)
 set(SERVICE_COMPONENTS lambda iam)

--- a/cpp/example_code/lambda/cpp_lambda/calculator/CMakeLists.txt
+++ b/cpp/example_code/lambda/cpp_lambda/calculator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 set(CMAKE_CXX_STANDARD 11)
 project(cpp_lambda_calculator LANGUAGES CXX)
 

--- a/cpp/example_code/lambda/cpp_lambda/increment/CMakeLists.txt
+++ b/cpp/example_code/lambda/cpp_lambda/increment/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 set(CMAKE_CXX_STANDARD 11)
 project(cpp_lambda_increment LANGUAGES CXX)
 

--- a/cpp/example_code/lambda/hello_lambda/CMakeLists.txt
+++ b/cpp/example_code/lambda/hello_lambda/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.lambda.hello_lambda.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS lambda)

--- a/cpp/example_code/mediaconvert/CMakeLists.txt
+++ b/cpp/example_code/mediaconvert/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME mediaconvert)
 set(SERVICE_COMPONENTS mediaconvert)

--- a/cpp/example_code/neptune/CMakeLists.txt
+++ b/cpp/example_code/neptune/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(neptune-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/rds/CMakeLists.txt
+++ b/cpp/example_code/rds/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME rds)
 set(SERVICE_COMPONENTS rds)

--- a/cpp/example_code/rds/hello_rds/CMakeLists.txt
+++ b/cpp/example_code/rds/hello_rds/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.rds.hello_rds.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS rds)

--- a/cpp/example_code/redshift/CMakeLists.txt
+++ b/cpp/example_code/redshift/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(redshift-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/s3-crt/CMakeLists.txt
+++ b/cpp/example_code/s3-crt/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set this project's name.
 project("s3-crt-examples")

--- a/cpp/example_code/s3/CMakeLists.txt
+++ b/cpp/example_code/s3/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME)
 set(SERVICE_COMPONENTS s3 sts iam)

--- a/cpp/example_code/s3/hello_s3/CMakeLists.txt
+++ b/cpp/example_code/s3/hello_s3/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.s3.hello_s3.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS s3)

--- a/cpp/example_code/s3encryption/CMakeLists.txt
+++ b/cpp/example_code/s3encryption/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set this project's name.
 project("s3-encryption-examples")

--- a/cpp/example_code/secretsmanager/CMakeLists.txt
+++ b/cpp/example_code/secretsmanager/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 
 # Minimal CMakeLists.txt for the AWS SDK for C++.
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.13)
 set(CMAKE_CXX_STANDARD 11)
 project(secretsmanager-example LANGUAGES CXX)
 

--- a/cpp/example_code/ses/CMakeLists.txt
+++ b/cpp/example_code/ses/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(ses-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/sns/CMakeLists.txt
+++ b/cpp/example_code/sns/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME sns)
 set(SERVICE_COMPONENTS sns)

--- a/cpp/example_code/sns/hello_sns/CMakeLists.txt
+++ b/cpp/example_code/sns/hello_sns/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.sns.hello_sns.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS sns)

--- a/cpp/example_code/sqs/CMakeLists.txt
+++ b/cpp/example_code/sqs/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME sqs)
 set(SERVICE_COMPONENTS sqs)

--- a/cpp/example_code/sqs/hello_sqs/CMakeLists.txt
+++ b/cpp/example_code/sqs/hello_sqs/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # snippet-start:[cpp.example_code.sqs.hello_sqs.cmake]
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set the AWS service components used by this project.
 set(SERVICE_COMPONENTS sqs)

--- a/cpp/example_code/storage_gateway/CMakeLists.txt
+++ b/cpp/example_code/storage_gateway/CMakeLists.txt
@@ -7,7 +7,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(sg-examples)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/cpp/example_code/sts/CMakeLists.txt
+++ b/cpp/example_code/sts/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(SERVICE_NAME sts)
 set(SERVICE_COMPONENTS sts iam s3)

--- a/cpp/example_code/transcribe/CMakeLists.txt
+++ b/cpp/example_code/transcribe/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMakeLists.txt
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.13)
 set(CMAKE_CXX_STANDARD 11)
 project(get_transcript LANGUAGES CXX)
 

--- a/cpp/example_code/transfer-manager/CMakeLists.txt
+++ b/cpp/example_code/transfer-manager/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 # Set this project's name.
 project("tm-examples")


### PR DESCRIPTION
Align the minimum cmake version with the SDK requirement, which is 3.13.
Except for tests which require 3.14

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
