### PR TITLE
Weathertop - ProducerStack - Adding back trigger rule

### DIFF
--- a/.tools/test/eventbridge_rule_with_sns_fanout/cdk.json
+++ b/.tools/test/eventbridge_rule_with_sns_fanout/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/.tools/test/eventbridge_rule_with_sns_fanout/producer_stack/producer_stack.py
+++ b/.tools/test/eventbridge_rule_with_sns_fanout/producer_stack/producer_stack.py
@@ -24,6 +24,7 @@ class ProducerStack(Stack):
         self.init_publish_permissions(topic, acct_config)
         bucket = self.init_create_bucket(bucket_name)
         self.init_cross_account_log_role(acct_config, bucket)
+        self.init_rule(topic)
 
     def get_yaml_config(self, filepath):
         with open(filepath, "r") as file:


### PR DESCRIPTION
This PR enables triggering for automated testing. I had turned it off for a short period but it's time to now turn it back on to resume testing.