### PR TITLE
Fix resilient service region

### DIFF
--- a/python/cross_service/resilient_service/auto_scaler.py
+++ b/python/cross_service/resilient_service/auto_scaler.py
@@ -200,7 +200,7 @@ class AutoScaler:
                         inst_ready = True
             self.ssm_client.send_command(
                 InstanceIds=[instance_id], DocumentName='AWS-RunShellScript',
-                Parameters={'commands': ['cd / && sudo python3 server.py 80 us-west-2']})
+                Parameters={'commands': ['cd / && sudo python3 server.py 80']})
             log.info("Restarted the Python web server on instance %s.", instance_id)
         except ClientError as err:
             raise AutoScalerError(

--- a/python/cross_service/resilient_service/test/resources/server.py
+++ b/python/cross_service/resilient_service/test/resources/server.py
@@ -115,7 +115,7 @@ def run():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('port', default=80, type=int, help="The port where the HTTP server listens.")
-    parser.add_argument('region', default='us-west-2', help="The AWS Region of AWS resources used by this example.")
+    parser.add_argument('--region', default=ec2_metadata.region, help="The AWS Region of AWS resources used by this example.")
     args = parser.parse_args()
 
     server_port = args.port

--- a/workflows/resilient_service/SPECIFICATION.md
+++ b/workflows/resilient_service/SPECIFICATION.md
@@ -675,7 +675,7 @@ Select an instance, replace its instance profile, and reboot the instance.
    self.ssm_client.send_command(
        InstanceIds=[instance_id], 
        DocumentName='AWS-RunShellScript',
-       Parameters={'commands': ['cd / && sudo python3 server.py 80 us-west-2']})
+       Parameters={'commands': ['cd / && sudo python3 server.py 80']})
    ```
 
 Tell the user all about it:

--- a/workflows/resilient_service/resources/server.py
+++ b/workflows/resilient_service/resources/server.py
@@ -115,7 +115,7 @@ def run():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('port', default=80, type=int, help="The port where the HTTP server listens.")
-    parser.add_argument('region', default='us-west-2', help="The AWS Region of AWS resources used by this example.")
+    parser.add_argument('--region', default=ec2_metadata.region, help="The AWS Region of AWS resources used by this example.")
     args = parser.parse_args()
 
     server_port = args.port

--- a/workflows/resilient_service/resources/server_startup_script.sh
+++ b/workflows/resilient_service/resources/server_startup_script.sh
@@ -3,6 +3,5 @@ yum -y update
 sleep 30 # prevent "Error: Rpmdb changed underneath us"
 yum install python-pip -y
 python3 -m pip install boto3 ec2-metadata
-wget -O server.py https://raw.githubusercontent.com/Laren-AWS/aws-doc-sdk-examples/fix-resilient-service-region/workflows/resilient_service/resources/server.py
-# wget -O server.py https://raw.githubusercontent.com/awsdocs/aws-doc-sdk-examples/main/workflows/resilient_service/resources/server.py
+wget -O server.py https://raw.githubusercontent.com/awsdocs/aws-doc-sdk-examples/main/workflows/resilient_service/resources/server.py
 python3 server.py 80

--- a/workflows/resilient_service/resources/server_startup_script.sh
+++ b/workflows/resilient_service/resources/server_startup_script.sh
@@ -3,5 +3,6 @@ yum -y update
 sleep 30 # prevent "Error: Rpmdb changed underneath us"
 yum install python-pip -y
 python3 -m pip install boto3 ec2-metadata
-wget -O server.py https://raw.githubusercontent.com/awsdocs/aws-doc-sdk-examples/main/workflows/resilient_service/resources/server.py
+wget -O server.py https://raw.githubusercontent.com/Laren-AWS/aws-doc-sdk-examples/fix-resilient-service-region/workflows/resilient_service/resources/server.py
+# wget -O server.py https://raw.githubusercontent.com/awsdocs/aws-doc-sdk-examples/main/workflows/resilient_service/resources/server.py
 python3 server.py 80

--- a/workflows/resilient_service/resources/server_startup_script.sh
+++ b/workflows/resilient_service/resources/server_startup_script.sh
@@ -4,4 +4,4 @@ sleep 30 # prevent "Error: Rpmdb changed underneath us"
 yum install python-pip -y
 python3 -m pip install boto3 ec2-metadata
 wget -O server.py https://raw.githubusercontent.com/awsdocs/aws-doc-sdk-examples/main/workflows/resilient_service/resources/server.py
-python3 server.py 80 us-west-2
+python3 server.py 80


### PR DESCRIPTION
The resilient service scenario hardcoded the region in the startup script and required it be sent to the Python web server.

This updates the web server to use `ec2_metadata.region` so that the web server uses the same region as the instance and sending the region is no longer required.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
