### PR TITLE
Update all Cargo.tomls to be versioned

### DIFF
--- a/rustv1/cross_service/detect_faces/Cargo.toml
+++ b/rustv1/cross_service/detect_faces/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "1.0.1"
-aws-sdk-rekognition = "1.2.0"
-aws-sdk-s3 = "1.2.0"
-aws-smithy-types = { features = ["rt-tokio"],  version = "1.0.1"}
+aws-config = { version = "1.0.1" }
+aws-sdk-rekognition = { version = "1.3.0" }
+aws-sdk-s3 = { version = "1.4.0" }
+aws-smithy-types = { version = "1.0.1", features = ["rt-tokio"] }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/cross_service/detect_labels/Cargo.toml
+++ b/rustv1/cross_service/detect_labels/Cargo.toml
@@ -10,12 +10,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "1.0.1"
-aws-sdk-dynamodb = "1.2.0"
-aws-sdk-rekognition = "1.2.0"
-aws-sdk-s3 = "1.2.0"
-aws-smithy-types = { features = ["rt-tokio"],  version = "1.0.1"}
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { version = "1.0.1" }
+aws-sdk-dynamodb = { version = "1.3.0" }
+aws-sdk-rekognition = { version = "1.3.0" }
+aws-sdk-s3 = { version = "1.4.0" }
+aws-smithy-types = { version = "1.0.1", features = ["rt-tokio"] }
+aws-types = { version = "1.0.1" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/cross_service/photo_asset_management/Cargo.toml
+++ b/rustv1/cross_service/photo_asset_management/Cargo.toml
@@ -14,13 +14,13 @@ _HANDLER = "labels"
 
 [dependencies]
 anyhow = "1.0.70"
-aws-config = "1.0.1"
-aws-sdk-dynamodb = "1.2.0"
-aws-sdk-rekognition = "1.2.0"
-aws-sdk-s3 = "1.2.0"
-aws-sdk-sns = "1.2.0"
-aws-smithy-runtime = "1.0.1"
-aws-smithy-types-convert ={ features = ["convert-chrono"],  version = "0.60.0"}
+aws-config = { version = "1.0.1" }
+aws-sdk-dynamodb = { version = "1.3.0" }
+aws-sdk-rekognition = { version = "1.3.0" }
+aws-sdk-s3 = { version = "1.4.0" }
+aws-sdk-sns = { version = "1.3.0" }
+aws-smithy-runtime = { version = "1.0.1" }
+aws-smithy-types-convert = { version = "0.60.0", features = ["convert-chrono"] }
 aws_lambda_events = { version = "0.11.1", features = ["s3", "apigw"], default-features = false }
 bytes = "1.4.0"
 chrono = "0.4.24"

--- a/rustv1/cross_service/photo_asset_management/integration/Cargo.toml
+++ b/rustv1/cross_service/photo_asset_management/integration/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 
 [dependencies]
-aws-config = "1.0.1"
-aws-sdk-dynamodb = "1.2.0"
-aws-sdk-rekognition = "1.2.0"
+aws-config = { version = "1.0.1" }
+aws-sdk-dynamodb = { version = "1.3.0" }
+aws-sdk-rekognition = { version = "1.3.0" }
 photo_asset_management = { path = "../"}
 tokio = { version = "1.27.0", features = ["macros"] }
 tracing = "0.1.37"

--- a/rustv1/cross_service/rest_ses/Cargo.toml
+++ b/rustv1/cross_service/rest_ses/Cargo.toml
@@ -14,12 +14,12 @@ name = "rest_ses"
 [dependencies]
 actix-web = "4"
 actix-web-prom = "0.6.0"
-aws-config = "1.0.1"
-aws-sdk-cloudwatchlogs = "1.2.0"
-aws-sdk-rdsdata = "1.2.0"
-aws-sdk-ses = "1.2.0"
-aws-smithy-types = "1.0.1"
-aws-smithy-runtime = "1.0.1"
+aws-config = { version = "1.0.1" }
+aws-sdk-cloudwatchlogs = { version = "1.3.0" }
+aws-sdk-rdsdata = { version = "1.3.0" }
+aws-sdk-ses = { version = "1.3.0" }
+aws-smithy-types = { version = "1.0.1" }
+aws-smithy-runtime = { version = "1.0.1" }
 chrono = { version = "0.4.22", default-features = false, features = [
     "clock",
     "serde",
@@ -46,7 +46,7 @@ uuid = { version = "1.2.1", features = ["v4", "serde"] }
 xlsxwriter = "0.6.0"
 
 [dev-dependencies]
-aws-smithy-runtime = "1.0.1"
+aws-smithy-runtime = { version = "1.0.1" }
 fake = { version = "2.5.0", features = ["uuid"] }
 once_cell = "1.15.0"
 rand = "0.8.5"

--- a/rustv1/cross_service/telephone/Cargo.toml
+++ b/rustv1/cross_service/telephone/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "1.0.1"
-aws-sdk-polly = "1.2.0"
-aws-sdk-s3 = "1.2.0"
-aws-sdk-transcribe = "1.2.0"
-aws-smithy-types = { features = ["rt-tokio"],  version = "1.0.1"}
+aws-config = { version = "1.0.1" }
+aws-sdk-polly = { version = "1.3.0" }
+aws-sdk-s3 = { version = "1.4.0" }
+aws-sdk-transcribe = { version = "1.3.0" }
+aws-smithy-types = { version = "1.0.1", features = ["rt-tokio"] }
 anyhow = "1"
 tokio = { version = "1.20.1", features = ["full"] }
 bytes = "1"

--- a/rustv1/examples/apigateway/Cargo.toml
+++ b/rustv1/examples/apigateway/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-apigateway = "1.2.0"
-aws-smithy-types-convert = { features = [
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-apigateway = { version = "1.3.0" }
+aws-smithy-types-convert = { version = "0.60.0", features = [
   "convert-chrono",
-],  version = "0.60.0"}
+] }
 clap = { version = "~4.4", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/rustv1/examples/apigatewaymanagement/Cargo.toml
+++ b/rustv1/examples/apigatewaymanagement/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-apigatewaymanagement = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-apigatewaymanagement = { version = "1.3.0" }
 http = "0.2.5"
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }

--- a/rustv1/examples/applicationautoscaling/Cargo.toml
+++ b/rustv1/examples/applicationautoscaling/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-applicationautoscaling = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-applicationautoscaling = { version = "1.4.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/aurora/Cargo.toml
+++ b/rustv1/examples/aurora/Cargo.toml
@@ -11,10 +11,10 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1.0.75"
 assert_matches = "1.5.0"
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-smithy-types = "1.0.1"
-aws-smithy-runtime-api = "1.0.1"
-aws-sdk-rds = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-smithy-types = { version = "1.0.1" }
+aws-smithy-runtime-api = { version = "1.0.1" }
+aws-sdk-rds = { version = "1.3.0" }
 inquire = "0.6.2"
 mockall = "0.11.4"
 phf = { version = "0.11.2", features = ["std", "macros"] }

--- a/rustv1/examples/auto-scaling/Cargo.toml
+++ b/rustv1/examples/auto-scaling/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-autoscaling = "1.2.0"
-aws-sdk-ec2 = "1.2.0"
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-autoscaling = { version = "1.3.0" }
+aws-sdk-ec2 = { version = "1.3.0" }
+aws-types = { version = "1.0.1" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/autoscalingplans/Cargo.toml
+++ b/rustv1/examples/autoscalingplans/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-autoscalingplans = "1.2.0"
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-sdk-autoscalingplans = { version = "1.3.0" }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-types = { version = "1.0.1" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/batch/Cargo.toml
+++ b/rustv1/examples/batch/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-batch = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-batch = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/cloudformation/Cargo.toml
+++ b/rustv1/examples/cloudformation/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-cloudformation = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-cloudformation = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/cloudwatch/Cargo.toml
+++ b/rustv1/examples/cloudwatch/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-cloudwatch = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-cloudwatch = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/cloudwatchlogs/Cargo.toml
+++ b/rustv1/examples/cloudwatchlogs/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-cloudwatchlogs = "1.2.0"
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-cloudwatchlogs = { version = "1.3.0" }
+aws-types = { version = "1.0.1" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/cognitoidentity/Cargo.toml
+++ b/rustv1/examples/cognitoidentity/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-cognitoidentity = "1.2.0"
-aws-smithy-types-convert = { features = [
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-cognitoidentity = { version = "1.3.0" }
+aws-smithy-types-convert = { version = "0.60.0", features = [
   "convert-chrono",
-],  version = "0.60.0"}
+] }
 chrono = "0.4"
 clap = { version = "~4.4", features = ["derive"] }
 thiserror = "1.0"

--- a/rustv1/examples/cognitoidentityprovider/Cargo.toml
+++ b/rustv1/examples/cognitoidentityprovider/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-cognitoidentityprovider = "1.2.0"
-aws-smithy-types-convert = { features = [
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-cognitoidentityprovider = { version = "1.3.0" }
+aws-smithy-types-convert = { version = "0.60.0", features = [
   "convert-chrono",
-],  version = "0.60.0"}
+] }
 clap = { version = "~4.4", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/rustv1/examples/cognitosync/Cargo.toml
+++ b/rustv1/examples/cognitosync/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-cognitosync = "1.2.0"
-aws-smithy-types-convert = { features = [
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-cognitosync = { version = "1.3.0" }
+aws-smithy-types-convert = { version = "0.60.0", features = [
   "convert-chrono",
-],  version = "0.60.0"}
+] }
 clap = { version = "~4.4", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/rustv1/examples/concurrency/Cargo.toml
+++ b/rustv1/examples/concurrency/Cargo.toml
@@ -21,7 +21,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 
 [dev-dependencies]
-aws-config = "1.0.1"
-aws-sdk-s3 = "1.2.0"
-aws-sdk-sqs = "1.2.0"
+aws-config = { version = "1.0.1" }
+aws-sdk-s3 = { version = "1.4.0" }
+aws-sdk-sqs = { version = "1.3.0" }
 fastrand = "1.8.0"

--- a/rustv1/examples/config/Cargo.toml
+++ b/rustv1/examples/config/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-config = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-config = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/custom-root-certificates/Cargo.toml
+++ b/rustv1/examples/custom-root-certificates/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 description = "An example demonstrating setting a custom root certificate with rustls"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
 # bringing our own HTTPs so no need for the default features
-aws-sdk-s3 = { version = "1.2.0", default-features = false }
+aws-sdk-s3 = { version = "1.4.0", default-features = false }
 tokio = { version = "1.21.2", features = ["full"] }
 rustls = "0.21.9"
 hyper-rustls = { version = "0.24.2", features = ["http2"] }
-aws-smithy-runtime = { version = "1.0.2", features = ["tls-rustls"] }
+aws-smithy-runtime = { version = "1.0.1", features = ["tls-rustls"] }

--- a/rustv1/examples/dynamodb/Cargo.toml
+++ b/rustv1/examples/dynamodb/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
-aws-sdk-dynamodb = "1.2.0"
-aws-smithy-runtime = { features = ["test-util"],  version = "1.0.1"}
-aws-smithy-types = "1.0.1"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-http = { version = "0.60.0" }
+aws-sdk-dynamodb = { version = "1.3.0" }
+aws-smithy-runtime = { version = "1.0.1", features = ["test-util"] }
+aws-smithy-types = { version = "1.0.1" }
 axum = "0.5.16"
 clap = { version = "~4.4", features = ["derive"] }
 futures = "0.3"

--- a/rustv1/examples/ebs/Cargo.toml
+++ b/rustv1/examples/ebs/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-ebs = "1.2.0"
-aws-sdk-ec2 = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-ebs = { version = "1.3.0" }
+aws-sdk-ec2 = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 base64 = "0.13.0"
 sha2 = "0.9.5"

--- a/rustv1/examples/ec2/Cargo.toml
+++ b/rustv1/examples/ec2/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2021"
 
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-ec2 = "1.2.0"
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-ec2 = { version = "1.3.0" }
+aws-types = { version = "1.0.1" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/rustv1/examples/ecr/Cargo.toml
+++ b/rustv1/examples/ecr/Cargo.toml
@@ -8,9 +8,9 @@ authors = [
 edition = "2021"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-ecr = "1.2.0"
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-ecr = { version = "1.3.0" }
+aws-types = { version = "1.0.1" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/ecs/Cargo.toml
+++ b/rustv1/examples/ecs/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-ecs = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-ecs = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/eks/Cargo.toml
+++ b/rustv1/examples/eks/Cargo.toml
@@ -8,9 +8,9 @@ authors = [
 edition = "2021"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-eks = "1.2.0"
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-eks = { version = "1.3.0" }
+aws-types = { version = "1.0.1" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/firehose/Cargo.toml
+++ b/rustv1/examples/firehose/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-firehose = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-firehose = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/globalaccelerator/Cargo.toml
+++ b/rustv1/examples/globalaccelerator/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-globalaccelerator = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-globalaccelerator = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = "0.1.8"
 clap = { version = "~4.4", features = ["derive"] }

--- a/rustv1/examples/glue/Cargo.toml
+++ b/rustv1/examples/glue/Cargo.toml
@@ -13,12 +13,12 @@ name = "scenario"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-glue = "1.2.0"
-aws-sdk-s3 = "1.2.0"
-aws-http = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
-aws-smithy-types = "1.0.1"
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-glue = { version = "1.4.0" }
+aws-sdk-s3 = { version = "1.4.0" }
+aws-http = { version = "0.60.0" }
+aws-smithy-types = { version = "1.0.1" }
+aws-types = { version = "1.0.1" }
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing = "0.1.37"

--- a/rustv1/examples/greengrassv2/Cargo.toml
+++ b/rustv1/examples/greengrassv2/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Aaron Tsui <aaron.tsui@outlook.com>"]
 edition = "2021"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-greengrassv2 = "1.2.0"
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-greengrassv2 = { version = "1.3.0" }
+aws-types = { version = "1.0.1" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/rustv1/examples/iam/Cargo.toml
+++ b/rustv1/examples/iam/Cargo.toml
@@ -17,11 +17,11 @@ name = "iam_getting_started"
 path = "src/bin/iam-getting-started.rs"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-credential-types = { features = ["hardcoded-credentials"],  version = "1.0.1"}
-aws-sdk-iam = "1.2.0"
-aws-sdk-s3 = "1.2.0"
-aws-sdk-sts = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-credential-types = { version = "1.0.1", features = ["hardcoded-credentials"] }
+aws-sdk-iam = { version = "1.3.0" }
+aws-sdk-s3 = { version = "1.4.0" }
+aws-sdk-sts = { version = "1.3.1" }
 sdk-examples-test-utils = { path = "../../test-utils" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }

--- a/rustv1/examples/iot/Cargo.toml
+++ b/rustv1/examples/iot/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-iot = "1.2.0"
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-iot = { version = "1.3.0" }
+aws-types = { version = "1.0.1" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/kinesis/Cargo.toml
+++ b/rustv1/examples/kinesis/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-kinesis = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-kinesis = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/kms/Cargo.toml
+++ b/rustv1/examples/kms/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 description = "Example usage of the KMS service"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-kms = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-kms = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 base64 = "0.13.0"
 clap = { version = "~4.4", features = ["derive"] }

--- a/rustv1/examples/lambda/Cargo.toml
+++ b/rustv1/examples/lambda/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-ec2 = "1.2.0"
-aws-sdk-iam = "1.2.0"
-aws-sdk-lambda = "1.2.0"
-aws-sdk-s3 = "1.2.0"
-aws-smithy-types = "1.0.1"
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-ec2 = { version = "1.3.0" }
+aws-sdk-iam = { version = "1.3.0" }
+aws-sdk-lambda = { version = "1.3.0" }
+aws-sdk-s3 = { version = "1.4.0" }
+aws-smithy-types = { version = "1.0.1" }
+aws-types = { version = "1.0.1" }
 clap = { version = "~4.4", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/localstack/Cargo.toml
+++ b/rustv1/examples/localstack/Cargo.toml
@@ -6,9 +6,9 @@ authors = ["Doug Schwartz <dougsch@amazon.com>"]
 edition = "2021"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-s3 = "1.2.0"
-aws-sdk-sqs = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-s3 = { version = "1.4.0" }
+aws-sdk-sqs = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 http = "0.2"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/logging/logger/Cargo.toml
+++ b/rustv1/examples/logging/logger/Cargo.toml
@@ -11,8 +11,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-dynamodb = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-dynamodb = { version = "1.3.0" }
 # snippet-start:[logging.rust.logger-cargo.toml-env_logger]
 env_logger = "0.9.0"
 # snippet-end:[logging.rust.logger-cargo.toml-env_logger]

--- a/rustv1/examples/logging/tracing/Cargo.toml
+++ b/rustv1/examples/logging/tracing/Cargo.toml
@@ -11,8 +11,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-dynamodb = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-dynamodb = { version = "1.3.0" }
 clap = { version = "~4.4", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }
 # snippet-start:[logging.rust.tracing-cargo.toml-tracing_subscriber]

--- a/rustv1/examples/medialive/Cargo.toml
+++ b/rustv1/examples/medialive/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-medialive = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-medialive = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/mediapackage/Cargo.toml
+++ b/rustv1/examples/mediapackage/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-mediapackage = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-mediapackage = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/polly/Cargo.toml
+++ b/rustv1/examples/polly/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-polly = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-polly = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 bytes = "1"
 clap = { version = "~4.4", features = ["derive"] }

--- a/rustv1/examples/qldb/Cargo.toml
+++ b/rustv1/examples/qldb/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-qldb = "1.2.0"
-aws-sdk-qldbsession = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-qldb = { version = "1.3.0" }
+aws-sdk-qldbsession = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = { version = "0.1.9", features = ["default"] }
 clap = { version = "~4.4", features = ["derive"] }

--- a/rustv1/examples/rds/Cargo.toml
+++ b/rustv1/examples/rds/Cargo.toml
@@ -14,9 +14,9 @@ version = "0.1.0"
 anyhow = "1.0.75"
 assert_matches = "1.5.0"
 async-trait = "0.1.73"
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-smithy-runtime-api = "1.0.1"
-aws-sdk-rds = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-smithy-runtime-api = { version = "1.0.1" }
+aws-sdk-rds = { version = "1.3.0" }
 clap = { version = "~4.4", features = ["derive"] }
 inquire = "0.6.2"
 mockall = "0.11.4"

--- a/rustv1/examples/rdsdata/Cargo.toml
+++ b/rustv1/examples/rdsdata/Cargo.toml
@@ -10,8 +10,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-rdsdata = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-rdsdata = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/route53/Cargo.toml
+++ b/rustv1/examples/route53/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-route53 = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-route53 = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/s3/Cargo.toml
+++ b/rustv1/examples/s3/Cargo.toml
@@ -21,13 +21,13 @@ assert_cmd = "2.0"
 predicates = "3.0.3"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
 # snippet-start:[s3.rust.s3-object-lambda-cargo.toml]
 # snippet-end:[s3.rust.s3-object-lambda-cargo.toml]
-aws-sdk-s3 = { features = ["rt-tokio"], version = "1.2.0"}
-aws-smithy-runtime = "1.0.1"
-aws-smithy-runtime-api = { features = ["client"],  version = "1.0.1"}
-aws-smithy-types = { features = ["http-body-0-4-x"],  version = "1.0.1"}
+aws-sdk-s3 = { version = "1.4.0", features = ["rt-tokio"] }
+aws-smithy-runtime = { version = "1.0.1" }
+aws-smithy-runtime-api = { version = "1.0.1", features = ["client"] }
+aws-smithy-types = { version = "1.0.1", features = ["http-body-0-4-x"] }
 sdk-examples-test-utils = { path = "../../test-utils" }
 anyhow = "1.0.70"
 bytes = "1.4.0"

--- a/rustv1/examples/sagemaker/Cargo.toml
+++ b/rustv1/examples/sagemaker/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-sagemaker = "1.2.0"
-aws-smithy-types-convert = { features = [
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-sagemaker = { version = "1.5.0" }
+aws-smithy-types-convert = { version = "0.60.0", features = [
   "convert-chrono",
-],  version = "0.60.0"}
+] }
 clap = { version = "~4.4", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/rustv1/examples/sdk-config/Cargo.toml
+++ b/rustv1/examples/sdk-config/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-credential-types = "1.0.1"
-aws-sdk-s3 = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-credential-types = { version = "1.0.1" }
+aws-sdk-s3 = { version = "1.4.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/secretsmanager/Cargo.toml
+++ b/rustv1/examples/secretsmanager/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 description = "Example usage of the SecretManager service"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-secretsmanager = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-secretsmanager = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/sending-presigned-requests/Cargo.toml
+++ b/rustv1/examples/sending-presigned-requests/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-s3 = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-s3 = { version = "1.4.0" }
 http = "0.2.6"
 hyper = "0.14"
 reqwest = "0.11"

--- a/rustv1/examples/ses/Cargo.toml
+++ b/rustv1/examples/ses/Cargo.toml
@@ -8,8 +8,8 @@ authors = [
 edition = "2021"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-sesv2 = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-sesv2 = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/sitewise/Cargo.toml
+++ b/rustv1/examples/sitewise/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 # For more keys and their definitions, see https://doc.rust-lang.org/cargo/reference/manifest.html.
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-iotsitewise = "1.2.0"
-aws-smithy-types-convert = { features = [
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-iotsitewise = { version = "1.3.0" }
+aws-smithy-types-convert = { version = "0.60.0", features = [
   "convert-chrono",
-],  version = "0.60.0"}
+] }
 clap = { version = "~4.4", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.20.1", features = ["full"] } 

--- a/rustv1/examples/snowball/Cargo.toml
+++ b/rustv1/examples/snowball/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-snowball = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-snowball = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/sns/Cargo.toml
+++ b/rustv1/examples/sns/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-sns = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-sns = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/sqs/Cargo.toml
+++ b/rustv1/examples/sqs/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-sqs = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-sqs = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/ssm/Cargo.toml
+++ b/rustv1/examples/ssm/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-ssm = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-ssm = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/stepfunction/Cargo.toml
+++ b/rustv1/examples/stepfunction/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Daniele Frasca <https://github.com/ymwjbxxq/>"]
 edition = "2021"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-sfn = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-sfn = { version = "1.3.0" }
 tokio = { version = "1.20.1", features = ["full"] }
 clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/sts/Cargo.toml
+++ b/rustv1/examples/sts/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-sts = "1.2.0"
-aws-smithy-types = "1.0.1"
-aws-types = "1.0.1"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-sts = { version = "1.3.1" }
+aws-smithy-types = { version = "1.0.1" }
+aws-types = { version = "1.0.1" }
 clap = { version = "~4.4", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rustv1/examples/testing/Cargo.toml
+++ b/rustv1/examples/testing/Cargo.toml
@@ -10,13 +10,13 @@ edition = "2021"
 # snippet-start:[testing.rust.Cargo.toml]
 [dependencies]
 async-trait = "0.1.51"
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-credential-types = { features = [ "hardcoded-credentials", ],  version = "1.0.1"}
-aws-sdk-s3 = "1.2.0"
-aws-smithy-types = "1.0.1"
-aws-smithy-runtime = { features = ["test-util"],  version = "1.0.1"}
-aws-smithy-runtime-api = { features = ["test-util"],  version = "1.0.1"}
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next" }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-credential-types = { version = "1.0.1", features = [ "hardcoded-credentials", ] }
+aws-sdk-s3 = { version = "1.4.0" }
+aws-smithy-types = { version = "1.0.1" }
+aws-smithy-runtime = { version = "1.0.1", features = ["test-util"] }
+aws-smithy-runtime-api = { version = "1.0.1", features = ["test-util"] }
+aws-types = { version = "1.0.1" }
 clap = { version = "~4.4", features = ["derive"] }
 http = "0.2.9"
 mockall = "0.11.4"

--- a/rustv1/examples/textract/Cargo.toml
+++ b/rustv1/examples/textract/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 # For more keys and their definitions, see https://doc.rust-lang.org/cargo/reference/manifest.html.
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-textract = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-textract = { version = "1.3.0" }
 tokio = { version = "1.27", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 thiserror = "1.0.49"
-aws-types = "0.56.1"
+aws-types = { version = "1.0.1" }

--- a/rustv1/examples/tls/Cargo.toml
+++ b/rustv1/examples/tls/Cargo.toml
@@ -12,9 +12,9 @@ name = "tls"
 path = "src/lib.rs"
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-smithy-runtime = "1.0.1"
-aws-sdk-kms = { version = "1.2.0", default-features = false }
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-smithy-runtime = { version = "1.0.1" }
+aws-sdk-kms = { version = "1.3.0", default-features = false }
 webpki-roots = "0.22.4"
 tokio = { version = "1.20.1", features = ["full"] }
 rustls = "0.20.6"

--- a/rustv1/examples/transcribestreaming/Cargo.toml
+++ b/rustv1/examples/transcribestreaming/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { features = ["behavior-version-latest"], version = "1.0.1"}
-aws-sdk-transcribestreaming = "1.2.0"
+aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }
+aws-sdk-transcribestreaming = { version = "1.3.0" }
 async-stream = "0.3"
 bytes = "1"
 hound = "3.4"

--- a/rustv1/lambda/calculator/Cargo.toml
+++ b/rustv1/lambda/calculator/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "1.0.1"
-aws-sdk-ec2 = "1.2.0"
-aws-sdk-lambda = "1.2.0"
-aws-sdk-s3 = "1.2.0"
+aws-config = { version = "1.0.1" }
+aws-sdk-ec2 = { version = "1.3.0" }
+aws-sdk-lambda = { version = "1.3.0" }
+aws-sdk-s3 = { version = "1.4.0" }
 lambda_runtime = "0.8.0"
 clap = { version = "~4.4", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["full"] }

--- a/rustv1/test-utils/Cargo.toml
+++ b/rustv1/test-utils/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-aws-config = "1.0.1"
-aws-smithy-types = "1.0.1"
-aws-smithy-runtime = { features = ["test-util"],  version = "1.0.1"}
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "next"}
+aws-config = { version = "1.0.1" }
+aws-smithy-types = { version = "1.0.1" }
+aws-smithy-runtime = { version = "1.0.1", features = ["test-util"] }
+aws-types = { version = "1.0.1" }
 http = "0.2"
 tokio = "1.33.0"
 

--- a/rustv1/webassembly/Cargo.toml
+++ b/rustv1/webassembly/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 aws-config = { version = "1.0.1", default-features = false }
-aws-credential-types = { features = ["hardcoded-credentials"],  version = "1.0.1"}
-aws-sdk-lambda = { version = "1.2.0", default-features = false }
-aws-smithy-async = "1.0.1"
-aws-smithy-runtime-api = "1.0.1"
-aws-smithy-types = "1.0.1"
+aws-credential-types = { version = "1.0.1", features = ["hardcoded-credentials"] }
+aws-sdk-lambda = { version = "1.3.0", default-features = false }
+aws-smithy-async = { version = "1.0.1" }
+aws-smithy-runtime-api = { version = "1.0.1" }
+aws-smithy-types = { version = "1.0.1" }
 async-trait = "0.1.63"
 console_error_panic_hook = "0.1.7"
 http = "0.2.8"


### PR DESCRIPTION
This pull request applies the following command to this repo:
```
sdk-versioner use-version-dependencies --versions-toml ../../aws-sdk-rust/versions.toml .
```

This makes the repo compile much faster since cloning `aws-sdk-rust` is no longer required.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
