### PR TITLE
Fix: Typo in Bedrock Python example metadata

### DIFF
--- a/.doc_gen/metadata/bedrock-runtime_metadata.yaml
+++ b/.doc_gen/metadata/bedrock-runtime_metadata.yaml
@@ -233,7 +233,7 @@ bedrock-runtime_InvokeJurassic2:
     Python:
       versions:
         - sdk_version: 3
-          github: python/example_code/bedrockruntime
+          github: python/example_code/bedrock-runtime
           excerpts:
             - description: Invoke the AI21 Labs Jurassic-2 foundation model to generate text.
               snippet_tags:
@@ -293,7 +293,7 @@ bedrock-runtime_InvokeLlama2:
     Python:
       versions:
         - sdk_version: 3
-          github: python/example_code/bedrockruntime
+          github: python/example_code/bedrock-runtime
           excerpts:
             - description: Invoke the Meta Llama 2 Chat foundation model to generate text.
               snippet_tags:


### PR DESCRIPTION
This pull request fixes a typo in the python example metadata.
---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
