### PR TITLE
Rust: DynamoDB Local snippet missing key details

### DIFF
--- a/rustv1/examples/dynamodb/src/bin/list-tables-local.rs
+++ b/rustv1/examples/dynamodb/src/bin/list-tables-local.rs
@@ -4,23 +4,33 @@
 #![allow(clippy::result_large_err)]
 
 // snippet-start:[dynamodb.rust.list-tables-local]
+use aws_config::BehaviorVersion;
 use aws_sdk_dynamodb::{Client, Error};
-use clap::Parser;
-use dynamodb_code_examples::{make_config, scenario::list::list_tables, Opt};
 
 /// Lists your tables in DynamoDB local.
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let config = make_config(Opt::parse()).await?;
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .test_credentials()
+        .load()
+        .await;
     let dynamodb_local_config = aws_sdk_dynamodb::config::Builder::from(&config)
+        // Override the endpoint in the config to use a local dynamodb server.
         .endpoint_url(
-            // 8000 is the default dynamodb port
+            // DynamoDB run locally uses port 8000 by default.
             "http://localhost:8000",
         )
         .build();
 
     let client = Client::from_conf(dynamodb_local_config);
-    list_tables(&client).await?;
+
+    let resp = client.list_tables().send().await?;
+
+    println!("Found {} tables", resp.table_names().len());
+    for name in resp.table_names() {
+        println!("  {}", name);
+    }
+
     Ok(())
 }
 // snippet-end:[dynamodb.rust.list-tables-local]


### PR DESCRIPTION
This pull request makes the rust local dynamodb example snippet self contained.

Closes: #5908 

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
