### PR TITLE
Fix examples that used S3 fields that are now nullable

### DIFF
--- a/rust_dev_preview/examples/s3/src/bin/s3-multipart-upload.rs
+++ b/rust_dev_preview/examples/s3/src/bin/s3-multipart-upload.rs
@@ -148,7 +148,11 @@ async fn run_example() -> Result<(), Error> {
     // snippet-end:[rust.example_code.s3.complete_multipart_upload]
 
     let data: GetObjectOutput = s3_service::download_object(&client, &bucket_name, &key).await?;
-    let data_length: u64 = data.content_length().try_into().unwrap();
+    let data_length: u64 = data
+        .content_length()
+        .unwrap_or_default()
+        .try_into()
+        .unwrap();
     if file.metadata().unwrap().len() == data_length {
         println!("Data lengths match.");
     } else {

--- a/rust_dev_preview/examples/s3/src/s3-service-lib.rs
+++ b/rust_dev_preview/examples/s3/src/s3-service-lib.rs
@@ -61,7 +61,7 @@ pub async fn delete_objects(client: &Client, bucket_name: &str) -> Result<Vec<St
 
     eprintln!("{objects:?}");
 
-    match objects.key_count {
+    match objects.key_count.unwrap_or_default() {
         0 => Ok(return_keys),
         _ => Err(Error::unhandled(
             "There were still objects left in the bucket.",

--- a/rust_dev_preview/examples/testing/src/enums.rs
+++ b/rust_dev_preview/examples/testing/src/enums.rs
@@ -72,7 +72,7 @@ impl ListObjects {
         Ok(ListObjectsResult {
             objects: response.contents().to_vec(),
             next_continuation_token: response.next_continuation_token.clone(),
-            has_more: response.is_truncated(),
+            has_more: response.is_truncated() == Some(true),
         })
     }
     // snippet-end:[testing.rust.enums-real-list-objects]
@@ -122,7 +122,7 @@ async fn determine_prefix_file_size(
 
         // Add up the file sizes we got back
         for object in result.objects {
-            total_size_bytes += object.size() as usize;
+            total_size_bytes += object.size().unwrap_or(0) as usize;
         }
 
         // Handle pagination, and break the loop if there are no more pages

--- a/rust_dev_preview/examples/testing/src/main.rs
+++ b/rust_dev_preview/examples/testing/src/main.rs
@@ -56,12 +56,12 @@ async fn determine_prefix_file_size(
         // Add up the file sizes we got back
         let contents = response.contents();
         for object in contents {
-            total_size_bytes += object.size() as usize;
+            total_size_bytes += object.size().unwrap_or(0) as usize;
         }
 
         // Handle pagination, and break the loop if there are no more pages
         next_token = response.next_continuation_token.clone();
-        if !response.is_truncated() {
+        if response.is_truncated() != Some(true) {
             break;
         }
     }

--- a/rust_dev_preview/examples/testing/src/replay.rs
+++ b/rust_dev_preview/examples/testing/src/replay.rs
@@ -29,7 +29,7 @@ pub async fn determine_prefix_file_size(
 
         // Add up the file sizes we got back
         for object in result.contents() {
-            total_size_bytes += object.size() as usize;
+            total_size_bytes += object.size().unwrap_or(0) as usize;
         }
 
         // Handle pagination, and break the loop if there are no more pages

--- a/rust_dev_preview/examples/testing/src/traits.rs
+++ b/rust_dev_preview/examples/testing/src/traits.rs
@@ -57,7 +57,7 @@ impl ListObjects for S3ListObjects {
         Ok(ListObjectsResult {
             objects: response.contents().to_vec(),
             next_continuation_token: response.next_continuation_token.clone(),
-            has_more: response.is_truncated(),
+            has_more: response.is_truncated() == Some(true),
         })
     }
 }
@@ -119,7 +119,7 @@ pub async fn determine_prefix_file_size(
 
         // Add up the file sizes we got back
         for object in result.objects {
-            total_size_bytes += object.size() as usize;
+            total_size_bytes += object.size().unwrap_or(0) as usize;
         }
 
         // Handle pagination, and break the loop if there are no more pages

--- a/rust_dev_preview/examples/testing/src/wrapper.rs
+++ b/rust_dev_preview/examples/testing/src/wrapper.rs
@@ -68,7 +68,7 @@ pub async fn determine_prefix_file_size(
 
         // Add up the file sizes we got back
         for object in result.contents() {
-            total_size_bytes += object.size() as usize;
+            total_size_bytes += object.size().unwrap_or(0) as usize;
         }
 
         // Handle pagination, and break the loop if there are no more pages


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request updates S3 examples to sync with an upcoming model update.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
