### PR TITLE
Rust: use std::io::Write::write_all to not have potential data loss.

### DIFF
--- a/rust_dev_preview/cross_service/photo_asset_management/src/uploader.rs
+++ b/rust_dev_preview/cross_service/photo_asset_management/src/uploader.rs
@@ -57,9 +57,10 @@ impl<'a> ZipUpload<'a> {
 
         let mut byte_count = 0_usize;
         while let Some(bytes) = object.body.try_next().await? {
-            let bytes = self.zip.write(&bytes)?;
-            byte_count += bytes;
-            tracing::trace!("Intermediate read of {bytes} (total {byte_count})");
+            let bytes_len = bytes.len();
+            self.zip.write_all(&bytes)?;
+            byte_count += bytes_len;
+            tracing::trace!("Intermediate read of {bytes_len} (total {byte_count})");
         }
 
         Ok(())

--- a/rust_dev_preview/examples/s3/src/bin/get-object.rs
+++ b/rust_dev_preview/examples/s3/src/bin/get-object.rs
@@ -32,9 +32,10 @@ async fn get_object(client: Client, opt: Opt) -> Result<usize, anyhow::Error> {
 
     let mut byte_count = 0_usize;
     while let Some(bytes) = object.body.try_next().await? {
-        let bytes = file.write(&bytes)?;
-        byte_count += bytes;
-        trace!("Intermediate write of {bytes}");
+        let bytes_len = bytes.len();
+        file.write_all(&bytes)?;
+        trace!("Intermediate write of {bytes_len}");
+        byte_count += bytes_len;
     }
 
     Ok(byte_count)


### PR DESCRIPTION
Closes #5530


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
