### PR TITLE
[Tools] Restore placeholder curated sources.yaml

### DIFF
--- a/.doc_gen/metadata/curated/sources.yaml
+++ b/.doc_gen/metadata/curated/sources.yaml
@@ -1,0 +1,4 @@
+placeholder-examples:
+  name: Placeholder curated examples
+  description: Placeholder source description until we add actual curated examples.
+  url: https://github.com/aws/not-a-real-repo


### PR DESCRIPTION
This file was accidentally deleted in an earlier PR, but it appears to be required by a backend tool to avoid generating an empty file. Until that issue is resolved, I'll restore this file.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
