### PR TITLE
Remove extra /para tag to fix the build.

### DIFF
--- a/.doc_gen/metadata/cloudfront_metadata.yaml
+++ b/.doc_gen/metadata/cloudfront_metadata.yaml
@@ -95,7 +95,7 @@ cloudfront_CreateDistribution:
                 The following example uses an &S3long; (&S3;) bucket as a content origin.</para>
                 <para>After creating the distribution, 
                 the code creates a <ulink url="https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/cloudfront/waiters/CloudFrontWaiter.html">CloudFrontWaiter</ulink> 
-                to wait until the distribution is deployed before returning the distribution</para>.
+                to wait until the distribution is deployed before returning the distribution.
               snippet_tags:
                 - cloudfront.java2.createdistribution.import
                 - cloudfront.java2.createdistribution.main


### PR DESCRIPTION
description is wrapped in `<para></para>` so the extra `</para>` malformed the XML.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
