### PR TITLE
[Tools] Add HTML-only list of SDKs that will not be included in the PDF build

### DIFF
--- a/.doc_gen/templates/zonbook/library_by_sdk_chapter.xml
+++ b/.doc_gen/templates/zonbook/library_by_sdk_chapter.xml
@@ -1,5 +1,6 @@
 {{- template "prologue"}}
 {{- $omitted_sdks := makeSlice "java_1" "cli_2"}}
+{{- $html_only_sdks := makeSlice "cli_2"}}
 {{- $chapter_id := "code_example_library_by_sdk"}}
 {{- $include_docs := "file://AWSShared/code-samples/docs/"}}
 {{- if isSnapshot}}
@@ -47,8 +48,14 @@
             {{- $skip_sdk = true}}
         {{- end}}
     {{- end}}
+    {{- $html_only := ""}}
+    {{- range $only := $html_only_sdks}}
+        {{- if eq $only $sdk_ver}}
+            {{- $html_only = "buildtype=\"html\""}}
+        {{- end}}
+    {{- end}}
     {{- if not $skip_sdk}}
-    <section id="{{$sdk_ver}}_code_examples" role="topic">
+    <section id="{{$sdk_ver}}_code_examples" role="topic" {{$html_only}}>
         <info>
             <title id="{{$sdk_ver}}_code_examples.title">Code examples for {{$sdk_examples.SdkEntity.Short}}</title>
             <titleabbrev id="{{$sdk_ver}}_code_examples.titleabbrev">{{$sdk_examples.SdkEntity.Short}}</titleabbrev>


### PR DESCRIPTION
This update adds the ability to designate a list of SDKs that should be omitted from the PDF build, and adds CLI to that list.
However, currently the CLI examples are not yet included in the HTML build either, so there will be no apparent change to the output, this just gets us ready to flip the switch at a future point.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
