### PR TITLE
Rust: Remove words 'developer preview' from READMEs

### DIFF
--- a/rustv1/README.md
+++ b/rustv1/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-These examples demonstrate how to perform several operations using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform several operations using the AWS SDK for Rust.
 
 ## ⚠ Important
 

--- a/rustv1/cross_service/README.md
+++ b/rustv1/cross_service/README.md
@@ -1,8 +1,8 @@
-# AWS SDK for Rust cross-service code examples 
+# AWS SDK for Rust cross-service code examples
 
 ## Purpose
 
-These code examples demonstrate how to perform two or more service operations using the developer preview version of the AWS SDK for Rust.
+These code examples demonstrate how to perform two or more service operations using the AWS SDK for Rust.
 
 Amazon Simple Storage Service (Amazon S3) is storage for the internet. You can use Amazon S3 to store and retrieve any amount of data at any time, from anywhere on the web.
 
@@ -55,44 +55,46 @@ You must have an AWS account, and have configured your default credentials and A
 ### detect_faces
 
 This code example:
+
 - Saves the image in an Amazon Simple Storage Service (Amazon S3) bucket with an "uploads/" prefix.
 - Displays facial details age range, gender, and emotion (smiling, etc.).
 
 ```
-cd detect_faces; 
+cd detect_faces;
 cargo run -- -b BUCKET -f FILENAME [-r REGION] [-v]
 ```
 
 - _BUCKET_ is the name of the Amazon S3 bucket where the JPG, JPEG, or PNG file is uploaded.
 - _FILENAME_ is the name of the file to upload.
-  It must have a __jpg__, __jpeg__, or __png__ file extension.  
+  It must have a **jpg**, **jpeg**, or **png** file extension.
 - _REGION_ is the name of the Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ### detect_labels
 
 This code example:
+
 - Gets EXIF information from a JPG, JPEG, or PNG file.
 - Uploads the file to an Amazon S3 bucket.
 - Uses Amazon Rekognition to identify the three top attributes (labels in Amazon Rekognition) in the file.
 - Adds the EXIF and label information to an Amazon DynamoDB table.
 
 ```
-cd detect_labels; 
+cd detect_labels;
 cargo run -- -b BUCKET -f FILENAME -t TABLE [-r REGION] [-v]
 ```
 
 - _BUCKET_ is the name of the Amazon S3 bucket where the JPG, JPEG, or PNG file is uploaded.
 - _FILENAME_ is the name of the file to upload.
-  It must have a __jpg__, __jpeg__, or __png__ file extension.
+  It must have a **jpg**, **jpeg**, or **png** file extension.
 - _TABLE_ is the DynamoDB table in which the EXIF and label information is stored.
-  It must use the primary key __filename__.
+  It must use the primary key **filename**.
 - _REGION_ is the name of the Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ### telephone
 
@@ -103,14 +105,14 @@ cd telephone
 cargo run -- -f FILENAME -b BUCKET -j JOB-NAME  [-r REGION] [-v]
 ```
 
-- __FILENAME__ is the name of the input file.
-  The output is saved in MP3 format in a file with the same basename, but with an __mp3__ extension.
-- __BUCKET__ is the Amazon S3 bucket to which the MP3 file is uploaded.
-- __JOB-NAME__ is the unique name of the job.
+- **FILENAME** is the name of the input file.
+  The output is saved in MP3 format in a file with the same basename, but with an **mp3** extension.
+- **BUCKET** is the Amazon S3 bucket to which the MP3 file is uploaded.
+- **JOB-NAME** is the unique name of the job.
 - _REGION_ is the Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ## Resources
 
@@ -124,8 +126,8 @@ cargo run -- -f FILENAME -b BUCKET -j JOB-NAME  [-r REGION] [-v]
 
 ## Contributing
 
-To propose a new code example to the AWS documentation team, 
-see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md). 
-The team prefers to create code examples that show broad scenarios rather than individual API calls. 
+To propose a new code example to the AWS documentation team,
+see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md).
+The team prefers to create code examples that show broad scenarios rather than individual API calls.
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/rustv1/examples/apigatewaymanagement/README.md
+++ b/rustv1/examples/apigatewaymanagement/README.md
@@ -2,14 +2,15 @@
 
 ## Purpose
 
-These examples demonstrate how to perform several Amazon API Gateway Management API (API Gateway Management API) operations using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform several Amazon API Gateway Management API (API Gateway Management API) operations using the AWS SDK for Rust.
 
 The Amazon API Gateway Management API allows you to directly manage runtime aspects of your deployed APIs. To use it,
 you must explicitly set the SDK's endpoint to point to the endpoint of your deployed API. The endpoint must be of the
 form `https://[api-id].execute-api.[region].amazonaws.com/[stage]` where:
-* `api-id` is the ID of your API.
-* `region` is the Region of your API.
-* `stage` is the deployment stage of your API,
+
+- `api-id` is the ID of your API.
+- `region` is the Region of your API.
+- `stage` is the deployment stage of your API,
   or the endpoint corresponding to your API's
   custom domain and base path.
 
@@ -19,7 +20,7 @@ form `https://[api-id].execute-api.[region].amazonaws.com/[stage]` where:
 
 ## ⚠ Important
 
-- We recommend that you grant this code least privilege, 
+- We recommend that you grant this code least privilege,
   or at most the minimum permissions required to perform the task.
   For more information, see
   [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
@@ -46,9 +47,9 @@ This example sends data to a connection.
 - _CONNECTION-ID_ is the ID of the connection where the data is sent.
 - _DATA_ is the data to send to the connection.
 - _REGION_ is name of the Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ## Resources
 
@@ -58,8 +59,8 @@ This example sends data to a connection.
 
 ## Contributing
 
-To propose a new code example to the AWS documentation team, 
-see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md). 
+To propose a new code example to the AWS documentation team,
+see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md).
 The team prefers to create code examples that show broad scenarios rather than individual API calls.
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/rustv1/examples/applicationautoscaling/README.md
+++ b/rustv1/examples/applicationautoscaling/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-These examples demonstrate how to perform several AWS Application Auto Scaling (Application Auto Scaling) operations using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform several AWS Application Auto Scaling (Application Auto Scaling) operations using the AWS SDK for Rust.
 
 Application Auto Scaling enables auto scaling for resources beyond just EC2, either with scaling policies or with scheduled scaling.
 
@@ -12,7 +12,7 @@ Application Auto Scaling enables auto scaling for resources beyond just EC2, eit
 
 ## ⚠ Important
 
-- We recommend that you grant this code least privilege, 
+- We recommend that you grant this code least privilege,
   or at most the minimum permissions required to perform the task.
   For more information, see
   [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
@@ -35,9 +35,9 @@ This example lists your Application Auto Scaling policies in the Region.
 `cargo run --bin describe-scaling-policies -- [-r REGION] [-v]`
 
 - _REGION_ is name of the Region where the stacks are located.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ## Resources
 
@@ -47,8 +47,8 @@ This example lists your Application Auto Scaling policies in the Region.
 
 ## Contributing
 
-To propose a new code example to the AWS documentation team, 
-see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md). 
+To propose a new code example to the AWS documentation team,
+see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md).
 The team prefers to create code examples that show broad scenarios rather than individual API calls.
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/rustv1/examples/autoscalingplans/README.md
+++ b/rustv1/examples/autoscalingplans/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-These examples demonstrate how to perform several Auto Scaling group operations using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform several Auto Scaling group operations using the AWS SDK for Rust.
 
 Use scaling plans to set up scaling policies across a collection of supported resources from services including Aurora, DynamoDB, EC2 Spot, and ECS.
 
@@ -12,7 +12,7 @@ Use scaling plans to set up scaling policies across a collection of supported re
 
 ## ⚠ Important
 
-- We recommend that you grant this code least privilege, 
+- We recommend that you grant this code least privilege,
   or at most the minimum permissions required to perform the task.
   For more information, see
   [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
@@ -31,9 +31,9 @@ This example lists your auto scaling plans in the Region.
 `cargo run --bin describe-scaling-plans -- [-r REGION] [-v]`
 
 - _REGION_ is name of the Region where the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ## Resources
 
@@ -43,8 +43,8 @@ This example lists your auto scaling plans in the Region.
 
 ## Contributing
 
-To propose a new code example to the AWS documentation team, 
-see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md). 
+To propose a new code example to the AWS documentation team,
+see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md).
 The team prefers to create code examples that show broad scenarios rather than individual API calls.
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/rustv1/examples/cognitoidentityprovider/README.md
+++ b/rustv1/examples/cognitoidentityprovider/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This code example demonstrate how to perform an Amazon Cognito user pool operation using the developer preview version of the AWS SDK for Rust.
+This code example demonstrate how to perform an Amazon Cognito user pool operation using the AWS SDK for Rust.
 
 Amazon Cognito user pools enable you to sign in to your web or mobile app through Amazon Cognito.
 
@@ -12,7 +12,7 @@ Amazon Cognito user pools enable you to sign in to your web or mobile app throug
 
 ## ⚠ Important
 
-- We recommend that you grant this code least privilege, 
+- We recommend that you grant this code least privilege,
   or at most the minimum permissions required to perform the task.
   For more information, see
   [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
@@ -35,9 +35,9 @@ This example lists your Amazon Cognito user pools in the Region.
 `cargo run --bin list-user-pools -- [-r REGION] [-v]`
 
 - _DEFAULT-REGION_ is name of the Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ## Resources
 
@@ -47,8 +47,8 @@ This example lists your Amazon Cognito user pools in the Region.
 
 ## Contributing
 
-To propose a new code example to the AWS documentation team, 
-see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md). 
-The team prefers to create code examples that show broad scenarios rather than individual API calls. 
+To propose a new code example to the AWS documentation team,
+see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md).
+The team prefers to create code examples that show broad scenarios rather than individual API calls.
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/rustv1/examples/globalaccelerator/README.md
+++ b/rustv1/examples/globalaccelerator/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-These examples demonstrate how to perform AWS Global Accelerator operations using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform AWS Global Accelerator operations using the AWS SDK for Rust.
 
 AWS Global Accelerator is a networking service that improves the performance of your users’ traffic by up to 60% using Amazon Web Services’ global network infrastructure.
 
@@ -12,7 +12,7 @@ AWS Global Accelerator is a networking service that improves the performance of 
 
 ## ⚠ Important
 
-- We recommend that you grant this code least privilege, 
+- We recommend that you grant this code least privilege,
   or at most the minimum permissions required to perform the task.
   For more information, see
   [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
@@ -34,18 +34,18 @@ This example lists your Global Accelerator accelerator names and ARNs.
 
 `cargo run --bin globalaccelerator-helloworld [-v]`
 
-- __-v__ displays additional information.
+- **-v** displays additional information.
 
 ## Resources
 
 - [AWS SDK for Rust repo](https://github.com/awslabs/aws-sdk-rust)
 - [AWS SDK for Rust API Reference for Global Accelerator](https://docs.rs/aws-sdk-globalaccelerator)
-- [AWS SDK for Rust API Reference Guide](https://awslabs.github.io/aws-sdk-rust/aws_sdk_config/index.html) 
+- [AWS SDK for Rust API Reference Guide](https://awslabs.github.io/aws-sdk-rust/aws_sdk_config/index.html)
 
 ## Contributing
 
-To propose a new code example to the AWS documentation team, 
-see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md). 
+To propose a new code example to the AWS documentation team,
+see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md).
 The team prefers to create code examples that show broad scenarios rather than individual API calls.
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/rustv1/examples/greengrassv2/README.md
+++ b/rustv1/examples/greengrassv2/README.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-These examples demonstrate how to perform several AWS Greengrass V2 operations using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform several AWS Greengrass V2 operations using the AWS SDK for Rust.
 
-AWS IoT Greengrass seamlessly extends AWS onto physical devices so they can act locally on the data they generate, while still using the cloud for management, analytics, and durable storage. 
+AWS IoT Greengrass seamlessly extends AWS onto physical devices so they can act locally on the data they generate, while still using the cloud for management, analytics, and durable storage.
 
 ## Code examples
 
@@ -12,7 +12,7 @@ AWS IoT Greengrass seamlessly extends AWS onto physical devices so they can act 
 
 ## ⚠ Important
 
-- We recommend that you grant this code least privilege, 
+- We recommend that you grant this code least privilege,
   or at most the minimum permissions required to perform the task.
   For more information, see
   [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
@@ -30,25 +30,25 @@ You must have an AWS account, and have configured your default credentials and A
 
 ### list-core-devices
 
-This example lists the name, status, and last update timestamp of your IoT Greengrass V2 devices in the Region. 
+This example lists the name, status, and last update timestamp of your IoT Greengrass V2 devices in the Region.
 
 `cargo run --bin list-core-devices -- [-r REGION] [-v]`
 
 - _REGION_ is the Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ## Resources
 
 - [AWS SDK for Rust repo](https://github.com/awslabs/aws-sdk-rust)
 - - [AWS SDK for Rust API Reference for Greengrass V2](https://docs.rs/aws-sdk-greengrassv2)
-- [AWS SDK for Rust API Reference Guide](https://awslabs.github.io/aws-sdk-rust/aws_sdk_config/index.html) 
+- [AWS SDK for Rust API Reference Guide](https://awslabs.github.io/aws-sdk-rust/aws_sdk_config/index.html)
 
 ## Contributing
 
-To propose a new code example to the AWS documentation team, 
-see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md). 
+To propose a new code example to the AWS documentation team,
+see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md).
 The team prefers to create code examples that show broad scenarios rather than individual API calls.
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/rustv1/examples/logging/README.md
+++ b/rustv1/examples/logging/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-These examples demonstrate how to perform logging and tracing using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform logging and tracing using the AWS SDK for Rust.
 
 ## Code examples
 

--- a/rustv1/examples/route53/README.md
+++ b/rustv1/examples/route53/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-These examples demonstrate how to perform several Amazon Route 53 operations using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform several Amazon Route 53 operations using the AWS SDK for Rust.
 
 Amazon Route 53 is a highly available and scalable Domain Name System (DNS) web service.
 
@@ -12,7 +12,7 @@ Amazon Route 53 is a highly available and scalable Domain Name System (DNS) web 
 
 ## ⚠ Important
 
-- We recommend that you grant this code least privilege, 
+- We recommend that you grant this code least privilege,
   or at most the minimum permissions required to perform the task.
   For more information, see
   [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
@@ -35,9 +35,9 @@ This example displays the IDs and names of the hosted zones in the Region.
 `cargo run --bin route53-helloworld -- [-r REGION] [-v]`
 
 - _REGION_ is the Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ## Resources
 
@@ -47,8 +47,8 @@ This example displays the IDs and names of the hosted zones in the Region.
 
 ## Contributing
 
-To propose a new code example to the AWS documentation team, 
-see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md). 
+To propose a new code example to the AWS documentation team,
+see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md).
 The team prefers to create code examples that show broad scenarios rather than individual API calls.
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/rustv1/examples/s3/src/bin/s3-getting-started.rs
+++ b/rustv1/examples/s3/src/bin/s3-getting-started.rs
@@ -8,7 +8,7 @@
 /*
 Purpose
 
-Shows how to use the developer preview version of the AWS SDK for Rust to get started using
+Shows how to use the AWS SDK for Rust to get started using
 Amazon Simple Storage Service (Amazon S3). Create a bucket, move objects into and out of it,
 and delete all resources at the end of the demo.
 

--- a/rustv1/examples/sending-presigned-requests/README.md
+++ b/rustv1/examples/sending-presigned-requests/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-These examples demonstrate how to perform several operations using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform several operations using the AWS SDK for Rust.
 
 ## ⚠ Important
 

--- a/rustv1/examples/sitewise/README.md
+++ b/rustv1/examples/sitewise/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-These examples demonstrate how to perform several AWS IoT SiteWise operations using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform several AWS IoT SiteWise operations using the AWS SDK for Rust.
 
 AWS IoT SiteWise is a managed service that simplifies collecting, organizing, and analyzing industrial equipment data.
 
@@ -13,7 +13,7 @@ AWS IoT SiteWise is a managed service that simplifies collecting, organizing, an
 ## ⚠ Important
 
 - Running this code might result in charges to your AWS account.
-- We recommend that you grant this code least privilege, 
+- We recommend that you grant this code least privilege,
   or at most the minimum permissions required to perform the task.
   For more information, see
   [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
@@ -39,9 +39,9 @@ This example lists AWS IoT SiteWise assets in the Region.
   - TOP_LEVEL - The list includes only top-level assets in the asset hierarchy tree.
 - _ASSET-MODEL-ID_ The ID of the asset model by which to filter the list of assets. This parameter is required if you choose ALL for _FILTER_.
 - _REGION_ The Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 If the example succeeds, it displays the Amazon Resource Name (ARN) of the new role.
 
@@ -52,9 +52,9 @@ This example list AWS IoT SiteWise asset models in the Region.
 `cargo run --bin list-asset-models -- [-r REGION] [-v]`
 
 - _REGION_ The Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ### list-portals.rs
 
@@ -63,9 +63,9 @@ This example list AWS IoT SiteWise portals in the Region.
 `cargo run --bin list-portals -- [-r REGION] [-v]`
 
 - _REGION_ The Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ### describe-asset.rs
 
@@ -75,20 +75,20 @@ This example describe an AWS IoT SiteWise asset in the Region.
 
 - _ASSET-ID_ The ID of the asset by which to filter the list of assets.
 - _REGION_ The Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ## Resources
 
 - [AWS SDK for Rust repo](https://github.com/awslabs/aws-sdk-rust)
 - - [AWS SDK for Rust API Reference for AWS IoT SiteWise](https://docs.rs/aws-sdk-iotsitewise)
-- [AWS SDK for Rust API Reference Guide](https://awslabs.github.io/aws-sdk-rust/aws_sdk_config/index.html) 
+- [AWS SDK for Rust API Reference Guide](https://awslabs.github.io/aws-sdk-rust/aws_sdk_config/index.html)
 
 ## Contributing
 
-To propose a new code example to the AWS documentation team, 
-see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md). 
+To propose a new code example to the AWS documentation team,
+see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md).
 The team prefers to create code examples that show broad scenarios rather than individual API calls.
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/rustv1/examples/snowball/README.md
+++ b/rustv1/examples/snowball/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-These examples demonstrate how to perform several AWS Snowball (Snowball) operations using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform several AWS Snowball (Snowball) operations using the AWS SDK for Rust.
 
 Snowball uses physical storage devices to transfer large amounts of data between Amazon Simple Storage Service (Amazon S3) and your onsite data storage location at faster-than-internet speeds.
 
@@ -14,7 +14,7 @@ Snowball uses physical storage devices to transfer large amounts of data between
 
 ## ⚠ Important
 
-- We recommend that you grant this code least privilege, 
+- We recommend that you grant this code least privilege,
   or at most the minimum permissions required to perform the task.
   For more information, see
   [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
@@ -49,9 +49,9 @@ This example creates an AWS Snowball address.
 - _STREET2_ is the second street portion of the address.
 - _STREET3_ is the third street portion of the address.
 - _REGION_ is the AWS Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.  
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ### describe-addresses
 
@@ -60,9 +60,9 @@ This example lists your AWS Snowball addresses.
 `cargo run --bin describe-addresses -- [-r REGION] [-v]`
 
 - _REGION_ is the AWS Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.  
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ### list-jobs
 
@@ -71,20 +71,20 @@ This example lists your AWS Snowball jobs.
 `cargo run --bin list-jobs -- [-r REGION] [-v]`
 
 - _REGION_ is the AWS Region in which the client is created.
-  If not supplied, uses the value of the __AWS_REGION__ environment variable.
-  If the environment variable is not set, defaults to __us-west-2__.
-- __-v__ displays additional information.  
+  If not supplied, uses the value of the **AWS_REGION** environment variable.
+  If the environment variable is not set, defaults to **us-west-2**.
+- **-v** displays additional information.
 
 ## Resources
 
 - [AWS SDK for Rust repo](https://github.com/awslabs/aws-sdk-rust)
 - [AWS SDK for Rust API Reference for Snowball](https://docs.rs/aws-sdk-snowball)
-- [AWS SDK for Rust API Reference Guide](https://awslabs.github.io/aws-sdk-rust/aws_sdk_config/index.html) 
+- [AWS SDK for Rust API Reference Guide](https://awslabs.github.io/aws-sdk-rust/aws_sdk_config/index.html)
 
 ## Contributing
 
-To propose a new code example to the AWS documentation team, 
-see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md). 
+To propose a new code example to the AWS documentation team,
+see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md).
 The team prefers to create code examples that show broad scenarios rather than individual API calls.
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/rustv1/examples/stepfunction/README.md
+++ b/rustv1/examples/stepfunction/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-These examples demonstrate how to perform several AWS Step Functions operations using the developer preview version of the AWS SDK for Rust.
+These examples demonstrate how to perform several AWS Step Functions operations using the AWS SDK for Rust.
 
 AWS Step Functions is a low-code, visual workflow service that developers use to build distributed applications, automate IT and business processes, and build data and machine learning pipelines using AWS services. Workflows manage failures, retries, parallelization, service integrations, and observability so developers can focus on higher-value business logic.
 
@@ -13,7 +13,7 @@ AWS Step Functions is a low-code, visual workflow service that developers use to
 
 ## ⚠ Important
 
-- We recommend that you grant this code least privilege, 
+- We recommend that you grant this code least privilege,
   or at most the minimum permissions required to perform the task.
   For more information, see
   [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
@@ -23,23 +23,21 @@ AWS Step Functions is a low-code, visual workflow service that developers use to
   [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 - Running this code might result in charges to your AWS account.
 
-
 ### Prerequisites
 
 You must have an AWS account, and have configured your default credentials and AWS Region as described in [https://github.com/awslabs/aws-sdk-rust](https://github.com/awslabs/aws-sdk-rust).
-You must create an [AWS Step Functions definition](https://serverlessland.com/patterns?services=sfn) 
-
+You must create an [AWS Step Functions definition](https://serverlessland.com/patterns?services=sfn)
 
 ## Resources
 
 - [AWS SDK for Rust repo](https://github.com/awslabs/aws-sdk-rust)
 - [AWS SDK for Rust API Reference for Amazon SQS](https://docs.rs/aws-sdk-sfn)
-- [AWS SDK for Rust API Reference Guide](https://awslabs.github.io/aws-sdk-rust/aws_sdk_config/index.html) 
+- [AWS SDK for Rust API Reference Guide](https://awslabs.github.io/aws-sdk-rust/aws_sdk_config/index.html)
 
 ## Contributing
 
-To propose a new code example to the AWS documentation team, 
-see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md). 
+To propose a new code example to the AWS documentation team,
+see [CONTRIBUTING.md](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/CONTRIBUTING.md).
 The team prefers to create code examples that show broad scenarios rather than individual API calls.
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/rustv1/webassembly/README.md
+++ b/rustv1/webassembly/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This example demonstrates how to package in a WebAssembly module that uses the developer preview version of the AWS SDK for Rust.
+This example demonstrates how to package in a WebAssembly module that uses the AWS SDK for Rust.
 
 ## Code examples
 


### PR DESCRIPTION


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
