### PR TITLE
PHP: Update CloudFront signing URL examples to a supported API version

### DIFF
--- a/php/example_code/cloudfront/SignCookie.php
+++ b/php/example_code/cloudfront/SignCookie.php
@@ -62,7 +62,7 @@ function signACookie()
 
     $cloudFrontClient = new CloudFrontClient([
         'profile' => 'default',
-        'version' => '2014-11-06',
+        'version' => '2018-06-18',
         'region' => 'us-east-1'
     ]);
 

--- a/php/example_code/cloudfront/SignCookiePolicy.php
+++ b/php/example_code/cloudfront/SignCookiePolicy.php
@@ -73,7 +73,7 @@ POLICY;
 
     $cloudFrontClient = new CloudFrontClient([
         'profile' => 'default',
-        'version' => '2014-11-06',
+        'version' => '2018-06-18',
         'region' => 'us-east-1'
     ]);
 

--- a/php/example_code/cloudfront/SignPrivateDistribution.php
+++ b/php/example_code/cloudfront/SignPrivateDistribution.php
@@ -61,7 +61,7 @@ function signAPrivateDistribution()
     
     $cloudFrontClient = new CloudFrontClient([
         'profile' => 'default',
-        'version' => '2014-11-06',
+        'version' => '2018-06-18',
         'region' => 'us-east-1'
     ]);
     

--- a/php/example_code/cloudfront/SignPrivateDistributionPolicy.php
+++ b/php/example_code/cloudfront/SignPrivateDistributionPolicy.php
@@ -74,7 +74,7 @@ POLICY;
     
     $cloudFrontClient = new CloudFrontClient([
         'profile' => 'default',
-        'version' => '2014-11-06',
+        'version' => '2018-06-18',
         'region' => 'us-east-1'
     ]);
     


### PR DESCRIPTION
Starting in [`aws/aws-sdk-php`](https://github.com/aws/aws-sdk-php) version 3.281.13, CloudFront API version `2014-11-06` stopped working. It is also no longer on the supported version list [here](https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.CloudFront.CloudFrontClient.html).

I've updated the version to `2018-06-18` to a working version and to bring it inline with the other non-URL signing examples.

Some more details can be found in the discussion I created [here](https://github.com/aws/aws-sdk-php/discussions/2783).

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
