### PR TITLE
Java: Fix Bedrock and BedrockRuntime package and artifact IDs

### DIFF
--- a/javav2/example_code/bedrock-runtime/pom.xml
+++ b/javav2/example_code/bedrock-runtime/pom.xml
@@ -3,8 +3,8 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>BedrockJ2Project</groupId>
-    <artifactId>BedrockJ2Project</artifactId>
+    <groupId>org.example</groupId>
+    <artifactId>BedrockRuntime</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javav2/example_code/bedrock/pom.xml
+++ b/javav2/example_code/bedrock/pom.xml
@@ -3,8 +3,8 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>BedrockJ2Project</groupId>
-    <artifactId>BedrockJ2Project</artifactId>
+    <groupId>org.example</groupId>
+    <artifactId>Bedrock</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This pull request replaces the generic package and artifact IDs for the bedrock and bedrock-runtime examples

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
