### PR TITLE
Python: Remove reference to HTML format for SNS multi-message example.

### DIFF
--- a/python/example_code/sns/sns_basics.py
+++ b/python/example_code/sns/sns_basics.py
@@ -246,8 +246,8 @@ class SnsWrapper:
         """
         Publishes a multi-format message to a topic. A multi-format message takes
         different forms based on the protocol of the subscriber. For example,
-        an SMS subscriber might receive a short, text-only version of the message
-        while an email subscriber could receive an HTML version of the message.
+        an SMS subscriber might receive a short version of the message
+        while an email subscriber could receive a longer version.
 
         :param topic: The topic to publish to.
         :param subject: The subject of the message.


### PR DESCRIPTION
This pull request moves a confusing reference to HTML format for SNS multi-message example. Closes an internal feedback ticket issue.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
