### PR TITLE
Remove delete action from label auditor.

### DIFF
--- a/.github/workflows/label-auditor.yml
+++ b/.github/workflows/label-auditor.yml
@@ -34,5 +34,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/allowed-labels.yml
-          skip-delete: false
+          skip-delete: true
           dry-run: false


### PR DESCRIPTION
Due to multiple incidents of data loss by accidental runs where an old config file doesn't contain a label and therefore deletes the label, this action should enable skip-delete to prevent this situation. It does mean we'll need to manually delete any labels we truly want gone.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
