### PR TITLE
Python: Update runtimes in cross-service examples using 3.7

### DIFF
--- a/python/cross_service/apigateway_websocket_chat/setup.yaml
+++ b/python/cross_service/apigateway_websocket_chat/setup.yaml
@@ -70,7 +70,7 @@ Resources:
           table_name:
             Ref: docexamplewebsocketchat902A2E60
       Handler: lambda_chat.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.11
     DependsOn:
       - docexampleapigatewaywebsocketchatDefaultPolicyDC1046A1
       - docexampleapigatewaywebsocketchatE8890FEB

--- a/python/cross_service/rekognition_content_moderation/cloudformation.yaml
+++ b/python/cross_service/rekognition_content_moderation/cloudformation.yaml
@@ -56,7 +56,7 @@ Resources:
         ZipFile: |
           import json
           import boto3
-          import botocore.vendored.requests.packages.urllib3 as urllib3
+          import urllib3
           import io
 
 
@@ -118,7 +118,7 @@ Resources:
       Timeout: 35
       MemorySize: 128
       Role: !GetAtt lambdaIAMRole.Arn
-      Runtime: python3.7
+      Runtime: python3.11
 
   lambdaApiGatewayInvoke:
     Type: AWS::Lambda::Permission

--- a/python/cross_service/stepfunctions_messenger/setup.yaml
+++ b/python/cross_service/stepfunctions_messenger/setup.yaml
@@ -77,7 +77,7 @@ Resources:
           - docexamplestepfunctionslambdamessagesroleA963E816
           - Arn
       Handler: index.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.11
     DependsOn:
       - docexamplestepfunctionslambdamessagesroleDefaultPolicy2726D8C5
       - docexamplestepfunctionslambdamessagesroleA963E816


### PR DESCRIPTION
This pull request updates the runtime version for Python cross-service examples which were using 3.7 to use 3.11. Verified all examples and tests run correctly with the new version.

Closes #5400 

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
