### PR TITLE
Fix prerequisites link in s3 examples README

### DIFF
--- a/rust_dev_preview/examples/s3/README.md
+++ b/rust_dev_preview/examples/s3/README.md
@@ -24,7 +24,7 @@ Shows how to use the AWS SDK for Rust to work with Amazon Simple Storage Service
 
 ### Prerequisites
 
-For prerequisites, see the [README](../README.md#Prerequisites) in the `rust_dev_preview` folder.
+For prerequisites, see the [README](../../README.md#Prerequisites) in the `rust_dev_preview` folder.
 
 
 <!--custom.prerequisites.start-->


### PR DESCRIPTION
Fix prerequisites link leading to the wrong folder

<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request fixes the broken link to the rust_dev_preview README prerequisites in the s3 example README.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
