### PR TITLE
Tools - Fix typo in .tools/readmes/README.md

### DIFF
--- a/.tools/readmes/README.md
+++ b/.tools/readmes/README.md
@@ -113,7 +113,7 @@ empty if you don't need custom content.
 versions, and services.
 
 ```
-python .tools/readmes/multi.py --language <language1>:<version> <language2>:<version> --service <service1> <service2>
+python .tools/readmes/multi.py --languages <language1>:<version> <language2>:<version> --service <service1> <service2>
 ```
 
 For example, to generate S3 and STS READMEs for Python sdk version 3 and Go sdk version 2:


### PR DESCRIPTION
This pull request fixes a typo in the command line arguments for multi.py

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
