### PR TITLE
Fixed kotlin ref link in metadata

### DIFF
--- a/.doc_gen/metadata/sdks.yaml
+++ b/.doc_gen/metadata/sdks.yaml
@@ -191,7 +191,7 @@ Kotlin:
       api_ref:
         uid: "SdkForKotlinV1"
         name: "&guide-kotlin-api;"
-        link_template: "https://github.com/awslabs/aws-sdk-kotlin#generating-api-documentation"
+        link_template: "https://sdk.amazonaws.com/kotlin/api/latest/index.html"
   guide: "&guide-kotlin-dev;"
 .NET:
   property: csharp


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request fixes the invalid link to the Kotlin API reference documentation.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
