### PR TITLE
Java SQS: move snippet tags

### DIFF
--- a/.doc_gen/metadata/cloudfront_metadata.yaml
+++ b/.doc_gen/metadata/cloudfront_metadata.yaml
@@ -92,7 +92,7 @@ cloudfront_CreateDistribution:
           sdkguide:
           excerpts:
             - description: >-
-                The following example uses an &S3long; (&S3;) bucket as a content origin. 
+                The following example uses an &S3long; (&S3;) bucket as a content origin.</para>
                 <para>After creating the distribution, 
                 the code creates a <ulink url="https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/cloudfront/waiters/CloudFrontWaiter.html">CloudFrontWaiter</ulink> 
                 to wait until the distribution is deployed before returning the distribution</para>.

--- a/javav2/example_code/sqs/src/main/java/com/example/sqs/SQSExample.java
+++ b/javav2/example_code/sqs/src/main/java/com/example/sqs/SQSExample.java
@@ -67,13 +67,13 @@ public class SQSExample {
             GetQueueUrlResponse getQueueUrlResponse = sqsClient
                     .getQueueUrl(GetQueueUrlRequest.builder().queueName(queueName).build());
             return getQueueUrlResponse.queueUrl();
+            // snippet-end:[sqs.java2.sqs_example.get_queue]
 
         } catch (SqsException e) {
             System.err.println(e.awsErrorDetails().errorMessage());
             System.exit(1);
         }
         return "";
-        // snippet-end:[sqs.java2.sqs_example.get_queue]
     }
 
     public static void listQueues(SqsClient sqsClient) {
@@ -148,8 +148,8 @@ public class SQSExample {
     public static List<Message> receiveMessages(SqsClient sqsClient, String queueUrl) {
 
         System.out.println("\nReceive messages");
+        // snippet-start:[sqs.java2.sqs_example.retrieve_messages]
         try {
-            // snippet-start:[sqs.java2.sqs_example.retrieve_messages]
             ReceiveMessageRequest receiveMessageRequest = ReceiveMessageRequest.builder()
                     .queueUrl(queueUrl)
                     .maxNumberOfMessages(5)
@@ -186,8 +186,8 @@ public class SQSExample {
 
     public static void deleteMessages(SqsClient sqsClient, String queueUrl, List<Message> messages) {
         System.out.println("\nDelete Messages");
-        // snippet-start:[sqs.java2.sqs_example.delete_message]
 
+        // snippet-start:[sqs.java2.sqs_example.delete_message]
         try {
             for (Message message : messages) {
                 DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
@@ -196,12 +196,11 @@ public class SQSExample {
                         .build();
                 sqsClient.deleteMessage(deleteMessageRequest);
             }
-            // snippet-end:[sqs.java2.sqs_example.delete_message]
-
         } catch (SqsException e) {
             System.err.println(e.awsErrorDetails().errorMessage());
             System.exit(1);
         }
+        // snippet-end:[sqs.java2.sqs_example.delete_message]
     }
 }
 // snippet-end:[sqs.java2.sqs_example.main]


### PR DESCRIPTION
Java cloudfront: add missing </para> tag

This pull request moves snippet tags to logically group clauses. This PR also fixes a missing XML para end tag in the Java CloudFront metadata.

(This PR replaces https://github.com/awsdocs/aws-doc-sdk-examples/pull/6112, which was deleted when I re-created my fork).

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
