### PR TITLE
[Cygni] Fix some <programlisting> descriptions and add version to CLI

### DIFF
--- a/.doc_gen/cross-content/phrases-code-examples.ent
+++ b/.doc_gen/cross-content/phrases-code-examples.ent
@@ -30,6 +30,11 @@
 <!ENTITY Bashlong '&CLIlong; with Bash script'>
 <!ENTITY Bash '&CLI; with Bash script'>
 
+<!-- CLI v2 -->
+
+<!ENTITY CLI2long '&CLIlong; version 2'>
+<!ENTITY CLI2 '&CLI; version 2'>
+
 <!-- API Gateway Management API -->
 
 <!ENTITY ABPMA '&ABP; Management API'>

--- a/.doc_gen/metadata/sdks.yaml
+++ b/.doc_gen/metadata/sdks.yaml
@@ -207,8 +207,8 @@ CLI:
   syntax: none
   sdk:
     2:
-      long: "&CLIlong;"
-      short: "&CLI;"
+      long: "&CLI2long;"
+      short: "&CLI2;"
       expanded:
         long: "AWS Command Line Interface"
         short: "AWS CLI"

--- a/.doc_gen/metadata/services.yaml
+++ b/.doc_gen/metadata/services.yaml
@@ -2003,7 +2003,7 @@ medical-imaging:
     short: HealthImaging
   blurb: is a HIPAA-eligible service that helps health care providers and their medical imaging ISV partners store, transform, and apply machine learning to medical images.
   guide:
-    subtitle: User Guide
+    subtitle: Developer Guide
     url: healthimaging/latest/devguide/what-is.html
   api_ref: healthimaging/latest/APIReference/Welcome.html
   tags:

--- a/.doc_gen/templates/zonbook/example_language_template.xml
+++ b/.doc_gen/templates/zonbook/example_language_template.xml
@@ -45,7 +45,7 @@
             {{- range $version.Excerpts}}
             <block>
                 {{- if .Description}}
-                    {{- if and (lt 15 (len .Description)) (eq (slice .Description 0 15) "<programlisting")}}
+                    {{- if hasPrefix .Description "<programlisting"}}
                     {{.Description}}
                     {{- else}}
                     <para>{{.Description}}</para>

--- a/.doc_gen/templates/zonbook/example_language_template.xml
+++ b/.doc_gen/templates/zonbook/example_language_template.xml
@@ -44,7 +44,13 @@
             {{- end}}
             {{- range $version.Excerpts}}
             <block>
-                <para>{{.Description}}</para>
+                {{- if .Description}}
+                    {{- if and (lt 15 (len .Description)) (eq (slice .Description 0 15) "<programlisting")}}
+                    {{.Description}}
+                    {{- else}}
+                    <para>{{.Description}}</para>
+                    {{- end}}
+                {{- end}}
                 {{- if .SnippetTags}}
                 <!-- The following line break must be preserved and left-justified exactly as-is, to keep snippets looking good. -->
                 <programlisting language="{{.Syntax}}">{{range .SnippetTags}}<xi:include parse="text" href="{{$include_base}}snippets/{{.}}.txt"/>


### PR DESCRIPTION
CLI examples include output, which is rendered as ZonBook `programlisting`. Descriptions were previously always wrapped in `para` tags, but this causes problems in the authoring environment. This update adds the `para` tags only when the description exists and does not start with `programlisting`.

This update also adds the `version 2` to the CLI entities that are used for the CLI version 2 output.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
