### PR TITLE
Tools: Remove the meta keyword that includes the title

### DIFF
--- a/.doc_gen/templates/zonbook/utility/service_examples.xml
+++ b/.doc_gen/templates/zonbook/utility/service_examples.xml
@@ -26,7 +26,6 @@
         <keywordset>
             <keyword>code example</keyword>
             <keyword>&AWS; SDK</keyword>
-            <keyword>{{.Title}}</keyword>
         </keywordset>
     </info>
     <xi:include href="{{$include_docs}}{{.ExampleId}}_desc.xml"></xi:include>


### PR DESCRIPTION
Remove the meta keyword that include the title because it prevents the use of additional formatting within titles.
The schema validator in the doc build disallows any additional tags inside keywords, but we must include <code> tags to correctly format API names that are in titles.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
