### PR TITLE
Swift: Add service error handler to example

### DIFF
--- a/swift/example_code/swift-sdk/ErrorHandling/Package.swift
+++ b/swift/example_code/swift-sdk/ErrorHandling/Package.swift
@@ -1,7 +1,6 @@
 // swift-tools-version: 5.5
-//
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0.
+// SPDX-License-Identifier: Apache-2.0
 //
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.

--- a/swift/example_code/swift-sdk/ErrorHandling/Package.swift
+++ b/swift/example_code/swift-sdk/ErrorHandling/Package.swift
@@ -1,11 +1,10 @@
-﻿// swift-tools-version: 5.5
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-// The swift-tools-version declares the minimum version of Swift required to
-// build this package.
+// swift-tools-version: 5.5
 //
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+//
+// The swift-tools-version declares the minimum version of Swift required to
+// build this package.
 
 import PackageDescription
 
@@ -20,7 +19,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.34.0"
+            from: "0.36.0"
         ),
     ],
     targets: [

--- a/swift/example_code/swift-sdk/ErrorHandling/Package.swift
+++ b/swift/example_code/swift-sdk/ErrorHandling/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version: 5.5
 //
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0.
 //
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.

--- a/swift/example_code/swift-sdk/ErrorHandling/Sources/entry.swift
+++ b/swift/example_code/swift-sdk/ErrorHandling/Sources/entry.swift
@@ -6,6 +6,7 @@
 import Foundation
 import AwsCommonRuntimeKit
 import ClientRuntime
+import AWSClientRuntime
 import AWSS3
 
 /// Main entry point.
@@ -24,7 +25,7 @@ struct ErrorHandlingExample {
 
             _ = try await client.listBuckets(input: ListBucketsInput())
             print("Done.")
-        } catch let error as ServiceError {
+        } catch let error as AWSServiceError {
             print("Service error of type \(error.typeName ?? "<unknown>"): \(error.message ?? "<no message>")")
         } catch let error as CommonRunTimeError {
             switch error {

--- a/swift/example_code/swift-sdk/ErrorHandling/Sources/entry.swift
+++ b/swift/example_code/swift-sdk/ErrorHandling/Sources/entry.swift
@@ -23,6 +23,11 @@ struct ErrorHandlingExample {
 
             _ = try await client.listBuckets(input: ListBucketsInput())
             print("Done")
+        } catch let error as ServiceError {
+            print("Service error of type {}: {}",
+                error.typeName ?? "<unknown>",
+                error.message ?? "<no message>"
+            )
         } catch let error as CommonRunTimeError {
             switch error {
                 case .crtError(let error):
@@ -33,8 +38,6 @@ struct ErrorHandlingExample {
                     // SDK, but is here to future-proof this error handler.
                     dump(error, name: "Unknown type of CommonRunTimeError")
             }
-        } catch let error as CRTError {
-            print("CRT Error (code \(error.code)) (\(error.name)): \(error.message)")
         } catch {
             print("Some other error")
         }

--- a/swift/example_code/swift-sdk/ErrorHandling/Sources/entry.swift
+++ b/swift/example_code/swift-sdk/ErrorHandling/Sources/entry.swift
@@ -15,19 +15,17 @@ struct ErrorHandlingExample {
         await SDKLoggingSystem.initialize(logLevel: .error)
 
         print("Calling ListBuckets using a Region name that doesn't exist. This")
-        print("should result in a DNS resolution error.")
+        print("should result in a DNS resolution error in the underlying Common")
+        print("Runtime (CRT).")
 
         // snippet-start:[errors.swift.service-error]
         do {
             let client = try S3Client(region: "un-real-1")
 
             _ = try await client.listBuckets(input: ListBucketsInput())
-            print("Done")
+            print("Done.")
         } catch let error as ServiceError {
-            print("Service error of type {}: {}",
-                error.typeName ?? "<unknown>",
-                error.message ?? "<no message>"
-            )
+            print("Service error of type \(error.typeName ?? "<unknown>"): \(error.message ?? "<no message>")")
         } catch let error as CommonRunTimeError {
             switch error {
                 case .crtError(let error):
@@ -45,7 +43,7 @@ struct ErrorHandlingExample {
 
         print("\n\n")
         print("Calling GetObject with bucket and key names that likely don't")
-        print("exist. If that's the case, this will result in an HTTP error 403")
+        print("exist. If they don't, this will result in an HTTP error 403")
         print("(Forbidden).")
 
         // snippet-start:[errors.swift.http-error]
@@ -58,9 +56,9 @@ struct ErrorHandlingExample {
             ))
             print("Found a matching bucket but shouldn't have!")
         } catch let error as HTTPError {
-            print("HTTP error; status code: \(error.httpResponse.statusCode.rawValue)")
+            print("HTTP error; status code: \(error.httpResponse.statusCode.rawValue).")
         } catch {
-            dump(error)
+            dump(error, name: "Unexpected error")
         }
         // snippet-end:[errors.swift.http-error]
     }

--- a/swift/example_code/swift-sdk/ErrorHandling/Sources/entry.swift
+++ b/swift/example_code/swift-sdk/ErrorHandling/Sources/entry.swift
@@ -9,40 +9,51 @@ import ClientRuntime
 import AWSClientRuntime
 import AWSS3
 
+let body = "This is the body of an Amazon S3 object."
+
 /// Main entry point.
 @main
 struct ErrorHandlingExample {
     static func main() async {
         await SDKLoggingSystem.initialize(logLevel: .error)
 
-        print("Calling ListBuckets using a Region name that doesn't exist. This")
-        print("should result in a DNS resolution error in the underlying Common")
-        print("Runtime (CRT).")
+        let bucketName = "ErrorHandling-Bucket-\(Int.random(in: 1000000..<10000000))"
+        let objectKey = "ErrorHandling-Object-\(Int.random(in: 1000000..<10000000))"
+
+        // SAMPLE 1: Handling a service error.
+
+        print("=== Sample 1: Service errors ===\n")
+        print("Attempting to add an object to an Amazon S3 bucket that doesn't")
+        print("exist. This should result in a ServiceError of type NoSuchError...")
 
         // snippet-start:[errors.swift.service-error]
         do {
-            let client = try S3Client(region: "un-real-1")
+            let client = try S3Client(region: "us-east-1")
 
-            _ = try await client.listBuckets(input: ListBucketsInput())
+            _ = try await client.putObject(input: PutObjectInput(
+                body: ByteStream.data(Data(body.utf8)),
+                bucket: bucketName,
+                key: objectKey
+            ))
             print("Done.")
         } catch let error as AWSServiceError {
-            print("Service error of type \(error.typeName ?? "<unknown>"): \(error.message ?? "<no message>")")
-        } catch let error as CommonRunTimeError {
-            switch error {
-                case .crtError(let error):
-                    print("Common RunTime error: (code \(error.code)) (\(error.name)): \(error.message)")
-                    break
-                default:
-                    // This should never happen in current versions of the
-                    // SDK, but is here to future-proof this error handler.
-                    dump(error, name: "Unknown type of CommonRunTimeError")
+            let errorCode = error.errorCode ?? "<none>"
+            let message = error.message ?? "<no message>"
+
+            switch errorCode {
+            case "NoSuchBucket":
+                print("   | The bucket \"\(bucketName)\" doesn't exist. This is the expected result.")
+                print("   | In a real app, you might ask the user whether to use a different name or")
+                print("   | create the bucket here.")
+            default:
+                print("   | Service error of type \(error.typeName ?? "<unknown>"): \(message)")
             }
         } catch {
-            print("Some other error")
+            print("Some other error occurred.")
         }
         // snippet-end:[errors.swift.service-error]
 
-        print("\n\n")
+        print("\n=== Sample 2: HTTP errors ===\n")
         print("Calling GetObject with bucket and key names that likely don't")
         print("exist. If they don't, this will result in an HTTP error 403")
         print("(Forbidden).")
@@ -55,12 +66,40 @@ struct ErrorHandlingExample {
                 bucket: "not-a-real-bucket",
                 key: "not-a-real-key"
             ))
-            print("Found a matching bucket but shouldn't have!")
+            print("   | Found a matching bucket but shouldn't have!")
         } catch let error as HTTPError {
-            print("HTTP error; status code: \(error.httpResponse.statusCode.rawValue).")
+            print("   | HTTP error; status code: \(error.httpResponse.statusCode.rawValue). This is the")
+            print("   | expected result.")
         } catch {
-            dump(error, name: "Unexpected error")
+            dump(error, name: "   | An unexpected error occurred.")
         }
         // snippet-end:[errors.swift.http-error]
+
+        print("\n=== Sample 3: Common Runtime errors ===\n")
+        print("Calling ListBuckets using a Region name that doesn't exist. This")
+        print("should result in a DNS resolution error in the underlying Common")
+        print("Runtime (CRT)...")
+
+        // snippet-start:[errors.swift.crt-error]
+        do {
+            let client = try S3Client(region: "un-real-1")
+            
+            _ = try await client.listBuckets(input: ListBucketsInput()) 
+            print("Done.")
+        } catch let error as CommonRunTimeError {
+            switch error {
+            case .crtError(let error):
+                print("   | Common RunTime error: (code \(error.code)) (\(error.name)): \(error.message)")
+                print("   | This is the expected result.")
+                break
+            default:
+                // This should never happen in current versions of the
+                // SDK, but is here to future-proof this error handler.
+                dump(error, name: "   | Unknown type of CommonRunTimeError. This is not expected.")
+            }
+        } catch {
+            print("Some other error")
+        }
+        // snippet-end:[errors.swift.crt-error]
     }
 }


### PR DESCRIPTION
Previously, the example was getting used to show handling
service errors without actually doing so. Now it does.

Also removed unneeded block from other part of the
code.

<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
