### PR TITLE
Rust: Remove setup tasks that are not needed with larger runners.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,19 +17,7 @@ jobs:
     runs-on: aws-doc-sdk-examples_ubuntu-latest_16-core
     steps:
       - name: setup
-        run: >
-          sudo apt-get update && sudo apt-get install -y libclang-dev  &&
-          (
-          echo "Removing unwanted software... " ;
-          echo "Before:" ; df -h ;
-          sudo apt-get clean ; 
-          sudo rm -rf /usr/share/dotnet ;
-          sudo rm -rf /usr/local/lib/android ;
-          sudo rm -rf /opt/ghc ;
-          sudo rm -rf /opt/hostedtoolcache/CodeQL ;
-          sudo docker image prune --all --force ;
-          echo "After:" ; df -h ;
-          )
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.70.0"


### PR DESCRIPTION
This clean up was necessary with the default runners, because they would run out of disk space downloading the Rust SDK dependencies. Two things have changed:

1. We have moved to the crates.io 1.x releases, drastically reducing required dependency disk size
2. We have switched to larger runners, which have larger disk available.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
