### PR TITLE
[Metadata] Fix typos and add services

### DIFF
--- a/.doc_gen/metadata/ec2_metadata.yaml
+++ b/.doc_gen/metadata/ec2_metadata.yaml
@@ -1653,7 +1653,7 @@ ec2_CreateTags:
                 - cpp.example_code.ec2.CreateTags
   services:
     ec2: {CreateTags}
-ec2_createRouteTable:
+ec2_CreateRouteTable:
   title: Create a route table in Amazon Virtual Private Cloud (Amazon VPC) and associate it with a subnet
   title_abbrev: Create a route table
   synopsis: create route table and associate with &EC2; subnet.
@@ -1671,7 +1671,7 @@ ec2_createRouteTable:
   services:
     ec2:
       {CreateRouteTable}
-ec2_createSubnet:
+ec2_CreateSubnet:
   title: Create and tag a subnet in Amazon Virtual Private Cloud (Amazon VPC)
   title_abbrev: Create a subnet
   synopsis: create an &EC2; subnet.
@@ -1689,7 +1689,7 @@ ec2_createSubnet:
   services:
     ec2:
       {CreateSubnet}
-ec2_createVpc:
+ec2_CreateVpc:
   title: Create a Amazon Virtual Private Cloud (Amazon VPC)
   title_abbrev: Create a Amazon Virtual Private Cloud (Amazon VPC)
   synopsis: create a Amazon Virtual Private Cloud (Amazon VPC).

--- a/.doc_gen/metadata/route53domains_metadata.yaml
+++ b/.doc_gen/metadata/route53domains_metadata.yaml
@@ -33,7 +33,7 @@ route-53_Hello:
               snippet_tags:
                 - Route53.dotnetv3.HelloRoute53
   services:
-    route53-domains: {ListPrices}
+    route-53-domains: {ListPrices}
 route-53_CheckDomainAvailability:
   title: Check the availability of a domain using an &AWS; SDK
   title_abbrev: Check domain availability
@@ -68,7 +68,7 @@ route-53_CheckDomainAvailability:
               snippet_tags:
                 - Route53.dotnetv3.CheckDomainAvailability
   services:
-    route53-domains: {CheckDomainAvailability}
+    route-53-domains: {CheckDomainAvailability}
 route-53_CheckDomainTransferability:
   title: Check the transferability of a domain using an &AWS; SDK
   title_abbrev: Check domain transferability
@@ -103,7 +103,7 @@ route-53_CheckDomainTransferability:
               snippet_tags:
                 - Route53.dotnetv3.CheckDomainTransferability
   services:
-    route53-domains: {CheckDomainTransferability}
+    route-53-domains: {CheckDomainTransferability}
 route-53_GetDomainDetails:
   title: Get &R53DR; domain details using an &AWS; SDK
   title_abbrev: Get domain details
@@ -138,7 +138,7 @@ route-53_GetDomainDetails:
               snippet_tags:
                 - Route53.dotnetv3.GetDomainDetail
   services:
-    route53-domains: {GetDomainDetail}
+    route-53-domains: {GetDomainDetail}
 route-53_GetDomainSuggestions:
   title: Get &R53DR; domain name suggestions using an &AWS; SDK
   title_abbrev: Get suggested domain names
@@ -173,7 +173,7 @@ route-53_GetDomainSuggestions:
               snippet_tags:
                 - Route53.dotnetv3.GetDomainSuggestions
   services:
-    route53-domains: {GetDomainSuggestions}
+    route-53-domains: {GetDomainSuggestions}
 route-53_GetOperationDetails:
   title: Get details on a &R53DR; operation using an &AWS; SDK
   title_abbrev: Get operation details
@@ -208,7 +208,7 @@ route-53_GetOperationDetails:
               snippet_tags:
                 - Route53.dotnetv3.GetOperationDetail
   services:
-    route53-domains: {GetOperationDetail}
+    route-53-domains: {GetOperationDetail}
 route-53_ListPrices:
   title: List &R53DR; domain prices using an &AWS; SDK
   title_abbrev: List domain prices
@@ -243,7 +243,7 @@ route-53_ListPrices:
               snippet_tags:
                 - Route53.dotnetv3.ListPrices
   services:
-    route53-domains: {ListPrices}
+    route-53-domains: {ListPrices}
 route-53_ListDomains:
   title: List &R53DR; registered domains using an &AWS; SDK
   title_abbrev: List domains
@@ -278,7 +278,7 @@ route-53_ListDomains:
               snippet_tags:
                 - Route53.dotnetv3.ListDomains
   services:
-    route53-domains: {ListDomains}
+    route-53-domains: {ListDomains}
 route-53_ListOperations:
   title: List &R53DR; operations using an &AWS; SDK
   title_abbrev: List operations
@@ -313,7 +313,7 @@ route-53_ListOperations:
               snippet_tags:
                 - Route53.dotnetv3.ListOperations
   services:
-    route53-domains: {ListOperations}
+    route-53-domains: {ListOperations}
 route-53_RegisterDomain:
   title: Register a domain with &R53DR; using an &AWS; SDK
   title_abbrev: Register a domain
@@ -348,7 +348,7 @@ route-53_RegisterDomain:
               snippet_tags:
                 - Route53.dotnetv3.RegisterDomain
   services:
-    route53-domains: {RegisterDomain}
+    route-53-domains: {RegisterDomain}
 route-53_ViewBilling:
   title: View &R53DR; billing records using an &AWS; SDK
   title_abbrev: View billing
@@ -383,7 +383,7 @@ route-53_ViewBilling:
               snippet_tags:
                 - Route53.dotnetv3.ViewBilling
   services:
-    route53-domains: {ViewBilling}
+    route-53-domains: {ViewBilling}
 route-53_Scenario_GetStartedRoute53Domains:
   title: Get started with &R53DR; using an &AWS; SDK
   title_abbrev: Get started with domains
@@ -428,6 +428,6 @@ route-53_Scenario_GetStartedRoute53Domains:
               snippet_tags:
                 - Route53.dotnetv3.Route53Wrapper
   services:
-    route53-domains: {CheckDomainAvailability, CheckDomainTransferability, GetDomainDetail, GetDomainSuggestions,
-                      GetOperationDetail, ListPrices, ListDomains, ListOperations,
-                      RegisterDomain, ViewBilling}
+    route-53-domains: {CheckDomainAvailability, CheckDomainTransferability, GetDomainDetail, GetDomainSuggestions,
+                       GetOperationDetail, ListPrices, ListDomains, ListOperations,
+                       RegisterDomain, ViewBilling}

--- a/.doc_gen/metadata/sdks.yaml
+++ b/.doc_gen/metadata/sdks.yaml
@@ -207,8 +207,8 @@ CLI:
   syntax: none
   sdk:
     2:
-      long: "&CLI2long;"
-      short: "&CLI2;"
+      long: "&CLIlong;"
+      short: "&CLI;"
       expanded:
         long: "AWS Command Line Interface"
         short: "AWS CLI"

--- a/.doc_gen/metadata/services.yaml
+++ b/.doc_gen/metadata/services.yaml
@@ -375,7 +375,7 @@ chime:
     url: chime/latest/ug/what-is-chime.html
   long: '&CHMlong;'
   short: '&CHM;'
-  sort: Amazon Chime
+  sort: Chime
   tags:
     product_categories: {}
   version: '2018-05-01'
@@ -833,6 +833,21 @@ database-migration-service:
   tags:
     product_categories: {}
   version: '2016-01-01'
+datasync:
+  api_ref: datasync/latest/userguide/API_Reference.html
+  blurb: is an online data movement and discovery service that simplifies data migration and helps you quickly, easily, and securely transfer your file or object data to, from, and between AWS storage services.
+  expanded:
+    long: AWS DataSync
+    short: DataSync
+  guide:
+    subtitle: User Guide
+    url: datasync/latest/userguide/what-is-datasync.html
+  long: '&DSYlong;'
+  short: '&DSY;'
+  sort: DataSync
+  tags:
+    product_categories: {}
+  version: '2018-11-09'
 dax:
   api_ref: amazondynamodb/latest/APIReference/Welcome.html
   blurb: ''
@@ -919,7 +934,7 @@ dlm:
     url: AWSEC2/latest/UserGuide/snapshot-lifecycle.html
   long: '&DLMlong;'
   short: '&DLM;'
-  sort: Amazon Data Lifecycle Manager
+  sort: Data Lifecycle Manager
   tags:
     product_categories: {}
   version: '2018-01-12'
@@ -1070,7 +1085,7 @@ efs:
     url: efs/latest/ug/whatisefs.html
   long: '&EFSlong;'
   short: '&EFS;'
-  sort: Amazon EFS
+  sort: EFS
   tags:
     product_categories: {}
   version: '2015-02-01'
@@ -1295,7 +1310,7 @@ gamelift:
     url: gamelift/latest/developerguide/gamelift-intro.html
   long: '&AGSlong;'
   short: '&AGS;'
-  sort: Amazon GameLift
+  sort: GameLift
   tags:
     product_categories: {}
   version: '2015-10-01'
@@ -1479,7 +1494,7 @@ inspector:
     url: inspector/latest/user/what-is-inspector.html
   long: '&INSlong;'
   short: '&INS;'
-  sort: Amazon Inspector
+  sort: Inspector
   tags:
     product_categories: {}
   version: '2016-02-16'
@@ -1649,6 +1664,21 @@ iotsitewise:
   tags:
     product_categories: {}
   version: '2019-12-02'
+iotthingsgraph:
+  api_ref: iot-twinmaker/latest/apireference/Welcome.html
+  blurb: ''
+  expanded:
+    long: AWS IoT Things Graph
+    short: AWS IoT Things Graph
+  guide:
+    subtitle: User Guide
+    url: iot-twinmaker/latest/guide/what-is-twinmaker.html
+  long: '&ITTGlong;'
+  short: '&ITTG;'
+  sort: IoT Things Graph
+  tags:
+    product_categories: {}
+  version: '2018-09-06'
 ivs:
   api_ref: ivs/latest/APIReference/Welcome.html
   blurb: ''
@@ -2510,7 +2540,7 @@ route-53:
   tags:
     product_categories: {'Networking &amp; Content Delivery'}
   version: route53-2013-04-01
-route53-domains:
+route-53-domains:
   bundle: route-53
   long: '&R53DRlong;'
   short: '&R53DR;'
@@ -2582,7 +2612,7 @@ s3-control:
     url: AmazonS3/latest/userguide/Welcome.html
   long: '&S3Controllong;'
   short: '&S3Control;'
-  sort: Amazon S3 Control
+  sort: S3 Control
   tags:
     product_categories: {}
   version: '2018-08-20'
@@ -2642,7 +2672,7 @@ serverlessapplicationrepository:
     url: serverlessrepo/latest/devguide/what-is-serverlessrepo.html
   long: '&SARlong;'
   short: '&SAR;'
-  sort: AWS Serverless Application Repository
+  sort: Serverless Application Repository
   tags:
     product_categories: {}
   version: '2017-09-08'
@@ -2931,7 +2961,7 @@ swf:
     url: amazonswf/latest/developerguide/swf-welcome.html
   long: '&SWFlong;'
   short: '&SWF;'
-  sort: Amazon SWF
+  sort: SWF
   tags:
     product_categories: {}
   version: '2012-01-25'
@@ -3052,7 +3082,7 @@ waf-regional:
     url: waf/latest/developerguide/waf-chapter.html
   long: '&WAFRegionallong;'
   short: '&WAFRegional;'
-  sort: AWS WAF
+  sort: WAF
   tags:
     product_categories: {}
   version: '2016-11-28'
@@ -3082,7 +3112,7 @@ workdocs:
     url: workdocs/latest/developerguide/what_is.html
   long: '&WDlong;'
   short: '&WD;'
-  sort: Amazon WorkDocs
+  sort: WorkDocs
   tags:
     product_categories: {}
   version: '2016-05-01'
@@ -3097,7 +3127,7 @@ workmail:
     url: workmail/latest/userguide/what_is.html
   long: '&WMlong;'
   short: '&WM;'
-  sort: Amazon WorkMail
+  sort: WorkMail
   tags:
     product_categories: {}
   version: '2017-10-01'
@@ -3112,7 +3142,7 @@ workmailmessageflow:
     url: workmail/latest/userguide/what_is.html
   long: '&WMFlowlong;'
   short: '&WMFlow;'
-  sort: Amazon WorkMail Message Flow
+  sort: WorkMail Message Flow
   tags:
     product_categories: {}
   version: '2019-05-01'


### PR DESCRIPTION
This update fixes a smattering of typos in the SOS metadata that came up while reviewing the new inclusion of CLI examples.
Also adds a few services so the CLI example build can link them.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
