### PR TITLE
Swift Fix incorrect comment in mocking sample

### DIFF
--- a/swift/example_code/swift-sdk/mocking/Sources/BucketManager.swift
+++ b/swift/example_code/swift-sdk/mocking/Sources/BucketManager.swift
@@ -19,7 +19,7 @@ public class BucketManager {
     /// ``MockS3Session``.
     var session: S3SessionProtocol
 
-    /// Initialize the ``S3Manager`` to call Amazon S3 functions using the
+    /// Initialize the ``BucketManager`` to call Amazon S3 functions using the
     /// specified object that implements ``S3SessionProtocol``.
     ///
     /// - Parameter session: The session object to use when calling Amazon S3.


### PR DESCRIPTION
A comment was referring to a class by an old name. Now fixed to use the current name of the class for this example.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
