### PR TITLE
JavaV2_crossservice_Fix broken link to github code base

### DIFF
--- a/.doc_gen/cross-content/cross_RDSDataTracker_Java_block.xml
+++ b/.doc_gen/cross-content/cross_RDSDataTracker_Java_block.xml
@@ -10,7 +10,7 @@
     <para>
         For complete source code and instructions on how to set up a Spring REST API that queries Amazon Aurora Serverless data and for use by
         a React application, see the full example on
-        <ulink url="https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/javav2/usecases/Creating_Spring_RDS_%20Rest">GitHub</ulink>.
+        <ulink url="https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/javav2/usecases/Creating_Spring_RDS_Rest">GitHub</ulink>.
     </para>
     <para>
         For complete source code and instructions on how to set up and run an example that uses the JDBC API, see the full example on


### PR DESCRIPTION
This pull request fixes a broken link from the SoS cross-service example page to the GitHub repo.

It addresses [this ticket](https://issues.amazon.com/issues/V1208534401).

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
