### PR TITLE
JavaScript (v3): Tests - Check all queue names instead of just first in SQS test; increase wait time on resilient wkflw.

### DIFF
--- a/javascriptv3/example_code/cross-services/wkflw-resilient-service/steps-destroy.js
+++ b/javascriptv3/example_code/cross-services/wkflw-resilient-service/steps-destroy.js
@@ -239,7 +239,7 @@ export const destroySteps = [
   new ScenarioAction("deleteAutoScalingGroup", async (state) => {
     try {
       await terminateGroupInstances(NAMES.autoScalingGroupName);
-      await retry({ intervalInMs: 30000, maxRetries: 60 }, async () => {
+      await retry({ intervalInMs: 60000, maxRetries: 60 }, async () => {
         await deleteAutoScalingGroup(NAMES.autoScalingGroupName);
       });
     } catch (e) {

--- a/javascriptv3/example_code/cross-services/wkflw-resilient-service/vite.config.js
+++ b/javascriptv3/example_code/cross-services/wkflw-resilient-service/vite.config.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from "vitest/config";
 
-const TEST_TIMEOUT_IN_MINUTES = 45;
+const TEST_TIMEOUT_IN_MINUTES = 60;
 const MS_IN_SECOND = 1000;
 const SECONDS_IN_MINUTE = 60;
 

--- a/javascriptv3/example_code/sqs/tests/queue-actions.integration.test.js
+++ b/javascriptv3/example_code/sqs/tests/queue-actions.integration.test.js
@@ -35,8 +35,8 @@ describe("queue actions", () => {
 
     await retry({ intervalInMs: 1000, maxRetries: 60 }, async () => {
       const urls = await listQueues();
-
-      expect(urls[0]).toEqual(expect.stringContaining(queueName));
+      const queueNameFound = urls.some((url) => url.indexOf(queueName) > -1);
+      expect(queueNameFound).toBe(true);
     });
 
     await setQueueAttributes(queueUrl);


### PR DESCRIPTION


<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request attempts to fix two issues:
1. The `queue-actions.integration.test.js` was checking for queue name matches, but only checking against the first queue returned from ListQueues. This changes it to check the full list.
2. The resilient workflow scenario keeps timing out. This changes the timeout of a particular retry to be a full hour.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
