### PR TITLE
Update AWS CLI entries in sdks.yaml

### DIFF
--- a/.doc_gen/metadata/sdks.yaml
+++ b/.doc_gen/metadata/sdks.yaml
@@ -215,7 +215,7 @@ CLI:
         short: "AWS CLI"
       guide: "cli/latest/userguide/cli-chap-welcome.html"
       title_override:
-        title: "AWS CLI command examples"
+        title: "&CLI; command examples"
         title_abbrev: "Command examples"
       api_ref:
         uid: "aws-cli"
@@ -232,7 +232,7 @@ Bash:
         short: "AWS CLI with Bash script"
       guide: "cli/latest/userguide/cli-chap-welcome.html"
       title_override:
-        title: "AWS CLI with Bash script code examples"
+        title: "&Bash; code examples"
         title_abbrev: "Bash script examples"
       api_ref:
         uid: "aws-cli"

--- a/.doc_gen/metadata/sdks.yaml
+++ b/.doc_gen/metadata/sdks.yaml
@@ -212,8 +212,11 @@ CLI:
       short: "&CLI;"
       expanded:
         long: "AWS Command Line Interface"
-        short: "Command Line Interface"
+        short: "AWS CLI"
       guide: "cli/latest/userguide/cli-chap-welcome.html"
+      title_override:
+        title: "AWS CLI command examples"
+        title_abbrev: "Command examples"
       api_ref:
         uid: "aws-cli"
         name: "&guide-cli-ref;"
@@ -226,8 +229,11 @@ Bash:
       short: "&Bash;"
       expanded:
         long: "AWS Command Line Interface with Bash script"
-        short: "Command Line Interface with Bash script"
+        short: "AWS CLI with Bash script"
       guide: "cli/latest/userguide/cli-chap-welcome.html"
+      title_override:
+        title: "AWS CLI with Bash script code examples"
+        title_abbrev: "Bash script examples"
       api_ref:
         uid: "aws-cli"
         name: "&guide-cli-ref;"


### PR DESCRIPTION
Per discussion with Laren, I've updated the metadata for the two AWS CLI sections.

Reasons for abbreviation update, the AWS CLI User Guide will include both  AWS CLI and Bash scripting sections, and they can't have the same title abbreviations.

Updated to the short version found in the AWS CLI user guide.

<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request...

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
