### PR TITLE
Python: Update ses_generate_smtp_credentials.py with missing regions SES

### DIFF
--- a/python/example_code/ses/ses_generate_smtp_credentials.py
+++ b/python/example_code/ses/ses_generate_smtp_credentials.py
@@ -30,6 +30,8 @@ SMTP_REGIONS = [
     "eu-central-1",  # Europe (Frankfurt)
     "eu-west-1",  # Europe (Ireland)
     "eu-west-2",  # Europe (London)
+    "eu-south-1",  # Europe (Milan)
+    "eu-north-1",  # Europe (Stockholm)
     "sa-east-1",  # South America (Sao Paulo)
     "us-gov-west-1",  # AWS GovCloud (US)
 ]


### PR DESCRIPTION
Added two missing European regions - Milan and Stockholm

<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request adds two missing European regions - Milan and Stockholm.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
