### PR TITLE
Rust: Restrict `clap` dependency to 4.2.x to avoid MSRV update

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
           )
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.69
           components: clippy, rustfmt
       - uses: actions/checkout@v3
       - name: Rust format

--- a/rust_dev_preview/cross_service/detect_faces/Cargo.toml
+++ b/rust_dev_preview/cross_service/detect_faces/Cargo.toml
@@ -14,5 +14,5 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/cross_service/detect_labels/Cargo.toml
+++ b/rust_dev_preview/cross_service/detect_labels/Cargo.toml
@@ -16,6 +16,6 @@ aws-sdk-rekognition = { git = "https://github.com/awslabs/aws-sdk-rust", branch 
 aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 kamadak-exif = "0.5.4"

--- a/rust_dev_preview/cross_service/telephone/Cargo.toml
+++ b/rust_dev_preview/cross_service/telephone/Cargo.toml
@@ -16,5 +16,5 @@ tokio = { version = "1.20.1", features = ["full"] }
 bytes = "1"
 reqwest = "0.11.4"
 serde_json = "1.0"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/apigateway/Cargo.toml
+++ b/rust_dev_preview/examples/apigateway/Cargo.toml
@@ -11,7 +11,7 @@ aws-sdk-apigateway = { git = "https://github.com/awslabs/aws-sdk-rust", branch =
 aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/apigatewaymanagement/Cargo.toml
+++ b/rust_dev_preview/examples/apigatewaymanagement/Cargo.toml
@@ -14,5 +14,5 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-apigatewaymanagement = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 http = "0.2.5"
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/applicationautoscaling/Cargo.toml
+++ b/rust_dev_preview/examples/applicationautoscaling/Cargo.toml
@@ -12,5 +12,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-applicationautoscaling = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/autoscaling/Cargo.toml
+++ b/rust_dev_preview/examples/autoscaling/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-autoscaling = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/autoscalingplans/Cargo.toml
+++ b/rust_dev_preview/examples/autoscalingplans/Cargo.toml
@@ -14,5 +14,5 @@ aws-sdk-autoscalingplans = { git = "https://github.com/awslabs/aws-sdk-rust", br
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/batch/Cargo.toml
+++ b/rust_dev_preview/examples/batch/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-batch = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/cloudformation/Cargo.toml
+++ b/rust_dev_preview/examples/cloudformation/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-cloudformation = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/cloudwatch/Cargo.toml
+++ b/rust_dev_preview/examples/cloudwatch/Cargo.toml
@@ -14,5 +14,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-cloudwatch = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/cloudwatchlogs/Cargo.toml
+++ b/rust_dev_preview/examples/cloudwatchlogs/Cargo.toml
@@ -15,5 +15,5 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-cloudwatchlogs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/cognitoidentity/Cargo.toml
+++ b/rust_dev_preview/examples/cognitoidentity/Cargo.toml
@@ -16,7 +16,7 @@ aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", br
   "convert-chrono",
 ] }
 chrono = "0.4"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/cognitoidentityprovider/Cargo.toml
+++ b/rust_dev_preview/examples/cognitoidentityprovider/Cargo.toml
@@ -15,7 +15,7 @@ aws-sdk-cognitoidentityprovider = { git = "https://github.com/awslabs/aws-sdk-ru
 aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/cognitosync/Cargo.toml
+++ b/rust_dev_preview/examples/cognitosync/Cargo.toml
@@ -15,7 +15,7 @@ aws-sdk-cognitosync = { git = "https://github.com/awslabs/aws-sdk-rust", branch 
 aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/concurrency/Cargo.toml
+++ b/rust_dev_preview/examples/concurrency/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 futures = "0.3.25"
 tokio = { version = "1.20.1", features = ["full"] }
 tracing = "0.1.37"

--- a/rust_dev_preview/examples/config/Cargo.toml
+++ b/rust_dev_preview/examples/config/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/dynamodb/Cargo.toml
+++ b/rust_dev_preview/examples/dynamodb/Cargo.toml
@@ -32,7 +32,7 @@ sdk-examples-test-utils = { path = "../../test-utils" }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1"
 serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_22"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing = "0.1"
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/rust_dev_preview/examples/ebs/Cargo.toml
+++ b/rust_dev_preview/examples/ebs/Cargo.toml
@@ -16,5 +16,5 @@ aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next"
 tokio = { version = "1.20.1", features = ["full"] }
 base64 = "0.13.0"
 sha2 = "0.9.5"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/ec2/Cargo.toml
+++ b/rust_dev_preview/examples/ec2/Cargo.toml
@@ -14,5 +14,5 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/ecr/Cargo.toml
+++ b/rust_dev_preview/examples/ecr/Cargo.toml
@@ -12,5 +12,5 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-ecr = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/ecs/Cargo.toml
+++ b/rust_dev_preview/examples/ecs/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-ecs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/eks/Cargo.toml
+++ b/rust_dev_preview/examples/eks/Cargo.toml
@@ -12,5 +12,5 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-eks = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/firehose/Cargo.toml
+++ b/rust_dev_preview/examples/firehose/Cargo.toml
@@ -12,6 +12,6 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-firehose = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 

--- a/rust_dev_preview/examples/globalaccelerator/Cargo.toml
+++ b/rust_dev_preview/examples/globalaccelerator/Cargo.toml
@@ -11,5 +11,5 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-globalaccelerator = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = "0.1.8"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/glue/Cargo.toml
+++ b/rust_dev_preview/examples/glue/Cargo.toml
@@ -32,7 +32,7 @@ tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing = "0.1.37"
 async_once = "0.2.6"
 lazy_static = "1.4.0"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 thiserror = "1.0.37"
 secrecy = "0.8.0"
 uuid = { version = "1.2.1", features = ["v4"] }

--- a/rust_dev_preview/examples/greengrassv2/Cargo.toml
+++ b/rust_dev_preview/examples/greengrassv2/Cargo.toml
@@ -9,5 +9,5 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-greengrassv2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/rust_dev_preview/examples/iam/Cargo.toml
+++ b/rust_dev_preview/examples/iam/Cargo.toml
@@ -24,7 +24,7 @@ aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 sdk-examples-test-utils = { path = "../../test-utils" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 tower-service = "0.3.2"

--- a/rust_dev_preview/examples/iot/Cargo.toml
+++ b/rust_dev_preview/examples/iot/Cargo.toml
@@ -11,5 +11,5 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-iot = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/kinesis/Cargo.toml
+++ b/rust_dev_preview/examples/kinesis/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-kinesis = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/kms/Cargo.toml
+++ b/rust_dev_preview/examples/kms/Cargo.toml
@@ -18,5 +18,5 @@ aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = 
 ] }
 tokio = { version = "1.20.1", features = ["full"] }
 base64 = "0.13.0"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/lambda/Cargo.toml
+++ b/rust_dev_preview/examples/lambda/Cargo.toml
@@ -13,7 +13,7 @@ aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "ne
 aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-smithy-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing = "0.1.37"

--- a/rust_dev_preview/examples/logging/logger/Cargo.toml
+++ b/rust_dev_preview/examples/logging/logger/Cargo.toml
@@ -16,6 +16,6 @@ aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "
 # snippet-start:[logging.rust.logger-cargo.toml-env_logger]
 env_logger = "0.9.0"
 # snippet-end:[logging.rust.logger-cargo.toml-env_logger]
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }
 # snippet-end:[logging.rust.logger-cargo.toml]

--- a/rust_dev_preview/examples/logging/tracing/Cargo.toml
+++ b/rust_dev_preview/examples/logging/tracing/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 [dependencies]
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }
 # snippet-start:[logging.rust.tracing-cargo.toml-tracing_subscriber]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rust_dev_preview/examples/medialive/Cargo.toml
+++ b/rust_dev_preview/examples/medialive/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-medialive = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/mediapackage/Cargo.toml
+++ b/rust_dev_preview/examples/mediapackage/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-mediapackage = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/polly/Cargo.toml
+++ b/rust_dev_preview/examples/polly/Cargo.toml
@@ -14,5 +14,5 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-polly = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 bytes = "1"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/qldb/Cargo.toml
+++ b/rust_dev_preview/examples/qldb/Cargo.toml
@@ -15,5 +15,5 @@ aws-sdk-qldb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next
 aws-sdk-qldbsession = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = { version = "0.1.9", features = ["default"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/rds/Cargo.toml
+++ b/rust_dev_preview/examples/rds/Cargo.toml
@@ -13,5 +13,5 @@ version = "0.1.0"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-rds = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/rdsdata/Cargo.toml
+++ b/rust_dev_preview/examples/rdsdata/Cargo.toml
@@ -13,5 +13,5 @@ version = "0.1.0"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-rdsdata = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/route53/Cargo.toml
+++ b/rust_dev_preview/examples/route53/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-route53 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/s3/Cargo.toml
+++ b/rust_dev_preview/examples/s3/Cargo.toml
@@ -38,7 +38,7 @@ http = "0.2.8"
 http-body = "0.4.5"
 md-5 = "0.10.1"
 rand = "0.8.5"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = "0.1.8"

--- a/rust_dev_preview/examples/sagemaker/Cargo.toml
+++ b/rust_dev_preview/examples/sagemaker/Cargo.toml
@@ -15,7 +15,7 @@ aws-sdk-sagemaker = { git = "https://github.com/awslabs/aws-sdk-rust", branch = 
 aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/sdk-config/Cargo.toml
+++ b/rust_dev_preview/examples/sdk-config/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 lazy_static = "1.4.0"
 async_once = "0.2.6"

--- a/rust_dev_preview/examples/secretsmanager/Cargo.toml
+++ b/rust_dev_preview/examples/secretsmanager/Cargo.toml
@@ -12,5 +12,5 @@ description = "Example usage of the SecretManager service"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-secretsmanager = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/sending-presigned-requests/Cargo.toml
+++ b/rust_dev_preview/examples/sending-presigned-requests/Cargo.toml
@@ -13,6 +13,6 @@ aws-smithy-client = { git = "https://github.com/awslabs/aws-sdk-rust", branch = 
 http = "0.2.6"
 hyper = "0.14"
 reqwest = "0.11"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/ses/Cargo.toml
+++ b/rust_dev_preview/examples/ses/Cargo.toml
@@ -11,5 +11,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-sesv2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/sitewise/Cargo.toml
+++ b/rust_dev_preview/examples/sitewise/Cargo.toml
@@ -12,7 +12,7 @@ aws-sdk-iotsitewise = { git = "https://github.com/awslabs/aws-sdk-rust", branch 
 aws-smithy-types-convert = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next", features = [
   "convert-chrono",
 ] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] } 
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/snowball/Cargo.toml
+++ b/rust_dev_preview/examples/snowball/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-snowball = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/sns/Cargo.toml
+++ b/rust_dev_preview/examples/sns/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-sns = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/sqs/Cargo.toml
+++ b/rust_dev_preview/examples/sqs/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-sqs = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/ssm/Cargo.toml
+++ b/rust_dev_preview/examples/ssm/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-ssm = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/stepfunction/Cargo.toml
+++ b/rust_dev_preview/examples/stepfunction/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-sfn = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/examples/sts/Cargo.toml
+++ b/rust_dev_preview/examples/sts/Cargo.toml
@@ -13,6 +13,6 @@ aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" 
 aws-sdk-sts = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-types = {git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 

--- a/rust_dev_preview/examples/testing/Cargo.toml
+++ b/rust_dev_preview/examples/testing/Cargo.toml
@@ -23,7 +23,7 @@ aws-credential-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch
 ] }
 tokio = { version = "1.20.1", features = ["full"] }
 serde_json = "1"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 
 [[bin]]

--- a/rust_dev_preview/examples/transcribestreaming/Cargo.toml
+++ b/rust_dev_preview/examples/transcribestreaming/Cargo.toml
@@ -15,6 +15,6 @@ aws-sdk-transcribestreaming = { git = "https://github.com/awslabs/aws-sdk-rust",
 async-stream = "0.3"
 bytes = "1"
 hound = "3.4"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust_dev_preview/lambda/calculator/Cargo.toml
+++ b/rust_dev_preview/lambda/calculator/Cargo.toml
@@ -14,7 +14,7 @@ aws-sdk-ec2 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next"
 aws-sdk-lambda = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
 lambda_runtime = "0.8.0"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "~4.2", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter", "json"] }
 time = "0.3"


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request restricts the clap dep to the 4.2 series to avoid the MSRV bump to 1.70 introduced in Clap 4.4.x

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
