### PR TITLE
Bedrock Runtime: Replace documentation links

### DIFF
--- a/gov2/bedrock-runtime/actions/invoke_model.go
+++ b/gov2/bedrock-runtime/actions/invoke_model.go
@@ -28,7 +28,7 @@ type InvokeModelWrapper struct {
 
 // Each model provider has their own individual request and response formats.
 // For the format, ranges, and default values for Anthropic Claude, refer to:
-// https://docs.anthropic.com/claude/reference/complete_post
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
 
 type ClaudeRequest struct {
 	Prompt            string   `json:"prompt"`

--- a/gov2/bedrock-runtime/actions/invoke_model.go
+++ b/gov2/bedrock-runtime/actions/invoke_model.go
@@ -79,7 +79,7 @@ func (wrapper InvokeModelWrapper) InvokeClaude(prompt string) (string, error) {
 
 // Each model provider has their own individual request and response formats.
 // For the format, ranges, and default values for AI21 Labs Jurassic-2, refer to:
-// https://docs.ai21.com/reference/j2-complete-ref
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-jurassic2.html
 
 type Jurassic2Request struct {
 	Prompt      string   `json:"prompt"`

--- a/javascriptv3/example_code/bedrock-runtime/actions/invoke-claude.js
+++ b/javascriptv3/example_code/bedrock-runtime/actions/invoke-claude.js
@@ -27,7 +27,7 @@ export const invokeClaude = async (prompt) => {
 
     /* The different model providers have individual request and response formats.
      * For the format, ranges, and default values for Anthropic Claude, refer to:
-     * https://docs.anthropic.com/claude/reference/complete_post
+     * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
      */
     const payload = {
         prompt: enclosedPrompt,

--- a/javascriptv3/example_code/bedrock-runtime/actions/invoke-jurassic2.js
+++ b/javascriptv3/example_code/bedrock-runtime/actions/invoke-jurassic2.js
@@ -30,7 +30,7 @@ export const invokeJurassic2 = async (prompt) => {
 
     /* The different model providers have individual request and response formats.
      * For the format, ranges, and default values for AI21 Labs Jurassic-2, refer to:
-     * https://docs.ai21.com/reference/j2-complete-ref
+     * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-jurassic2.html
      */
     const payload = {
         prompt,

--- a/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/InvokeModel.java
+++ b/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/InvokeModel.java
@@ -190,7 +190,7 @@ public class InvokeModel {
                  * The different model providers have individual request and response formats.
                  * For the format, ranges, and available style_presets of Stable Diffusion
                  * models refer to:
-                 * https://platform.stability.ai/docs/api-reference#tag/v1generation
+                 * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-stability-diffusion.html
                  */
 
                 String stableDiffusionModelId = "stability.stable-diffusion-xl";

--- a/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/InvokeModel.java
+++ b/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/InvokeModel.java
@@ -39,7 +39,7 @@ public class InvokeModel {
                 /*
                  * The different model providers have individual request and response formats.
                  * For the format, ranges, and default values for Anthropic Claude, refer to:
-                 * https://docs.anthropic.com/claude/reference/complete_post
+                 * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
                  */
 
                 String claudeModelId = "anthropic.claude-v2";

--- a/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/InvokeModel.java
+++ b/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/InvokeModel.java
@@ -89,7 +89,7 @@ public class InvokeModel {
                  * The different model providers have individual request and response formats.
                  * For the format, ranges, and default values for AI21 Labs Jurassic-2, refer
                  * to:
-                 * https://docs.ai21.com/reference/j2-complete-ref
+                 * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-jurassic2.html
                  */
 
                 String jurassic2ModelId = "ai21.j2-mid-v1";

--- a/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/InvokeModelAsync.java
+++ b/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/InvokeModelAsync.java
@@ -232,7 +232,7 @@ public class InvokeModelAsync {
          * The different model providers have individual request and response formats.
          * For the format, ranges, and available style_presets of Stable Diffusion
          * models refer to:
-         * https://platform.stability.ai/docs/api-reference#tag/v1generation
+         * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-stability-diffusion.html
          */
 
         String stableDiffusionModelId = "stability.stable-diffusion-xl";

--- a/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/InvokeModelAsync.java
+++ b/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/InvokeModelAsync.java
@@ -4,13 +4,13 @@
 package com.example.bedrockruntime;
 
 // snippet-start:[bedrock-runtime.java2.invoke_model_async.import]
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
-import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 
@@ -41,7 +41,7 @@ public class InvokeModelAsync {
         /*
          * The different model providers have individual request and response formats.
          * For the format, ranges, and default values for Anthropic Claude, refer to:
-         * https://docs.anthropic.com/claude/reference/complete_post
+         * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
          */
 
         String claudeModelId = "anthropic.claude-v2";
@@ -103,7 +103,7 @@ public class InvokeModelAsync {
         /*
          * The different model providers have individual request and response formats.
          * For the format, ranges, and default values for Anthropic Claude, refer to:
-         * https://docs.anthropic.com/claude/reference/complete_post
+         * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
          */
 
         String jurassic2ModelId = "ai21.j2-mid-v1";

--- a/php/example_code/bedrock-runtime/BedrockRuntimeService.php
+++ b/php/example_code/bedrock-runtime/BedrockRuntimeService.php
@@ -74,7 +74,7 @@ class BedrockRuntimeService extends \AwsUtilities\AWSServiceClass
     {
         # The different model providers have individual request and response formats.
         # For the format, ranges, and default values for AI21 Labs Jurassic-2, refer to:
-        # https://docs.ai21.com/reference/j2-complete-ref
+        # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-jurassic2.html
 
         $completion = "";
 

--- a/php/example_code/bedrock-runtime/BedrockRuntimeService.php
+++ b/php/example_code/bedrock-runtime/BedrockRuntimeService.php
@@ -144,7 +144,7 @@ class BedrockRuntimeService extends \AwsUtilities\AWSServiceClass
     {
         # The different model providers have individual request and response formats.
         # For the format, ranges, and available style_presets of Stable Diffusion models refer to:
-        # https://platform.stability.ai/docs/api-reference#tag/v1generation
+        # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-stability-diffusion.html
 
         $base64_image_data = "";
 

--- a/php/example_code/bedrock-runtime/BedrockRuntimeService.php
+++ b/php/example_code/bedrock-runtime/BedrockRuntimeService.php
@@ -35,7 +35,7 @@ class BedrockRuntimeService extends \AwsUtilities\AWSServiceClass
     {
         # The different model providers have individual request and response formats.
         # For the format, ranges, and default values for Anthropic Claude, refer to:
-        # https://docs.anthropic.com/claude/reference/complete_post
+        # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
 
         $completion = "";
 

--- a/python/example_code/bedrock-runtime/bedrock_runtime_wrapper.py
+++ b/python/example_code/bedrock-runtime/bedrock_runtime_wrapper.py
@@ -89,7 +89,7 @@ class BedrockRuntimeWrapper:
         try:
             # The different model providers have individual request and response formats.
             # For the format, ranges, and default values for AI21 Labs Jurassic-2, refer to:
-            # https://docs.ai21.com/reference/j2-complete-ref
+            # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-jurassic2.html
 
             body = {
                 "prompt": prompt,

--- a/python/example_code/bedrock-runtime/bedrock_runtime_wrapper.py
+++ b/python/example_code/bedrock-runtime/bedrock_runtime_wrapper.py
@@ -165,7 +165,7 @@ class BedrockRuntimeWrapper:
         try:
             # The different model providers have individual request and response formats.
             # For the format, ranges, and available style_presets of Stable Diffusion models refer to:
-            # https://platform.stability.ai/docs/api-reference#tag/v1generation
+            # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-stability-diffusion.html
 
             body = {
                 "text_prompts": [{"text": prompt}],

--- a/python/example_code/bedrock-runtime/bedrock_runtime_wrapper.py
+++ b/python/example_code/bedrock-runtime/bedrock_runtime_wrapper.py
@@ -49,7 +49,7 @@ class BedrockRuntimeWrapper:
         try:
             # The different model providers have individual request and response formats.
             # For the format, ranges, and default values for Anthropic Claude, refer to:
-            # https://docs.anthropic.com/claude/reference/complete_post
+            # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
 
             # Claude requires you to enclose the prompt as follows:
             enclosed_prompt = "Human: " + prompt + "\n\nAssistant:"
@@ -249,7 +249,7 @@ class BedrockRuntimeWrapper:
         try:
             # The different model providers have individual request and response formats.
             # For the format, ranges, and default values for Anthropic Claude, refer to:
-            # https://docs.anthropic.com/claude/reference/complete_post
+            # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
 
             # Claude requires you to enclose the prompt as follows:
             enclosed_prompt = "Human: " + prompt + "\n\nAssistant:"


### PR DESCRIPTION
This pull request replaces the documentation links in the invocation examples for third party models, as discussed with @AWSChris.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
