### PR TITLE
CPP: Fix mocks for weathertop

### DIFF
--- a/cpp/example_code/aurora/tests/aurora_gtests.cpp
+++ b/cpp/example_code/aurora/tests/aurora_gtests.cpp
@@ -10,6 +10,58 @@ Aws::SDKOptions AwsDocTest::Aurora_GTests::s_options;
 std::unique_ptr<Aws::Client::ClientConfiguration> AwsDocTest::Aurora_GTests::s_clientConfig;
 static const char ALLOCATION_TAG[] = "AURORA_GTEST";
 
+
+/*
+ * Subclass MockHTTPCLient to respond to credential requests.
+ * Otherwise, the stored responses are returned for credential requests
+ * and not the service API calls.
+ */
+class CustomMockHTTPClient : public MockHttpClient {
+public:
+    explicit CustomMockHTTPClient(
+            const std::shared_ptr<Aws::Http::HttpRequest> &requestTmp) {
+        std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                ALLOCATION_TAG, requestTmp);
+        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->SetResponseCode(Aws::Http::HttpResponseCode::OK);
+        Aws::Utils::DateTime expiration =
+                Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
+
+        goodResponse->GetResponseBody() << R"({
+"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
+"AccessKeyId":"ABCDEFGHIJK",
+"SecretAccessKey":"ABCDEFGHIJK",
+"Token":"ABCDEFGHIJK==",
+"Expiration":")"
+                                        << expiration.ToGmtString(
+                                                Aws::Utils::DateFormat::ISO_8601)
+                                        << R"("
+    })";
+        this->AddResponseToReturn(goodResponse);
+
+        mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);
+    }
+
+    std::shared_ptr<Aws::Http::HttpResponse>
+    MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
+                Aws::Utils::RateLimits::RateLimiterInterface *readLimiter,
+                Aws::Utils::RateLimits::RateLimiterInterface *writeLimiter) const override {
+
+        // Do not use stored responses for a credentials request.
+        if (request->GetURIString().find("/credentials/") != std::string::npos) {
+            std::cout << "CustomMockHTTPClient returning credentials request."
+                      << std::endl;
+            return mCredentialsResponse;
+        }
+        else {
+            return MockHttpClient::MakeRequest(request, readLimiter, writeLimiter);
+        }
+    }
+
+private:
+    std::shared_ptr<Aws::Http::HttpResponse> mCredentialsResponse;
+};
+
 void AwsDocTest::Aurora_GTests::SetUpTestSuite() {
     InitAPI(s_options);
 
@@ -79,13 +131,14 @@ int AwsDocTest::MyStringBuffer::underflow() {
 }
 
 AwsDocTest::MockHTTP::MockHTTP() {
-    mockHttpClient = Aws::MakeShared<MockHttpClient>(ALLOCATION_TAG);
-    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
-    mockHttpClientFactory->SetClient(mockHttpClient);
-    SetHttpClientFactory(mockHttpClientFactory);
     requestTmp = CreateHttpRequest(Aws::Http::URI("https://test.com/"),
                                    Aws::Http::HttpMethod::HTTP_GET,
                                    Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    mockHttpClient = Aws::MakeShared<CustomMockHTTPClient>(
+            ALLOCATION_TAG, requestTmp);
+    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
+    mockHttpClientFactory->SetClient(mockHttpClient);
+    SetHttpClientFactory(mockHttpClientFactory);
 }
 
 AwsDocTest::MockHTTP::~MockHTTP() {
@@ -95,19 +148,21 @@ AwsDocTest::MockHTTP::~MockHTTP() {
 
 bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
                                                Aws::Http::HttpResponseCode httpResponseCode) {
+    std::string filePath = std::string(SRC_DIR) + "/" + fileName;
 
-    std::ifstream inStream(std::string(SRC_DIR) + "/" + fileName);
+    std::ifstream inStream(filePath);
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
-        goodResponse->AddHeader("Content-Type", "text/xml");
+        goodResponse->AddHeader("Content-Type", "text/json");
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);
+
         return true;
     }
 
-    std::cerr << "MockHTTP::addResponseWithBody open file error '" << fileName << "'."
+    std::cerr << "MockHTTP::addResponseWithBody open file error '" << filePath << "'."
               << std::endl;
 
     return false;

--- a/cpp/example_code/aurora/tests/aurora_gtests.cpp
+++ b/cpp/example_code/aurora/tests/aurora_gtests.cpp
@@ -27,16 +27,12 @@ public:
         Aws::Utils::DateTime expiration =
                 Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
 
-        goodResponse->GetResponseBody() << R"({
-"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
-"AccessKeyId":"ABCDEFGHIJK",
-"SecretAccessKey":"ABCDEFGHIJK",
-"Token":"ABCDEFGHIJK==",
-"Expiration":")"
-                                        << expiration.ToGmtString(
-                                                Aws::Utils::DateFormat::ISO_8601)
-                                        << R"("
-    })";
+        goodResponse->GetResponseBody() << "{"
+                                        << R"("RoleArn":"arn:aws:iam::123456789012:role/MockRole",)"
+                                        << R"("AccessKeyId":"ABCDEFGHIJK",)"
+                                        << R"("SecretAccessKey":"ABCDEFGHIJK",)"
+                                        << R"(Token":"ABCDEFGHIJK==","Expiration":")" << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601) << "\""
+                                        << "}";
         this->AddResponseToReturn(goodResponse);
 
         mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);

--- a/cpp/example_code/aurora/tests/aurora_gtests.cpp
+++ b/cpp/example_code/aurora/tests/aurora_gtests.cpp
@@ -154,7 +154,7 @@ bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
-        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->AddHeader("Content-Type", "text/xml");
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);

--- a/cpp/example_code/autoscaling/tests/autoscaling_gtests.cpp
+++ b/cpp/example_code/autoscaling/tests/autoscaling_gtests.cpp
@@ -27,16 +27,12 @@ public:
         Aws::Utils::DateTime expiration =
                 Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
 
-        goodResponse->GetResponseBody() << R"({
-"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
-"AccessKeyId":"ABCDEFGHIJK",
-"SecretAccessKey":"ABCDEFGHIJK",
-"Token":"ABCDEFGHIJK==",
-"Expiration":")"
-                                        << expiration.ToGmtString(
-                                                Aws::Utils::DateFormat::ISO_8601)
-                                        << R"("
-    })";
+        goodResponse->GetResponseBody() << "{"
+                                        << R"("RoleArn":"arn:aws:iam::123456789012:role/MockRole",)"
+                                        << R"("AccessKeyId":"ABCDEFGHIJK",)"
+                                        << R"("SecretAccessKey":"ABCDEFGHIJK",)"
+                                        << R"(Token":"ABCDEFGHIJK==","Expiration":")" << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601) << "\""
+                                        << "}";
         this->AddResponseToReturn(goodResponse);
 
         mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);

--- a/cpp/example_code/autoscaling/tests/autoscaling_gtests.cpp
+++ b/cpp/example_code/autoscaling/tests/autoscaling_gtests.cpp
@@ -5,10 +5,62 @@
 #include <fstream>
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/testing/mocks/http/MockHttpClient.h>
+
 static const char ALLOCATION_TAG[] = "AUTOSCALING_GTEST";
 
 Aws::SDKOptions AwsDocTest::AutoScaling_GTests::s_options;
 std::unique_ptr<Aws::Client::ClientConfiguration> AwsDocTest::AutoScaling_GTests::s_clientConfig;
+
+/*
+ * Subclass MockHTTPCLient to respond to credential requests.
+ * Otherwise, the stored responses are returned for credential requests
+ * and not the service API calls.
+ */
+class CustomMockHTTPClient : public MockHttpClient {
+public:
+    explicit CustomMockHTTPClient(
+            const std::shared_ptr<Aws::Http::HttpRequest> &requestTmp) {
+        std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                ALLOCATION_TAG, requestTmp);
+        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->SetResponseCode(Aws::Http::HttpResponseCode::OK);
+        Aws::Utils::DateTime expiration =
+                Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
+
+        goodResponse->GetResponseBody() << R"({
+"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
+"AccessKeyId":"ABCDEFGHIJK",
+"SecretAccessKey":"ABCDEFGHIJK",
+"Token":"ABCDEFGHIJK==",
+"Expiration":")"
+                                        << expiration.ToGmtString(
+                                                Aws::Utils::DateFormat::ISO_8601)
+                                        << R"("
+    })";
+        this->AddResponseToReturn(goodResponse);
+
+        mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);
+    }
+
+    std::shared_ptr<Aws::Http::HttpResponse>
+    MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
+                Aws::Utils::RateLimits::RateLimiterInterface *readLimiter,
+                Aws::Utils::RateLimits::RateLimiterInterface *writeLimiter) const override {
+
+        // Do not use stored responses for a credentials request.
+        if (request->GetURIString().find("/credentials/") != std::string::npos) {
+            std::cout << "CustomMockHTTPClient returning credentials request."
+                      << std::endl;
+            return mCredentialsResponse;
+        }
+        else {
+            return MockHttpClient::MakeRequest(request, readLimiter, writeLimiter);
+        }
+    }
+
+private:
+    std::shared_ptr<Aws::Http::HttpResponse> mCredentialsResponse;
+};
 
 void AwsDocTest::AutoScaling_GTests::SetUpTestSuite() {
     s_options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
@@ -81,13 +133,14 @@ int AwsDocTest::MyStringBuffer::underflow() {
 }
 
 AwsDocTest::MockHTTP::MockHTTP() {
-    mockHttpClient = Aws::MakeShared<MockHttpClient>(ALLOCATION_TAG);
-    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
-    mockHttpClientFactory->SetClient(mockHttpClient);
-    SetHttpClientFactory(mockHttpClientFactory);
     requestTmp = CreateHttpRequest(Aws::Http::URI("https://test.com/"),
                                    Aws::Http::HttpMethod::HTTP_GET,
                                    Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    mockHttpClient = Aws::MakeShared<CustomMockHTTPClient>(
+            ALLOCATION_TAG, requestTmp);
+    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
+    mockHttpClientFactory->SetClient(mockHttpClient);
+    SetHttpClientFactory(mockHttpClientFactory);
 }
 
 AwsDocTest::MockHTTP::~MockHTTP() {
@@ -97,22 +150,22 @@ AwsDocTest::MockHTTP::~MockHTTP() {
 
 bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
                                                Aws::Http::HttpResponseCode httpResponseCode) {
+    std::string filePath = std::string(SRC_DIR) + "/" + fileName;
 
-    std::string fullPath = std::string(SRC_DIR) + "/" + fileName;
-    std::ifstream inStream(fullPath);
+    std::ifstream inStream(filePath);
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
-        goodResponse->AddHeader("Content-Type", "text/xml");
+        goodResponse->AddHeader("Content-Type", "text/json");
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);
+
         return true;
     }
 
-    std::cerr << "MockHTTP::addResponseWithBody open file error '" << fullPath << "'."
+    std::cerr << "MockHTTP::addResponseWithBody open file error '" << filePath << "'."
               << std::endl;
 
     return false;
 }
-

--- a/cpp/example_code/autoscaling/tests/autoscaling_gtests.cpp
+++ b/cpp/example_code/autoscaling/tests/autoscaling_gtests.cpp
@@ -156,7 +156,7 @@ bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
-        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->AddHeader("Content-Type", "text/xml");
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);

--- a/cpp/example_code/cognito/tests/cognito_gtests.cpp
+++ b/cpp/example_code/cognito/tests/cognito_gtests.cpp
@@ -27,16 +27,12 @@ public:
         Aws::Utils::DateTime expiration =
                 Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
 
-        goodResponse->GetResponseBody() << R"({
-"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
-"AccessKeyId":"ABCDEFGHIJK",
-"SecretAccessKey":"ABCDEFGHIJK",
-"Token":"ABCDEFGHIJK==",
-"Expiration":")"
-                                        << expiration.ToGmtString(
-                                                Aws::Utils::DateFormat::ISO_8601)
-                                        << R"("
-    })";
+        goodResponse->GetResponseBody() << "{"
+                                        << R"("RoleArn":"arn:aws:iam::123456789012:role/MockRole",)"
+                                        << R"("AccessKeyId":"ABCDEFGHIJK",)"
+                                        << R"("SecretAccessKey":"ABCDEFGHIJK",)"
+                                        << R"(Token":"ABCDEFGHIJK==","Expiration":")" << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601) << "\""
+                                        << "}";
         this->AddResponseToReturn(goodResponse);
 
         mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);

--- a/cpp/example_code/cognito/tests/cognito_gtests.cpp
+++ b/cpp/example_code/cognito/tests/cognito_gtests.cpp
@@ -11,6 +11,57 @@ Aws::SDKOptions AwsDocTest::Cognito_GTests::s_options;
 std::unique_ptr<Aws::Client::ClientConfiguration> AwsDocTest::Cognito_GTests::s_clientConfig;
 static const char ALLOCATION_TAG[] = "COGNITO_GTEST";
 
+/*
+ * Subclass MockHTTPCLient to respond to credential requests.
+ * Otherwise, the stored responses are returned for credential requests
+ * and not the service API calls.
+ */
+class CustomMockHTTPClient : public MockHttpClient {
+public:
+    explicit CustomMockHTTPClient(
+            const std::shared_ptr<Aws::Http::HttpRequest> &requestTmp) {
+        std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                ALLOCATION_TAG, requestTmp);
+        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->SetResponseCode(Aws::Http::HttpResponseCode::OK);
+        Aws::Utils::DateTime expiration =
+                Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
+
+        goodResponse->GetResponseBody() << R"({
+"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
+"AccessKeyId":"ABCDEFGHIJK",
+"SecretAccessKey":"ABCDEFGHIJK",
+"Token":"ABCDEFGHIJK==",
+"Expiration":")"
+                                        << expiration.ToGmtString(
+                                                Aws::Utils::DateFormat::ISO_8601)
+                                        << R"("
+    })";
+        this->AddResponseToReturn(goodResponse);
+
+        mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);
+    }
+
+    std::shared_ptr<Aws::Http::HttpResponse>
+    MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
+                Aws::Utils::RateLimits::RateLimiterInterface *readLimiter,
+                Aws::Utils::RateLimits::RateLimiterInterface *writeLimiter) const override {
+
+        // Do not use stored responses for a credentials request.
+        if (request->GetURIString().find("/credentials/") != std::string::npos) {
+            std::cout << "CustomMockHTTPClient returning credentials request."
+                      << std::endl;
+            return mCredentialsResponse;
+        }
+        else {
+            return MockHttpClient::MakeRequest(request, readLimiter, writeLimiter);
+        }
+    }
+
+private:
+    std::shared_ptr<Aws::Http::HttpResponse> mCredentialsResponse;
+};
+
 void AwsDocTest::Cognito_GTests::SetUpTestSuite() {
     InitAPI(s_options);
 
@@ -70,15 +121,15 @@ bool AwsDocTest::Cognito_GTests::suppressStdOut() {
     return std::getenv("EXAMPLE_TESTS_LOG_ON") == nullptr;
 }
 
-
 AwsDocTest::MockHTTP::MockHTTP() {
-    mockHttpClient = Aws::MakeShared<MockHttpClient>(ALLOCATION_TAG);
-    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
-    mockHttpClientFactory->SetClient(mockHttpClient);
-    SetHttpClientFactory(mockHttpClientFactory);
     requestTmp = CreateHttpRequest(Aws::Http::URI("https://test.com/"),
                                    Aws::Http::HttpMethod::HTTP_GET,
                                    Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    mockHttpClient = Aws::MakeShared<CustomMockHTTPClient>(
+            ALLOCATION_TAG, requestTmp);
+    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
+    mockHttpClientFactory->SetClient(mockHttpClient);
+    SetHttpClientFactory(mockHttpClientFactory);
 }
 
 AwsDocTest::MockHTTP::~MockHTTP() {
@@ -94,7 +145,6 @@ void AwsDocTest::MockHTTP::addResponseWithBody(const std::string &body) {
     goodResponse->GetResponseBody() << body;
     mockHttpClient->AddResponseToReturn(goodResponse);
 }
-
 
 int AwsDocTest::MyStringBuffer::underflow() {
     int result = basic_stringbuf::underflow();

--- a/cpp/example_code/cross-service/topics_and_queues/tests/topics_and_queues_gtests.cpp
+++ b/cpp/example_code/cross-service/topics_and_queues/tests/topics_and_queues_gtests.cpp
@@ -35,16 +35,12 @@ namespace AwsDocTest {
             Aws::Utils::DateTime expiration =
                     Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
 
-            goodResponse->GetResponseBody() << R"({
-"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
-"AccessKeyId":"ABCDEFGHIJK",
-"SecretAccessKey":"ABCDEFGHIJK",
-"Token":"ABCDEFGHIJK==",
-"Expiration":")"
-                                            << expiration.ToGmtString(
-                                                    Aws::Utils::DateFormat::ISO_8601)
-                                            << R"("
-    })";
+            goodResponse->GetResponseBody() << "{"
+                                            << R"("RoleArn":"arn:aws:iam::123456789012:role/MockRole",)"
+                                            << R"("AccessKeyId":"ABCDEFGHIJK",)"
+                                            << R"("SecretAccessKey":"ABCDEFGHIJK",)"
+                                            << R"(Token":"ABCDEFGHIJK==","Expiration":")" << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601) << "\""
+                                            << "}";
             this->AddResponseToReturn(goodResponse);
 
             mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);

--- a/cpp/example_code/cross-service/topics_and_queues/tests/topics_and_queues_gtests.cpp
+++ b/cpp/example_code/cross-service/topics_and_queues/tests/topics_and_queues_gtests.cpp
@@ -18,6 +18,58 @@ namespace AwsDocTest {
     std::unique_ptr<Aws::Client::ClientConfiguration> TopicsAndQueues_GTests::s_clientConfig;
 
     static const Aws::String TOPIC_NAME_PREFIX("gtests_topic");
+
+/*
+ * Subclass MockHTTPCLient to respond to credential requests.
+ * Otherwise, the stored responses are returned for credential requests
+ * and not the service API calls.
+ */
+    class CustomMockHTTPClient : public MockHttpClient {
+    public:
+        explicit CustomMockHTTPClient(
+                const std::shared_ptr<Aws::Http::HttpRequest> &requestTmp) {
+            std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                    ALLOCATION_TAG, requestTmp);
+            goodResponse->AddHeader("Content-Type", "text/json");
+            goodResponse->SetResponseCode(Aws::Http::HttpResponseCode::OK);
+            Aws::Utils::DateTime expiration =
+                    Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
+
+            goodResponse->GetResponseBody() << R"({
+"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
+"AccessKeyId":"ABCDEFGHIJK",
+"SecretAccessKey":"ABCDEFGHIJK",
+"Token":"ABCDEFGHIJK==",
+"Expiration":")"
+                                            << expiration.ToGmtString(
+                                                    Aws::Utils::DateFormat::ISO_8601)
+                                            << R"("
+    })";
+            this->AddResponseToReturn(goodResponse);
+
+            mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);
+        }
+
+        std::shared_ptr<Aws::Http::HttpResponse>
+        MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
+                    Aws::Utils::RateLimits::RateLimiterInterface *readLimiter,
+                    Aws::Utils::RateLimits::RateLimiterInterface *writeLimiter) const override {
+
+            // Do not use stored responses for a credentials request.
+            if (request->GetURIString().find("/credentials/") != std::string::npos) {
+                std::cout << "CustomMockHTTPClient returning credentials request."
+                          << std::endl;
+                return mCredentialsResponse;
+            }
+            else {
+                return MockHttpClient::MakeRequest(request, readLimiter, writeLimiter);
+            }
+        }
+
+    private:
+        std::shared_ptr<Aws::Http::HttpResponse> mCredentialsResponse;
+    };
+
 }
 
 void AwsDocTest::TopicsAndQueues_GTests::SetUpTestSuite() {
@@ -86,13 +138,14 @@ int AwsDocTest::MyStringBuffer::underflow() {
 }
 
 AwsDocTest::MockHTTP::MockHTTP() {
-    mockHttpClient = Aws::MakeShared<MockHttpClient>(ALLOCATION_TAG);
-    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
-    mockHttpClientFactory->SetClient(mockHttpClient);
-    SetHttpClientFactory(mockHttpClientFactory);
     requestTmp = CreateHttpRequest(Aws::Http::URI("https://test.com/"),
                                    Aws::Http::HttpMethod::HTTP_GET,
                                    Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    mockHttpClient = Aws::MakeShared<CustomMockHTTPClient>(
+            ALLOCATION_TAG, requestTmp);
+    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
+    mockHttpClientFactory->SetClient(mockHttpClient);
+    SetHttpClientFactory(mockHttpClientFactory);
 }
 
 AwsDocTest::MockHTTP::~MockHTTP() {
@@ -102,19 +155,21 @@ AwsDocTest::MockHTTP::~MockHTTP() {
 
 bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
                                                Aws::Http::HttpResponseCode httpResponseCode) {
+    std::string filePath = std::string(SRC_DIR) + "/" + fileName;
 
-    std::ifstream inStream(std::string(SRC_DIR) + "/" + fileName);
+    std::ifstream inStream(filePath);
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
-        goodResponse->AddHeader("Content-Type", "text/xml");
+        goodResponse->AddHeader("Content-Type", "text/json");
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);
+
         return true;
     }
 
-    std::cerr << "MockHTTP::addResponseWithBody open file error '" << fileName << "'."
+    std::cerr << "MockHTTP::addResponseWithBody open file error '" << filePath << "'."
               << std::endl;
 
     return false;

--- a/cpp/example_code/cross-service/topics_and_queues/tests/topics_and_queues_gtests.cpp
+++ b/cpp/example_code/cross-service/topics_and_queues/tests/topics_and_queues_gtests.cpp
@@ -161,7 +161,7 @@ bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
-        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->AddHeader("Content-Type", "text/xml");
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);

--- a/cpp/example_code/mediaconvert/tests/MediaConvert_gtests.cpp
+++ b/cpp/example_code/mediaconvert/tests/MediaConvert_gtests.cpp
@@ -27,16 +27,12 @@ public:
         Aws::Utils::DateTime expiration =
                 Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
 
-        goodResponse->GetResponseBody() << R"({
-"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
-"AccessKeyId":"ABCDEFGHIJK",
-"SecretAccessKey":"ABCDEFGHIJK",
-"Token":"ABCDEFGHIJK==",
-"Expiration":")"
-                                        << expiration.ToGmtString(
-                                                Aws::Utils::DateFormat::ISO_8601)
-                                        << R"("
-    })";
+        goodResponse->GetResponseBody() << "{"
+                                        << R"("RoleArn":"arn:aws:iam::123456789012:role/MockRole",)"
+                                        << R"("AccessKeyId":"ABCDEFGHIJK",)"
+                                        << R"("SecretAccessKey":"ABCDEFGHIJK",)"
+                                        << R"(Token":"ABCDEFGHIJK==","Expiration":")" << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601) << "\""
+                                        << "}";
         this->AddResponseToReturn(goodResponse);
 
         mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);

--- a/cpp/example_code/mediaconvert/tests/MediaConvert_gtests.cpp
+++ b/cpp/example_code/mediaconvert/tests/MediaConvert_gtests.cpp
@@ -7,14 +7,18 @@
 #include <aws/mediaconvert/MediaConvertClient.h>
 #include <aws/testing/mocks/http/MockHttpClient.h>
 
-// Debug testing framework start.
 #include <aws/core/utils/logging/ConsoleLogSystem.h>
 
 static const char ALLOCATION_TAG[] = "RDS_GTEST";
 
-class DebugMockHTTPClient : public MockHttpClient {
+/*
+ * Subclass MockHTTPCLient to respond to credential requests.
+ * Otherwise, the stored responses are returned for credential requests
+ * and not the service API calls.
+ */
+class CustomMockHTTPClient : public MockHttpClient {
 public:
-    explicit DebugMockHTTPClient(
+    explicit CustomMockHTTPClient(
             const std::shared_ptr<Aws::Http::HttpRequest> &requestTmp) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
@@ -23,18 +27,16 @@ public:
         Aws::Utils::DateTime expiration =
                 Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
 
-        std::stringstream stringStream;
-        stringStream << R"({
+        goodResponse->GetResponseBody() << R"({
 "RoleArn":"arn:aws:iam::123456789012:role/MockRole",
 "AccessKeyId":"ABCDEFGHIJK",
 "SecretAccessKey":"ABCDEFGHIJK",
 "Token":"ABCDEFGHIJK==",
 "Expiration":")"
-                     << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601)
-                     << R"("
+                                        << expiration.ToGmtString(
+                                                Aws::Utils::DateFormat::ISO_8601)
+                                        << R"("
     })";
-        std::cerr << "Credentials response\n" << stringStream.str() << std::endl;
-        goodResponse->GetResponseBody() << stringStream.rdbuf();
         this->AddResponseToReturn(goodResponse);
 
         mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);
@@ -47,7 +49,7 @@ public:
 
         // Do not use stored responses for a credentials request.
         if (request->GetURIString().find("/credentials/") != std::string::npos) {
-            std::cout << "DebugMockHTTPClient returning credentials request."
+            std::cout << "CustomMockHTTPClient returning credentials request."
                       << std::endl;
             return mCredentialsResponse;
         }
@@ -59,20 +61,11 @@ public:
 private:
     std::shared_ptr<Aws::Http::HttpResponse> mCredentialsResponse;
 };
-// Debug testing framework end.
 
 Aws::SDKOptions AwsDocTest::MediaConvert_GTests::s_options;
 std::unique_ptr<Aws::Client::ClientConfiguration> AwsDocTest::MediaConvert_GTests::s_clientConfig;
 
 void AwsDocTest::MediaConvert_GTests::SetUpTestSuite() {
-    // Debug testing framework start.
-    s_options.loggingOptions.logger_create_fn = []() {
-            std::cerr << "Log create function called. " << std::endl;
-            return Aws::MakeShared<Aws::Utils::Logging::ConsoleLogSystem>(
-                    ALLOCATION_TAG, Aws::Utils::Logging::LogLevel::Debug);
-    };
-    s_options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
-    // Debug testing framework end.
     InitAPI(s_options);
 
     // s_clientConfig must be a pointer because the client config must be initialized
@@ -128,8 +121,7 @@ void AwsDocTest::MediaConvert_GTests::AddCommandLineResponses(
 
 
 bool AwsDocTest::MediaConvert_GTests::suppressStdOut() {
-    // return std::getenv("EXAMPLE_TESTS_LOG_ON") == nullptr;
-    return false; // Temporary override to debug testing framework.
+    return std::getenv("EXAMPLE_TESTS_LOG_ON") == nullptr;
 }
 
 int AwsDocTest::MyStringBuffer::underflow() {
@@ -146,19 +138,14 @@ AwsDocTest::MockHTTP::MockHTTP() {
     requestTmp = CreateHttpRequest(Aws::Http::URI("https://test.com/"),
                                    Aws::Http::HttpMethod::HTTP_GET,
                                    Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
-    mockHttpClient = Aws::MakeShared<DebugMockHTTPClient>(
-            ALLOCATION_TAG, requestTmp); // Debug testing framework.
+    mockHttpClient = Aws::MakeShared<CustomMockHTTPClient>(
+            ALLOCATION_TAG, requestTmp);
     mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
     mockHttpClientFactory->SetClient(mockHttpClient);
     SetHttpClientFactory(mockHttpClientFactory);
-
-    std::cout << "AwsDocTest::MockHTTP::MockHTTP called."
-              << std::endl; // Debug testing framework.
 }
 
 AwsDocTest::MockHTTP::~MockHTTP() {
-    std::cout << "AwsDocTest::MockHTTP::~MockHTTP called."
-              << std::endl; // Debug testing framework.
     Aws::Http::CleanupHttp();
     Aws::Http::InitHttp();
 }
@@ -166,9 +153,7 @@ AwsDocTest::MockHTTP::~MockHTTP() {
 bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
                                                Aws::Http::HttpResponseCode httpResponseCode) {
     std::string filePath = std::string(SRC_DIR) + "/" + fileName;
-    std::cout << "AwsDocTest::MockHTTP::addResponseWithBody called with file "
-              << filePath
-              << "." << std::endl; // Debug testing framework.
+
     std::ifstream inStream(filePath);
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
@@ -178,9 +163,6 @@ bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);
 
-        std::cout << "AwsDocTest::MockHTTP::addResponseWithBody response added  "
-                  << goodResponse.get()
-                  << "." << std::endl; // Debug testing framework.
         return true;
     }
 

--- a/cpp/example_code/medical-imaging/tests/medical-imaging_gtests.cpp
+++ b/cpp/example_code/medical-imaging/tests/medical-imaging_gtests.cpp
@@ -10,6 +10,57 @@ Aws::SDKOptions AwsDocTest::MedicalImaging_GTests::s_options;
 std::unique_ptr<Aws::Client::ClientConfiguration> AwsDocTest::MedicalImaging_GTests::s_clientConfig;
 static const char ALLOCATION_TAG[] = "Medical_Inmging_GTEST";
 
+/*
+ * Subclass MockHTTPCLient to respond to credential requests.
+ * Otherwise, the stored responses are returned for credential requests
+ * and not the service API calls.
+ */
+class CustomMockHTTPClient : public MockHttpClient {
+public:
+    explicit CustomMockHTTPClient(
+            const std::shared_ptr<Aws::Http::HttpRequest> &requestTmp) {
+        std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                ALLOCATION_TAG, requestTmp);
+        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->SetResponseCode(Aws::Http::HttpResponseCode::OK);
+        Aws::Utils::DateTime expiration =
+                Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
+
+        goodResponse->GetResponseBody() << R"({
+"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
+"AccessKeyId":"ABCDEFGHIJK",
+"SecretAccessKey":"ABCDEFGHIJK",
+"Token":"ABCDEFGHIJK==",
+"Expiration":")"
+                                        << expiration.ToGmtString(
+                                                Aws::Utils::DateFormat::ISO_8601)
+                                        << R"("
+    })";
+        this->AddResponseToReturn(goodResponse);
+
+        mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);
+    }
+
+    std::shared_ptr<Aws::Http::HttpResponse>
+    MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
+                Aws::Utils::RateLimits::RateLimiterInterface *readLimiter,
+                Aws::Utils::RateLimits::RateLimiterInterface *writeLimiter) const override {
+
+        // Do not use stored responses for a credentials request.
+        if (request->GetURIString().find("/credentials/") != std::string::npos) {
+            std::cout << "CustomMockHTTPClient returning credentials request."
+                      << std::endl;
+            return mCredentialsResponse;
+        }
+        else {
+            return MockHttpClient::MakeRequest(request, readLimiter, writeLimiter);
+        }
+    }
+
+private:
+    std::shared_ptr<Aws::Http::HttpResponse> mCredentialsResponse;
+};
+
 void AwsDocTest::MedicalImaging_GTests::SetUpTestSuite() {
     InitAPI(s_options);
 
@@ -81,13 +132,14 @@ int AwsDocTest::MyStringBuffer::underflow() {
 }
 
 AwsDocTest::MockHTTP::MockHTTP() {
-    mockHttpClient = Aws::MakeShared<MockHttpClient>(ALLOCATION_TAG);
-    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
-    mockHttpClientFactory->SetClient(mockHttpClient);
-    SetHttpClientFactory(mockHttpClientFactory);
     requestTmp = CreateHttpRequest(Aws::Http::URI("https://test.com/"),
                                    Aws::Http::HttpMethod::HTTP_GET,
                                    Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    mockHttpClient = Aws::MakeShared<CustomMockHTTPClient>(
+            ALLOCATION_TAG, requestTmp);
+    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
+    mockHttpClientFactory->SetClient(mockHttpClient);
+    SetHttpClientFactory(mockHttpClientFactory);
 }
 
 AwsDocTest::MockHTTP::~MockHTTP() {
@@ -97,8 +149,9 @@ AwsDocTest::MockHTTP::~MockHTTP() {
 
 bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
                                                Aws::Http::HttpResponseCode httpResponseCode) {
+    std::string filePath = std::string(SRC_DIR) + "/" + fileName;
 
-    std::ifstream inStream(std::string(SRC_DIR) + "/" + fileName);
+    std::ifstream inStream(filePath);
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
@@ -106,10 +159,11 @@ bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);
+
         return true;
     }
 
-    std::cerr << "MockHTTP::addResponseWithBody open file error '" << fileName << "'."
+    std::cerr << "MockHTTP::addResponseWithBody open file error '" << filePath << "'."
               << std::endl;
 
     return false;

--- a/cpp/example_code/medical-imaging/tests/medical-imaging_gtests.cpp
+++ b/cpp/example_code/medical-imaging/tests/medical-imaging_gtests.cpp
@@ -26,16 +26,12 @@ public:
         Aws::Utils::DateTime expiration =
                 Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
 
-        goodResponse->GetResponseBody() << R"({
-"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
-"AccessKeyId":"ABCDEFGHIJK",
-"SecretAccessKey":"ABCDEFGHIJK",
-"Token":"ABCDEFGHIJK==",
-"Expiration":")"
-                                        << expiration.ToGmtString(
-                                                Aws::Utils::DateFormat::ISO_8601)
-                                        << R"("
-    })";
+        goodResponse->GetResponseBody() << "{"
+                                        << R"("RoleArn":"arn:aws:iam::123456789012:role/MockRole",)"
+                                        << R"("AccessKeyId":"ABCDEFGHIJK",)"
+                                        << R"("SecretAccessKey":"ABCDEFGHIJK",)"
+                                        << R"(Token":"ABCDEFGHIJK==","Expiration":")" << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601) << "\""
+                                        << "}";
         this->AddResponseToReturn(goodResponse);
 
         mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);

--- a/cpp/example_code/rds/tests/rds_gtests.cpp
+++ b/cpp/example_code/rds/tests/rds_gtests.cpp
@@ -10,6 +10,57 @@ Aws::SDKOptions AwsDocTest::RDS_GTests::s_options;
 std::unique_ptr<Aws::Client::ClientConfiguration> AwsDocTest::RDS_GTests::s_clientConfig;
 static const char ALLOCATION_TAG[] = "RDS_GTEST";
 
+/*
+ * Subclass MockHTTPCLient to respond to credential requests.
+ * Otherwise, the stored responses are returned for credential requests
+ * and not the service API calls.
+ */
+class CustomMockHTTPClient : public MockHttpClient {
+public:
+    explicit CustomMockHTTPClient(
+            const std::shared_ptr<Aws::Http::HttpRequest> &requestTmp) {
+        std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                ALLOCATION_TAG, requestTmp);
+        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->SetResponseCode(Aws::Http::HttpResponseCode::OK);
+        Aws::Utils::DateTime expiration =
+                Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
+
+        goodResponse->GetResponseBody() << R"({
+"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
+"AccessKeyId":"ABCDEFGHIJK",
+"SecretAccessKey":"ABCDEFGHIJK",
+"Token":"ABCDEFGHIJK==",
+"Expiration":")"
+                                        << expiration.ToGmtString(
+                                                Aws::Utils::DateFormat::ISO_8601)
+                                        << R"("
+    })";
+        this->AddResponseToReturn(goodResponse);
+
+        mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);
+    }
+
+    std::shared_ptr<Aws::Http::HttpResponse>
+    MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
+                Aws::Utils::RateLimits::RateLimiterInterface *readLimiter,
+                Aws::Utils::RateLimits::RateLimiterInterface *writeLimiter) const override {
+
+        // Do not use stored responses for a credentials request.
+        if (request->GetURIString().find("/credentials/") != std::string::npos) {
+            std::cout << "CustomMockHTTPClient returning credentials request."
+                      << std::endl;
+            return mCredentialsResponse;
+        }
+        else {
+            return MockHttpClient::MakeRequest(request, readLimiter, writeLimiter);
+        }
+    }
+
+private:
+    std::shared_ptr<Aws::Http::HttpResponse> mCredentialsResponse;
+};
+
 void AwsDocTest::RDS_GTests::SetUpTestSuite() {
     InitAPI(s_options);
 
@@ -79,13 +130,14 @@ int AwsDocTest::MyStringBuffer::underflow() {
 }
 
 AwsDocTest::MockHTTP::MockHTTP() {
-    mockHttpClient = Aws::MakeShared<MockHttpClient>(ALLOCATION_TAG);
-    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
-    mockHttpClientFactory->SetClient(mockHttpClient);
-    SetHttpClientFactory(mockHttpClientFactory);
     requestTmp = CreateHttpRequest(Aws::Http::URI("https://test.com/"),
                                    Aws::Http::HttpMethod::HTTP_GET,
                                    Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    mockHttpClient = Aws::MakeShared<CustomMockHTTPClient>(
+            ALLOCATION_TAG, requestTmp);
+    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
+    mockHttpClientFactory->SetClient(mockHttpClient);
+    SetHttpClientFactory(mockHttpClientFactory);
 }
 
 AwsDocTest::MockHTTP::~MockHTTP() {
@@ -95,19 +147,21 @@ AwsDocTest::MockHTTP::~MockHTTP() {
 
 bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
                                                Aws::Http::HttpResponseCode httpResponseCode) {
+    std::string filePath = std::string(SRC_DIR) + "/" + fileName;
 
-    std::ifstream inStream(std::string(SRC_DIR) + "/" + fileName);
+    std::ifstream inStream(filePath);
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
-        goodResponse->AddHeader("Content-Type", "text/xml");
+        goodResponse->AddHeader("Content-Type", "text/json");
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);
+
         return true;
     }
 
-    std::cerr << "MockHTTP::addResponseWithBody open file error '" << fileName << "'."
+    std::cerr << "MockHTTP::addResponseWithBody open file error '" << filePath << "'."
               << std::endl;
 
     return false;

--- a/cpp/example_code/rds/tests/rds_gtests.cpp
+++ b/cpp/example_code/rds/tests/rds_gtests.cpp
@@ -153,7 +153,7 @@ bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
-        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->AddHeader("Content-Type", "text/xml");
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);

--- a/cpp/example_code/rds/tests/rds_gtests.cpp
+++ b/cpp/example_code/rds/tests/rds_gtests.cpp
@@ -26,16 +26,12 @@ public:
         Aws::Utils::DateTime expiration =
                 Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
 
-        goodResponse->GetResponseBody() << R"({
-"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
-"AccessKeyId":"ABCDEFGHIJK",
-"SecretAccessKey":"ABCDEFGHIJK",
-"Token":"ABCDEFGHIJK==",
-"Expiration":")"
-                                        << expiration.ToGmtString(
-                                                Aws::Utils::DateFormat::ISO_8601)
-                                        << R"("
-    })";
+        goodResponse->GetResponseBody() << "{"
+                                        << R"("RoleArn":"arn:aws:iam::123456789012:role/MockRole",)"
+                                        << R"("AccessKeyId":"ABCDEFGHIJK",)"
+                                        << R"("SecretAccessKey":"ABCDEFGHIJK",)"
+                                        << R"(Token":"ABCDEFGHIJK==","Expiration":")" << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601) << "\""
+                                        << "}";
         this->AddResponseToReturn(goodResponse);
 
         mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);

--- a/cpp/example_code/ses/tests/ses_gtests.cpp
+++ b/cpp/example_code/ses/tests/ses_gtests.cpp
@@ -28,16 +28,12 @@ public:
         Aws::Utils::DateTime expiration =
                 Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
 
-        goodResponse->GetResponseBody() << R"({
-"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
-"AccessKeyId":"ABCDEFGHIJK",
-"SecretAccessKey":"ABCDEFGHIJK",
-"Token":"ABCDEFGHIJK==",
-"Expiration":")"
-                                        << expiration.ToGmtString(
-                                                Aws::Utils::DateFormat::ISO_8601)
-                                        << R"("
-    })";
+        goodResponse->GetResponseBody() << "{"
+                                        << R"("RoleArn":"arn:aws:iam::123456789012:role/MockRole",)"
+                                        << R"("AccessKeyId":"ABCDEFGHIJK",)"
+                                        << R"("SecretAccessKey":"ABCDEFGHIJK",)"
+                                        << R"(Token":"ABCDEFGHIJK==","Expiration":")" << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601) << "\""
+                                        << "}";
         this->AddResponseToReturn(goodResponse);
 
         mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);

--- a/cpp/example_code/ses/tests/ses_gtests.cpp
+++ b/cpp/example_code/ses/tests/ses_gtests.cpp
@@ -12,6 +12,57 @@ Aws::SDKOptions AwsDocTest::SES_GTests::s_options;
 std::unique_ptr<Aws::Client::ClientConfiguration> AwsDocTest::SES_GTests::s_clientConfig;
 static const char ALLOCATION_TAG[] = "SES_GTEST";
 
+/*
+ * Subclass MockHTTPCLient to respond to credential requests.
+ * Otherwise, the stored responses are returned for credential requests
+ * and not the service API calls.
+ */
+class CustomMockHTTPClient : public MockHttpClient {
+public:
+    explicit CustomMockHTTPClient(
+            const std::shared_ptr<Aws::Http::HttpRequest> &requestTmp) {
+        std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                ALLOCATION_TAG, requestTmp);
+        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->SetResponseCode(Aws::Http::HttpResponseCode::OK);
+        Aws::Utils::DateTime expiration =
+                Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
+
+        goodResponse->GetResponseBody() << R"({
+"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
+"AccessKeyId":"ABCDEFGHIJK",
+"SecretAccessKey":"ABCDEFGHIJK",
+"Token":"ABCDEFGHIJK==",
+"Expiration":")"
+                                        << expiration.ToGmtString(
+                                                Aws::Utils::DateFormat::ISO_8601)
+                                        << R"("
+    })";
+        this->AddResponseToReturn(goodResponse);
+
+        mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);
+    }
+
+    std::shared_ptr<Aws::Http::HttpResponse>
+    MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
+                Aws::Utils::RateLimits::RateLimiterInterface *readLimiter,
+                Aws::Utils::RateLimits::RateLimiterInterface *writeLimiter) const override {
+
+        // Do not use stored responses for a credentials request.
+        if (request->GetURIString().find("/credentials/") != std::string::npos) {
+            std::cout << "CustomMockHTTPClient returning credentials request."
+                      << std::endl;
+            return mCredentialsResponse;
+        }
+        else {
+            return MockHttpClient::MakeRequest(request, readLimiter, writeLimiter);
+        }
+    }
+
+private:
+    std::shared_ptr<Aws::Http::HttpResponse> mCredentialsResponse;
+};
+
 void AwsDocTest::SES_GTests::SetUpTestSuite() {
     InitAPI(s_options);
 
@@ -21,7 +72,7 @@ void AwsDocTest::SES_GTests::SetUpTestSuite() {
 }
 
 void AwsDocTest::SES_GTests::TearDownTestSuite() {
-     ShutdownAPI(s_options);
+    ShutdownAPI(s_options);
 
 }
 
@@ -80,15 +131,15 @@ int AwsDocTest::MyStringBuffer::underflow() {
     return result;
 }
 
-
 AwsDocTest::MockHTTP::MockHTTP() {
-    mockHttpClient = Aws::MakeShared<MockHttpClient>(ALLOCATION_TAG);
-    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
-    mockHttpClientFactory->SetClient(mockHttpClient);
-    SetHttpClientFactory(mockHttpClientFactory);
     requestTmp = CreateHttpRequest(Aws::Http::URI("https://test.com/"),
                                    Aws::Http::HttpMethod::HTTP_GET,
                                    Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    mockHttpClient = Aws::MakeShared<CustomMockHTTPClient>(
+            ALLOCATION_TAG, requestTmp);
+    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
+    mockHttpClientFactory->SetClient(mockHttpClient);
+    SetHttpClientFactory(mockHttpClientFactory);
 }
 
 AwsDocTest::MockHTTP::~MockHTTP() {
@@ -98,8 +149,9 @@ AwsDocTest::MockHTTP::~MockHTTP() {
 
 bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
                                                Aws::Http::HttpResponseCode httpResponseCode) {
+    std::string filePath = std::string(SRC_DIR) + "/" + fileName;
 
-    std::ifstream inStream(std::string(SRC_DIR) + "/" + fileName);
+    std::ifstream inStream(filePath);
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
@@ -107,10 +159,11 @@ bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);
+
         return true;
     }
 
-    std::cerr << "MockHTTP::addResponseWithBody open file error '" << fileName << "'."
+    std::cerr << "MockHTTP::addResponseWithBody open file error '" << filePath << "'."
               << std::endl;
 
     return false;

--- a/cpp/example_code/sns/tests/sns_gtests.cpp
+++ b/cpp/example_code/sns/tests/sns_gtests.cpp
@@ -20,6 +20,57 @@ namespace AwsDocTest {
     Aws::String SNS_GTests::s_stashedSubscriptionARN;
 
     static const Aws::String TOPIC_NAME_PREFIX("gtests_topic");
+
+/*
+ * Subclass MockHTTPCLient to respond to credential requests.
+ * Otherwise, the stored responses are returned for credential requests
+ * and not the service API calls.
+ */
+    class CustomMockHTTPClient : public MockHttpClient {
+    public:
+        explicit CustomMockHTTPClient(
+                const std::shared_ptr<Aws::Http::HttpRequest> &requestTmp) {
+            std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                    ALLOCATION_TAG, requestTmp);
+            goodResponse->AddHeader("Content-Type", "text/json");
+            goodResponse->SetResponseCode(Aws::Http::HttpResponseCode::OK);
+            Aws::Utils::DateTime expiration =
+                    Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
+
+            goodResponse->GetResponseBody() << R"({
+"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
+"AccessKeyId":"ABCDEFGHIJK",
+"SecretAccessKey":"ABCDEFGHIJK",
+"Token":"ABCDEFGHIJK==",
+"Expiration":")"
+                                            << expiration.ToGmtString(
+                                                    Aws::Utils::DateFormat::ISO_8601)
+                                            << R"("
+    })";
+            this->AddResponseToReturn(goodResponse);
+
+            mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);
+        }
+
+        std::shared_ptr<Aws::Http::HttpResponse>
+        MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
+                    Aws::Utils::RateLimits::RateLimiterInterface *readLimiter,
+                    Aws::Utils::RateLimits::RateLimiterInterface *writeLimiter) const override {
+
+            // Do not use stored responses for a credentials request.
+            if (request->GetURIString().find("/credentials/") != std::string::npos) {
+                std::cout << "CustomMockHTTPClient returning credentials request."
+                          << std::endl;
+                return mCredentialsResponse;
+            }
+            else {
+                return MockHttpClient::MakeRequest(request, readLimiter, writeLimiter);
+            }
+        }
+
+    private:
+        std::shared_ptr<Aws::Http::HttpResponse> mCredentialsResponse;
+    };
 }
 
 void AwsDocTest::SNS_GTests::SetUpTestSuite() {
@@ -221,13 +272,14 @@ int AwsDocTest::MyStringBuffer::underflow() {
 }
 
 AwsDocTest::MockHTTP::MockHTTP() {
-    mockHttpClient = Aws::MakeShared<MockHttpClient>(ALLOCATION_TAG);
-    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
-    mockHttpClientFactory->SetClient(mockHttpClient);
-    SetHttpClientFactory(mockHttpClientFactory);
     requestTmp = CreateHttpRequest(Aws::Http::URI("https://test.com/"),
                                    Aws::Http::HttpMethod::HTTP_GET,
                                    Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    mockHttpClient = Aws::MakeShared<CustomMockHTTPClient>(
+            ALLOCATION_TAG, requestTmp);
+    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
+    mockHttpClientFactory->SetClient(mockHttpClient);
+    SetHttpClientFactory(mockHttpClientFactory);
 }
 
 AwsDocTest::MockHTTP::~MockHTTP() {
@@ -237,19 +289,21 @@ AwsDocTest::MockHTTP::~MockHTTP() {
 
 bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
                                                Aws::Http::HttpResponseCode httpResponseCode) {
+    std::string filePath = std::string(SRC_DIR) + "/" + fileName;
 
-    std::ifstream inStream(std::string(SRC_DIR) + "/" + fileName);
+    std::ifstream inStream(filePath);
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
-        goodResponse->AddHeader("Content-Type", "text/xml");
+        goodResponse->AddHeader("Content-Type", "text/json");
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);
+
         return true;
     }
 
-    std::cerr << "MockHTTP::addResponseWithBody open file error '" << fileName << "'."
+    std::cerr << "MockHTTP::addResponseWithBody open file error '" << filePath << "'."
               << std::endl;
 
     return false;

--- a/cpp/example_code/sns/tests/sns_gtests.cpp
+++ b/cpp/example_code/sns/tests/sns_gtests.cpp
@@ -295,7 +295,7 @@ bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
     if (inStream) {
         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
                 ALLOCATION_TAG, requestTmp);
-        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->AddHeader("Content-Type", "text/xml");
         goodResponse->SetResponseCode(httpResponseCode);
         goodResponse->GetResponseBody() << inStream.rdbuf();
         mockHttpClient->AddResponseToReturn(goodResponse);

--- a/cpp/example_code/sns/tests/sns_gtests.cpp
+++ b/cpp/example_code/sns/tests/sns_gtests.cpp
@@ -37,16 +37,12 @@ namespace AwsDocTest {
             Aws::Utils::DateTime expiration =
                     Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
 
-            goodResponse->GetResponseBody() << R"({
-"RoleArn":"arn:aws:iam::123456789012:role/MockRole",
-"AccessKeyId":"ABCDEFGHIJK",
-"SecretAccessKey":"ABCDEFGHIJK",
-"Token":"ABCDEFGHIJK==",
-"Expiration":")"
-                                            << expiration.ToGmtString(
-                                                    Aws::Utils::DateFormat::ISO_8601)
-                                            << R"("
-    })";
+            goodResponse->GetResponseBody() << "{"
+                                            << R"("RoleArn":"arn:aws:iam::123456789012:role/MockRole",)"
+                                            << R"("AccessKeyId":"ABCDEFGHIJK",)"
+                                            << R"("SecretAccessKey":"ABCDEFGHIJK",)"
+                                            << R"(Token":"ABCDEFGHIJK==","Expiration":")" << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601) << "\""
+                                            << "}";
             this->AddResponseToReturn(goodResponse);
 
             mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);

--- a/cpp/run_automated_tests.py
+++ b/cpp/run_automated_tests.py
@@ -261,9 +261,12 @@ def main(argv):
         passed_count = passed_count + hello_passed_count
         failed_count = failed_count + hello_failed_count
 
-    print("-" * 88)
-    print(f"{passed_count} tests passed.")
-    print(f"{failed_count} tests failed.")
+    if err_code == 0:
+        print("-" * 88)
+        print(f"{passed_count} tests passed.")
+        print(f"{failed_count} tests failed.")
+    else :
+        print("Test failed because of build error.")
 
     print(f"Execution duration - {datetime.datetime.now() - start_time}")
 

--- a/cpp/run_automated_tests.py
+++ b/cpp/run_automated_tests.py
@@ -265,7 +265,7 @@ def main(argv):
         print("-" * 88)
         print(f"{passed_count} tests passed.")
         print(f"{failed_count} tests failed.")
-    else :
+    else:
         print("Test failed because of build error.")
 
     print(f"Execution duration - {datetime.datetime.now() - start_time}")


### PR DESCRIPTION
This fixes the testing mocks to handle credential requests in the Weathertop environment

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
