### PR TITLE
JavaScript v3: Add code examples to demonstrate the InvokeModel actions for Llama2 Chat & Titan Text

### DIFF
--- a/.doc_gen/metadata/bedrock-runtime_metadata.yaml
+++ b/.doc_gen/metadata/bedrock-runtime_metadata.yaml
@@ -257,6 +257,14 @@ bedrock-runtime_InvokeLlama2:
             - description: Invoke the Meta Llama 2 Chat foundation model to generate text.
               snippet_tags:
                 - bedrock-runtime.java2.invoke_llama2.main
+    JavaScript:
+      versions:
+        - sdk_version: 3
+          github: javascriptv3/example_code/bedrock-runtime
+          excerpts:
+            - description: Invoke the Meta Llama 2 Chat foundation model to generate text.
+              snippet_files:
+                - javascriptv3/example_code/bedrock-runtime/actions/invoke-llama2.js
     PHP:
       versions:
         - sdk_version: 3

--- a/.doc_gen/metadata/bedrock-runtime_metadata.yaml
+++ b/.doc_gen/metadata/bedrock-runtime_metadata.yaml
@@ -60,6 +60,23 @@ bedrock-runtime_InvokeAmazonTitanImageGeneratorForImageGeneration:
   services:
     bedrock-runtime: {InvokeModel}
 
+bedrock-runtime_InvokeAmazonTitanImageGeneratorForTextGeneration:
+  title: Invoke the Amazon Titan Text G1 model on &BR; for text generation
+  title_abbrev: Text generation with Amazon Titan Text G1
+  synopsis: invoke the Amazon Titan Text G1 model on &BR; for text generation.
+  category:
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 3
+          github: javascriptv3/example_code/bedrock-runtime
+          excerpts:
+            - description: Invoke the Amazon Titan Text G1 foundation model to generate text.
+              snippet_files:
+                - javascriptv3/example_code/bedrock-runtime/actions/invoke-titan-text-express-v1.js
+  services:
+    bedrock-runtime: {InvokeModel}
+
 bedrock-runtime_InvokeStableDiffusionForImageGeneration:
   title: Invoke the Stability.ai Stable Diffusion XL model on &BR; for image generation
   title_abbrev: Image generation with Stability.ai Stable Diffusion XL

--- a/javascriptv3/example_code/bedrock-runtime/README.md
+++ b/javascriptv3/example_code/bedrock-runtime/README.md
@@ -35,7 +35,9 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `javas
 Code excerpts that show you how to call individual service functions.
 
 - [Text generation with AI21 Labs Jurassic-2](javascriptv3/example_code/bedrock-runtime/actions/invoke-jurassic2.js) (`InvokeModel`)
+- [Text generation with Amazon Titan Text G1](javascriptv3/example_code/bedrock-runtime/actions/invoke-titan-text-express-v1.js) (`InvokeModel`)
 - [Text generation with Anthropic Claude 2](javascriptv3/example_code/bedrock-runtime/actions/invoke-claude.js) (`InvokeModel`)
+- [Text generation with Meta Llama 2 Chat](javascriptv3/example_code/bedrock-runtime/actions/invoke-llama2.js) (`InvokeModel`)
 
 
 <!--custom.examples.start-->

--- a/javascriptv3/example_code/bedrock-runtime/actions/invoke-llama2.js
+++ b/javascriptv3/example_code/bedrock-runtime/actions/invoke-llama2.js
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {fileURLToPath} from "url";
+
+import {BedrockRuntimeClient, InvokeModelCommand} from "@aws-sdk/client-bedrock-runtime";
+
+/**
+ * @typedef {Object} ResponseBody
+ * @property {generation} text
+ */
+
+/**
+ * Invokes the Meta Llama 2 large-language model to run an inference
+ * using the input provided in the request body.
+ *
+ * @param {string} prompt - The prompt that you want Llama-2 to complete.
+ * @returns {string} The inference response (generation) from the model.
+ */
+export const invokeLlama2 = async (prompt) => {
+    const client = new BedrockRuntimeClient( { region: 'us-east-1' } );
+
+    const modelId = 'meta.llama2-13b-chat-v1';
+
+    /* The different model providers have individual request and response formats.
+     * For the format, ranges, and default values for Meta Llama 2 Chat, refer to:
+     * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
+     */
+    const payload = {
+        prompt,
+        temperature: 0.5,
+        top_p: 0.9,
+        max_gen_len: 512,
+    };
+
+    const command = new InvokeModelCommand({
+        body: JSON.stringify(payload),
+        contentType: 'application/json',
+        accept: 'application/json',
+        modelId,
+    });
+
+    try {
+        const response = await client.send(command);
+        const decodedResponseBody = new TextDecoder().decode(response.body);
+
+        /** @type {ResponseBody} */
+        const responseBody = JSON.parse(decodedResponseBody);
+
+        return responseBody.generation;
+
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+// Invoke the function if this file was run directly.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    const prompt = 'Complete the following: "Once upon a time..."';
+    console.log('\nModel: Meta Llama 2 Chat');
+    console.log(`Prompt: ${prompt}`);
+
+    const completion = await invokeLlama2(prompt);
+    console.log('Completion:');
+    console.log(completion);
+    console.log('\n');
+}

--- a/javascriptv3/example_code/bedrock-runtime/actions/invoke-llama2.js
+++ b/javascriptv3/example_code/bedrock-runtime/actions/invoke-llama2.js
@@ -11,7 +11,7 @@ import {BedrockRuntimeClient, InvokeModelCommand} from "@aws-sdk/client-bedrock-
  */
 
 /**
- * Invokes the Meta Llama 2 large-language model to run an inference
+ * Invokes the Meta Llama 2 Chat model to run an inference
  * using the input provided in the request body.
  *
  * @param {string} prompt - The prompt that you want Llama-2 to complete.

--- a/javascriptv3/example_code/bedrock-runtime/actions/invoke-titan-text-express-v1.js
+++ b/javascriptv3/example_code/bedrock-runtime/actions/invoke-titan-text-express-v1.js
@@ -81,7 +81,6 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     console.log('\nModel: Titan Text Express v1');
     console.log(`Prompt: ${prompt}`);
 
-    /** @type {object[]} */
     const results = await invokeTitanTextExpressV1(prompt);
     console.log('Completion:');
     for (const result of results) {

--- a/javascriptv3/example_code/bedrock-runtime/actions/invoke-titan-text-express-v1.js
+++ b/javascriptv3/example_code/bedrock-runtime/actions/invoke-titan-text-express-v1.js
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {fileURLToPath} from "url";
+
+import {BedrockRuntimeClient, InvokeModelCommand} from "@aws-sdk/client-bedrock-runtime";
+
+/**
+ * @typedef {Object} ResponseBody
+ * @property {Object[]} results
+ */
+
+/**
+ * Invokes the Titan Text G1 - Express model to run an inference
+ * using the input provided in the request body.
+ *
+ * @param {string} prompt - The prompt that you want Titan Text Express to complete.
+ * @returns {object[]} The inference response (results) from the model.
+ */
+export const invokeTitanTextExpressV1 = async (prompt) => {
+    const client = new BedrockRuntimeClient( { region: 'us-east-1' } );
+
+    const modelId = 'amazon.titan-text-express-v1';
+
+    /* The different model providers have individual request and response formats.
+     * For the format, ranges, and default values for Titan text, refer to:
+     * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-text.html
+     */
+    const textGenerationConfig = {
+        maxTokenCount: 4096,
+        stopSequences: [],
+        temperature: 0,
+        topP: 1,
+    };
+
+    const payload = {
+        inputText: prompt,
+        textGenerationConfig,
+    };
+
+    const command = new InvokeModelCommand({
+        body: JSON.stringify(payload),
+        contentType: 'application/json',
+        accept: 'application/json',
+        modelId,
+    });
+
+    try {
+        const response = await client.send(command);
+        const decodedResponseBody = new TextDecoder().decode(response.body);
+        console.log(decodedResponseBody);
+
+        /** @type {ResponseBody} */
+        const responseBody = JSON.parse(decodedResponseBody);
+        return responseBody.results
+
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+// Invoke the function if this file was run directly.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    const prompt = `Meeting transcript: Miguel: Hi Brant, I want to discuss the workstream  
+    for our new product launch Brant: Sure Miguel, is there anything in particular you want
+    to discuss? Miguel: Yes, I want to talk about how users enter into the product.
+    Brant: Ok, in that case let me add in Namita. Namita: Hey everyone 
+    Brant: Hi Namita, Miguel wants to discuss how users enter into the product.
+    Miguel: its too complicated and we should remove friction.  
+    for example, why do I need to fill out additional forms?  
+    I also find it difficult to find where to access the product
+    when I first land on the landing page. Brant: I would also add that
+    I think there are too many steps. Namita: Ok, I can work on the
+    landing page to make the product more discoverable but brant
+    can you work on the additonal forms? Brant: Yes but I would need 
+    to work with James from another team as he needs to unblock the sign up workflow.
+    Miguel can you document any other concerns so that I can discuss with James only once?
+    Miguel: Sure.
+    From the meeting transcript above, Create a list of action items for each person.`;
+
+    console.log('\nModel: Titan Text Express v1');
+    console.log(`Prompt: ${prompt}`);
+
+    /** @type {object[]} */
+    const results = await invokeTitanTextExpressV1(prompt);
+    console.log('Completion:');
+    for (const result of results) {
+        console.log(result.outputText);
+    }
+    console.log('\n');
+}

--- a/javascriptv3/example_code/bedrock-runtime/actions/invoke-titan-text-express-v1.js
+++ b/javascriptv3/example_code/bedrock-runtime/actions/invoke-titan-text-express-v1.js
@@ -48,7 +48,6 @@ export const invokeTitanTextExpressV1 = async (prompt) => {
     try {
         const response = await client.send(command);
         const decodedResponseBody = new TextDecoder().decode(response.body);
-        console.log(decodedResponseBody);
 
         /** @type {ResponseBody} */
         const responseBody = JSON.parse(decodedResponseBody);

--- a/javascriptv3/example_code/bedrock-runtime/package.json
+++ b/javascriptv3/example_code/bedrock-runtime/package.json
@@ -11,6 +11,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.489.0"
   },
   "devDependencies": {
-    "vitest": "^1.1.3"
+    "vitest": "^1.2.1",
+    "zod": "^3.22.4"
   }
 }

--- a/javascriptv3/example_code/bedrock-runtime/tests/invoke-model.integration.test.js
+++ b/javascriptv3/example_code/bedrock-runtime/tests/invoke-model.integration.test.js
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 import { invokeClaude } from '../actions/invoke-claude.js';
 import { invokeJurassic2 } from '../actions/invoke-jurassic2.js';
 import { invokeLlama2 } from '../actions/invoke-llama2.js';
+import { invokeTitanTextExpressV1 } from "../actions/invoke-titan-text-express-v1.js";
 
 const TEST_PROMPT = 'Hello, this is a test prompt';
 
@@ -30,5 +31,16 @@ describe('invoke llama-2 with test prompt', () => {
         const response = await invokeLlama2(TEST_PROMPT);
         expect(typeof response).toBe('string');
         expect(response).not.toBe('');
+    })
+})
+
+describe('invoke titan-text-express-v1 with test prompt', () => {
+    it('should return a text completion', async () => {
+        const response = await invokeTitanTextExpressV1(TEST_PROMPT);
+        expect(typeof response).toBe('object');
+        for (const result of response) {
+            expect(result).toHaveProperty('outputText');
+            expect(result.outputText).not.toBe('');
+        }
     })
 })

--- a/javascriptv3/example_code/bedrock-runtime/tests/invoke-model.integration.test.js
+++ b/javascriptv3/example_code/bedrock-runtime/tests/invoke-model.integration.test.js
@@ -5,6 +5,7 @@ import { describe, it, expect } from "vitest";
 
 import { invokeClaude } from '../actions/invoke-claude.js';
 import { invokeJurassic2 } from '../actions/invoke-jurassic2.js';
+import { invokeLlama2 } from '../actions/invoke-llama2.js';
 
 const TEST_PROMPT = 'Hello, this is a test prompt';
 
@@ -19,6 +20,14 @@ describe('invoke claude with test prompt', () => {
 describe('invoke jurassic-2 with test prompt', () => {
     it('should return a text completion', async () => {
         const response = await invokeJurassic2(TEST_PROMPT);
+        expect(typeof response).toBe('string');
+        expect(response).not.toBe('');
+    })
+})
+
+describe('invoke llama-2 with test prompt', () => {
+    it('should return a text completion', async () => {
+        const response = await invokeLlama2(TEST_PROMPT);
         expect(typeof response).toBe('string');
         expect(response).not.toBe('');
     })


### PR DESCRIPTION
This pull request adds two JavaScript v3 code examples including their respective tests for the Amazon Bedrock Runtime API:

- [x] Text generation with Llama2 Chat (InvokeModel)
- [x] Text generation with Titan Text (InvokeModel)
- [x] updatem README.md

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
