### PR TITLE
Rust: add empty check in delete multiple objects example for S3 

### DIFF
--- a/rustv1/examples/s3/src/s3-service-lib.rs
+++ b/rustv1/examples/s3/src/s3-service-lib.rs
@@ -42,7 +42,7 @@ pub async fn delete_objects(client: &Client, bucket_name: &str) -> Result<Vec<St
     }
 
     let return_keys = delete_objects.iter().map(|o| o.key.clone()).collect();
-    
+
     if !delete_objects.is_empty() {
         client
             .delete_objects()

--- a/rustv1/examples/s3/src/s3-service-lib.rs
+++ b/rustv1/examples/s3/src/s3-service-lib.rs
@@ -42,18 +42,20 @@ pub async fn delete_objects(client: &Client, bucket_name: &str) -> Result<Vec<St
     }
 
     let return_keys = delete_objects.iter().map(|o| o.key.clone()).collect();
-
-    client
-        .delete_objects()
-        .bucket(bucket_name)
-        .delete(
-            Delete::builder()
-                .set_objects(Some(delete_objects))
-                .build()
-                .map_err(Error::from)?,
-        )
-        .send()
-        .await?;
+    
+    if !delete_objects.is_empty() {
+        client
+            .delete_objects()
+            .bucket(bucket_name)
+            .delete(
+                Delete::builder()
+                    .set_objects(Some(delete_objects))
+                    .build()
+                    .map_err(Error::from)?,
+            )
+            .send()
+            .await?;
+    }
 
     let objects: ListObjectsV2Output = client.list_objects_v2().bucket(bucket_name).send().await?;
 


### PR DESCRIPTION
If delete_objects is empty the request will fail XML-validation, I think. Perhaps it's nice to have a check included in the example?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
