### PR TITLE
[Go] Example updates: S3 CopyObject and DeleteObjects

### DIFF
--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -210,7 +210,7 @@ s3_CopyObject:
             - description:
               snippet_tags:
                 - gov2.s3.BucketBasics.struct
-                - gov2.s3.CopyObject
+                - gov2.s3.CopyObject.ToBucket
     Kotlin:
       versions:
         - sdk_version: 1

--- a/gov2/s3/README.md
+++ b/gov2/s3/README.md
@@ -38,14 +38,14 @@ For prerequisites, see the [README](../README.md#Prerequisites) in the `gov2` fo
 
 Code excerpts that show you how to call individual service functions.
 
-- [Copy an object from one bucket to another](actions/bucket_basics.go#L202) (`CopyObject`)
+- [Copy an object from one bucket to another](actions/bucket_basics.go#L220) (`CopyObject`)
 - [Create a bucket](actions/bucket_basics.go#L81) (`CreateBucket`)
-- [Delete an empty bucket](actions/bucket_basics.go#L258) (`DeleteBucket`)
-- [Delete multiple objects](actions/bucket_basics.go#L238) (`DeleteObjects`)
+- [Delete an empty bucket](actions/bucket_basics.go#L278) (`DeleteBucket`)
+- [Delete multiple objects](actions/bucket_basics.go#L256) (`DeleteObjects`)
 - [Determine the existence of a bucket](actions/bucket_basics.go#L51) (`HeadBucket`)
 - [Get an object from a bucket](actions/bucket_basics.go#L149) (`GetObject`)
 - [List buckets](actions/bucket_basics.go#L35) (`ListBuckets`)
-- [List objects in a bucket](actions/bucket_basics.go#L220) (`ListObjectsV2`)
+- [List objects in a bucket](actions/bucket_basics.go#L238) (`ListObjectsV2`)
 - [Upload an object to a bucket](actions/bucket_basics.go#L100) (`PutObject`)
 
 ### Scenarios

--- a/gov2/s3/actions/bucket_basics.go
+++ b/gov2/s3/actions/bucket_basics.go
@@ -217,6 +217,24 @@ func (basics BucketBasics) CopyToFolder(bucketName string, objectKey string, fol
 
 // snippet-end:[gov2.s3.CopyObject]
 
+// snippet-start:[gov2.s3.CopyObject.ToBucket]
+
+// CopyToBucket copies an object in a bucket to another bucket.
+func (basics BucketBasics) CopyToBucket(sourceBucket string, destinationBucket string, objectKey string) error {
+	_, err := basics.S3Client.CopyObject(context.TODO(), &s3.CopyObjectInput{
+		Bucket:     aws.String(destinationBucket),
+		CopySource: aws.String(fmt.Sprintf("%v/%v", sourceBucket, objectKey)),
+		Key:        aws.String(objectKey),
+	})
+	if err != nil {
+		log.Printf("Couldn't copy object from %v:%v to %v:%v. Here's why: %v\n",
+			sourceBucket, objectKey, destinationBucket, objectKey, err)
+	}
+	return err
+}
+
+// snippet-end:[gov2.s3.CopyObject.ToBucket]
+
 // snippet-start:[gov2.s3.ListObjectsV2]
 
 // ListObjects lists the objects in a bucket.
@@ -243,12 +261,14 @@ func (basics BucketBasics) DeleteObjects(bucketName string, objectKeys []string)
 	for _, key := range objectKeys {
 		objectIds = append(objectIds, types.ObjectIdentifier{Key: aws.String(key)})
 	}
-	_, err := basics.S3Client.DeleteObjects(context.TODO(), &s3.DeleteObjectsInput{
+	output, err := basics.S3Client.DeleteObjects(context.TODO(), &s3.DeleteObjectsInput{
 		Bucket: aws.String(bucketName),
 		Delete: &types.Delete{Objects: objectIds},
 	})
 	if err != nil {
 		log.Printf("Couldn't delete objects from bucket %v. Here's why: %v\n", bucketName, err)
+	} else {
+		log.Printf("Deleted %v objects.\n", len(output.Deleted))
 	}
 	return err
 }

--- a/gov2/s3/actions/bucket_basics_test.go
+++ b/gov2/s3/actions/bucket_basics_test.go
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for action not covered by scenarios.
+
+package actions
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/awsdocs/aws-doc-sdk-examples/gov2/s3/stubs"
+	"github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools"
+)
+
+func enterTest() (*testtools.AwsmStubber, *BucketBasics) {
+	stubber := testtools.NewStubber()
+	basics := &BucketBasics{S3Client: s3.NewFromConfig(*stubber.SdkConfig)}
+	return stubber, basics
+}
+
+func TestBucketBasics_CopyToBucket(t *testing.T) {
+	t.Run("NoErrors", func(t *testing.T) { CopyToBucket(nil, t) })
+	t.Run("TestError", func(t *testing.T) { CopyToBucket(&testtools.StubError{Err: errors.New("TestError")}, t) })
+}
+
+func CopyToBucket(raiseErr *testtools.StubError, t *testing.T) {
+	stubber, basics := enterTest()
+	stubber.Add(stubs.StubCopyObject("source-bucket", "object-key", "dest-bucket", "object-key", raiseErr))
+
+	err := basics.CopyToBucket("source-bucket", "dest-bucket", "object-key")
+
+	testtools.VerifyError(err, raiseErr, t)
+	testtools.ExitTest(stubber, t)
+}

--- a/gov2/s3/scenarios/scenario_presigning_test.go
+++ b/gov2/s3/scenarios/scenario_presigning_test.go
@@ -53,7 +53,9 @@ type PresigningScenarioTest struct {
 func (scenTest *PresigningScenarioTest) SetupDataAndStubs() []testtools.Stub {
 	bucketName := "test-bucket-1"
 	testConfig, err := config.LoadDefaultConfig(context.TODO())
-	if err != nil {panic(err)}
+	if err != nil {
+		panic(err)
+	}
 	objectKey := "doc-example-key"
 	scenTest.TestBody = io.NopCloser(strings.NewReader("Test data!"))
 	scenTest.Answers = []string{


### PR DESCRIPTION
From feedback, added an S3 CopyToBucket example so that the code matches the description.
Added output of number of objects deleted to DeleteObjects example.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
