### PR TITLE
Add .prettierrc.yaml to set bracket spacing for metadata.

### DIFF
--- a/.doc_gen/metadata/.prettierrc.yaml
+++ b/.doc_gen/metadata/.prettierrc.yaml
@@ -1,0 +1,1 @@
+bracketSpacing: false


### PR DESCRIPTION
This helps those of us using prettier. This is unfortunately not an option in editorconfig.


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
