### PR TITLE
Python: Fix typo in Bedrock Agents scenario comment

### DIFF
--- a/python/example_code/bedrock-agent/scenario_get_started_with_agents.py
+++ b/python/example_code/bedrock-agent/scenario_get_started_with_agents.py
@@ -94,7 +94,7 @@ class BedrockAgentScenarioWrapper:
         self._allow_agent_to_invoke_function()
         self._let_function_accept_invocations_from_agent()
 
-        # Create an action group to connects the agent with the Lambda function
+        # Create an action group to connect the agent with the Lambda function
         self._create_agent_action_group()
 
         # If the agent has been modified or any components have been added, prepare the agent again


### PR DESCRIPTION
This pull request fixes a typo in a comment in the Bedrock Agents example scenario for Python.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
