### PR TITLE
Python: Updated two mislabeled logger.error lines in bedrock_runtime_wrapper.py sample file.

### DIFF
--- a/python/example_code/bedrock-runtime/bedrock_runtime_wrapper.py
+++ b/python/example_code/bedrock-runtime/bedrock_runtime_wrapper.py
@@ -232,7 +232,7 @@ class BedrockRuntimeWrapper:
             return base64_image_data
 
         except ClientError:
-            logger.error("Couldn't invoke Stable Diffusion XL")
+            logger.error("Couldn't invoke Titan Image generator")
             raise
 
     # snippet-end:[python.example_code.bedrock-runtime.InvokeTitanImage]
@@ -270,7 +270,7 @@ class BedrockRuntimeWrapper:
                 yield chunk
 
         except ClientError:
-            logger.error("Couldn't invoke Titan Image Generator")
+            logger.error("Couldn't invoke Anthropic Claude v2")
             raise
 
     # snippet-end:[python.example_code.bedrock-runtime.InvokeModelWithResponseStream]


### PR DESCRIPTION
---
x By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
