### PR TITLE
Python: Add prompt chaining scenario for Amazon Bedrock and AWS Step Functions

### DIFF
--- a/.doc_gen/cross-content/cross_ServerlessPromptChaining_Python_block.xml
+++ b/.doc_gen/cross-content/cross_ServerlessPromptChaining_Python_block.xml
@@ -20,7 +20,7 @@
         </listitem>
         <listitem>
             <para>
-                Generate a short story about a given topic. This example illustrates how the AI can iteratively process a list of items.
+                Generate a short story about a given topic. This example illustrates how the AI can iteratively process a list of items that it previously generated.
             </para>
         </listitem>
         <listitem>

--- a/.doc_gen/cross-content/cross_ServerlessPromptChaining_Python_block.xml
+++ b/.doc_gen/cross-content/cross_ServerlessPromptChaining_Python_block.xml
@@ -40,7 +40,7 @@
         </listitem>
         <listitem>
             <para>
-                Find and summarize today's highest trending GitHub repository. This example illustrates chaining two <ulink url="https://www.promptingguide.ai/techniques/react">ReAct prompts</ulink> (also known as ReAct agents) in a two-step sequential pipeline to interact with GitHub's API.
+                Find and summarize today's highest trending GitHub repository. This example illustrates chaining multiple AI agents that interact with external APIs.
             </para>
         </listitem>
     </itemizedlist>

--- a/.doc_gen/cross-content/cross_ServerlessPromptChaining_Python_block.xml
+++ b/.doc_gen/cross-content/cross_ServerlessPromptChaining_Python_block.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "file://zonbook/docbookx.dtd" [
+        <!ENTITY % phrases-shared SYSTEM "file://AWSShared/common/phrases-shared.ent">
+        %phrases-shared;
+        ]>
+<block>
+    <para>
+        The Amazon Bedrock Serverless Prompt Chaining scenario demonstrates how
+        <ulink url="https://aws.amazon.com/step-functions/">AWS Step Functions</ulink>,
+        <ulink url="https://aws.amazon.com/bedrock/">Amazon Bedrock</ulink>,
+        and <ulink url="https://aws.amazon.com/bedrock/agents/">Amazon Bedrock Agents</ulink>
+        can be used to build and orchestrate complex, serverless, and highly scalable generative AI applications.
+        It contains the following working examples:
+    </para>
+    <itemizedlist>
+        <listitem>
+            <para>
+                Write an analysis of a given novel for a literature blog. This example illustrates a simple, sequential chain of prompts.
+            </para>
+        </listitem>
+        <listitem>
+            <para>
+                Generate a short story about a given topic. This example illustrates how the AI can iteratively process a list of items.
+            </para>
+        </listitem>
+        <listitem>
+            <para>
+                Create an itinerary for a weekend vacation to a given destination. This example illustrates how to parallelize multiple distinct prompts.
+            </para>
+        </listitem>
+        <listitem>
+            <para>
+                Pitch movie ideas to a human user acting as a movie producer. This example illustrates how to parallelize the same prompt with different inference parameters, how to backtrack to a previous step in the chain, and how to include human input as part of the workflow.
+            </para>
+        </listitem>
+        <listitem>
+            <para>
+                Plan a meal based on ingredients the user has at hand. This example illustrates how prompt chains can incorporate two distinct AI conversations, with two AI personas engaging in a debate with each other to improve the final outcome.
+            </para>
+        </listitem>
+        <listitem>
+            <para>
+                Find and summarize today's highest trending GitHub repository. This example illustrates chaining two <ulink url="https://www.promptingguide.ai/techniques/react">ReAct prompts</ulink> (also known as ReAct agents) in a two-step sequential pipeline to interact with GitHub's API.
+            </para>
+        </listitem>
+    </itemizedlist>
+    <para>
+        For complete source code and instructions to set up and run, see the full project on <ulink url="https://github.com/aws-samples/amazon-bedrock-serverless-prompt-chaining">GitHub</ulink>.
+    </para>
+</block>

--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -779,9 +779,9 @@ cross_Testing:
   services:
     s3:
 cross_ServerlessPromptChaining:
-  title: Build and orchestrate generative AI applications with &SFN; and &BR;
+  title: Build and orchestrate generative AI applications with &BR; and &SFN;
   title_abbrev: Orchestrate generative AI applications with &SFN;
-  synopsis: build and orchestrate generative AI applications with &SFN; and &BR;.
+  synopsis: build and orchestrate generative AI applications with &BR; and &SFN;.
   category: Scenarios
   languages:
     Python:

--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -778,3 +778,20 @@ cross_Testing:
                 - rustv1/examples/testing/src/replay.rs
   services:
     s3:
+cross_ServerlessPromptChaining:
+  title: Build and orchestrate generative AI applications with &SFN; and &BR;
+  title_abbrev: Orchestrate generative AI applications with &SFN;
+  synopsis: build and orchestrate generative AI applications with &SFN; and &BR;.
+  category: Scenarios
+  languages:
+    Python:
+      versions:
+        - sdk_version: 3
+          block_content: cross_ServerlessPromptChaining_Python_block.xml
+  service_main: bedrock
+  services:
+    bedrock:
+    bedrock-runtime:
+    bedrock-agent:
+    bedrock-agent-runtime:
+    sfn:

--- a/python/example_code/bedrock/README.md
+++ b/python/example_code/bedrock/README.md
@@ -43,6 +43,12 @@ Code excerpts that show you how to call individual service functions.
 
 
 <!--custom.examples.start-->
+### Scenarios
+
+Code examples that show you how to accomplish a specific task by calling multiple
+functions within the same service.
+
+- [Build and orchestrate generative AI applications with AWS Step Functions](https://github.com/aws-samples/amazon-bedrock-serverless-prompt-chaining)
 <!--custom.examples.end-->
 
 ## Run the examples


### PR DESCRIPTION
This pull request adds a cross-service example for Amazon Bedrock and AWS Step Functions linking to https://github.com/aws-samples/amazon-bedrock-serverless-prompt-chaining, contributed by @clareliguori
 
---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
