### PR TITLE
JavaScript (v3): Increase test timeout for SQS integ tests.

### DIFF
--- a/javascriptv3/example_code/sqs/vite.config.ts
+++ b/javascriptv3/example_code/sqs/vite.config.ts
@@ -5,6 +5,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    testTimeout: 240000,
+    testTimeout: 900000,
   },
 });


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request increases the timeout for SQS integration tests in the hope that it will allow the test enough time to finish in weathertop.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
