### PR TITLE
[Rust]: Add more SoS tags to test samples

### DIFF
--- a/rust_dev_preview/examples/testing/src/replay.rs
+++ b/rust_dev_preview/examples/testing/src/replay.rs
@@ -101,7 +101,7 @@ mod test {
     // snippet-start:[testing.rust.replay-test-multiple]
     #[tokio::test]
     async fn test_multiple_pages() {
-        // snippet-start:[testing.rust.replay-create-client]
+        // snippet-start:[testing.rust.replay-create-replay]
         let page_1 = ReplayEvent::new(
                 http::Request::builder()
                     .method("GET")
@@ -125,7 +125,8 @@ mod test {
                     .unwrap(),
             );
         let replay_client = StaticReplayClient::new(vec![page_1, page_2]);
-        // snippet-end:[testing.rust.replay-create-client]
+        // snippet-end:[testing.rust.replay-create-replay]
+        // snippet-start:[testing.rust.replay-create-client]
         let client: s3::Client = s3::Client::from_conf(
             s3::Config::builder()
                 .credentials_provider(make_s3_test_credentials())
@@ -133,8 +134,10 @@ mod test {
                 .http_client(replay_client.clone())
                 .build(),
         );
+        // snippet-end:[testing.rust.replay-create-client]
 
         // Run the code we want to test with it
+        // snippet-start:[testing.rust.replay-test-and-verify]
         let size = determine_prefix_file_size(client, "test-bucket", "test-prefix")
             .await
             .unwrap();
@@ -142,6 +145,7 @@ mod test {
         assert_eq!(19, size);
 
         replay_client.assert_requests_match(&[]);
+        // snippet-end:[testing.rust.replay-test-and-verify]
     }
     // snippet-end:[testing.rust.replay-test-multiple]
 }

--- a/rust_dev_preview/examples/testing/src/replay.rs
+++ b/rust_dev_preview/examples/testing/src/replay.rs
@@ -101,6 +101,7 @@ mod test {
     // snippet-start:[testing.rust.replay-test-multiple]
     #[tokio::test]
     async fn test_multiple_pages() {
+        // snippet-start:[testing.rust.replay-create-client]
         let page_1 = ReplayEvent::new(
                 http::Request::builder()
                     .method("GET")
@@ -124,6 +125,7 @@ mod test {
                     .unwrap(),
             );
         let replay_client = StaticReplayClient::new(vec![page_1, page_2]);
+        // snippet-start:[testing.rust.replay-create-client]
         let client: s3::Client = s3::Client::from_conf(
             s3::Config::builder()
                 .credentials_provider(make_s3_test_credentials())

--- a/rust_dev_preview/examples/testing/src/replay.rs
+++ b/rust_dev_preview/examples/testing/src/replay.rs
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+// snippet-start:[testing.rust.replay-uses]
 use aws_sdk_s3 as s3;
+// snippet-end:[testing.rust.replay-uses]
 
 #[allow(dead_code)]
 // snippet-start:[testing.rust.replay]

--- a/rust_dev_preview/examples/testing/src/replay.rs
+++ b/rust_dev_preview/examples/testing/src/replay.rs
@@ -42,6 +42,7 @@ pub async fn determine_prefix_file_size(
 
 #[allow(dead_code)]
 // snippet-start:[testing.rust.replay-tests]
+// snippet-start:[testing.rust.replay-make-credentials]
 fn make_s3_test_credentials() -> s3::config::Credentials {
     s3::config::Credentials::new(
         "ATESTCLIENT",
@@ -51,9 +52,12 @@ fn make_s3_test_credentials() -> s3::config::Credentials {
         "",
     )
 }
+// snippet-end:[testing.rust.replay-make-credentials]
 
+// snippet-start:[testing.rust.replay-test-module]
 #[cfg(test)]
 mod test {
+    // snippet-start:[testing.rust.replay-test-single]
     use super::*;
     use aws_sdk_s3 as s3;
     use aws_smithy_runtime::client::http::test_util::{ReplayEvent, StaticReplayClient};
@@ -90,7 +94,9 @@ mod test {
         assert_eq!(7, size);
         replay_client.assert_requests_match(&[]);
     }
+    // snippet-end:[testing.rust.replay-test-single]
 
+    // snippet-start:[testing.rust.replay-test-multiple]
     #[tokio::test]
     async fn test_multiple_pages() {
         let page_1 = ReplayEvent::new(
@@ -133,5 +139,7 @@ mod test {
 
         replay_client.assert_requests_match(&[]);
     }
-    // snippet-end:[testing.rust.replay-tests]
+    // snippet-end:[testing.rust.replay-test-multiple]
 }
+// snippet-end:[testing.rust.replay-tests]
+// snippet-end:[testing.rust.replay-test-module]

--- a/rust_dev_preview/examples/testing/src/replay.rs
+++ b/rust_dev_preview/examples/testing/src/replay.rs
@@ -125,7 +125,7 @@ mod test {
                     .unwrap(),
             );
         let replay_client = StaticReplayClient::new(vec![page_1, page_2]);
-        // snippet-start:[testing.rust.replay-create-client]
+        // snippet-end:[testing.rust.replay-create-client]
         let client: s3::Client = s3::Client::from_conf(
             s3::Config::builder()
                 .credentials_provider(make_s3_test_credentials())

--- a/rust_dev_preview/examples/testing/src/wrapper.rs
+++ b/rust_dev_preview/examples/testing/src/wrapper.rs
@@ -3,18 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+// snippet-start:[testing.rust.wrapper]
 use aws_sdk_s3 as s3;
 #[allow(unused_imports)]
 use mockall::automock;
 
 use s3::operation::list_objects_v2::{ListObjectsV2Error, ListObjectsV2Output};
 
-// snippet-start:[testing.rust.wrapper]
+// snippet-start:[testing.rust.wrapper-which-impl]
 #[cfg(test)]
 pub use MockS3Impl as S3;
 #[cfg(not(test))]
 pub use S3Impl as S3;
+// snippet-end:[testing.rust.wrapper-which-impl]
 
+// snippet-start:[testing.rust.wrapper-impl]
 #[allow(dead_code)]
 pub struct S3Impl {
     inner: s3::Client,
@@ -43,8 +46,10 @@ impl S3Impl {
             .await
     }
 }
+// snippet-end:[testing.rust.wrapper-impl]
 
 #[allow(dead_code)]
+// snippet-start:[testing.rust.wrapper-func]
 pub async fn determine_prefix_file_size(
     // Now we take a reference to our trait object instead of the S3 client
     // s3_list: ListObjectsService,
@@ -72,23 +77,28 @@ pub async fn determine_prefix_file_size(
     }
     Ok(total_size_bytes)
 }
+// snippet-start:[testing.rust.wrapper-func]
 // snippet-end:[testing.rust.wrapper]
 
 #[allow(dead_code)]
 // This time, we add a helper function for making pages
+// snippet-start:[testing.rust.wrapper-make-page]
 fn make_page(sizes: &[i64]) -> Vec<s3::types::Object> {
     sizes
         .iter()
         .map(|size| s3::types::Object::builder().size(*size).build())
         .collect()
 }
+// snippet-end:[testing.rust.wrapper-make-page]
 
+// snippet-start:[testing.rust.wrapper-test-mod]
 #[cfg(test)]
 mod test {
+    // snippet-start:[testing.rust.wrapper-tests]
     use super::*;
     use mockall::predicate::eq;
 
-    // snippet-start:[testing.rust.wrapper-tests]
+    // snippet-start:[testing.rust.wrapper-test-single]
     #[tokio::test]
     async fn test_single_page() {
         let mut mock = MockS3Impl::default();
@@ -108,7 +118,9 @@ mod test {
         // Verify we got the correct total size back
         assert_eq!(7, size);
     }
+    // snippet-end:[testing.rust.wrapper-test-single]
 
+    // snippet-start:[testing.rust.wrapper-test-multiple]
     #[tokio::test]
     async fn test_multiple_pages() {
         // Create the Mock instance with two pages of objects now
@@ -140,5 +152,7 @@ mod test {
 
         assert_eq!(19, size);
     }
+    // snippet-end:[testing.rust.wrapper-test-multiple]
     // snippet-end:[testing.rust.wrapper-tests]
 }
+// snippet-start:[testing.rust.wrapper-test-mod]

--- a/rust_dev_preview/examples/testing/src/wrapper.rs
+++ b/rust_dev_preview/examples/testing/src/wrapper.rs
@@ -4,11 +4,13 @@
  */
 
 // snippet-start:[testing.rust.wrapper]
+// snippet-start:[testing.rust.wrapper-uses]
 use aws_sdk_s3 as s3;
 #[allow(unused_imports)]
 use mockall::automock;
 
 use s3::operation::list_objects_v2::{ListObjectsV2Error, ListObjectsV2Output};
+// snippet-end:[testing.rust.wrapper-uses]
 
 // snippet-start:[testing.rust.wrapper-which-impl]
 #[cfg(test)]

--- a/rust_dev_preview/examples/testing/src/wrapper.rs
+++ b/rust_dev_preview/examples/testing/src/wrapper.rs
@@ -82,17 +82,6 @@ pub async fn determine_prefix_file_size(
 // snippet-end:[testing.rust.wrapper-func]
 // snippet-end:[testing.rust.wrapper]
 
-#[allow(dead_code)]
-// This time, we add a helper function for making pages
-// snippet-start:[testing.rust.wrapper-make-page]
-fn make_page(sizes: &[i64]) -> Vec<s3::types::Object> {
-    sizes
-        .iter()
-        .map(|size| s3::types::Object::builder().size(*size).build())
-        .collect()
-}
-// snippet-end:[testing.rust.wrapper-make-page]
-
 // snippet-start:[testing.rust.wrapper-test-mod]
 #[cfg(test)]
 mod test {
@@ -108,7 +97,11 @@ mod test {
             .with(eq("test-bucket"), eq("test-prefix"), eq(None))
             .return_once(|_, _, _| {
                 Ok(ListObjectsV2Output::builder()
-                    .set_contents(Some(make_page(&[5, 2])))
+                    .set_contents(Some(vec![
+                        // Mock content for ListObjectsV2 response
+                        s3::types::Object::builder().size(5).build(),
+                        s3::types::Object::builder().size(2).build(),
+                    ]))
                     .build())
             });
 
@@ -131,7 +124,11 @@ mod test {
             .with(eq("test-bucket"), eq("test-prefix"), eq(None))
             .return_once(|_, _, _| {
                 Ok(ListObjectsV2Output::builder()
-                    .set_contents(Some(make_page(&[5, 2])))
+                    .set_contents(Some(vec![
+                        // Mock content for ListObjectsV2 response
+                        s3::types::Object::builder().size(5).build(),
+                        s3::types::Object::builder().size(2).build(),
+                    ]))
                     .set_next_continuation_token(Some("next".to_string()))
                     .build())
             });
@@ -143,7 +140,11 @@ mod test {
             )
             .return_once(|_, _, _| {
                 Ok(ListObjectsV2Output::builder()
-                    .set_contents(Some(make_page(&[3, 9])))
+                    .set_contents(Some(vec![
+                        // Mock content for ListObjectsV2 response
+                        s3::types::Object::builder().size(3).build(),
+                        s3::types::Object::builder().size(9).build(),
+                    ]))
                     .build())
             });
 

--- a/rust_dev_preview/examples/testing/src/wrapper.rs
+++ b/rust_dev_preview/examples/testing/src/wrapper.rs
@@ -50,8 +50,8 @@ impl S3Impl {
 }
 // snippet-end:[testing.rust.wrapper-impl]
 
-#[allow(dead_code)]
 // snippet-start:[testing.rust.wrapper-func]
+#[allow(dead_code)]
 pub async fn determine_prefix_file_size(
     // Now we take a reference to our trait object instead of the S3 client
     // s3_list: ListObjectsService,

--- a/rust_dev_preview/examples/testing/src/wrapper.rs
+++ b/rust_dev_preview/examples/testing/src/wrapper.rs
@@ -79,7 +79,7 @@ pub async fn determine_prefix_file_size(
     }
     Ok(total_size_bytes)
 }
-// snippet-start:[testing.rust.wrapper-func]
+// snippet-end:[testing.rust.wrapper-func]
 // snippet-end:[testing.rust.wrapper]
 
 #[allow(dead_code)]
@@ -157,4 +157,4 @@ mod test {
     // snippet-end:[testing.rust.wrapper-test-multiple]
     // snippet-end:[testing.rust.wrapper-tests]
 }
-// snippet-start:[testing.rust.wrapper-test-mod]
+// snippet-end:[testing.rust.wrapper-test-mod]


### PR DESCRIPTION
This PR just adds more SoS tags to the testing examples for the Rust SDK.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
