### PR TITLE
Fix: Typo in Bedrock Runtime readmes

### DIFF
--- a/.doc_gen/metadata/bedrock-runtime_metadata.yaml
+++ b/.doc_gen/metadata/bedrock-runtime_metadata.yaml
@@ -167,7 +167,7 @@ bedrock-runtime_InvokeClaude:
 
 bedrock-runtime_InvokeJurassic2:
   title: Invoke the AI21 Labs Jurassic-2 model on &BR; for text generation
-  title_abbrev: Text generation with AI21 Labs Jurassic-2;
+  title_abbrev: Text generation with AI21 Labs Jurassic-2
   synopsis: invoke the AI21 Labs Jurassic-2 model on &BR; for text generation.
   category:
   languages:

--- a/gov2/bedrock-runtime/README.md
+++ b/gov2/bedrock-runtime/README.md
@@ -40,7 +40,7 @@ For prerequisites, see the [README](../README.md#Prerequisites) in the `gov2` fo
 Code excerpts that show you how to call individual service functions.
 
 - [Image generation with Amazon Titan Image Generator G1](actions/invoke_model.go#L178) (`InvokeModel`)
-- [Text generation with AI21 Labs Jurassic-2;](actions/invoke_model.go#L78) (`InvokeModel`)
+- [Text generation with AI21 Labs Jurassic-2](actions/invoke_model.go#L78) (`InvokeModel`)
 - [Text generation with Anthropic Claude 2](actions/invoke_model.go#L27) (`InvokeModel`)
 - [Text generation with Anthropic Claude 2 with a response stream](actions/invoke_model_with_response_stream.go#L30) (`InvokeModelWithResponseStream`)
 - [Text generation with Meta Llama 2 Chat](actions/invoke_model.go#L130) (`InvokeModel`)

--- a/javav2/example_code/bedrock-runtime/Readme.md
+++ b/javav2/example_code/bedrock-runtime/Readme.md
@@ -34,12 +34,12 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `javav
 
 Code excerpts that show you how to call individual service functions.
 
-- [Image generation with Amazon Titan Image Generator G1](src/main/java/com/example/bedrockruntime/InvokeModelAsync.java#L286) (`InvokeModel`)
-- [Image generation with Stability.ai Stable Diffusion XL](src/main/java/com/example/bedrockruntime/InvokeModelAsync.java#L220) (`InvokeModel`)
-- [Text generation with AI21 Labs Jurassic-2;](src/main/java/com/example/bedrockruntime/InvokeModelAsync.java#L99) (`InvokeModel`)
-- [Text generation with Anthropic Claude 2](src/main/java/com/example/bedrockruntime/InvokeModelAsync.java#L38) (`InvokeModel`)
-- [Text generation with Anthropic Claude 2 with a response stream](src/main/java/com/example/bedrockruntime/InvokeModelWithResponseStream.java#L34) (`InvokeModelWithResponseStream`)
-- [Text generation with Meta Llama 2 Chat](src/main/java/com/example/bedrockruntime/InvokeModelAsync.java#L161) (`InvokeModel`)
+- [Image generation with Amazon Titan Image Generator G1](src/main/java/com/example/bedrockruntime/InvokeModelAsync.java#L288) (`InvokeModel`)
+- [Image generation with Stability.ai Stable Diffusion XL](src/main/java/com/example/bedrockruntime/InvokeModelAsync.java#L218) (`InvokeModel`)
+- [Text generation with AI21 Labs Jurassic-2](src/main/java/com/example/bedrockruntime/InvokeModelAsync.java#L94) (`InvokeModel`)
+- [Text generation with Anthropic Claude 2](src/main/java/com/example/bedrockruntime/InvokeModelAsync.java#L32) (`InvokeModel`)
+- [Text generation with Anthropic Claude 2 with a response stream](src/main/java/com/example/bedrockruntime/InvokeModelWithResponseStream.java#L28) (`InvokeModelWithResponseStream`)
+- [Text generation with Meta Llama 2 Chat](src/main/java/com/example/bedrockruntime/InvokeModelAsync.java#L157) (`InvokeModel`)
 
 
 <!--custom.examples.start-->

--- a/php/example_code/bedrock-runtime/README.md
+++ b/php/example_code/bedrock-runtime/README.md
@@ -40,11 +40,11 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `php` 
 
 Code excerpts that show you how to call individual service functions.
 
-- [Image generation with Amazon Titan Image Generator G1](BedrockRuntimeService.php#L185) (`InvokeModel`)
-- [Image generation with Stability.ai Stable Diffusion XL](BedrockRuntimeService.php#L143) (`InvokeModel`)
-- [Text generation with AI21 Labs Jurassic-2;](BedrockRuntimeService.php#L73) (`InvokeModel`)
-- [Text generation with Anthropic Claude 2](BedrockRuntimeService.php#L34) (`InvokeModel`)
-- [Text generation with Meta Llama 2 Chat](BedrockRuntimeService.php#L108) (`InvokeModel`)
+- [Image generation with Amazon Titan Image Generator G1](BedrockRuntimeService.php#L184) (`InvokeModel`)
+- [Image generation with Stability.ai Stable Diffusion XL](BedrockRuntimeService.php#L142) (`InvokeModel`)
+- [Text generation with AI21 Labs Jurassic-2](BedrockRuntimeService.php#L72) (`InvokeModel`)
+- [Text generation with Anthropic Claude 2](BedrockRuntimeService.php#L33) (`InvokeModel`)
+- [Text generation with Meta Llama 2 Chat](BedrockRuntimeService.php#L107) (`InvokeModel`)
 
 ### Scenarios
 

--- a/python/example_code/bedrock-runtime/README.md
+++ b/python/example_code/bedrock-runtime/README.md
@@ -41,7 +41,7 @@ Code excerpts that show you how to call individual service functions.
 
 - [Image generation with Amazon Titan Image Generator G1](bedrock_runtime_wrapper.py#L195) (`InvokeModel`)
 - [Image generation with Stability.ai Stable Diffusion XL](bedrock_runtime_wrapper.py#L152) (`InvokeModel`)
-- [Text generation with AI21 Labs Jurassic-2;](bedrock_runtime_wrapper.py#L79) (`InvokeModel`)
+- [Text generation with AI21 Labs Jurassic-2](bedrock_runtime_wrapper.py#L79) (`InvokeModel`)
 - [Text generation with Anthropic Claude 2](bedrock_runtime_wrapper.py#L39) (`InvokeModel`)
 - [Text generation with Anthropic Claude 2 with a response stream](bedrock_runtime_wrapper.py#L240) (`InvokeModelWithResponseStream`)
 - [Text generation with Meta Llama 2 Chat](bedrock_runtime_wrapper.py#L115) (`InvokeModel`)


### PR DESCRIPTION
This pull request addresses a small but impactful typo in the Bedrock Runtime documentation. An extraneous semicolon, which was inadvertently included, has been removed.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._