### PR TITLE
.NET v3: SNS fix List the subscribes of a topic example.

### DIFF
--- a/dotnetv3/SNS/ListSNSSubscriptionsExample/ListSNSSubscriptionsExample/ListSNSSubscriptionsExample.csproj
+++ b/dotnetv3/SNS/ListSNSSubscriptionsExample/ListSNSSubscriptionsExample/ListSNSSubscriptionsExample.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.2.2" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.2.21" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.201" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.200.20" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/dotnetv3/SNS/ListSNSSubscriptionsExample/ListSNSSubscriptionsExample/ListSubscriptions.cs
+++ b/dotnetv3/SNS/ListSNSSubscriptionsExample/ListSNSSubscriptionsExample/ListSubscriptions.cs
@@ -20,22 +20,53 @@ namespace ListSNSSubscriptionsExample
         {
             IAmazonSimpleNotificationService client = new AmazonSimpleNotificationServiceClient();
 
-            var subscriptions = await GetSubscriptionsListAsync(client);
+            Console.WriteLine("Enter a topic ARN to list subscriptions for a specific topic, " +
+                              "or press Enter to list subscriptions for all topics.");
+            var topicArn = Console.ReadLine();
+            Console.WriteLine();
+
+            var subscriptions = await GetSubscriptionsListAsync(client, topicArn);
 
             DisplaySubscriptionList(subscriptions);
         }
 
         /// <summary>
-        /// Gets a list of the existing Amazon SNS subscriptions.
+        /// Gets a list of the existing Amazon SNS subscriptions, optionally by specifying a specific topic ARN.
         /// </summary>
         /// <param name="client">The initialized Amazon SNS client object used
         /// to obtain the list of subscriptions.</param>
-        /// <returns>A List containing information about each subscription.</returns>
-        public static async Task<List<Subscription>> GetSubscriptionsListAsync(IAmazonSimpleNotificationService client)
+        /// <param name="topicArn">The optional ARN of a specific topic. Defaults to null.</param>
+        /// <returns>A list containing information about each subscription.</returns>
+        public static async Task<List<Subscription>> GetSubscriptionsListAsync(IAmazonSimpleNotificationService client, string topicArn = null)
         {
-            var response = await client.ListSubscriptionsAsync();
+            var results = new List<Subscription>();
 
-            return response.Subscriptions;
+            if (!string.IsNullOrEmpty(topicArn))
+            {
+                var paginateByTopic = client.Paginators.ListSubscriptionsByTopic(
+                    new ListSubscriptionsByTopicRequest()
+                    {
+                       TopicArn = topicArn,
+                    });
+
+                // Get the entire list using the paginator.
+                await foreach (var subscription in paginateByTopic.Subscriptions)
+                {
+                    results.Add(subscription);
+                }
+            }
+            else
+            {
+                var paginateAllSubscriptions = client.Paginators.ListSubscriptions(new ListSubscriptionsRequest());
+
+                // Get the entire list using the paginator.
+                await foreach (var subscription in paginateAllSubscriptions.Subscriptions)
+                {
+                    results.Add(subscription);
+                }
+            }
+
+            return results;
         }
 
         /// <summary>
@@ -56,5 +87,6 @@ namespace ListSNSSubscriptionsExample
             }
         }
     }
+
     // snippet-end:[SNS.dotnetv3.ListSNSSubscriptionsExample]
 }

--- a/dotnetv3/SNS/ListSNSSubscriptionsExample/ListSNSSubscriptionsExample/ListSubscriptions.cs
+++ b/dotnetv3/SNS/ListSNSSubscriptionsExample/ListSNSSubscriptionsExample/ListSubscriptions.cs
@@ -46,7 +46,7 @@ namespace ListSNSSubscriptionsExample
                 var paginateByTopic = client.Paginators.ListSubscriptionsByTopic(
                     new ListSubscriptionsByTopicRequest()
                     {
-                       TopicArn = topicArn,
+                        TopicArn = topicArn,
                     });
 
                 // Get the entire list using the paginator.

--- a/dotnetv3/SNS/ListSNSSubscriptionsExample/ListSNSSubscriptionsExample/ListSubscriptions.cs
+++ b/dotnetv3/SNS/ListSNSSubscriptionsExample/ListSNSSubscriptionsExample/ListSubscriptions.cs
@@ -31,7 +31,7 @@ namespace ListSNSSubscriptionsExample
         }
 
         /// <summary>
-        /// Gets a list of the existing Amazon SNS subscriptions, optionally by specifying a specific topic ARN.
+        /// Gets a list of the existing Amazon SNS subscriptions, optionally by specifying a topic ARN.
         /// </summary>
         /// <param name="client">The initialized Amazon SNS client object used
         /// to obtain the list of subscriptions.</param>


### PR DESCRIPTION
This pull request fixes an issue with the .NET SNS example for "List the subscribers of a topic", which was instead listing all subscribers. Fixes a customer-reported issue and ticket.

Closes #5285 

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
