### PR TITLE
CPP: No need to wait for a final transcript to be received in transcribe streaming

### DIFF
--- a/cpp/example_code/transcribe/get_transcript.cpp
+++ b/cpp/example_code/transcribe/get_transcript.cpp
@@ -19,7 +19,11 @@ using namespace Aws::TranscribeStreamingService::Model;
 
 //TODO(User): Update path to location of local .wav test file, if necessary.
 static const Aws::String FILE_NAME{MEDIA_DIR "/transcribe-test-file.wav"};
-static const int BUFFER_SIZE = 1024;
+static const int SAMPLE_RATE = 8000; // for the file above
+// If you're able to specify chunk size with your audio type (such as with PCM), set each chunk to between 50 ms and 200 ms
+static const int CHUNK_LENGTH = 125;
+// chunk_size_in_bytes = chunk_duration_in_millisecond / 1000 * audio_sample_rate * 2
+static const int BUFFER_SIZE = CHUNK_LENGTH * SAMPLE_RATE / 1000 * 2;
 
 // snippet-start:[transcribe.cpp.stream_transcription_async.code]
 int main() {
@@ -73,7 +77,7 @@ int main() {
         });
 
         StartStreamTranscriptionRequest request;
-        request.SetMediaSampleRateHertz(8000);
+        request.SetMediaSampleRateHertz(SAMPLE_RATE);
         request.SetLanguageCode(LanguageCode::en_US);
         request.SetMediaEncoding(
                 MediaEncoding::pcm); // wav and aiff files are PCM formats.
@@ -122,9 +126,6 @@ int main() {
                     std::cout << "Successfully sent the empty frame" << std::endl;
                 }
                 stream.flush();
-                // Wait until the final transcript or an error is received.
-                // Closing the stream prematurely will trigger an error.
-                canCloseStream.WaitOne();
                 stream.Close();
          };
 


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

starting the AWS CPP SDK version [1.11.252](https://github.com/aws/aws-sdk-cpp/commits/1.11.252/), the lines 
```
                // Wait until the final transcript or an error is received.
                // Closing the stream prematurely will trigger an error.
                canCloseStream.WaitOne();
```
are no longer needed.
SDK now encodes and the sends the final empty frame that is accepted by a remote.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
