### PR TITLE
[Metadata] Serverless snippets -> Serverless examples name change.

### DIFF
--- a/.doc_gen/cross-content/phrases-code-examples.ent
+++ b/.doc_gen/cross-content/phrases-code-examples.ent
@@ -63,8 +63,8 @@
 <!ENTITY PERSRlong '&PERSlong; Runtime'>
 <!ENTITY PERSR '&PERS; Runtime'>
 
-<!-- Serverless Snippets -->
-<!ENTITY Serverless 'Serverless Snippets'>
+<!-- Serverless examples -->
+<!ENTITY Serverless 'Serverless examples'>
 <!-- Transcribe Medical -->
 <!ENTITY TSCMlong '&TSClong; Medical'>
 <!ENTITY TSCM '&TSC; Medical'>


### PR DESCRIPTION
"Serverless snippets" (tributary) are being renamed to "Serverless examples". They've made the change on their side, this is the change we need to make on our side to complete the job.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
