### PR TITLE
Update zip_next to 0.11.0

### DIFF
--- a/rustv1/cross_service/photo_asset_management/Cargo.toml
+++ b/rustv1/cross_service/photo_asset_management/Cargo.toml
@@ -42,4 +42,4 @@ tokio-stream = "0.1.12"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 uuid = { version = "1.3.1", features = ["v4"] }
-zip_next = { version = "0.10.2", default-features=false, features = ["chrono", "deflate"] }
+zip_next = { version = "0.11.0", default-features=false, features = ["chrono", "deflate"] }


### PR DESCRIPTION
This pull request updates `zip_next` to `0.11.0`. This version provides fixes for several bugs that were found by overhauling the fuzz tests. The interface to read archives and decompress unencrypted files remains the same.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
