### PR TITLE
Bash: Move linter to its own workflow.

### DIFF
--- a/.github/workflows/sh-check.yml
+++ b/.github/workflows/sh-check.yml
@@ -5,7 +5,8 @@ on:
       - "aws-cli/**"
   pull_request:
     paths:
-      - "aws-cli/**"
+      - '!java/**'
+      - 'aws-cli/**'
   workflow_dispatch:
     paths:
       - "aws-cli/**"

--- a/.github/workflows/sh-check.yml
+++ b/.github/workflows/sh-check.yml
@@ -22,3 +22,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           sh_checker_comment: true
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/sh-check.yml
+++ b/.github/workflows/sh-check.yml
@@ -1,17 +1,9 @@
 name: Lint Bash
+
 on:
-  push:
-    paths:
-      - '!java/**'
-      - "aws-cli/**"
-  pull_request:
-    paths:
-      - '!java/**'
-      - 'aws-cli/**'
+  pull_request: # This action does not use the paths argument.
   workflow_dispatch:
-    paths:
-      - '!java/**'
-      - "aws-cli/**"
+    
 jobs:
   sh-checker:
     name: Lint Bash
@@ -24,12 +16,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           sh_checker_comment: true
-  shellcheck:
-    name: Shellcheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
-        with:
-          scandir: 'aws-cli'
+          sh_checker_only_diff: true

--- a/.github/workflows/sh-check.yml
+++ b/.github/workflows/sh-check.yml
@@ -1,10 +1,14 @@
 name: Lint Bash
 on:
+  push:
+    paths:
+      - "aws-cli/**"
   pull_request:
-    branches: [main]
     paths:
       - "aws-cli/**"
   workflow_dispatch:
+    paths:
+      - "aws-cli/**"
 jobs:
   sh-checker:
     name: Lint Bash

--- a/.github/workflows/sh-check.yml
+++ b/.github/workflows/sh-check.yml
@@ -1,0 +1,19 @@
+name: Lint Bash
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "aws-cli/**"
+  workflow_dispatch:
+jobs:
+  sh-checker:
+    name: Lint Bash
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Lint Bash
+        uses: luizm/action-sh-checker@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          sh_checker_comment: true

--- a/.github/workflows/sh-check.yml
+++ b/.github/workflows/sh-check.yml
@@ -19,3 +19,4 @@ jobs:
         with:
           sh_checker_comment: true
           sh_checker_only_diff: true
+          sh_checker_shfmt_disable: true

--- a/.github/workflows/sh-check.yml
+++ b/.github/workflows/sh-check.yml
@@ -2,6 +2,7 @@ name: Lint Bash
 on:
   push:
     paths:
+      - '!java/**'
       - "aws-cli/**"
   pull_request:
     paths:
@@ -9,6 +10,7 @@ on:
       - 'aws-cli/**'
   workflow_dispatch:
     paths:
+      - '!java/**'
       - "aws-cli/**"
 jobs:
   sh-checker:
@@ -29,3 +31,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: 'aws-cli'

--- a/.github/workflows/sh-check.yml
+++ b/.github/workflows/sh-check.yml
@@ -1,9 +1,11 @@
+# This uses the action https://github.com/marketplace/actions/sh-checker
+
 name: Lint Bash
 
 on:
-  pull_request: # This action does not use the paths argument.
+  pull_request: # This action does not use the paths option.
   workflow_dispatch:
-    
+
 jobs:
   sh-checker:
     name: Lint Bash

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -37,7 +37,6 @@ jobs:
           VALIDATE_PYTHON_BLACK: true
           VALIDATE_RUBY: true
           VALIDATE_KOTLIN: true
-          VALIDATE_BASH: true
   yamllint:
     name: Lint Yaml
     # The type of runner that the job will run on


### PR DESCRIPTION
This removes the Bash option in SuperLinter
It enables a bash specific linter, https://github.com/marketplace/actions/sh-checker

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
