### PR TITLE
Tools - Testing: Removing hardcoded ENV in favor of config

### DIFF
--- a/.tools/test/config/resources.yaml
+++ b/.tools/test/config/resources.yaml
@@ -1,2 +1,3 @@
 topic_name: "aws-weathertop-central-sns-fanout-topic"
 bucket_name: "aws-weathertop-central-log-bucket"
+admin_acct: "808326389482"

--- a/.tools/test/sqs_lambda_to_batch_fargate/README.md
+++ b/.tools/test/sqs_lambda_to_batch_fargate/README.md
@@ -24,18 +24,6 @@ For example, if your language is Java, use:
 ```
 export LANGUAGE_NAME=javav2
 ```
-
-Also, save the AWS account ID of the AWS account that is currently emitting 
-events for this stack to process.
-```
-export PRODUCER_ACCOUNT_ID=12345678901
-```
-
-Lastly, save the name of the SNS topic that will be producing the previously mentioned events.
-If created using [this Producer CDK code](../eventbridge_rule_with_sns_fanout/README.md), it will look something like this:
-```
-export FANOUT_TOPIC_NAME=ProducerStack-fanouttopic6EFF7954-pYvxBdNPbEWM
-```
 ---
 
 ## AWS CDK setup and deployment

--- a/.tools/test/sqs_lambda_to_batch_fargate/consumer_stack/consumer_stack.py
+++ b/.tools/test/sqs_lambda_to_batch_fargate/consumer_stack/consumer_stack.py
@@ -21,7 +21,6 @@ from constructs import Construct
 
 # Raises KeyError if environment variable doesn't exist.
 language_name = os.environ["LANGUAGE_NAME"]
-producer_account_id = os.environ["PRODUCER_ACCOUNT_ID"]
 
 
 class ConsumerStack(Stack):
@@ -30,6 +29,7 @@ class ConsumerStack(Stack):
         resource_config = self.get_yaml_config("../config/resources.yaml")
         topic_name = resource_config["topic_name"]
         producer_bucket_name = resource_config["bucket_name"]
+        self.producer_account_id = resource_config["admin_acct"]
         sns_topic = self.init_get_topic(topic_name)
         sqs_queue = sqs.Queue(self, f"BatchJobQueue-{language_name}")
         self.init_subscribe_sns(sqs_queue, sns_topic)
@@ -143,7 +143,7 @@ class ConsumerStack(Stack):
         statement = iam.PolicyStatement()
         statement.add_resources(sqs_queue.queue_arn)
         statement.add_actions("sqs:*")
-        statement.add_arn_principal(f"arn:aws:iam::{producer_account_id}:root")
+        statement.add_arn_principal(f"arn:aws:iam::{self.producer_account_id}:root")
         statement.add_arn_principal(f"arn:aws:iam::{Aws.ACCOUNT_ID}:root")
         statement.add_condition("ArnLike", {"aws:SourceArn": sns_topic.topic_arn})
         sqs_queue.add_to_resource_policy(statement)


### PR DESCRIPTION
This PR removes a bit of manual configuration (an ENV variable) and puts the value in a config file. Also removes related lines in the docs, plus an extra line that should have been removed previously.