### PR TITLE
Fix typo in template snaphots.

### DIFF
--- a/.doc_gen/templates/zonbook/example_curated_template.xml
+++ b/.doc_gen/templates/zonbook/example_curated_template.xml
@@ -1,7 +1,7 @@
 {{- template "prologue"}}
 {{- $include_docs := "file://AWSShared/code-samples/docs/"}}
 {{- if isSnapshot}}
-    {{- $include_docs := ""}}
+    {{- $include_docs = ""}}
 {{- end}}
 <block>
     {{- if .BlockContent}}

--- a/.doc_gen/templates/zonbook/example_language_template.xml
+++ b/.doc_gen/templates/zonbook/example_language_template.xml
@@ -3,7 +3,7 @@
 {{- $include_docs := "file://AWSShared/code-samples/docs/"}}
 {{- if isSnapshot}}
     {{- $include_base = ""}}
-    {{- $include_docs := ""}}
+    {{- $include_docs = ""}}
 {{- end}}
 {{- define "github_note"}}
 <note>

--- a/.doc_gen/templates/zonbook/utility/curated_examples.xml
+++ b/.doc_gen/templates/zonbook/utility/curated_examples.xml
@@ -2,7 +2,7 @@
 {{- $curated_set := .}}
 {{- $include_docs := "file://AWSShared/code-samples/docs/"}}
 {{- if isSnapshot}}
-    {{- $include_docs := ""}}
+    {{- $include_docs = ""}}
 {{- end}}
 <para role="topiclist-abbrev">Examples</para>
 {{- range $curated_set.Examples}}

--- a/.doc_gen/templates/zonbook/utility/hello.xml
+++ b/.doc_gen/templates/zonbook/utility/hello.xml
@@ -12,7 +12,7 @@
 {{- end}}
 {{- $include_docs := "file://AWSShared/code-samples/docs/"}}
 {{- if isSnapshot}}
-    {{- $include_docs := ""}}
+    {{- $include_docs = ""}}
 {{- end}}
 {{- if $hello.Examples}}
 <para><emphasis role="bold">Get started</emphasis></para>

--- a/.doc_gen/templates/zonbook/utility/sdk_api_examples.xml
+++ b/.doc_gen/templates/zonbook/utility/sdk_api_examples.xml
@@ -3,7 +3,7 @@
 {{- $sdk_prefix := index . 1}}
 {{- $include_docs := "file://AWSShared/code-samples/docs/"}}
 {{- if isSnapshot}}
-    {{- $include_docs := ""}}
+    {{- $include_docs = ""}}
 {{- end}}
 {{- if $examples.ApiExamples}}
 <section id="{{$sdk_prefix}}_code_examples_categorized" role="topic">

--- a/.doc_gen/templates/zonbook/utility/sdk_cross_examples.xml
+++ b/.doc_gen/templates/zonbook/utility/sdk_cross_examples.xml
@@ -3,7 +3,7 @@
 {{- $sdk_prefix := index . 1}}
 {{- $include_docs := "file://AWSShared/code-samples/docs/"}}
 {{- if isSnapshot}}
-    {{- $include_docs := ""}}
+    {{- $include_docs = ""}}
 {{- end}}
 {{- if $examples.CrossServiceExamples}}
 <section id="{{$sdk_prefix}}_code_examples_cross_service" role="topic">

--- a/.doc_gen/templates/zonbook/utility/service_examples.xml
+++ b/.doc_gen/templates/zonbook/utility/service_examples.xml
@@ -8,7 +8,7 @@
 {{- end}}
 {{- $include_docs := "file://AWSShared/code-samples/docs/"}}
 {{- if isSnapshot}}
-    {{- $include_docs := ""}}
+    {{- $include_docs = ""}}
 {{- end}}
 <para role="topiclist-abbrev">Examples</para>
 {{- range $examples.Examples}}


### PR DESCRIPTION
Fix a typo in the templates that broke snapshot builds (the `:=` operator creates a new variable in the local scope that shadows the outer variable).

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
