### PR TITLE
GitHub Settings - Remove Testing label

### DIFF
--- a/.github/allowed-labels.yml
+++ b/.github/allowed-labels.yml
@@ -103,9 +103,6 @@
 - name: CloudFormation
   description: "Relates to CloudFormation templates"
   color: "f5f7f9"
-- name: Testing
-  description: "Relates to integration testing"
-  color: "f5f7f9"
 - name: GitHub settings
   color: "f5f7f9"
   description: "This affects GitHub settings"

--- a/.github/label-ruleset.yml
+++ b/.github/label-ruleset.yml
@@ -38,7 +38,5 @@ CloudFormation:
   - cloudformation/**/*
 Tools:
   - .tools/**/*
-Testing:
-  - test/**/*
 GitHub settings:
   - .github/**/*


### PR DESCRIPTION
This PR removes the testing label, as we no longer have a Testing directory.

All issues and PR's with the Testing label have been relabeled to Tools.

Proof:
* https://github.com/awsdocs/aws-doc-sdk-examples/issues?q=label%3ATesting+
* https://github.com/awsdocs/aws-doc-sdk-examples/issues?q=label%3ATools+