### PR TITLE
Rust: Fix example compilation

### DIFF
--- a/rust_dev_preview/cross_service/detect_faces/Cargo.toml
+++ b/rust_dev_preview/cross_service/detect_faces/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/cross_service/detect_labels/Cargo.toml
+++ b/rust_dev_preview/cross_service/detect_labels/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/cross_service/photo_asset_management/Cargo.toml
+++ b/rust_dev_preview/cross_service/photo_asset_management/Cargo.toml
@@ -14,16 +14,16 @@ _HANDLER = "labels"
 
 [dependencies]
 anyhow = "1.0.70"
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sns = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sns = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "test-util",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert ={ git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["convert-chrono"] }
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert ={ git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["convert-chrono"] }
 aws_lambda_events = { version = "0.10.0", features = ["s3", "apigw"], default-features = false }
 bytes = "1.4.0"
 chrono = "0.4.24"

--- a/rust_dev_preview/cross_service/photo_asset_management/integration/Cargo.toml
+++ b/rust_dev_preview/cross_service/photo_asset_management/integration/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 photo_asset_management = { path = "../"}
 tokio = { version = "1.27.0", features = ["macros"] }
 tracing = "0.1.37"

--- a/rust_dev_preview/cross_service/rest_ses/Cargo.toml
+++ b/rust_dev_preview/cross_service/rest_ses/Cargo.toml
@@ -14,10 +14,10 @@ name = "rest_ses"
 [dependencies]
 actix-web = "4"
 actix-web-prom = "0.6.0"
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cloudwatchlogs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rdsdata = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ses = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cloudwatchlogs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rdsdata = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ses = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 chrono = { version = "0.4.22", default-features = false, features = [
     "clock",
     "serde",
@@ -44,8 +44,8 @@ uuid = { version = "1.2.1", features = ["v4", "serde"] }
 xlsxwriter = "0.6.0"
 
 [dev-dependencies]
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["test-util"] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["test-util"] }
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 fake = { version = "2.5.0", features = ["uuid"] }
 once_cell = "1.15.0"
 rand = "0.8.5"

--- a/rust_dev_preview/cross_service/rust-toolchain.toml
+++ b/rust_dev_preview/cross_service/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # This should be kept in sync with https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv
 [toolchain]
-channel = "1.66.1"
+channel = "1.69.0"

--- a/rust_dev_preview/cross_service/telephone/Cargo.toml
+++ b/rust_dev_preview/cross_service/telephone/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-polly = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-transcribe = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-polly = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-transcribe = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 anyhow = "1"
 tokio = { version = "1.20.1", features = ["full"] }
 bytes = "1"

--- a/rust_dev_preview/examples/apigateway/Cargo.toml
+++ b/rust_dev_preview/examples/apigateway/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-apigateway = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-apigateway = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/rust_dev_preview/examples/apigatewaymanagement/Cargo.toml
+++ b/rust_dev_preview/examples/apigatewaymanagement/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-apigatewaymanagement = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-apigatewaymanagement = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 http = "0.2.5"
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/rust_dev_preview/examples/applicationautoscaling/Cargo.toml
+++ b/rust_dev_preview/examples/applicationautoscaling/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-applicationautoscaling = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-applicationautoscaling = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/autoscaling/Cargo.toml
+++ b/rust_dev_preview/examples/autoscaling/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-autoscaling = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-autoscaling = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/autoscalingplans/Cargo.toml
+++ b/rust_dev_preview/examples/autoscalingplans/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-autoscalingplans = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-sdk-autoscalingplans = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/batch/Cargo.toml
+++ b/rust_dev_preview/examples/batch/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-batch = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-batch = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/cloudformation/Cargo.toml
+++ b/rust_dev_preview/examples/cloudformation/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cloudformation = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cloudformation = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/cloudwatch/Cargo.toml
+++ b/rust_dev_preview/examples/cloudwatch/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cloudwatch = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cloudwatch = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/cloudwatchlogs/Cargo.toml
+++ b/rust_dev_preview/examples/cloudwatchlogs/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cloudwatchlogs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cloudwatchlogs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/cognitoidentity/Cargo.toml
+++ b/rust_dev_preview/examples/cognitoidentity/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cognitoidentity = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cognitoidentity = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 chrono = "0.4"

--- a/rust_dev_preview/examples/cognitoidentityprovider/Cargo.toml
+++ b/rust_dev_preview/examples/cognitoidentityprovider/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cognitoidentityprovider = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cognitoidentityprovider = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/rust_dev_preview/examples/cognitosync/Cargo.toml
+++ b/rust_dev_preview/examples/cognitosync/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-cognitosync = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-cognitosync = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/rust_dev_preview/examples/concurrency/Cargo.toml
+++ b/rust_dev_preview/examples/concurrency/Cargo.toml
@@ -21,7 +21,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 
 [dev-dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 fastrand = "1.8.0"

--- a/rust_dev_preview/examples/config/Cargo.toml
+++ b/rust_dev_preview/examples/config/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/custom-root-certificates/Cargo.toml
+++ b/rust_dev_preview/examples/custom-root-certificates/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 description = "An example demonstrating setting a custom root certificate with rustls"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 # bringing our own HTTPs so no need for the default features
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false }
 tokio = { version = "1.21.2", features = ["full"] }
 rustls = "0.20.7"
 hyper-rustls = { version = "0.23.0", features = ["http2"] }

--- a/rust_dev_preview/examples/dynamodb/Cargo.toml
+++ b/rust_dev_preview/examples/dynamodb/Cargo.toml
@@ -11,18 +11,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "client-hyper",
   "rustls",
   "rt-tokio",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "rt-tokio",
 ] }
-aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 axum = "0.5.16"
 http = "0.2.5"
 futures = "0.3"

--- a/rust_dev_preview/examples/dynamodb/src/bin/crud.rs
+++ b/rust_dev_preview/examples/dynamodb/src/bin/crud.rs
@@ -6,15 +6,14 @@
 #![allow(clippy::result_large_err)]
 
 use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_dynamodb::error::SdkError;
+use aws_sdk_dynamodb::operation::create_table::CreateTableError;
+use aws_sdk_dynamodb::operation::put_item::PutItemError;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ProvisionedThroughput,
     ScalarAttributeType, Select, TableStatus,
 };
 use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};
-use aws_smithy_http::result::SdkError;
-
-use aws_sdk_dynamodb::operation::create_table::CreateTableError;
-use aws_sdk_dynamodb::operation::put_item::PutItemError;
 use clap::Parser;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};

--- a/rust_dev_preview/examples/dynamodb/src/bin/partiql.rs
+++ b/rust_dev_preview/examples/dynamodb/src/bin/partiql.rs
@@ -6,15 +6,14 @@
 #![allow(clippy::result_large_err)]
 
 use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_dynamodb::error::SdkError;
+use aws_sdk_dynamodb::operation::create_table::CreateTableError;
+use aws_sdk_dynamodb::operation::execute_statement::ExecuteStatementError;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ProvisionedThroughput,
     ScalarAttributeType, TableStatus,
 };
 use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};
-use aws_smithy_http::result::SdkError;
-
-use aws_sdk_dynamodb::operation::create_table::CreateTableError;
-use aws_sdk_dynamodb::operation::execute_statement::ExecuteStatementError;
 use clap::Parser;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};

--- a/rust_dev_preview/examples/dynamodb/src/scenario/movies/mod.rs
+++ b/rust_dev_preview/examples/dynamodb/src/scenario/movies/mod.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
-
+use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::types::{AttributeValue, PutRequest};
-use aws_smithy_client::SdkError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 use thiserror::Error;
 
 pub const TABLE_NAME: &str = "movies";
@@ -39,11 +38,12 @@ impl From<serde_dynamo::Error> for MovieError {
     }
 }
 
-impl<E> From<SdkError<E>> for MovieError
+impl<E, R> From<SdkError<E, R>> for MovieError
 where
     E: std::fmt::Debug,
+    R: std::fmt::Debug,
 {
-    fn from(err: SdkError<E>) -> Self {
+    fn from(err: SdkError<E, R>) -> Self {
         MovieError::Unknown(format!("{err:?}"))
     }
 }

--- a/rust_dev_preview/examples/ebs/Cargo.toml
+++ b/rust_dev_preview/examples/ebs/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ebs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ebs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 base64 = "0.13.0"
 sha2 = "0.9.5"

--- a/rust_dev_preview/examples/ec2/Cargo.toml
+++ b/rust_dev_preview/examples/ec2/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/ecr/Cargo.toml
+++ b/rust_dev_preview/examples/ecr/Cargo.toml
@@ -8,9 +8,9 @@ authors = [
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ecr = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ecr = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/ecs/Cargo.toml
+++ b/rust_dev_preview/examples/ecs/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ecs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ecs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/eks/Cargo.toml
+++ b/rust_dev_preview/examples/eks/Cargo.toml
@@ -8,9 +8,9 @@ authors = [
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-eks = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-eks = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/firehose/Cargo.toml
+++ b/rust_dev_preview/examples/firehose/Cargo.toml
@@ -9,9 +9,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-firehose = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = {git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-firehose = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/firehose/src/bin/put-records-batch.rs
+++ b/rust_dev_preview/examples/firehose/src/bin/put-records-batch.rs
@@ -10,8 +10,7 @@ use aws_sdk_firehose::error::SdkError;
 use aws_sdk_firehose::operation::put_record_batch::{PutRecordBatchError, PutRecordBatchOutput};
 use aws_sdk_firehose::primitives::Blob;
 use aws_sdk_firehose::types::Record;
-use aws_sdk_firehose::{meta::PKG_VERSION, Client, Error};
-use aws_types::region::Region;
+use aws_sdk_firehose::{config::Region, meta::PKG_VERSION, Client, Error};
 use clap::Parser;
 
 #[derive(Debug, Parser)]

--- a/rust_dev_preview/examples/globalaccelerator/Cargo.toml
+++ b/rust_dev_preview/examples/globalaccelerator/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-globalaccelerator = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-globalaccelerator = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = "0.1.8"
 clap = { version = "4.2.1", features = ["derive"] }

--- a/rust_dev_preview/examples/glue/Cargo.toml
+++ b/rust_dev_preview/examples/glue/Cargo.toml
@@ -13,20 +13,20 @@ name = "scenario"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-glue = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-glue = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "client-hyper",
   "rustls",
   "rt-tokio",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "rt-tokio",
 ] }
-aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing = "0.1.37"

--- a/rust_dev_preview/examples/greengrassv2/Cargo.toml
+++ b/rust_dev_preview/examples/greengrassv2/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Aaron Tsui <aaron.tsui@outlook.com>"]
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-greengrassv2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-greengrassv2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/rust_dev_preview/examples/iam/Cargo.toml
+++ b/rust_dev_preview/examples/iam/Cargo.toml
@@ -17,15 +17,11 @@ name = "iam_getting_started"
 path = "src/bin/iam-getting-started.rs"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["hardcoded-credentials"] }
-aws-hyper = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-iam = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["test-util"] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["hardcoded-credentials"] }
+aws-sdk-iam = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 sdk-examples-test-utils = { path = "../../test-utils" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/rust_dev_preview/examples/iot/Cargo.toml
+++ b/rust_dev_preview/examples/iot/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-iot = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-iot = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/kinesis/Cargo.toml
+++ b/rust_dev_preview/examples/kinesis/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-kinesis = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-kinesis = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/kms/Cargo.toml
+++ b/rust_dev_preview/examples/kms/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 description = "Example usage of the KMS service"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-kms = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-kms = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "client-hyper",
   "rustls",
   "rt-tokio",

--- a/rust_dev_preview/examples/lambda/Cargo.toml
+++ b/rust_dev_preview/examples/lambda/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-iam = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-iam = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 clap = { version = "4.2.1", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/localstack/Cargo.toml
+++ b/rust_dev_preview/examples/localstack/Cargo.toml
@@ -6,9 +6,9 @@ authors = ["Doug Schwartz <dougsch@amazon.com>"]
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 http = "0.2"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/logging/logger/Cargo.toml
+++ b/rust_dev_preview/examples/logging/logger/Cargo.toml
@@ -11,8 +11,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 # snippet-start:[logging.rust.logger-cargo.toml-env_logger]
 env_logger = "0.9.0"
 # snippet-end:[logging.rust.logger-cargo.toml-env_logger]

--- a/rust_dev_preview/examples/logging/tracing/Cargo.toml
+++ b/rust_dev_preview/examples/logging/tracing/Cargo.toml
@@ -11,8 +11,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 clap = { version = "4.2.1", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }
 # snippet-start:[logging.rust.tracing-cargo.toml-tracing_subscriber]

--- a/rust_dev_preview/examples/medialive/Cargo.toml
+++ b/rust_dev_preview/examples/medialive/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-medialive = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-medialive = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/mediapackage/Cargo.toml
+++ b/rust_dev_preview/examples/mediapackage/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-mediapackage = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-mediapackage = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/polly/Cargo.toml
+++ b/rust_dev_preview/examples/polly/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-polly = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-polly = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 bytes = "1"
 clap = { version = "4.2.1", features = ["derive"] }

--- a/rust_dev_preview/examples/qldb/Cargo.toml
+++ b/rust_dev_preview/examples/qldb/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-qldb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-qldbsession = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-qldb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-qldbsession = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = { version = "0.1.9", features = ["default"] }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/rust_dev_preview/examples/rds/Cargo.toml
+++ b/rust_dev_preview/examples/rds/Cargo.toml
@@ -10,8 +10,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rds = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rds = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/rdsdata/Cargo.toml
+++ b/rust_dev_preview/examples/rdsdata/Cargo.toml
@@ -10,8 +10,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-rdsdata = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-rdsdata = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/route53/Cargo.toml
+++ b/rust_dev_preview/examples/route53/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-route53 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-route53 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/rust-toolchain.toml
+++ b/rust_dev_preview/examples/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # This should be kept in sync with https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv
 [toolchain]
-channel = "1.66.1"
+channel = "1.69.0"

--- a/rust_dev_preview/examples/s3/Cargo.toml
+++ b/rust_dev_preview/examples/s3/Cargo.toml
@@ -21,16 +21,16 @@ assert_cmd = "2.0"
 predicates = "3.0.3"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 # snippet-start:[s3.rust.s3-object-lambda-cargo.toml]
-aws-endpoint = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-endpoint = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 # snippet-end:[s3.rust.s3-object-lambda-cargo.toml]
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "test-util",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["rt-tokio"] }
-aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["rt-tokio"] }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 sdk-examples-test-utils = { path = "../../test-utils" }
 bytes = "1.4.0"
 futures-util = { version = "0.3.21", features = ["alloc"] }

--- a/rust_dev_preview/examples/s3/src/bin/if-modified-since.rs
+++ b/rust_dev_preview/examples/s3/src/bin/if-modified-since.rs
@@ -7,10 +7,9 @@
 use aws_sdk_s3::{
     error::SdkError,
     operation::head_object::HeadObjectError,
-    primitives::{ByteStream, DateTime},
+    primitives::{ByteStream, DateTime, DateTimeFormat},
     Client, Error,
 };
-use aws_smithy_types::date_time::Format;
 use http::StatusCode;
 use tracing::{error, warn};
 
@@ -85,7 +84,7 @@ async fn main() -> Result<(), Error> {
         Ok(output) => (Ok(output.last_modified().cloned()), output.e_tag),
         Err(err) => match err {
             SdkError::ServiceError(err) => {
-                let http = err.raw().http();
+                let http = err.raw();
                 match http.status() {
                     StatusCode::NOT_MODIFIED => (
                         Ok(Some(
@@ -94,7 +93,7 @@ async fn main() -> Result<(), Error> {
                                     .get("last-modified")
                                     .map(|t| t.to_str().unwrap())
                                     .unwrap(),
-                                Format::HttpDate,
+                                DateTimeFormat::HttpDate,
                             )
                             .unwrap(),
                         )),

--- a/rust_dev_preview/examples/s3/src/bin/put-object-progress.rs
+++ b/rust_dev_preview/examples/s3/src/bin/put-object-progress.rs
@@ -1,4 +1,5 @@
 use std::{
+    convert::Infallible,
     mem,
     path::PathBuf,
     pin::Pin,
@@ -60,7 +61,7 @@ impl ProgressBody<SdkBody> {
     // this "change the wheels on the fly" utility.
     pub fn replace(
         mut value: http::Request<SdkBody>,
-    ) -> Result<http::Request<SdkBody>, anyhow::Error> {
+    ) -> Result<http::Request<SdkBody>, Infallible> {
         let body = mem::replace(value.body_mut(), SdkBody::taken()).map(|body| {
             let len = body.content_length().expect("upload body sized"); // TODO - panics
             let body = ProgressBody::new(body, len);
@@ -160,7 +161,7 @@ async fn put_object(client: &Client, opts: &Opt) -> Result<(), anyhow::Error> {
     let customized = request
         .customize()
         .await?
-        .map_request(ProgressBody::<SdkBody>::replace)?;
+        .map_request(ProgressBody::<SdkBody>::replace);
 
     let out = customized.send().await?;
 

--- a/rust_dev_preview/examples/sagemaker/Cargo.toml
+++ b/rust_dev_preview/examples/sagemaker/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sagemaker = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sagemaker = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/rust_dev_preview/examples/sdk-config/Cargo.toml
+++ b/rust_dev_preview/examples/sdk-config/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/secretsmanager/Cargo.toml
+++ b/rust_dev_preview/examples/secretsmanager/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 description = "Example usage of the SecretManager service"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-secretsmanager = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-secretsmanager = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/sending-presigned-requests/Cargo.toml
+++ b/rust_dev_preview/examples/sending-presigned-requests/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 http = "0.2.6"
 hyper = "0.14"
 reqwest = "0.11"

--- a/rust_dev_preview/examples/ses/Cargo.toml
+++ b/rust_dev_preview/examples/ses/Cargo.toml
@@ -8,8 +8,8 @@ authors = [
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sesv2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sesv2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/sitewise/Cargo.toml
+++ b/rust_dev_preview/examples/sitewise/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 # For more keys and their definitions, see https://doc.rust-lang.org/cargo/reference/manifest.html.
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-iotsitewise = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-iotsitewise = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/rust_dev_preview/examples/snowball/Cargo.toml
+++ b/rust_dev_preview/examples/snowball/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-snowball = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-snowball = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/sns/Cargo.toml
+++ b/rust_dev_preview/examples/sns/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sns = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sns = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/sqs/Cargo.toml
+++ b/rust_dev_preview/examples/sqs/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/ssm/Cargo.toml
+++ b/rust_dev_preview/examples/ssm/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ssm = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ssm = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/stepfunction/Cargo.toml
+++ b/rust_dev_preview/examples/stepfunction/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Daniele Frasca <https://github.com/ymwjbxxq/>"]
 edition = "2021"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sfn = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sfn = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/sts/Cargo.toml
+++ b/rust_dev_preview/examples/sts/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = {git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = {git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "4.2.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/testing/Cargo.toml
+++ b/rust_dev_preview/examples/testing/Cargo.toml
@@ -11,14 +11,14 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.51"
 # snippet-end:[testing.rust.Cargo.toml]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "test-util",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "hardcoded-credentials",
 ] }
 tokio = { version = "1.20.1", features = ["full"] }

--- a/rust_dev_preview/examples/textract/Cargo.toml
+++ b/rust_dev_preview/examples/textract/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 # For more keys and their definitions, see https://doc.rust-lang.org/cargo/reference/manifest.html.
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-textract = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-textract = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.27", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/tls/Cargo.toml
+++ b/rust_dev_preview/examples/tls/Cargo.toml
@@ -12,9 +12,9 @@ name = "tls"
 path = "src/lib.rs"
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-kms = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-kms = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false }
 webpki-roots = "0.22.4"
 tokio = { version = "1.20.1", features = ["full"] }
 rustls = "0.20.6"

--- a/rust_dev_preview/examples/tls/src/lib.rs
+++ b/rust_dev_preview/examples/tls/src/lib.rs
@@ -14,7 +14,6 @@ This example assumes you have set up environment variables for authentication.
 
 */
 
-use aws_config::provider_config::ProviderConfig;
 use aws_sdk_kms::Error;
 use aws_smithy_client::hyper_ext;
 use rustls::RootCertStore;
@@ -50,9 +49,7 @@ pub async fn connect_via_tls_13() -> Result<(), Error> {
         .enable_http2()
         .build();
 
-    let provider_config = ProviderConfig::default().with_tcp_connector(rustls_connector.clone());
     let shared_conf = aws_config::from_env()
-        .configure(provider_config)
         .http_connector(hyper_ext::Adapter::builder().build(rustls_connector))
         .load()
         .await;

--- a/rust_dev_preview/examples/transcribestreaming/Cargo.toml
+++ b/rust_dev_preview/examples/transcribestreaming/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-transcribestreaming = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-transcribestreaming = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 async-stream = "0.3"
 bytes = "1"
 hound = "3.4"

--- a/rust_dev_preview/lambda/calculator/Cargo.toml
+++ b/rust_dev_preview/lambda/calculator/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 lambda_runtime = "0.8.0"
 clap = { version = "4.2.1", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }

--- a/rust_dev_preview/test-utils/Cargo.toml
+++ b/rust_dev_preview/test-utils/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = [
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "test-util",
 ] }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main"}
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next"}
 http = "0.2"
 
 [lib]

--- a/rust_dev_preview/webassembly/Cargo.toml
+++ b/rust_dev_preview/webassembly/Cargo.toml
@@ -13,7 +13,6 @@ crate-type = ["cdylib"]
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
 aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["hardcoded-credentials"] }
 aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
-aws-smithy-async = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
 aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
 aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["event-stream"] }
 aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }

--- a/rust_dev_preview/webassembly/Cargo.toml
+++ b/rust_dev_preview/webassembly/Cargo.toml
@@ -10,12 +10,12 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
-aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["hardcoded-credentials"] }
-aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
-aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", default-features = false }
-aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", features = ["event-stream"] }
-aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false }
+aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["hardcoded-credentials"] }
+aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false }
+aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", default-features = false }
+aws-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = ["event-stream"] }
+aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 async-trait = "0.1.63"
 console_error_panic_hook = "0.1.7"
 http = "0.2.8"


### PR DESCRIPTION
There are some breaking changes in the latest Rust SDK release that require changes to examples in order to fix compile errors. This PR fixes all the Rust examples with the latest SDK.

The dependencies need to get updated to use aws-sdk-rust/next in some cases where code changes to the SDK were required to fix the examples. The examples need to be fixed in aws-doc-sdk-examples before we can release those SDK changes since the SDK release process requires successfully compiling examples (or at least, now it does after we fixed a bug where it wasn't).

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
