### PR TITLE
[Go] Added pagination to all Go DynamoDB examples that can be paginated.

### DIFF
--- a/gov2/dynamodb/README.md
+++ b/gov2/dynamodb/README.md
@@ -34,18 +34,18 @@ For prerequisites, see the [README](../README.md#Prerequisites) in the `gov2` fo
 Code excerpts that show you how to call individual service functions.
 
 - [Create a table](actions/table_basics.go#L54) (`CreateTable`)
-- [Delete a table](actions/table_basics.go#L326) (`DeleteTable`)
-- [Delete an item from a table](actions/table_basics.go#L311) (`DeleteItem`)
-- [Get an item from a table](actions/table_basics.go#L216) (`GetItem`)
+- [Delete a table](actions/table_basics.go#L347) (`DeleteTable`)
+- [Delete an item from a table](actions/table_basics.go#L332) (`DeleteItem`)
+- [Get an item from a table](actions/table_basics.go#L221) (`GetItem`)
 - [Get information about a table](actions/table_basics.go#L31) (`DescribeTable`)
 - [List tables](actions/table_basics.go#L99) (`ListTables`)
-- [Put an item in a table](actions/table_basics.go#L116) (`PutItem`)
-- [Query a table](actions/table_basics.go#L238) (`Query`)
+- [Put an item in a table](actions/table_basics.go#L121) (`PutItem`)
+- [Query a table](actions/table_basics.go#L243) (`Query`)
 - [Run a PartiQL statement](actions/partiql.go#L30) (`ExecuteStatement`)
-- [Run batches of PartiQL statements](actions/partiql.go#L149) (`BatchExecuteStatement`)
-- [Scan a table](actions/table_basics.go#L272) (`Scan`)
-- [Update an item in a table](actions/table_basics.go#L135) (`UpdateItem`)
-- [Write a batch of items](actions/table_basics.go#L172) (`BatchWriteItem`)
+- [Run batches of PartiQL statements](actions/partiql.go#L164) (`BatchExecuteStatement`)
+- [Scan a table](actions/table_basics.go#L285) (`Scan`)
+- [Update an item in a table](actions/table_basics.go#L140) (`UpdateItem`)
+- [Write a batch of items](actions/table_basics.go#L177) (`BatchWriteItem`)
 
 ### Scenarios
 

--- a/gov2/dynamodb/actions/partiql_test.go
+++ b/gov2/dynamodb/actions/partiql_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/awsdocs/aws-doc-sdk-examples/gov2/dynamodb/stubs"
 	"github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools"
@@ -34,7 +35,7 @@ func AddMoviePartiQL(raiseErr *testtools.StubError, t *testing.T) {
 
 	stubber.Add(stubs.StubExecuteStatement(
 		fmt.Sprintf("INSERT INTO \"%v\" VALUE {'title': ?, 'year': ?, 'info': ?}", runner.TableName),
-		[]interface{}{movie.Title, movie.Year, movie.Info}, nil, raiseErr))
+		[]interface{}{movie.Title, movie.Year, movie.Info}, nil, nil, nil, nil, raiseErr))
 
 	err := runner.AddMovie(movie)
 
@@ -55,7 +56,7 @@ func GetMoviePartiQL(raiseErr *testtools.StubError, t *testing.T) {
 
 	stubber.Add(stubs.StubExecuteStatement(
 		fmt.Sprintf("SELECT * FROM \"%v\" WHERE title=? AND year=?", runner.TableName),
-		[]interface{}{movie.Title, movie.Year}, movie, raiseErr))
+		[]interface{}{movie.Title, movie.Year}, nil, nil, movie, nil, raiseErr))
 
 	gotMovie, err := runner.GetMovie(movie.Title, movie.Year)
 
@@ -81,9 +82,9 @@ func GetAllMoviesPartiQL(raiseErr *testtools.StubError, t *testing.T) {
 
 	stubber.Add(stubs.StubExecuteStatement(
 		fmt.Sprintf("SELECT title, info.rating FROM \"%v\"", runner.TableName),
-		nil, outProjection, raiseErr))
+		nil, aws.Int32(2), nil, outProjection, nil, raiseErr))
 
-	gotProjections, err := runner.GetAllMovies()
+	gotProjections, err := runner.GetAllMovies(2)
 
 	testtools.VerifyError(err, raiseErr, t)
 	if err == nil {
@@ -111,7 +112,7 @@ func UpdateMoviePartiQL(raiseErr *testtools.StubError, t *testing.T) {
 
 	stubber.Add(stubs.StubExecuteStatement(
 		fmt.Sprintf("UPDATE \"%v\" SET info.rating=? WHERE title=? AND year=?", runner.TableName),
-		[]interface{}{newRating, movie.Title, movie.Year}, movie, raiseErr))
+		[]interface{}{newRating, movie.Title, movie.Year}, nil, nil, movie, nil, raiseErr))
 
 	err := runner.UpdateMovie(movie, newRating)
 
@@ -132,7 +133,7 @@ func DeleteMoviePartiQL(raiseErr *testtools.StubError, t *testing.T) {
 
 	stubber.Add(stubs.StubExecuteStatement(
 		fmt.Sprintf("DELETE FROM \"%v\" WHERE title=? AND year=?", runner.TableName),
-		[]interface{}{movie.Title, movie.Year}, movie, raiseErr))
+		[]interface{}{movie.Title, movie.Year}, nil, nil, movie, nil, raiseErr))
 
 	err := runner.DeleteMovie(movie)
 

--- a/gov2/dynamodb/scenarios/scenario_partiql_batch.go
+++ b/gov2/dynamodb/scenarios/scenario_partiql_batch.go
@@ -19,8 +19,8 @@ import (
 // RunPartiQLBatchScenario shows you how to use the AWS SDK for Go
 // to run batches of PartiQL statements to query a table that stores data about movies.
 //
-// * Use batches of PartiQL statements to add, get, update, and delete data for
-//   individual movies.
+//   - Use batches of PartiQL statements to add, get, update, and delete data for
+//     individual movies.
 //
 // This example creates an Amazon DynamoDB service client from the specified sdkConfig so that
 // you can replace it with a mocked or stubbed config for unit testing.
@@ -108,8 +108,10 @@ func RunPartiQLBatchScenario(sdkConfig aws.Config, tableName string) {
 	log.Println(strings.Repeat("-", 88))
 
 	log.Println("Getting projected data from the table to verify our update.")
-	projections, err := runner.GetAllMovies()
+	log.Println("Using a page size of 2 to demonstrate paging.")
+	projections, err := runner.GetAllMovies(2)
 	if err == nil {
+		log.Println("All movies:")
 		for _, projection := range projections {
 			log.Println(projection)
 		}

--- a/gov2/dynamodb/scenarios/scenario_partiql_batch_test.go
+++ b/gov2/dynamodb/scenarios/scenario_partiql_batch_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/awsdocs/aws-doc-sdk-examples/gov2/dynamodb/actions"
 	"github.com/awsdocs/aws-doc-sdk-examples/gov2/dynamodb/stubs"
@@ -53,6 +54,8 @@ func (scenTest *PartiQLBatchScenarioTest) SetupDataAndStubs() []testtools.Stub {
 	},
 	}
 	newRatings := []float64{7.7, 4.4, 1.1}
+	pageSize := int32(2)
+	pageToken := "test-token"
 
 	insertStatements := make([]string, len(customMovies))
 	updateStatements := make([]string, len(customMovies))
@@ -89,7 +92,10 @@ func (scenTest *PartiQLBatchScenarioTest) SetupDataAndStubs() []testtools.Stub {
 	stubList = append(stubList, stubs.StubBatchExecuteStatement(updateStatements, updateParamList, nil, nil))
 	stubList = append(stubList, stubs.StubExecuteStatement(
 		fmt.Sprintf("SELECT title, info.rating FROM \"%v\"", scenTest.TableName),
-		nil, projectedMovies, nil))
+		nil, aws.Int32(pageSize), nil, projectedMovies[0:pageSize], aws.String(pageToken), nil))
+	stubList = append(stubList, stubs.StubExecuteStatement(
+		fmt.Sprintf("SELECT title, info.rating FROM \"%v\"", scenTest.TableName),
+		nil, aws.Int32(pageSize), aws.String(pageToken), projectedMovies[pageSize:len(projectedMovies)], nil, nil))
 	stubList = append(stubList, stubs.StubBatchExecuteStatement(deleteStatements, getDelParamList, nil, nil))
 	stubList = append(stubList, stubs.StubDeleteTable(scenTest.TableName, nil))
 

--- a/gov2/dynamodb/scenarios/scenario_partiql_single_test.go
+++ b/gov2/dynamodb/scenarios/scenario_partiql_single_test.go
@@ -51,19 +51,19 @@ func (scenTest *PartiQLSingleScenarioTest) SetupDataAndStubs() []testtools.Stub 
 	stubList = append(stubList, stubs.StubDescribeTable(scenTest.TableName, nil))
 	stubList = append(stubList, stubs.StubExecuteStatement(
 		fmt.Sprintf("INSERT INTO \"%v\" VALUE {'title': ?, 'year': ?, 'info': ?}", scenTest.TableName),
-		[]interface{}{movie.Title, movie.Year, movie.Info}, nil, nil))
+		[]interface{}{movie.Title, movie.Year, movie.Info}, nil, nil, nil, nil, nil))
 	stubList = append(stubList, stubs.StubExecuteStatement(
 		fmt.Sprintf("SELECT * FROM \"%v\" WHERE title=? AND year=?", scenTest.TableName),
-		[]interface{}{movie.Title, movie.Year}, movie, nil))
+		[]interface{}{movie.Title, movie.Year}, nil, nil, movie, nil, nil))
 	stubList = append(stubList, stubs.StubExecuteStatement(
 		fmt.Sprintf("UPDATE \"%v\" SET info.rating=? WHERE title=? AND year=?", scenTest.TableName),
-		[]interface{}{newRating, movie.Title, movie.Year}, movie, nil))
+		[]interface{}{newRating, movie.Title, movie.Year}, nil, nil, movie, nil, nil))
 	stubList = append(stubList, stubs.StubExecuteStatement(
 		fmt.Sprintf("SELECT * FROM \"%v\" WHERE title=? AND year=?", scenTest.TableName),
-		[]interface{}{movie.Title, movie.Year}, movie, nil))
+		[]interface{}{movie.Title, movie.Year}, nil, nil, movie, nil, nil))
 	stubList = append(stubList, stubs.StubExecuteStatement(
 		fmt.Sprintf("DELETE FROM \"%v\" WHERE title=? AND year=?", scenTest.TableName),
-		[]interface{}{movie.Title, movie.Year}, movie, nil))
+		[]interface{}{movie.Title, movie.Year}, nil, nil, movie, nil, nil))
 	stubList = append(stubList, stubs.StubDeleteTable(scenTest.TableName, nil))
 
 	return stubList

--- a/gov2/dynamodb/stubs/partiql_stubs.go
+++ b/gov2/dynamodb/stubs/partiql_stubs.go
@@ -17,8 +17,8 @@ import (
 )
 
 func StubExecuteStatement(
-	statement string, params []interface{}, output interface{},
-	raiseErr *testtools.StubError) testtools.Stub {
+	statement string, params []interface{}, limit *int32, nextInputToken *string, output interface{},
+	nextOutputToken *string, raiseErr *testtools.StubError) testtools.Stub {
 	var paramAttribs []types.AttributeValue
 	var err error
 	if params != nil {
@@ -34,12 +34,15 @@ func StubExecuteStatement(
 			panic(err)
 		}
 		statementOutput.Items = append(statementOutput.Items, outputAttribs)
+		statementOutput.NextToken = nextOutputToken
 	}
 	return testtools.Stub{
 		OperationName: "ExecuteStatement",
-		Input:         &dynamodb.ExecuteStatementInput{Statement: aws.String(statement), Parameters: paramAttribs},
-		Output:        &statementOutput,
-		Error:         raiseErr,
+		Input: &dynamodb.ExecuteStatementInput{
+			Statement: aws.String(statement), Parameters: paramAttribs,
+			Limit: limit, NextToken: nextInputToken},
+		Output: &statementOutput,
+		Error:  raiseErr,
 	}
 }
 


### PR DESCRIPTION
None of the Go DynamoDB examples used pagination. In particular, this was a problem for PartiQL because it's not well documented how to paginate ExecuteStatement (because there's no supplied paginator).

This PR adds paginators to all examples that get data that can be paginated.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
