### PR TITLE
Rust: use largest test runner to see time savings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,22 +14,11 @@ permissions:
 jobs:
   check:
     name: Check
-    runs-on: temporary-sizing-testing_ubuntu-latest_32-core
+    runs-on: temporary-sizing-testing_ubuntu-latest_64-core
     steps:
       - name: setup
         run: >
           sudo apt-get update && sudo apt-get install -y libclang-dev  &&
-          (
-          echo "Removing unwanted software... " ;
-          echo "Before:" ; df -h ;
-          sudo apt-get clean ; 
-          sudo rm -rf /usr/share/dotnet ;
-          sudo rm -rf /usr/local/lib/android ;
-          sudo rm -rf /opt/ghc ;
-          sudo rm -rf /opt/hostedtoolcache/CodeQL ;
-          sudo docker image prune --all --force ;
-          echo "After:" ; df -h ;
-          )
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.70.0"


### PR DESCRIPTION
This also removes the "Setup" cleaning, as we probably don't need to save that much space anymore.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
