### PR TITLE
Add examples to SOS that are being dropped from the guided examples in the Dev. guide.

### DIFF
--- a/.doc_gen/metadata/cognito-identity-provider_metadata.yaml
+++ b/.doc_gen/metadata/cognito-identity-provider_metadata.yaml
@@ -58,6 +58,15 @@ cognito-identity-provider_ListUserPools:
             - description:
               snippet_tags:
                 - cognitoidentityprovider.rust.list-user-pools
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/cognito
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - cognito.java2.ListUserPools.main
   services:
     cognito-identity-provider: {ListUserPools}
 cognito-identity-provider_SignUp:
@@ -747,6 +756,40 @@ cognito-identity-provider_DeleteUser:
                 - cpp.example_code.cognito.delete_user
   services:
     cognito-identity-provider: {DeleteUser}
+cognito-identity-provider_CreateUserPool:
+  title: Create an &COG; user pool using an &AWS; SDK
+  title_abbrev: Create a user pool
+  synopsis: create an &COG; user pool.
+  category:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/cognito
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - cognito.java2.create_user_pool.main
+  services:
+    cognito-identity-provider: {CreateUserPool}
+cognito-identity-provider_CreateUserPoolClientApp:
+  title: Create an &COG; user pool client app using an &AWS; SDK
+  title_abbrev: Create an app client
+  synopsis: create an &COG; user pool client app.
+  category:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/cognito
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - cognito.java2.user_pool.create_user_pool_client.main
+  services:
+    cognito-identity-provider: {CreateUserPoolClient}
 cognito-identity-provider_Scenario_SignUpUserWithMfa:
   title: Sign up a user with an &COG; user pool that requires MFA using an &AWS; SDK
   title_abbrev: Sign up a user with a user pool that requires MFA

--- a/.doc_gen/metadata/cognito-identity_metadata.yaml
+++ b/.doc_gen/metadata/cognito-identity_metadata.yaml
@@ -17,6 +17,15 @@ cognito-identity_ListIdentityPools:
             - description: Get the ID of an existing identity pool or create it if it doesn't already exist.
               snippet_tags:
                 - cognitoidentity.swift.get-or-create-pool-id
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/cognito
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - cognito.java2.listidentitypools.main
   services:
     cognito-identity: {CreateIdentityPool, ListIdentityPools}
 cognito-identity_CreateIdentityPool:
@@ -34,12 +43,21 @@ cognito-identity_CreateIdentityPool:
             - description: Create a new identity pool.
               snippet_tags:
                 - cognitoidentity.swift.create-identity-pool
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/cognito
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - cognito.java2.create_identity_pool.main
   services:
     cognito-identity: {CreateIdentityPool, ListIdentityPools}
 cognito-identity_DeleteIdentityPool:
-  title: Delete an &COGID; with a specified name
+  title: Delete an &COG; identity pool
   title_abbrev: Delete an identity pool
-  synopsis: delete an &COGID; given its ID.
+  synopsis: delete an &COG; identity pool.
   category:
   languages:
     Swift:
@@ -51,5 +69,31 @@ cognito-identity_DeleteIdentityPool:
             - description: Delete the specified identity pool.
               snippet_tags:
                 - cognitoidentity.swift.delete-identity-pool
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/cognito
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - cognito.java2.deleteidpool.main
   services:
     cognito-identity: {DeleteIdentityPool}
+cognito-identity_GetCredentialsForIdentity:
+  title: Get credentials for an &COG; identity using an &AWS; SDK
+  title_abbrev: Get credentials for an identity
+  synopsis: get credentials for an &COG; identity.
+  category:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/cognito
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - cognito.java2.GetIdentityCredentials.main
+  services:
+    cognito-identity: {GetCredentialsForIdentity}

--- a/.doc_gen/metadata/cognito-identity_metadata.yaml
+++ b/.doc_gen/metadata/cognito-identity_metadata.yaml
@@ -1,8 +1,8 @@
 # zexi 0.4.0
 cognito-identity_ListIdentityPools:
-  title: List &COGID; pools
+  title: List &COG; identity pools
   title_abbrev: List identity pools
-  synopsis: get a list of &COGID; pools.
+  synopsis: get a list of &COG; identity pools.
   category:
   languages:
     Swift:
@@ -29,9 +29,9 @@ cognito-identity_ListIdentityPools:
   services:
     cognito-identity: {CreateIdentityPool, ListIdentityPools}
 cognito-identity_CreateIdentityPool:
-  title: Create a new &COGID; with a specified name
+  title: Create an &COG; identity pool
   title_abbrev: Create an identity pool
-  synopsis: find the &COGID; with the given name, creating it if it's not found.
+  synopsis: create an &COG; identity pool.
   category:
   languages:
     Swift:

--- a/javav2/example_code/cognito/src/main/java/com/example/cognito/CreateUserPoolClient.java
+++ b/javav2/example_code/cognito/src/main/java/com/example/cognito/CreateUserPoolClient.java
@@ -16,12 +16,14 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.CognitoIden
 import software.amazon.awssdk.services.cognitoidentityprovider.model.CreateUserPoolClientRequest;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.CreateUserPoolClientResponse;
 //snippet-end:[cognito.java2.user_pool.create_user_pool_client.import]
-
 /**
+ * A user pool client app is an application that authenticates with Amazon Cognito user pools.
+ * When you create a user pool, you can configure app clients that allow mobile or web applications
+ * to call API operations to authenticate users, manage user attributes and profiles,
+ * and implement sign-up and sign-in flows.
+ *
  * Before running this Java V2 code example, set up your development environment, including your credentials.
- *
  * For more information, see the following documentation topic:
- *
  * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
  */
 public class CreateUserPoolClient {

--- a/javav2/example_code/cognito/src/main/java/com/example/cognito/GetIdentityCredentials.java
+++ b/javav2/example_code/cognito/src/main/java/com/example/cognito/GetIdentityCredentials.java
@@ -32,7 +32,7 @@ public class GetIdentityCredentials {
                 <identityId>\s
 
             Where:
-                identityId - The Id of an existing identity.
+                identityId - The Id of an existing identity in the format REGION:GUID.
             """;
 
         if (args.length != 1) {
@@ -57,7 +57,7 @@ public class GetIdentityCredentials {
                 .build();
 
             GetCredentialsForIdentityResponse response = cognitoClient.getCredentialsForIdentity(getCredentialsForIdentityRequest);
-            System.out.println("Identity ID " + response.identityId() + ", Access key ID " + response.credentials().accessKeyId());
+            System.out.println("Identity ID " + response.identityId() + ", Expiration " + response.credentials().expiration());
 
         } catch (CognitoIdentityProviderException e) {
             System.err.println(e.awsErrorDetails().errorMessage());


### PR DESCRIPTION
This pull request adds existing Java2 examples to SOS:
4 cognito-identity examples
3 cognito-identity-provider examples

There are also a few minor text changes.

The Amazon Cognito guided examples section will be removed after these examples are publicly available.

[CDD preview](http://tkhill-clouddesk.aka.corp.amazon.com/sos-metadata/build/AWSCodeExampleUsageDocs/AWSCodeExampleUsageDocs-3.0/AL2_x86_64/DEV.STD.PTHREAD/build/server-root/code-library/latest/ug/cognito-identity_code_examples.html).

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
