### PR TITLE
Zexi template change to make unique title IDs

### DIFF
--- a/.doc_gen/templates/zonbook/library_by_service_chapter.xml
+++ b/.doc_gen/templates/zonbook/library_by_service_chapter.xml
@@ -65,7 +65,7 @@
                 <listitem><para><phrase role="topcom"><ulink url="https://github.com/awsdocs/aws-doc-sdk-examples">&AWS; SDK Examples</ulink></phrase>
                     &endash; GitHub repo with complete code in preferred languages. Includes instructions for setting up and running the code.</para></listitem>
             </itemizedlist>
-            {{- template "hello" makeSlice $service.CategorizedExampleSets ""}}
+            {{- template "hello" makeSlice $service.CategorizedExampleSets "" $service.Model}}
             <para role="contents-abbrev">Code examples</para>
             {{- range $category := $service.CategoryNamesSorted}}
             {{- if ne $category "Hello"}}

--- a/.doc_gen/templates/zonbook/service_chapter_template.xml
+++ b/.doc_gen/templates/zonbook/service_chapter_template.xml
@@ -33,7 +33,7 @@
         {{.ServiceEntity.Caveat}}</para>
     {{- template "note_example_types" makeSlice $actions.Examples $scenarios.Examples $cross_service.Examples}}
     {{- template "note_complete_list"}}
-    {{- template "hello" makeSlice .CategorizedExampleSets ""}}
+    {{- template "hello" makeSlice .CategorizedExampleSets "" 0}}
     <para role="contents-abbrev">Code examples</para>
     {{- range $category := .CategoryNamesSorted}}
     {{- if ne $category "Hello"}}

--- a/.doc_gen/templates/zonbook/utility/hello.xml
+++ b/.doc_gen/templates/zonbook/utility/hello.xml
@@ -5,6 +5,11 @@
 {{- if not $example_suffix}}
     {{- $example_suffix = "tablist"}}
 {{- end}}
+{{- $prefix := index . 2}}
+{{- $example_prefix := ""}}
+{{- if $prefix}}
+    {{- $example_prefix = printf "%s_" $prefix}}
+{{- end}}
 {{- $include_docs := "file://AWSShared/code-samples/docs/"}}
 {{- if isSnapshot}}
     {{- $include_docs := ""}}
@@ -14,10 +19,10 @@
 <block>
     <collapsible expand-section="_collapse_all_">
         {{- range $hello.Examples}}
-        <section id="example_{{.ExampleId}}_section">
+        <section id="{{$example_prefix}}example_{{.ExampleId}}_section">
             <info>
-                <title id="example_{{.ExampleId}}_section.title">{{.Title}}</title>
-                <titleabbrev id="example_{{.ExampleId}}_section.titleabbrev">{{.TitleAbbrev}}</titleabbrev>
+                <title id="{{$example_prefix}}example_{{.ExampleId}}_section.title">{{.Title}}</title>
+                <titleabbrev id="{{$example_prefix}}example_{{.ExampleId}}_section.titleabbrev">{{.TitleAbbrev}}</titleabbrev>
                 <abstract>
                     <para>{{.Title}}</para>
                 </abstract>

--- a/.doc_gen/templates/zonbook/utility/sdk_api_examples.xml
+++ b/.doc_gen/templates/zonbook/utility/sdk_api_examples.xml
@@ -34,7 +34,7 @@
         {{- template "note_example_types" makeSlice 1 1 0}}
         <para>Each example includes a link to GitHub, where you can find
             instructions on how to set up and run the code in context.</para>
-        {{- template "hello" makeSlice $svc_examples.CategorizedExampleSets $examples.Language}}
+        {{- template "hello" makeSlice $svc_examples.CategorizedExampleSets $examples.Language $examples.LanguageSlug}}
         <para role="topiclist-abbrev"/>
         {{- range $category := $svc_examples.CategoryNamesSorted}}
         {{- if ne $category "Hello"}}

--- a/.doc_gen/templates/zonbook/utility/service_examples.xml
+++ b/.doc_gen/templates/zonbook/utility/service_examples.xml
@@ -18,8 +18,8 @@
 {{- end}}
 <section id="{{$svc_prefix}}example_{{.ExampleId}}_section" role="topic">
     <info>
-        <title id="example_{{.ExampleId}}_section.title">{{.Title}}</title>
-        <titleabbrev id="example_{{.ExampleId}}_section.titleabbrev">{{.TitleAbbrev}}</titleabbrev>
+        <title id="{{$svc_prefix}}example_{{.ExampleId}}_section.title">{{.Title}}</title>
+        <titleabbrev id="{{$svc_prefix}}example_{{.ExampleId}}_section.titleabbrev">{{.TitleAbbrev}}</titleabbrev>
         <abstract>
             <para>{{.Title}}</para>
         </abstract>
@@ -57,7 +57,7 @@
                 <listitem>
                     <para>
                         <xref linkend="{{$svc_prefix}}example_{{$rel_example}}_section"
-                              endterm="example_{{$rel_example}}_section.titleabbrev"/>
+                              endterm="{{$svc_prefix}}example_{{$rel_example}}_section.titleabbrev"/>
                     </para>
                 </listitem>
             {{- end}}


### PR DESCRIPTION
This is an update to the make example section titles unique in the Zonbook output from zexi.
* Previously, these titles were not unique in the code library. When this happens, Zonbook concatenates all the title together for duplicate entries.
* This update makes the titles unique by prefixing them with either the service or SDK slug of the guide that they are in.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
