### PR TITLE
C++:  updated windows build with curl lib

### DIFF
--- a/cpp/example_code/s3/CMakeLists.txt
+++ b/cpp/example_code/s3/CMakeLists.txt
@@ -4,8 +4,8 @@
 # Set the minimum required version of CMake for this project.
 cmake_minimum_required(VERSION 3.13)
 
-set(SERVICE_NAME)
-set(SERVICE_COMPONENTS s3 sts iam)
+set(SERVICE_NAME s3)
+set(SERVICE_COMPONENTS iam s3 sts)
 
 # Set this project's name.
 project("${SERVICE_NAME}-examples")
@@ -15,6 +15,10 @@ set(BUILD_SHARED_LIBS ON)
 
 # Set the C++ standard to use to build this target.
 set(CMAKE_CXX_STANDARD 11)
+
+
+# Build shared libraries by default.
+set(BUILD_SHARED_LIBS ON)
 
 # Use the MSVC variable to determine if this is a Windows build.
 set(WINDOWS_BUILD ${MSVC})
@@ -29,15 +33,14 @@ endif()
 find_package(AWSSDK REQUIRED COMPONENTS ${SERVICE_COMPONENTS})
 
 
-
 if(WINDOWS_BUILD)
      # Copy relevant AWS SDK for C++ libraries into the current binary directory for running and debugging.
 
-     # set(BIN_SUB_DIR "/Debug") # if you are building from the command line you may need to uncomment this 
+     # set(BIN_SUB_DIR "/Debug") # If you are building from the command line, you may need to uncomment this 
                                     # and set the proper subdirectory to the executables' location.
 
      AWSSDK_CPY_DYN_LIBS(SERVICE_COMPONENTS "" ${CMAKE_CURRENT_BINARY_DIR}${BIN_SUB_DIR})
-endif()
+ endif()
 
 # Add the code example-specific header files.
 file(GLOB AWSDOC_S3_HEADERS
@@ -52,15 +55,16 @@ if(NOT DEFINED AWSDOC_S3_SOURCE)
     )
 endif()
 
-# Check whether the target system is Windows, including Win64.
-if(WIN32)
-    list(FILTER AWSDOC_S3_SOURCE EXCLUDE REGEX "/list_buckets_disabling_dns_cache.cpp$") # Not supported in windows, see file for details
-
-    # Check whether the compiler is some version of Microsoft Visual C++, or another compiler simulating C++.
-    if(MSVC)
-        source_group("Header Files\\awsdoc\\s3" FILES ${AWSDOC_S3_HEADERS})
-        source_group("Source Files" FILES ${AWSDOC_S3_SOURCE})
-    endif(MSVC)
+# Handle special case of list_buckets_disabling_dns_cache.cpp on Windows.
+if(WINDOWS_BUILD)
+    list(FIND AWSSDK_CLIENT_LIBS "curl" CONTAINS_CURL)
+    if (CONTAINS_CURL EQUAL -1)
+            # Remove list_buckets_disabling_dns_cache.cpp when not using curl library for http.
+        list(FILTER AWSDOC_S3_SOURCE EXCLUDE REGEX "/list_buckets_disabling_dns_cache.cpp$") # Not supported in windows without curl, see file for details
+    else()
+        set(CURL_INCLUDE "c:/curl/include") # Update this with correct curl install location.
+        set(CURL_LIB "c:/curl/lib") # Update this with correct  curl install location.
+    endif()
 endif()
 
 foreach(file ${AWSDOC_S3_SOURCE})
@@ -73,9 +77,16 @@ foreach(file ${AWSDOC_S3_SOURCE})
 
     target_include_directories(${EXAMPLE_EXE} PUBLIC 
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>)
-    target_link_libraries(${EXAMPLE_EXE} ${AWSSDK_LINK_LIBRARIES} 
+        $<INSTALL_INTERFACE:include>
+        ${CURL_INCLUDE})
+    
+    target_link_libraries(${EXAMPLE_EXE} 
+        ${AWSSDK_LINK_LIBRARIES} 
         ${AWSSDK_PLATFORM_DEPS})
+
+    target_link_directories(${EXAMPLE_EXE} 
+        PUBLIC 
+        ${CURL_LIB})
 
  endforeach()
 

--- a/cpp/example_code/s3/list_buckets_disabling_dns_cache.cpp
+++ b/cpp/example_code/s3/list_buckets_disabling_dns_cache.cpp
@@ -131,6 +131,15 @@ int main(int argc, char *argv[]) {
         Aws::Client::ClientConfiguration clientConfig;
         // Optional: Set to the AWS Region in which the bucket was created (overrides config file).
         // clientConfig.region = "us-east-1";
+#ifdef _WIN32
+        // ATTENTION: On Windows with the AWS C++ SDK, this example only runs if the SDK is built
+        // with the curl library. 
+        // For more information, see the accompanying ReadMe.
+        // For more information, see "Building the SDK for Windows with curl".
+        // https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/setup-windows.html
+        //TODO(User): Update to the location of your .crt file.
+        clientConfig.caFile = "C:/curl/bin/cacert.pem";
+#endif
 
         AwsDoc::S3::ListBucketDisablingDnsCache(clientConfig);
     }

--- a/cpp/example_code/s3/tests/CMakeLists.txt
+++ b/cpp/example_code/s3/tests/CMakeLists.txt
@@ -17,8 +17,6 @@ set(CMAKE_CXX_STANDARD 14)
 # Build shared libraries by default.
 set(BUILD_SHARED_LIBS ON)
 
-enable_testing()
-
 find_package(GTest)
 
 if(NOT GTest_FOUND)
@@ -33,7 +31,6 @@ if(NOT GTest_FOUND)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
 endif()
-
 
 # Use the MSVC variable to determine if this is a Windows build.
 set(WINDOWS_BUILD ${MSVC})
@@ -52,7 +49,7 @@ add_executable(
 )
 
 if(WINDOWS_BUILD)
-      # set(BIN_SUB_DIR "/Debug") # if you are building from the command line you may need to uncomment this 
+      # set(BIN_SUB_DIR "/Debug") # If you are building from the command line, you may need to uncomment this 
                                     # and set the proper subdirectory to the executables' location.
 
     # Copy relevant AWS SDK for C++ libraries into the current binary directory for running and debugging.
@@ -82,17 +79,18 @@ if (NOT DEFINED GTEST_SOURCE_FILES)
     )
 endif()
 
-# Check whether the target system is Windows, including Win64.
-if(WIN32)
-    list(FILTER GTEST_SOURCE_FILES EXCLUDE REGEX "/gtest_list_buckets_disabling_dns_cache.cpp$") # Not supported in windows, see file for details
 
-    # Check whether the compiler is some version of Microsoft Visual C++, or another compiler simulating C++.
-    if(MSVC)
-        source_group("Header Files\\awsdoc\\s3" FILES ${AWSDOC_S3_HEADERS})
-        source_group("Source Files" FILES ${AWSDOC_S3_SOURCE})
-    endif(MSVC)
+# Handle special case of list_buckets_disabling_dns_cache.cpp on Windows.
+if(WINDOWS_BUILD)
+    list(FIND AWSSDK_CLIENT_LIBS "curl" CONTAINS_CURL)
+    if (CONTAINS_CURL EQUAL -1)
+            # remove list_buckets_disabling_dns_cache.cpp libs not using curl
+        list(FILTER AWSDOC_S3_SOURCE EXCLUDE REGEX "/list_buckets_disabling_dns_cache.cpp$") # Not supported in windows without curl, see file for details
+    else()
+        set(CURL_INCLUDE "c:/curl/include") # Update this with correct curl install location.
+        set(CURL_LIB "c:/curl/lib") # Update this with correct  curl install location.
+    endif()
 endif()
-
 enable_testing()
 
 
@@ -118,6 +116,7 @@ target_include_directories(
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         $<INSTALL_INTERFACE:../include>
+        ${CURL_INCLUDE}
 )
 
 target_compile_definitions(
@@ -132,6 +131,10 @@ target_link_libraries(
         ${AWSSDK_LINK_LIBRARIES}
         ${AWSSDK_PLATFORM_DEPS}
 )
+
+target_link_directories(${CURRENT_TARGET} 
+    PUBLIC 
+    ${CURL_LIB})
 
 include(GoogleTest)
 gtest_add_tests(

--- a/cpp/example_code/s3/tests/CMakeLists.txt
+++ b/cpp/example_code/s3/tests/CMakeLists.txt
@@ -79,13 +79,12 @@ if (NOT DEFINED GTEST_SOURCE_FILES)
     )
 endif()
 
-
 # Handle special case of list_buckets_disabling_dns_cache.cpp on Windows.
 if(WINDOWS_BUILD)
     list(FIND AWSSDK_CLIENT_LIBS "curl" CONTAINS_CURL)
     if (CONTAINS_CURL EQUAL -1)
             # remove list_buckets_disabling_dns_cache.cpp libs not using curl
-        list(FILTER AWSDOC_S3_SOURCE EXCLUDE REGEX "/list_buckets_disabling_dns_cache.cpp$") # Not supported in windows without curl, see file for details
+        list(FILTER GTEST_SOURCE_FILES EXCLUDE REGEX "/gtest_list_buckets_disabling_dns_cache.cpp$") # Not supported in windows without curl, see file for details
     else()
         set(CURL_INCLUDE "c:/curl/include") # Update this with correct curl install location.
         set(CURL_LIB "c:/curl/lib") # Update this with correct  curl install location.

--- a/cpp/example_code/transcribe/get_transcript.cpp
+++ b/cpp/example_code/transcribe/get_transcript.cpp
@@ -37,8 +37,8 @@ int main() {
         //Load a profile that has been granted AmazonTranscribeFullAccess AWS managed permission policy.
         Aws::Client::ClientConfiguration config;
 #ifdef _WIN32
-        // ATTENTION: On Windows with AWS SDK version 1.9, this example only runs if the SDK is built
-        // with the curl library.  (9/15/2022)
+        // ATTENTION: On Windows with the AWS C++ SDK, this example only runs if the SDK is built
+        // with the curl library. 
         // For more information, see the accompanying ReadMe.
         // For more information, see "Building the SDK for Windows with curl".
         // https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/setup-windows.html


### PR DESCRIPTION
This has no SOS or documentation changes.
Updated some comments.
Updated CMakeLists.txt
Enabled build of list_buckets_disabling_dns_cache.cpp on windows when using curl library

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
