### PR TITLE
Java & Python: Add FM Playground example applications in Amazon Bedrock

### DIFF
--- a/.doc_gen/cross-content/cross_FMPlayground_Java_block.xml
+++ b/.doc_gen/cross-content/cross_FMPlayground_Java_block.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "file://zonbook/docbookx.dtd" [
+  <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
+  %phrases-shared;
+]>
+<block>
+  <para>
+	  The Java Foundation Model (FM) Playground is a Spring Boot sample application that showcases how to use &BRlong; with Java. This example shows how Java developers can use &BR; to build generative AI-enabled applications. You can test and interact with &BR; foundation models by using the following three playgrounds:
+  </para>
+  <itemizedlist>
+    <listitem>
+      <para>A text playground.</para>
+    </listitem>
+    <listitem>
+      <para>A chat playground.</para>
+    </listitem>
+    <listitem>
+      <para>An image playground.</para>
+    </listitem>
+  </itemizedlist>
+  <para>The example also lists and displays the foundation models you have access to, along with their characteristics. For source code and deployment instructions, see the project in <ulink url="https://github.com/build-on-aws/java-fm-playground">GitHub</ulink>.
+  </para>
+</block>

--- a/.doc_gen/cross-content/cross_FMPlayground_Python_block.xml
+++ b/.doc_gen/cross-content/cross_FMPlayground_Python_block.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "file://zonbook/docbookx.dtd" [
+  <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
+  %phrases-shared;
+]>
+<block>
+  <para>
+	  The Python Foundation Model (FM) Playground is a Python/FastAPI sample application that showcases how to use &BRlong; with Python. This example shows how Python developers can use &BR; to build generative AI-enabled applications. You can test and interact with &BR; foundation models by using the following three playgrounds:
+  </para>
+  <itemizedlist>
+    <listitem>
+      <para>A text playground.</para>
+    </listitem>
+    <listitem>
+      <para>A chat playground.</para>
+    </listitem>
+    <listitem>
+      <para>An image playground.</para>
+    </listitem>
+  </itemizedlist>
+  <para>The example also lists and displays the foundation models you have access to, along with their characteristics. For source code and deployment instructions, see the project in <ulink url="https://github.com/build-on-aws/python-fm-playground">GitHub</ulink>.
+  </para>
+</block>

--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -704,6 +704,10 @@ cross_FMPlayground:
       versions:
         - sdk_version: 3
           block_content: cross_FMPlayground_NetV3_block.xml
+    Java:
+      versions:
+        - sdk_version: 2
+          block_content: cross_FMPlayground_Java_block.xml
   service_main: bedrock-runtime
   services:
     bedrock-runtime:

--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -708,6 +708,10 @@ cross_FMPlayground:
       versions:
         - sdk_version: 2
           block_content: cross_FMPlayground_Java_block.xml
+    Python:
+      versions:
+        - sdk_version: 3
+          block_content: cross_FMPlayground_Python_block.xml
   service_main: bedrock-runtime
   services:
     bedrock-runtime:


### PR DESCRIPTION
This pull request adds two cross service examples for Amazon Bedrock linking to the:
- Java FM Playground example application https://github.com/build-on-aws/java-fm-playground
- Python FM Playground example application https://github.com/build-on-aws/python-fm-playground

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
