### PR TITLE
Swift: Updates for Swift SDK 0.28.0

### DIFF
--- a/swift/example_code/ddb/ListTables/Package.swift
+++ b/swift/example_code/ddb/ListTables/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.10.0"
+            from: "0.28.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",

--- a/swift/example_code/ddb/ListTables/Sources/DatabaseManager.swift
+++ b/swift/example_code/ddb/ListTables/Sources/DatabaseManager.swift
@@ -14,14 +14,14 @@ public protocol DatabaseSession {
     /// A mockable entry point for the Amazon DynamoDB function
     /// `listTables()`. A DynamoDB implementation of `DatabaseSession` should
     /// call through to `DynamoDBClient.listTables()`, while a mocked
-    /// implementation should generate and return a `ListTablesOutputResponse`
+    /// implementation should generate and return a `ListTablesOutput`
     /// object with the desired results for testing purposes.
     ///
     /// - Parameter input: A `ListTablesInput` object specifying the input
     ///   parameters for the call to `listTables()`.
     ///
-    /// - Returns: A `ListTablesOutputResponse` structure with the results.
-    func listTables(input: ListTablesInput) async throws -> ListTablesOutputResponse
+    /// - Returns: A `ListTablesOutput` structure with the results.
+    func listTables(input: ListTablesInput) async throws -> ListTablesOutput
 }
 
 // snippet-start:[ddb.swift.dynamodbsession]
@@ -49,10 +49,10 @@ public struct DynamoDBSession: DatabaseSession {
     /// - Parameter input: The `input` parameter for `listTables()` as a
     ///   `ListTablesInput` object.
     ///
-    /// - Returns: The `ListTablesOutputResponse` returned by `listTables()`.
+    /// - Returns: The `ListTablesOutput` returned by `listTables()`.
     /// 
     /// - Throws: Errors from DynamoDB are thrown as usual.
-    public func listTables(input: ListTablesInput) async throws -> ListTablesOutputResponse {
+    public func listTables(input: ListTablesInput) async throws -> ListTablesOutput {
         return try await client.listTables(input: input)
     }
     // snippet-end:[ddb.swift.dynamodbsession.listtables]

--- a/swift/example_code/ddb/ListTables/Tests/ListTablesTests.swift
+++ b/swift/example_code/ddb/ListTables/Tests/ListTablesTests.swift
@@ -81,8 +81,8 @@ public struct MockDBSession: DatabaseSession {
     /// Mock version of the DynamoDB client's `listTables()` function. Returns
     /// values from the string array `fakeTableNames` or the one specified as
     /// an optional input when creating the `MockDBSession`.
-    public func listTables(input: ListTablesInput) async throws -> ListTablesOutputResponse {
-        var output = ListTablesOutputResponse(
+    public func listTables(input: ListTablesInput) async throws -> ListTablesOutput {
+        var output = ListTablesOutput(
             lastEvaluatedTableName: nil,
             tableNames: nil
         )

--- a/swift/example_code/s3/ListBuckets/Package.swift
+++ b/swift/example_code/s3/ListBuckets/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.20.0"
+            from: "0.28.0"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",

--- a/swift/example_code/s3/ListBuckets/Sources/ListBuckets/S3Session.swift
+++ b/swift/example_code/s3/ListBuckets/Sources/ListBuckets/S3Session.swift
@@ -17,7 +17,7 @@ import AWSS3
 /// A protocol defining the Amazon S3 functions we want to mock
 /// during testing.
 public protocol S3SessionProtocol {
-    func listBuckets(input: ListBucketsInput) async throws -> ListBucketsOutputResponse
+    func listBuckets(input: ListBucketsInput) async throws -> ListBucketsOutput
 }
 // snippet-end:[s3.swift.listbuckets.s3sessionprotocol]
 
@@ -41,9 +41,9 @@ public struct S3Session: S3SessionProtocol {
     /// Call through to the ``S3Client`` function `listBuckets()`.
     /// - Parameter input: The input to pass through to the SDK function
     ///   `listBuckets()`.
-    /// - Returns: A ``ListBucketsOutputResponse`` with the returned data.
+    /// - Returns: A ``ListBucketsOutput`` with the returned data.
     public func listBuckets(input: ListBucketsInput) async throws
-            -> ListBucketsOutputResponse {
+            -> ListBucketsOutput {
         return try await self.client.listBuckets(input: input)
     }
 }

--- a/swift/example_code/s3/ListBuckets/Tests/ListBucketsTests/ListBucketsTests.swift
+++ b/swift/example_code/s3/ListBuckets/Tests/ListBucketsTests/ListBucketsTests.swift
@@ -44,10 +44,10 @@ public struct MockS3Session: S3SessionProtocol {
     ///
     /// - Parameter input: The input to the `listBuckets()` function.
     ///
-    /// - Returns: A `ListBucketsOutputResponse` object containing the list of
+    /// - Returns: A `ListBucketsOutput` object containing the list of
     ///   buckets.
     public func listBuckets(input: ListBucketsInput) async throws
-            -> ListBucketsOutputResponse {
+            -> ListBucketsOutput {
         var bucketList: [S3ClientTypes.Bucket] = []
         let df = DateFormatter()
         df.dateFormat = "M/d/yy, h:mm:ss a z"
@@ -62,10 +62,10 @@ public struct MockS3Session: S3SessionProtocol {
             bucketList.append(bucket)
         }
         
-        // Create and return the `ListBucketsOutputResponse` object containing
+        // Create and return the `ListBucketsOutput` object containing
         // the results.
 
-        let response = ListBucketsOutputResponse(
+        let response = ListBucketsOutput(
             buckets: bucketList,
             owner: nil
         )

--- a/swift/example_code/swift-sdk/mocking/Package.swift
+++ b/swift/example_code/swift-sdk/mocking/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.20.0"
+            from: "0.28.0"
         )
     ],
     // snippet-start:[mocking.swift.package.targets]

--- a/swift/example_code/swift-sdk/mocking/Sources/S3Session.swift
+++ b/swift/example_code/swift-sdk/mocking/Sources/S3Session.swift
@@ -17,7 +17,7 @@ import AWSS3
 /// instead return mock results.
 public protocol S3SessionProtocol {
     func listBuckets(input: ListBucketsInput) async throws
-            -> ListBucketsOutputResponse
+            -> ListBucketsOutput
 }
 // snippet-end:[mocking.swift.protocol]
 
@@ -44,11 +44,11 @@ public class S3Session: S3SessionProtocol {
     /// - Parameter input: The input to pass through to the SDK function
     ///   `listBuckets()`.
     ///
-    /// - Returns: A ``ListBucketsOutputResponse`` with the returned data.
+    /// - Returns: A ``ListBucketsOutput`` with the returned data.
     ///
     // snippet-start:[mocking.swift.implement-real]
     public func listBuckets(input: ListBucketsInput) async throws
-            -> ListBucketsOutputResponse {
+            -> ListBucketsOutput {
         return try await self.client.listBuckets(input: input)
     }
     // snippet-end:[mocking.swift.implement-real]

--- a/swift/example_code/swift-sdk/mocking/Tests/MockS3Session.swift
+++ b/swift/example_code/swift-sdk/mocking/Tests/MockS3Session.swift
@@ -80,11 +80,11 @@ public class MockS3Session: S3SessionProtocol {
     ///
     /// - Parameter input: The input to the `listBuckets()` function.
     ///
-    /// - Returns: A `ListBucketsOutputResponse` object containing the list of
+    /// - Returns: A `ListBucketsOutput` object containing the list of
     ///   buckets.
     public func listBuckets(input: ListBucketsInput) async throws
-            -> ListBucketsOutputResponse {
-        let response = ListBucketsOutputResponse(
+            -> ListBucketsOutput {
+        let response = ListBucketsOutput(
             buckets: self.mockBuckets,
             owner: nil
         )


### PR DESCRIPTION
Updated tests to use the new names for return structs. The old `*OutputResponse` types are now `*Output`.

The affected tests are the ones for `s3/ListBuckets`, `ddb/ListTables`, and `swift-sdk/mocking`.

There's a build on my cloud desktop at http://sheppycloud.aka.corp.amazon.com:4302/swift_1_code_examples.html but these changes only affect the tests, so this won't really show anything useful.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
