### PR TITLE
Cpp: Weathertop - fix false negatives

### DIFF
--- a/cpp/example_code/aurora/tests/mock_input/4-DescribeDBClusterParameters.xml
+++ b/cpp/example_code/aurora/tests/mock_input/4-DescribeDBClusterParameters.xml
@@ -3,19 +3,26 @@
         <Marker>aW5ub2RiX2NoZWNrc3Vtcw==</Marker>
         <Parameters>
             <Parameter>
-                <AllowedValues>0,1</AllowedValues>
-                <ApplyType>static</ApplyType>
-                <DataType>boolean</DataType>
-                <Description>Controls whether user-defined functions that have only an xxx symbol for the main function
-                    can be loaded
-                </Description>
+                <AllowedValues>1-65535</AllowedValues>
+                <ApplyType>dynamic</ApplyType>
+                <DataType>integer</DataType>
+                <Description>Description text</Description>
                 <ApplyMethod>pending-reboot</ApplyMethod>
-                <Source>engine-default</Source>
-                <ParameterName>allow-suspicious-udfs</ParameterName>
-                <IsModifiable>false</IsModifiable>
-                <SupportedEngineModes>
-                    <member>provisioned</member>
-                </SupportedEngineModes>
+                <Source>user</Source>
+                <ParameterName>auto_increment_increment</ParameterName>
+                <IsModifiable>true</IsModifiable>
+                <ParameterValue>3</ParameterValue>
+            </Parameter>
+            <Parameter>
+                <AllowedValues>1-65535</AllowedValues>
+                <ApplyType>dynamic</ApplyType>
+                <DataType>integer</DataType>
+                <Description>Description text</Description>
+                <ApplyMethod>pending-reboot</ApplyMethod>
+                <Source>user</Source>
+                <ParameterName>auto_decrement_decrement</ParameterName>
+                <IsModifiable>true</IsModifiable>
+                <ParameterValue>3</ParameterValue>
             </Parameter>
         </Parameters>
     </DescribeDBClusterParametersResult>

--- a/cpp/example_code/aurora/tests/mock_input/5-DescribeDBClusterParameters.xml
+++ b/cpp/example_code/aurora/tests/mock_input/5-DescribeDBClusterParameters.xml
@@ -2,19 +2,26 @@
     <DescribeDBClusterParametersResult>
         <Parameters>
             <Parameter>
-                <AllowedValues>0,1</AllowedValues>
+                <AllowedValues>1-65535</AllowedValues>
                 <ApplyType>dynamic</ApplyType>
-                <DataType>boolean</DataType>
-                <Description>Enables per-index compression-related statistics in the
-                    INFORMATION_SCHEMA.INNODB_CMP_PER_INDEX table.
-                </Description>
+                <DataType>integer</DataType>
+                <Description>Description text</Description>
                 <ApplyMethod>pending-reboot</ApplyMethod>
-                <Source>engine-default</Source>
-                <ParameterName>innodb_cmp_per_index_enabled</ParameterName>
+                <Source>user</Source>
+                <ParameterName>auto_increment_increment</ParameterName>
                 <IsModifiable>true</IsModifiable>
-                <SupportedEngineModes>
-                    <member>provisioned</member>
-                </SupportedEngineModes>
+                <ParameterValue>3</ParameterValue>
+            </Parameter>
+            <Parameter>
+                <AllowedValues>1-65535</AllowedValues>
+                <ApplyType>dynamic</ApplyType>
+                <DataType>integer</DataType>
+                <Description>Description text</Description>
+                <ApplyMethod>pending-reboot</ApplyMethod>
+                <Source>user</Source>
+                <ParameterName>auto_decrement_decrement</ParameterName>
+                <IsModifiable>true</IsModifiable>
+                <ParameterValue>3</ParameterValue>
             </Parameter>
         </Parameters>
     </DescribeDBClusterParametersResult>

--- a/cpp/example_code/aurora/tests/mock_input/9-DescribeDBClusterParameters.xml
+++ b/cpp/example_code/aurora/tests/mock_input/9-DescribeDBClusterParameters.xml
@@ -12,6 +12,17 @@
                 <IsModifiable>true</IsModifiable>
                 <ParameterValue>3</ParameterValue>
             </Parameter>
+            <Parameter>
+                <AllowedValues>1-65535</AllowedValues>
+                <ApplyType>dynamic</ApplyType>
+                <DataType>integer</DataType>
+                <Description>Description text</Description>
+                <ApplyMethod>pending-reboot</ApplyMethod>
+                <Source>user</Source>
+                <ParameterName>auto_decrement_decrement</ParameterName>
+                <IsModifiable>true</IsModifiable>
+                <ParameterValue>3</ParameterValue>
+            </Parameter>
         </Parameters>
     </DescribeDBClusterParametersResult>
 </DescribeDBClusterParametersResponse>

--- a/cpp/example_code/autoscaling/tests/autoscaling_gtests.cpp
+++ b/cpp/example_code/autoscaling/tests/autoscaling_gtests.cpp
@@ -59,7 +59,6 @@ private:
 };
 
 void AwsDocTest::AutoScaling_GTests::SetUpTestSuite() {
-    s_options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
     InitAPI(s_options);
 
     // s_clientConfig must be a pointer because the client config must be initialized

--- a/cpp/example_code/iam/tests/CMakeLists.txt
+++ b/cpp/example_code/iam/tests/CMakeLists.txt
@@ -119,6 +119,7 @@ target_compile_definitions(
         ${CURRENT_TARGET}
         PUBLIC
         TESTING_BUILD
+        SRC_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
 target_link_libraries(

--- a/cpp/example_code/iam/tests/gtest_iam_create_user_assume_role_scenario.cpp
+++ b/cpp/example_code/iam/tests/gtest_iam_create_user_assume_role_scenario.cpp
@@ -15,10 +15,58 @@
 
 
 namespace AwsDocTest {
+    // This test requires a user. It fails when running in an EC2 instance that assumes a role.
+    // Add the 'U' indicating it only runs in a user environment.
     // NOLINTNEXTLINE(readability-named-parameter)
-    TEST_F(IAM_GTests, create_user_assume_role_scenario_2_) {
+    TEST_F(IAM_GTests, create_user_assume_role_scenario_2U_) {
 
         auto result = AwsDoc::IAM::iamCreateUserAssumeRoleScenario(*s_clientConfig);
+        EXPECT_TRUE(result);
+    }
+
+    // NOLINTNEXTLINE(readability-named-parameter)
+    TEST_F(IAM_GTests, create_user_assume_role_scenario_3_) {
+        MockHTTP mockHttp;
+        bool result = mockHttp.addResponseWithBody("mock_input/1-CreateUser.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/2-GetUser.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/3-CreateRole.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/4-CreatePolicy.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/5-AssumeRole.xml", Aws::Http::HttpResponseCode::FORBIDDEN);
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/10-AssumeRole.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/ListBucketsFailed.xml", Aws::Http::HttpResponseCode::FORBIDDEN);
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/11-AttachRolePolicy.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/ListBuckets.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/12-DetachRolePolicy.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/13-DeletePolicy.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/14-DeleteRole.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = mockHttp.addResponseWithBody("mock_input/15-DeleteUser.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = AwsDoc::IAM::iamCreateUserAssumeRoleScenario(*s_clientConfig);
         EXPECT_TRUE(result);
     }
 } // namespace AwsDocTest

--- a/cpp/example_code/iam/tests/iam_gtests.h
+++ b/cpp/example_code/iam/tests/iam_gtests.h
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#ifndef S3_EXAMPLES_S3_GTESTS_H
-#define S3_EXAMPLES_S3_GTESTS_H
+#ifndef IAM_EXAMPLES_IAM_GTESTS_H
+#define IAM_EXAMPLES_IAM_GTESTS_H
 
 #include <aws/core/Aws.h>
 #include <memory>
 #include <gtest/gtest.h>
+#include <aws/testing/mocks/http/MockHttpClient.h>
 
 namespace AwsDocTest {
 
@@ -88,6 +89,23 @@ namespace AwsDocTest {
         static Aws::String s_userName;
         static Aws::String s_policyArn;
     };
+
+    class MockHTTP {
+    public:
+        MockHTTP();
+
+        virtual ~MockHTTP();
+
+        bool addResponseWithBody(const std::string &fileName,
+                                 Aws::Http::HttpResponseCode httpResponseCode = Aws::Http::HttpResponseCode::OK);
+
+    private:
+
+        std::shared_ptr<MockHttpClient> mockHttpClient;
+        std::shared_ptr<MockHttpClientFactory> mockHttpClientFactory;
+        std::shared_ptr<Aws::Http::HttpRequest> requestTmp;
+    }; // MockHTTP
+
 } // AwsDocTest
 
-#endif //S3_EXAMPLES_S3_GTESTS_H
+#endif //IAM_EXAMPLES_IAM_GTESTS_H

--- a/cpp/example_code/iam/tests/mock_input/1-CreateUser.xml
+++ b/cpp/example_code/iam/tests/mock_input/1-CreateUser.xml
@@ -1,0 +1,14 @@
+<CreateUserResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">   <CreateUserResult>
+     <User>
+       <Path>/</Path>
+       <UserName>iam-demo-user</UserName>
+       <Arn>arn:aws:iam::1111111222222:user/iam-demo-user</Arn>
+       <UserId>AIDARZQKN6ARC25I5FZPP</UserId>
+       <CreateDate>2024-03-11T14:18:54Z</CreateDate>
+     </User>
+   </CreateUserResult>
+   <ResponseMetadata>
+     <RequestId>4c7cd91f-dace-4832-b892-cdfdf1f7c861</RequestId>
+   </ResponseMetadata>
+ </CreateUserResponse>
+ 

--- a/cpp/example_code/iam/tests/mock_input/10-AssumeRole.xml
+++ b/cpp/example_code/iam/tests/mock_input/10-AssumeRole.xml
@@ -1,0 +1,17 @@
+<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">   <AssumeRoleResult>
+     <AssumedRoleUser>
+       <AssumedRoleId>AROARZQKN6ARBA3MU7HQ4:iam-demo-role-session-facb92a0-a797-44e1-8430-c79a5b067201</AssumedRoleId>
+       <Arn>arn:aws:sts::1111111222222:assumed-role/iam-demo-role/iam-demo-role-session-facb92a0-a797-44e1-8430-c79a5b067201</Arn>
+     </AssumedRoleUser>
+     <Credentials>
+       <AccessKeyId>AAABBBBBBBBB</AccessKeyId>
+       <SecretAccessKey>AAABBBBBBBBB</SecretAccessKey>
+       <SessionToken>AAABBBBBBBBB+USs</SessionToken>
+       <Expiration>2040-03-11T15:19:02Z</Expiration>
+     </Credentials>
+   </AssumeRoleResult>
+   <ResponseMetadata>
+     <RequestId>d52b113b-597f-41e6-99d6-ed6e53a915bf</RequestId>
+   </ResponseMetadata>
+ </AssumeRoleResponse>
+ 

--- a/cpp/example_code/iam/tests/mock_input/11-AttachRolePolicy.xml
+++ b/cpp/example_code/iam/tests/mock_input/11-AttachRolePolicy.xml
@@ -1,0 +1,5 @@
+<AttachRolePolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">   <ResponseMetadata>
+     <RequestId>0c6e3333-33ae-4269-8338-979a8bd0346d</RequestId>
+   </ResponseMetadata>
+ </AttachRolePolicyResponse>
+ 

--- a/cpp/example_code/iam/tests/mock_input/12-DetachRolePolicy.xml
+++ b/cpp/example_code/iam/tests/mock_input/12-DetachRolePolicy.xml
@@ -1,0 +1,5 @@
+<DetachRolePolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">   <ResponseMetadata>
+     <RequestId>61891e46-50ca-48d0-8b50-0d958d863fb4</RequestId>
+   </ResponseMetadata>
+ </DetachRolePolicyResponse>
+ 

--- a/cpp/example_code/iam/tests/mock_input/13-DeletePolicy.xml
+++ b/cpp/example_code/iam/tests/mock_input/13-DeletePolicy.xml
@@ -1,0 +1,5 @@
+<DeletePolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">   <ResponseMetadata>
+     <RequestId>37c90b6c-06de-4a4d-9b1c-f5cdc19e6ef1</RequestId>
+   </ResponseMetadata>
+ </DeletePolicyResponse>
+ 

--- a/cpp/example_code/iam/tests/mock_input/14-DeleteRole.xml
+++ b/cpp/example_code/iam/tests/mock_input/14-DeleteRole.xml
@@ -1,0 +1,5 @@
+<DeleteRoleResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">   <ResponseMetadata>
+     <RequestId>0843a35e-a598-44a1-9eb1-f1adda10b162</RequestId>
+   </ResponseMetadata>
+ </DeleteRoleResponse>
+ 

--- a/cpp/example_code/iam/tests/mock_input/15-DeleteUser.xml
+++ b/cpp/example_code/iam/tests/mock_input/15-DeleteUser.xml
@@ -1,0 +1,5 @@
+<DeleteUserResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">   <ResponseMetadata>
+     <RequestId>545004dc-b93c-4174-8b7e-8abd11577996</RequestId>
+   </ResponseMetadata>
+ </DeleteUserResponse>
+ 

--- a/cpp/example_code/iam/tests/mock_input/2-GetUser.xml
+++ b/cpp/example_code/iam/tests/mock_input/2-GetUser.xml
@@ -1,0 +1,15 @@
+<GetUserResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">   <GetUserResult>
+     <User>
+       <Path>/</Path>
+       <PasswordLastUsed>2023-04-10T19:34:28Z</PasswordLastUsed>
+       <UserName>UnitTester</UserName>
+       <Arn>arn:aws:iam::1111111222222:user/UnitTester</Arn>
+       <UserId>AIDARZQKN6ARLXIC6YK7J</UserId>
+       <CreateDate>2022-08-10T13:38:30Z</CreateDate>
+     </User>
+   </GetUserResult>
+   <ResponseMetadata>
+     <RequestId>12edbe2c-76a6-416d-9470-4010556b1c59</RequestId>
+   </ResponseMetadata>
+ </GetUserResponse>
+ 

--- a/cpp/example_code/iam/tests/mock_input/3-CreateRole.xml
+++ b/cpp/example_code/iam/tests/mock_input/3-CreateRole.xml
@@ -1,0 +1,15 @@
+<CreateRoleResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">   <CreateRoleResult>
+     <Role>
+       <Path>/</Path>
+       <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22</AssumeRolePolicyDocument>
+       <RoleId>AROARZQKN6ARBA3MU7HQ4</RoleId>
+       <RoleName>iam-demo-role</RoleName>
+       <Arn>arn:aws:iam::1111111222222:role/iam-demo-role</Arn>
+       <CreateDate>2024-03-11T14:18:55Z</CreateDate>
+     </Role>
+   </CreateRoleResult>
+   <ResponseMetadata>
+     <RequestId>2ebda984-7277-4aac-87bb-7f64853faaeb</RequestId>
+   </ResponseMetadata>
+ </CreateRoleResponse>
+ 

--- a/cpp/example_code/iam/tests/mock_input/4-CreatePolicy.xml
+++ b/cpp/example_code/iam/tests/mock_input/4-CreatePolicy.xml
@@ -1,0 +1,19 @@
+<CreatePolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">   <CreatePolicyResult>
+     <Policy>
+       <PermissionsBoundaryUsageCount>0</PermissionsBoundaryUsageCount>
+       <Path>/</Path>
+       <UpdateDate>2024-03-11T14:18:55Z</UpdateDate>
+       <DefaultVersionId>v1</DefaultVersionId>
+       <PolicyId>ANPARZQKN6ARLSIG5ZFTU</PolicyId>
+       <IsAttachable>true</IsAttachable>
+       <PolicyName>iam-demo-policy</PolicyName>
+       <AttachmentCount>0</AttachmentCount>
+       <Arn>arn:aws:iam::1111111222222:policy/iam-demo-policy</Arn>
+       <CreateDate>2024-03-11T14:18:55Z</CreateDate>
+     </Policy>
+   </CreatePolicyResult>
+   <ResponseMetadata>
+     <RequestId>20aa0584-03a3-4578-8729-a59e32d52160</RequestId>
+   </ResponseMetadata>
+ </CreatePolicyResponse>
+ 

--- a/cpp/example_code/iam/tests/mock_input/5-AssumeRole.xml
+++ b/cpp/example_code/iam/tests/mock_input/5-AssumeRole.xml
@@ -1,0 +1,8 @@
+<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">   <Error>
+     <Type>Sender</Type>
+     <Code>AccessDenied</Code>
+     <Message>User: arn:aws:iam::1111111222222:user/UnitTester is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::1111111222222:role/iam-demo-role</Message>
+   </Error>
+   <RequestId>ba519513-71e5-4f0c-8aa9-1edd264cd084</RequestId>
+ </ErrorResponse>
+ 

--- a/cpp/example_code/iam/tests/mock_input/ListBuckets.xml
+++ b/cpp/example_code/iam/tests/mock_input/ListBuckets.xml
@@ -1,0 +1,16 @@
+<ListAllMyBucketsResult>
+    <Buckets>
+        <Bucket>
+            <CreationDate>2019-12-11T23:32:47+00:00</CreationDate>
+            <String>DOC-EXAMPLE-BUCKET</String>
+        </Bucket>
+        <Bucket>
+            <CreationDate>2019-11-10T23:32:13+00:00</CreationDate>
+            <String>DOC-EXAMPLE-BUCKET2</String>
+        </Bucket>
+    </Buckets>
+    <Owner>
+        <DisplayName>Account+Name</DisplayName>
+        <ID>AIDACKCEVSQ6C2EXAMPLE</ID>
+    </Owner>
+</ListAllMyBucketsResult>

--- a/cpp/example_code/iam/tests/mock_input/ListBucketsFailed.xml
+++ b/cpp/example_code/iam/tests/mock_input/ListBucketsFailed.xml
@@ -1,0 +1,1 @@
+<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>87ZC5R1YAC541JGB</RequestId><HostId>W3lf80Mi3D0OoIsiP1zwu39CHW7gjm785cs9Gu2uVicrGGo/BWJaXanLT6Kil/sle0Tk7mHUVzY=</HostId>

--- a/cpp/example_code/iot/describe_thing.cpp
+++ b/cpp/example_code/iot/describe_thing.cpp
@@ -72,7 +72,6 @@ int main(int argc, char **argv) {
         return 1;
     }
     Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
 
     Aws::InitAPI(options);
     {

--- a/cpp/example_code/iot/list_topic_rules.cpp
+++ b/cpp/example_code/iot/list_topic_rules.cpp
@@ -78,7 +78,6 @@ bool AwsDoc::IoT::listTopicRules(
 
 int main(int argc, char **argv) {
     Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
 
     Aws::InitAPI(options);
     {

--- a/cpp/example_code/mediaconvert/get_job.cpp
+++ b/cpp/example_code/mediaconvert/get_job.cpp
@@ -66,7 +66,7 @@ Where:
 )";
     }
     Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
+
     Aws::InitAPI(options);
     {
         Aws::String jobID = argv[1];

--- a/cpp/example_code/medical-imaging/get_image_frame.cpp
+++ b/cpp/example_code/medical-imaging/get_image_frame.cpp
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
         return 1;
     }
     Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
+
     Aws::InitAPI(options);
     {
         Aws::String dataStoreID = argv[1];

--- a/cpp/example_code/medical-imaging/get_image_set_metadata.cpp
+++ b/cpp/example_code/medical-imaging/get_image_set_metadata.cpp
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
         return 1;
     }
     Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
+
     Aws::InitAPI(options);
     {
         Aws::String dataStoreID = argv[1];

--- a/cpp/example_code/s3/list_buckets.cpp
+++ b/cpp/example_code/s3/list_buckets.cpp
@@ -61,7 +61,6 @@ int main() {
     //An instance of Aws::SDKOptions is passed to the Aws::InitAPI and 
     //Aws::ShutdownAPI methods. The same instance should be sent to both methods.
     Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
 
     //The AWS SDK for C++ must be initialized by calling Aws::InitAPI.
     InitAPI(options);

--- a/cpp/example_code/s3/tests/CMakeLists.txt
+++ b/cpp/example_code/s3/tests/CMakeLists.txt
@@ -122,6 +122,7 @@ target_compile_definitions(
         ${CURRENT_TARGET}
         PUBLIC
         TESTING_BUILD
+        SRC_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
 target_link_libraries(

--- a/cpp/example_code/s3/tests/S3_GTests.cpp
+++ b/cpp/example_code/s3/tests/S3_GTests.cpp
@@ -20,6 +20,54 @@ std::vector<Aws::String> AwsDocTest::S3_GTests::s_cachedS3Buckets;
 Aws::String AwsDocTest::S3_GTests::s_testFilePath;
 Aws::String AwsDocTest::S3_GTests::s_canonicalUserID;
 Aws::String AwsDocTest::S3_GTests::s_userArn;
+static const char ALLOCATION_TAG[] = "S3_GTEST";
+
+/*
+ * Subclass MockHTTPCLient to respond to credential requests.
+ * Otherwise, the stored responses are returned for credential requests
+ * and not the service API calls.
+ */
+class CustomMockHTTPClient : public MockHttpClient {
+public:
+    explicit CustomMockHTTPClient(
+            const std::shared_ptr<Aws::Http::HttpRequest> &requestTmp) {
+        std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                ALLOCATION_TAG, requestTmp);
+        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->SetResponseCode(Aws::Http::HttpResponseCode::OK);
+        Aws::Utils::DateTime expiration =
+                Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
+
+        goodResponse->GetResponseBody() << "{"
+                                        << R"("RoleArn":"arn:aws:iam::123456789012:role/MockRole",)"
+                                        << R"("AccessKeyId":"ABCDEFGHIJK",)"
+                                        << R"("SecretAccessKey":"ABCDEFGHIJK",)"
+                                        << R"(Token":"ABCDEFGHIJK==","Expiration":")" << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601) << "\""
+                                        << "}";
+        this->AddResponseToReturn(goodResponse);
+
+        mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);
+    }
+
+    std::shared_ptr<Aws::Http::HttpResponse>
+    MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
+                Aws::Utils::RateLimits::RateLimiterInterface *readLimiter,
+                Aws::Utils::RateLimits::RateLimiterInterface *writeLimiter) const override {
+
+        // Do not use stored responses for a credentials request.
+        if (request->GetURIString().find("/credentials/") != std::string::npos) {
+            std::cout << "CustomMockHTTPClient returning credentials request."
+                      << std::endl;
+            return mCredentialsResponse;
+        }
+        else {
+            return MockHttpClient::MakeRequest(request, readLimiter, writeLimiter);;
+        }
+    }
+
+private:
+    std::shared_ptr<Aws::Http::HttpResponse> mCredentialsResponse;
+};
 
 void AwsDocTest::S3_GTests::SetUpTestSuite() {
     InitAPI(s_options);
@@ -345,8 +393,51 @@ void AwsDocTest::S3_GTests::TearDown() {
     }
 }
 
+
+Aws::String AwsDocTest::S3_GTests::preconditionError() {
+    return "Failed to meet precondition.";
+}
+
 bool AwsDocTest::S3_GTests::suppressStdOut() {
     return std::getenv("EXAMPLE_TESTS_LOG_ON") == nullptr;
+}
+
+AwsDocTest::MockHTTP::MockHTTP() {
+    requestTmp = CreateHttpRequest(Aws::Http::URI("https://test.com/"),
+                                   Aws::Http::HttpMethod::HTTP_GET,
+                                   Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    mockHttpClient = Aws::MakeShared<CustomMockHTTPClient>(
+            ALLOCATION_TAG, requestTmp);
+    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
+    mockHttpClientFactory->SetClient(mockHttpClient);
+    SetHttpClientFactory(mockHttpClientFactory);
+}
+
+AwsDocTest::MockHTTP::~MockHTTP() {
+    Aws::Http::CleanupHttp();
+    Aws::Http::InitHttp();
+}
+
+bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
+                                               Aws::Http::HttpResponseCode httpResponseCode) {
+    std::string filePath = std::string(SRC_DIR) + "/" + fileName;
+
+    std::ifstream inStream(filePath);
+    if (inStream) {
+        std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                ALLOCATION_TAG, requestTmp);
+        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->SetResponseCode(httpResponseCode);
+        goodResponse->GetResponseBody() << inStream.rdbuf();
+        mockHttpClient->AddResponseToReturn(goodResponse);
+
+        return true;
+    }
+
+    std::cerr << "MockHTTP::addResponseWithBody open file error '" << filePath << "'."
+              << std::endl;
+
+    return false;
 }
 
 

--- a/cpp/example_code/s3/tests/S3_GTests.h
+++ b/cpp/example_code/s3/tests/S3_GTests.h
@@ -9,6 +9,7 @@
 #include <aws/s3/S3Client.h>
 #include <memory>
 #include <gtest/gtest.h>
+#include <aws/testing/mocks/http/MockHttpClient.h>
 
 namespace AwsDocTest {
 
@@ -49,6 +50,8 @@ namespace AwsDocTest {
 
         static Aws::String GetCanonicalUserID();
 
+        static Aws::String preconditionError();
+
         // s_clientConfig must be a pointer because the client config must be initialized after InitAPI.
         static std::unique_ptr<Aws::Client::ClientConfiguration> s_clientConfig;
 
@@ -67,6 +70,22 @@ namespace AwsDocTest {
         std::stringbuf m_coutBuffer;  // used just to silence cout.
         std::streambuf *m_savedBuffer = nullptr;
     };
+
+    class MockHTTP {
+    public:
+        MockHTTP();
+
+        virtual ~MockHTTP();
+
+        bool addResponseWithBody(const std::string &fileName,
+                                 Aws::Http::HttpResponseCode httpResponseCode = Aws::Http::HttpResponseCode::OK);
+
+    private:
+
+        std::shared_ptr<MockHttpClient> mockHttpClient;
+        std::shared_ptr<MockHttpClientFactory> mockHttpClientFactory;
+        std::shared_ptr<Aws::Http::HttpRequest> requestTmp;
+    }; // MockHTTP
 } // AwsDocTest
 
 #endif //S3_EXAMPLES_S3_GTESTS_H

--- a/cpp/example_code/s3/tests/gtest_delete_bucket_policy.cpp
+++ b/cpp/example_code/s3/tests/gtest_delete_bucket_policy.cpp
@@ -18,16 +18,31 @@
 static const int BUCKETS_NEEDED = 1;
 
 namespace AwsDocTest {
+    // This test requires a user. It fails when running in an EC2 instance that assumes a role.
+    // Add the 'U' indicating it only runs in a user environment.
 // NOLINTNEXTLINE(readability-named-parameter)
-    TEST_F(S3_GTests, delete_bucket_policy_2_) {
+    TEST_F(S3_GTests, delete_bucket_policy_2U_) {
         std::vector<Aws::String> bucketNames = GetCachedS3Buckets(BUCKETS_NEEDED);
         ASSERT_GE(bucketNames.size(), BUCKETS_NEEDED)
-                                    << "Unable to create bucket as precondition for test" << std::endl;
+                                    << "Unable to create bucket as precondition for test"
+                                    << std::endl;
 
         bool result = AddPolicyToBucket(bucketNames[0]);
-        ASSERT_TRUE(result) << "Unable to add policy to bucket as precondition for test" << std::endl;
+        ASSERT_TRUE(result) << "Unable to add policy to bucket as precondition for test"
+                            << std::endl;
 
         result = AwsDoc::S3::DeleteBucketPolicy(bucketNames[0], *s_clientConfig);
         ASSERT_TRUE(result);
     }
+
+// NOLINTNEXTLINE(readability-named-parameter)
+    TEST_F(S3_GTests, delete_bucket_policy_3_) {
+        MockHTTP mockHttp;
+        bool result = mockHttp.addResponseWithBody("mock_input/DeleteBucketPolicy.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = AwsDoc::S3::DeleteBucketPolicy("test_bucket", *s_clientConfig);
+        ASSERT_TRUE(result);
+    }
+
 } // namespace AwsDocTest

--- a/cpp/example_code/s3/tests/gtest_get_bucket_policy.cpp
+++ b/cpp/example_code/s3/tests/gtest_get_bucket_policy.cpp
@@ -17,8 +17,10 @@
 static const int BUCKETS_NEEDED = 1;
 
 namespace AwsDocTest {
+    // This test requires a user. It fails when running in an EC2 instance that assumes a role.
+    // Add the 'U' indicating it only runs in a user environment.
 // NOLINTNEXTLINE(readability-named-parameter)
-    TEST_F(S3_GTests, get_bucket_policy_2_) {
+    TEST_F(S3_GTests, get_bucket_policy_2U_) {
         std::vector<Aws::String> bucketNames = GetCachedS3Buckets(BUCKETS_NEEDED);
         ASSERT_GE(bucketNames.size(), BUCKETS_NEEDED)
                                     << "Unable to create bucket as precondition for test" << std::endl;
@@ -27,6 +29,16 @@ namespace AwsDocTest {
         ASSERT_TRUE(result) << "Unable to add policy to bucket as precondition for test" << std::endl;
 
         result = AwsDoc::S3::GetBucketPolicy(bucketNames[0], *s_clientConfig);
+        ASSERT_TRUE(result);
+    }
+
+    // NOLINTNEXTLINE(readability-named-parameter)
+      TEST_F(S3_GTests, get_bucket_policy_3_) {
+        MockHTTP mockHttp;
+        bool result = mockHttp.addResponseWithBody("mock_input/GetBucketPolicy.json");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        result = AwsDoc::S3::GetBucketPolicy("test_bucket", *s_clientConfig);
         ASSERT_TRUE(result);
     }
 } // namespace AwsDocTest

--- a/cpp/example_code/s3/tests/gtest_put_bucket_policy.cpp
+++ b/cpp/example_code/s3/tests/gtest_put_bucket_policy.cpp
@@ -17,8 +17,10 @@
 static const int BUCKETS_NEEDED = 1;
 
 namespace AwsDocTest {
+    // This test requires a user. It fails when running in an EC2 instance that assumes a role.
+    // Add the 'U' indicating it only runs in a user environment.
 // NOLINTNEXTLINE(readability-named-parameter)
-    TEST_F(S3_GTests, put_bucket_policy_2_) {
+    TEST_F(S3_GTests, put_bucket_policy_2U_) {
         std::vector<Aws::String> bucketNames = GetCachedS3Buckets(BUCKETS_NEEDED);
         ASSERT_GE(bucketNames.size(), BUCKETS_NEEDED)
                                     << "Unable to create bucket as precondition for test" << std::endl;
@@ -27,6 +29,30 @@ namespace AwsDocTest {
         ASSERT_TRUE(!policyString.empty()) << "Unable to add policy to bucket as precondition for test" << std::endl;
 
         bool result = AwsDoc::S3::PutBucketPolicy(bucketNames[0], policyString, *s_clientConfig);
+        ASSERT_TRUE(result);
+    }
+
+// NOLINTNEXTLINE(readability-named-parameter)
+    TEST_F(S3_GTests, put_bucket_policy_3_) {
+        MockHTTP mockHttp;
+        bool result = mockHttp.addResponseWithBody("mock_input/DeleteBucketPolicy.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+        Aws::String policyString = R"({
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "1",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::111111222222:user/UnitTester"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::doc-example-bucket/*"
+    }
+  ]
+})";
+
+        result = AwsDoc::S3::PutBucketPolicy("doc-example-bucket", policyString, *s_clientConfig);
         ASSERT_TRUE(result);
     }
 } // namespace AwsDocTest

--- a/cpp/example_code/s3/tests/mock_input/DeleteBucketPolicy.xml
+++ b/cpp/example_code/s3/tests/mock_input/DeleteBucketPolicy.xml
@@ -1,0 +1,4 @@
+<DeleteBucketPolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">   <ResponseMetadata>
+<RequestId>37c90b6c-06de-4a4d-9b1c-f5cdc19e6ef1</RequestId>
+</ResponseMetadata>
+</DeleteBucketPolicyResponse>

--- a/cpp/example_code/s3/tests/mock_input/GetBucketPolicy.json
+++ b/cpp/example_code/s3/tests/mock_input/GetBucketPolicy.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "1",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::111111222222:user/UnitTester"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::doc-example-bucket/*"
+    }
+  ]
+}

--- a/cpp/example_code/s3/tests/mock_input/PutBucketPolicy.xml
+++ b/cpp/example_code/s3/tests/mock_input/PutBucketPolicy.xml
@@ -1,0 +1,4 @@
+<PutBucketPolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">   <ResponseMetadata>
+    <RequestId>37c90b6c-06de-4a4d-9b1c-f5cdc19e6ef1</RequestId>
+</ResponseMetadata>
+</PutBucketPolicyResponse>

--- a/cpp/example_code/ses/verify_email_identity.cpp
+++ b/cpp/example_code/ses/verify_email_identity.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
     return 1;
   }
   Aws::SDKOptions options;
-  options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
+
   Aws::InitAPI(options);
   {
     Aws::String emailAddress(argv[1]);

--- a/cpp/example_code/sns/subscribe_lambda.cpp
+++ b/cpp/example_code/sns/subscribe_lambda.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
     }
 
     Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
+
     Aws::InitAPI(options);
     {
         Aws::String topicARN = argv[1];

--- a/cpp/example_code/sts/tests/CMakeLists.txt
+++ b/cpp/example_code/sts/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ target_compile_definitions(
         ${CURRENT_TARGET}
         PUBLIC
         TESTING_BUILD
+        SRC_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
 target_link_libraries(

--- a/cpp/example_code/sts/tests/gtest_assume_role.cpp
+++ b/cpp/example_code/sts/tests/gtest_assume_role.cpp
@@ -16,8 +16,10 @@
 #include "sts_gtests.h"
 
 namespace AwsDocTest {
+    // This test requires a user. It fails when running in an EC2 instance that assumes a role.
+    // Add the 'U' indicating it only runs in a user environment.
     // NOLINTNEXTLINE(readability-named-parameter)
-    TEST_F(STS_GTests, assume_role_2_) {
+    TEST_F(STS_GTests, assume_role_2U_) {
         Aws::String roleArn = getRoleArn();
         ASSERT_FALSE(roleArn.empty()) << preconditionError() << std::endl;
 
@@ -31,12 +33,31 @@ namespace AwsDocTest {
         for (int i = 0; i < 20; ++i) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
             if (AwsDoc::STS::assumeRole(roleArn, roleSessionName, externalId,
-                                                  credentials, *s_clientConfig))
+                                        credentials, *s_clientConfig))
             {
                 result = true;
                 break;
             }
         }
         ASSERT_TRUE(result);
-}
+    }
+
+    // NOLINTNEXTLINE(readability-named-parameter)
+    TEST_F(STS_GTests, assume_role_3_) {
+        MockHTTP mockHttp;
+        bool result = mockHttp.addResponseWithBody("mock_input/AssumeRole.xml");
+        ASSERT_TRUE(result) << preconditionError() << std::endl;
+
+        Aws::String roleSessionName = uuidName("role-session");
+        roleSessionName.resize(std::min(static_cast<size_t>(62), roleSessionName.length()));
+        Aws::String externalId = "012345";	// Optional, but recommended
+
+        Aws::String roleArn = "arn:aws:sts::1111112222222:assumed-role/doc-example-tests-role/doc-example-tests-role-session";
+
+        Aws::Auth::AWSCredentials credentials;
+
+        result = AwsDoc::STS::assumeRole(roleArn, roleSessionName, externalId,
+                                              credentials, *s_clientConfig);
+        ASSERT_TRUE(result);
+    }
 } // namespace AwsDocTest

--- a/cpp/example_code/sts/tests/mock_input/AssumeRole.xml
+++ b/cpp/example_code/sts/tests/mock_input/AssumeRole.xml
@@ -1,0 +1,17 @@
+<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+    <AssumeRoleResult>
+        <AssumedRoleUser>
+            <AssumedRoleId>AAAAAAAAAAA:doc-example-tests-role-session-</AssumedRoleId>
+            <Arn>arn:aws:sts::1111112222222:assumed-role/doc-example-tests-role/doc-example-tests-role-session</Arn>
+        </AssumedRoleUser>
+        <Credentials>
+            <AccessKeyId>AAAAAAAAA</AccessKeyId>
+            <SecretAccessKey>BBBBBBBBB/QF</SecretAccessKey>
+            <SessionToken>IQ/CCCCCCCCCC/tQ==</SessionToken>
+            <Expiration>2040-03-11T20:26:49Z</Expiration>
+        </Credentials>
+    </AssumeRoleResult>
+    <ResponseMetadata>
+        <RequestId>8112f069-93fd-45ae-b9ae-4c9411539635</RequestId>
+    </ResponseMetadata>
+</AssumeRoleResponse>

--- a/cpp/example_code/sts/tests/sts_gtests.cpp
+++ b/cpp/example_code/sts/tests/sts_gtests.cpp
@@ -13,6 +13,55 @@ Aws::SDKOptions AwsDocTest::STS_GTests::s_options;
 std::unique_ptr<Aws::Client::ClientConfiguration> AwsDocTest::STS_GTests::s_clientConfig;
 Aws::IAM::Model::Role AwsDocTest::STS_GTests::s_role;
 Aws::String AwsDocTest::STS_GTests::s_userArn;
+static const char ALLOCATION_TAG[] = "IAM_GTEST";
+
+/*
+ * Subclass MockHTTPCLient to respond to credential requests.
+ * Otherwise, the stored responses are returned for credential requests
+ * and not the service API calls.
+ */
+class CustomMockHTTPClient : public MockHttpClient {
+public:
+    explicit CustomMockHTTPClient(
+            const std::shared_ptr<Aws::Http::HttpRequest> &requestTmp) {
+        std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                ALLOCATION_TAG, requestTmp);
+        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->SetResponseCode(Aws::Http::HttpResponseCode::OK);
+        Aws::Utils::DateTime expiration =
+                Aws::Utils::DateTime::Now() + std::chrono::milliseconds(60000);
+
+        goodResponse->GetResponseBody() << "{"
+                                        << R"("RoleArn":"arn:aws:iam::123456789012:role/MockRole",)"
+                                        << R"("AccessKeyId":"ABCDEFGHIJK",)"
+                                        << R"("SecretAccessKey":"ABCDEFGHIJK",)"
+                                        << R"(Token":"ABCDEFGHIJK==","Expiration":")" << expiration.ToGmtString(Aws::Utils::DateFormat::ISO_8601) << "\""
+                                        << "}";
+        this->AddResponseToReturn(goodResponse);
+
+        mCredentialsResponse = MockHttpClient::MakeRequest(requestTmp);
+    }
+
+    std::shared_ptr<Aws::Http::HttpResponse>
+    MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest> &request,
+                Aws::Utils::RateLimits::RateLimiterInterface *readLimiter,
+                Aws::Utils::RateLimits::RateLimiterInterface *writeLimiter) const override {
+
+        // Do not use stored responses for a credentials request.
+        if (request->GetURIString().find("/credentials/") != std::string::npos) {
+            std::cout << "CustomMockHTTPClient returning credentials request."
+                      << std::endl;
+            return mCredentialsResponse;
+        }
+        else {
+            return MockHttpClient::MakeRequest(request, readLimiter, writeLimiter);;
+        }
+    }
+
+private:
+    std::shared_ptr<Aws::Http::HttpResponse> mCredentialsResponse;
+};
+
 
 void AwsDocTest::STS_GTests::SetUpTestSuite() {
     InitAPI(s_options);
@@ -138,6 +187,43 @@ Aws::String AwsDocTest::STS_GTests::preconditionError() {
 
 bool AwsDocTest::STS_GTests::suppressStdOut() {
     return std::getenv("EXAMPLE_TESTS_LOG_ON") == nullptr;
+}
+AwsDocTest::MockHTTP::MockHTTP() {
+    requestTmp = CreateHttpRequest(Aws::Http::URI("https://test.com/"),
+                                   Aws::Http::HttpMethod::HTTP_GET,
+                                   Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    mockHttpClient = Aws::MakeShared<CustomMockHTTPClient>(
+            ALLOCATION_TAG, requestTmp);
+    mockHttpClientFactory = Aws::MakeShared<MockHttpClientFactory>(ALLOCATION_TAG);
+    mockHttpClientFactory->SetClient(mockHttpClient);
+    SetHttpClientFactory(mockHttpClientFactory);
+}
+
+AwsDocTest::MockHTTP::~MockHTTP() {
+    Aws::Http::CleanupHttp();
+    Aws::Http::InitHttp();
+}
+
+bool AwsDocTest::MockHTTP::addResponseWithBody(const std::string &fileName,
+                                               Aws::Http::HttpResponseCode httpResponseCode) {
+    std::string filePath = std::string(SRC_DIR) + "/" + fileName;
+
+    std::ifstream inStream(filePath);
+    if (inStream) {
+        std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> goodResponse = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(
+                ALLOCATION_TAG, requestTmp);
+        goodResponse->AddHeader("Content-Type", "text/json");
+        goodResponse->SetResponseCode(httpResponseCode);
+        goodResponse->GetResponseBody() << inStream.rdbuf();
+        mockHttpClient->AddResponseToReturn(goodResponse);
+
+        return true;
+    }
+
+    std::cerr << "MockHTTP::addResponseWithBody open file error '" << filePath << "'."
+              << std::endl;
+
+    return false;
 }
 
 

--- a/cpp/example_code/sts/tests/sts_gtests.h
+++ b/cpp/example_code/sts/tests/sts_gtests.h
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#ifndef S3_EXAMPLES_S3_GTESTS_H
-#define S3_EXAMPLES_S3_GTESTS_H
+#ifndef STS_EXAMPLES_STS_GTESTS_H
+#define STS_EXAMPLES_STS_GTESTS_H
 
 #include <aws/core/Aws.h>
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/iam/model/Role.h>
 #include <memory>
 #include <gtest/gtest.h>
+#include <aws/testing/mocks/http/MockHttpClient.h>
 
 namespace AwsDocTest {
 
@@ -54,6 +55,24 @@ namespace AwsDocTest {
         static Aws::IAM::Model::Role s_role;
         static Aws::String s_userArn;
     };
+
+
+    class MockHTTP {
+    public:
+        MockHTTP();
+
+        virtual ~MockHTTP();
+
+        bool addResponseWithBody(const std::string &fileName,
+                                 Aws::Http::HttpResponseCode httpResponseCode = Aws::Http::HttpResponseCode::OK);
+
+    private:
+
+        std::shared_ptr<MockHttpClient> mockHttpClient;
+        std::shared_ptr<MockHttpClientFactory> mockHttpClientFactory;
+        std::shared_ptr<Aws::Http::HttpRequest> requestTmp;
+    }; // MockHTTP
+
 } // AwsDocTest
 
-#endif //S3_EXAMPLES_S3_GTESTS_H
+#endif //STS_EXAMPLES_STS_GTESTS_H

--- a/cpp/example_code/transcribe/get_transcript.cpp
+++ b/cpp/example_code/transcribe/get_transcript.cpp
@@ -28,7 +28,7 @@ static const int BUFFER_SIZE = CHUNK_LENGTH * SAMPLE_RATE / 1000 * 2;
 // snippet-start:[transcribe.cpp.stream_transcription_async.code]
 int main() {
     Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
+
     Aws::InitAPI(options);
     {
         //TODO(User): Set to the region of your AWS account.

--- a/cpp/example_code/transfer-manager/transferOnStream.cpp
+++ b/cpp/example_code/transfer-manager/transferOnStream.cpp
@@ -67,7 +67,6 @@ int main(int argc, char** argv)
     LOCAL_FILE_COPY += "_copy";
 
     Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace; //Turn on logging.
 
     Aws::InitAPI(options);
     {


### PR DESCRIPTION
The implementation for retrieving the current use account ID fails in Weathertop.
Replace all failing code with mocks.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
