### PR TITLE
Allow non-entity entries in expanded.short for SDKS

### DIFF
--- a/.doc_gen/validation/sdks_schema.yaml
+++ b/.doc_gen/validation/sdks_schema.yaml
@@ -12,7 +12,7 @@ version:
   short: include('entity_with_version_regex')
   expanded:
     long: str(upper_start=True, end_punc=False, check_aws=False)
-    short: str(upper_start=True, end_punc=False)
+    short: str(upper_start=True, end_punc=False, check_aws=False)
   guide: str()
   caveat: str(required=False, upper_start=True, end_punc=True)
   bookmark: str(required=False)


### PR DESCRIPTION
Expanded entries in sdks.yaml should *not* use entities. This updates the validator to correctly allow non-entity uses of AWS.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
