### PR TITLE
Rust: Remove 'make_page' testing helper

### DIFF
--- a/rust_dev_preview/examples/testing/src/enums.rs
+++ b/rust_dev_preview/examples/testing/src/enums.rs
@@ -150,7 +150,7 @@ mod test {
             expected_prefix: "test-prefix".into(),
             pages: vec![vec![
                 Object::builder().size(5).build(),
-                Object::builder().size(2).build()
+                Object::builder().size(2).build(),
             ]],
         };
 

--- a/rust_dev_preview/examples/testing/src/enums.rs
+++ b/rust_dev_preview/examples/testing/src/enums.rs
@@ -148,10 +148,10 @@ mod test {
         let fake = ListObjects::Test {
             expected_bucket: "test-bucket".into(),
             expected_prefix: "test-prefix".into(),
-            pages: vec![[5, 2i64]
-                .iter()
-                .map(|size| Object::builder().size(*size).build())
-                .collect()],
+            pages: vec![vec![
+                Object::builder().size(5).build(),
+                Object::builder().size(2).build()
+            ]],
         };
 
         // Run the code we want to test with it

--- a/rust_dev_preview/examples/testing/src/traits.rs
+++ b/rust_dev_preview/examples/testing/src/traits.rs
@@ -146,10 +146,10 @@ mod test {
         let fake = TestListObjects {
             expected_bucket: "test-bucket".into(),
             expected_prefix: "test-prefix".into(),
-            pages: vec![[5, 2i64]
-                .iter()
-                .map(|size| Object::builder().size(*size).build())
-                .collect()],
+            pages: vec![vec![
+                Object::builder().size(5).build(),
+                Object::builder().size(2).build(),
+            ]],
         };
 
         // Run the code we want to test with it

--- a/rust_dev_preview/examples/testing/src/wrapper.rs
+++ b/rust_dev_preview/examples/testing/src/wrapper.rs
@@ -74,15 +74,6 @@ pub async fn determine_prefix_file_size(
 }
 // snippet-end:[testing.rust.wrapper]
 
-#[allow(dead_code)]
-// This time, we add a helper function for making pages
-fn make_page(sizes: &[i64]) -> Vec<s3::types::Object> {
-    sizes
-        .iter()
-        .map(|size| s3::types::Object::builder().size(*size).build())
-        .collect()
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -96,7 +87,11 @@ mod test {
             .with(eq("test-bucket"), eq("test-prefix"), eq(None))
             .return_once(|_, _, _| {
                 Ok(ListObjectsV2Output::builder()
-                    .set_contents(Some(make_page(&[5, 2])))
+                    .set_contents(Some(vec![
+                        // Mock content for ListObjectsV2 response
+                        s3::types::Object::builder().size(5).build(),
+                        s3::types::Object::builder().size(2).build(),
+                    ]))
                     .build())
             });
 
@@ -117,7 +112,11 @@ mod test {
             .with(eq("test-bucket"), eq("test-prefix"), eq(None))
             .return_once(|_, _, _| {
                 Ok(ListObjectsV2Output::builder()
-                    .set_contents(Some(make_page(&[5, 2])))
+                    .set_contents(Some(vec![
+                        // Mock content for ListObjectsV2 response
+                        s3::types::Object::builder().size(5).build(),
+                        s3::types::Object::builder().size(2).build(),
+                    ]))
                     .set_next_continuation_token(Some("next".to_string()))
                     .build())
             });
@@ -129,7 +128,11 @@ mod test {
             )
             .return_once(|_, _, _| {
                 Ok(ListObjectsV2Output::builder()
-                    .set_contents(Some(make_page(&[3, 9])))
+                    .set_contents(Some(vec![
+                        // Mock content for ListObjectsV2 response
+                        s3::types::Object::builder().size(3).build(),
+                        s3::types::Object::builder().size(9).build(),
+                    ]))
                     .build())
             });
 


### PR DESCRIPTION
This pull request removes a helper that causes more confusion that benefit.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
