### PR TITLE
Fix AWS service names in Amazon Bedrock stubbers

### DIFF
--- a/python/test_tools/bedrock_runtime_stubber.py
+++ b/python/test_tools/bedrock_runtime_stubber.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Stub functions that are used by the Amazon EC2 Bedrock Runtime unit tests.
+Stub functions that are used by the Amazon Bedrock Runtime unit tests.
 
 When tests are run against an actual AWS account, the stubber class does not
 set up stubs and passes all calls through to the Boto3 client.

--- a/python/test_tools/bedrock_stubber.py
+++ b/python/test_tools/bedrock_stubber.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Stub functions that are used by the Amazon EC2 Bedrock unit tests.
+Stub functions that are used by the Amazon Bedrock unit tests.
 """
 
 from test_tools.example_stubber import ExampleStubber


### PR DESCRIPTION
This pull request fixes the AWS service names in the Amazon Bedrock stubbers.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
