### PR TITLE
Rust: Use into_paginator().items() when available.

### DIFF
--- a/rust_dev_preview/examples/globalaccelerator/src/bin/globalaccelerator-helloworld.rs
+++ b/rust_dev_preview/examples/globalaccelerator/src/bin/globalaccelerator-helloworld.rs
@@ -21,17 +21,21 @@ struct Opt {
 async fn show_accelerators(client: &Client) -> Result<(), Error> {
     println!("Welcome to the AWS Rust SDK Global Accelerator example!");
     println!();
-    let mut paginator = client.list_accelerators().into_paginator().send();
+    let accelerators = client
+        .list_accelerators()
+        .into_paginator()
+        .items()
+        .send()
+        .try_collect()
+        .await?;
 
-    while let Some(page) = paginator.try_next().await? {
-        for accelerator in page.accelerators().iter() {
-            let accelerator_arn = accelerator.name().unwrap_or_default();
-            let accelerator_name = accelerator.accelerator_arn().unwrap_or_default();
+    for accelerator in accelerators {
+        let accelerator_arn = accelerator.name().unwrap_or_default();
+        let accelerator_name = accelerator.accelerator_arn().unwrap_or_default();
 
-            println!("Accelerator Name : {}", accelerator_name);
-            println!("Accelerator ARN : {}", accelerator_arn);
-            println!();
-        }
+        println!("Accelerator Name : {}", accelerator_name);
+        println!("Accelerator ARN : {}", accelerator_arn);
+        println!();
     }
 
     Ok(())


### PR DESCRIPTION
Closes #5448.


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
