### PR TITLE
[SOS] Fix build break

### DIFF
--- a/.doc_gen/metadata/sns_metadata.yaml
+++ b/.doc_gen/metadata/sns_metadata.yaml
@@ -855,7 +855,7 @@ sns_PublishTextSMS:
                 - python.example_code.sns.SnsWrapper
                 - python.example_code.sns.Publish_TextMessage
   services:
-    sns:
+    sns: {Publish}
 sns_SetSmsAttributes:
   title: Set the default settings for sending &SNS; SMS messages using an &AWS; SDK
   title_abbrev: Set the default settings for sending SMS messages

--- a/.doc_gen/metadata/sns_metadata.yaml
+++ b/.doc_gen/metadata/sns_metadata.yaml
@@ -693,9 +693,6 @@ sns_Publish:
             - description: Publish a message to a topic.
               snippet_tags:
                 - SNS.dotnetv3.PublishToSNSTopicExample
-            - description: Publish an SMS text message.
-              snippet_tags:
-                - SNS.dotnetv3.SNSMessageExample
             - description: Publish a message to a topic with group, duplication, and attribute options.
               snippet_tags:
                 - TopicsAndQueues.dotnetv3.PublishWithOptions
@@ -709,9 +706,6 @@ sns_Publish:
           excerpts:
             - snippet_tags:
                 - sns.cpp.publish_to_topic.code
-            - description: Publish an SMS text message.
-            - snippet_tags:
-                - sns.cpp.publish_sms.code
             - description: Publish a message with an attribute.
               snippet_tags:
                 - cpp.example_code.cross-service.topics_and_queues.attribute_declare
@@ -737,9 +731,6 @@ sns_Publish:
             - description:
               snippet_tags:
                 - sns.kotlin.PublishTopic.main
-            - description: Publish an SMS text message.
-              snippet_tags:
-                - sns.kotlin.PublishTextSMS.main
     Java:
       versions:
         - sdk_version: 2
@@ -748,9 +739,6 @@ sns_Publish:
           excerpts:
             - snippet_tags:
                 - sns.java2.PublishTopic.main
-            - description: Publish an SMS text message.
-            - snippet_tags:
-                - sns.java2.PublishTextSMS.main
     JavaScript:
       versions:
         - sdk_version: 3
@@ -774,9 +762,6 @@ sns_Publish:
           excerpts:
             - snippet_tags:
                 - sns.php.publish_topic.complete
-            - description: Publish an SMS text message.
-            - snippet_tags:
-                - sns.php.publish_text_SMS.complete
     Python:
       versions:
         - sdk_version: 3
@@ -790,10 +775,6 @@ sns_Publish:
               snippet_tags:
                 - python.example_code.sns.SnsWrapper
                 - python.example_code.sns.Publish_MessageStructure
-            - description: Publish an SMS text message.
-            - snippet_tags:
-                - python.example_code.sns.SnsWrapper
-                - python.example_code.sns.Publish_TextMessage
     Ruby:
       versions:
         - sdk_version: 3
@@ -820,6 +801,61 @@ sns_Publish:
                 - sns.abapv1.publish_to_topic
   services:
     sns: {Publish}
+sns_PublishTextSMS:
+  title: Publish an &SNS; SMS text message using an &AWS; SDK
+  title_abbrev: Publish an SMS text message
+  synopsis: publish SMS messages using &SNS;.
+  category: Scenarios
+  languages:
+    .NET:
+      versions:
+        - sdk_version: 3
+          github: dotnetv3/SNS
+          excerpts:
+            - snippet_tags:
+                - SNS.dotnetv3.SNSMessageExample
+    C++:
+      versions:
+        - sdk_version: 1
+          github: cpp/example_code/sns
+          excerpts:
+            - snippet_tags:
+                - sns.cpp.publish_sms.code
+    Kotlin:
+      versions:
+        - sdk_version: 1
+          github: kotlin/services/sns
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - sns.kotlin.PublishTextSMS.main
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/sns
+          sdkguide:
+          excerpts:
+            - snippet_tags:
+                - sns.java2.PublishTextSMS.main
+    PHP:
+      versions:
+        - sdk_version: 3
+          github: php/example_code/sns
+          sdkguide: sdk-for-php/v3/developer-guide/sns-examples-sending-sms.html#publish-to-a-text-message-sms-message
+          excerpts:
+            - snippet_tags:
+                - sns.php.publish_text_SMS.complete
+    Python:
+      versions:
+        - sdk_version: 3
+          github: python/example_code/sns
+          excerpts:
+            - snippet_tags:
+                - python.example_code.sns.SnsWrapper
+                - python.example_code.sns.Publish_TextMessage
+  services:
+    sns:
 sns_SetSmsAttributes:
   title: Set the default settings for sending &SNS; SMS messages using an &AWS; SDK
   title_abbrev: Set the default settings for sending SMS messages

--- a/cpp/example_code/sns/README.md
+++ b/cpp/example_code/sns/README.md
@@ -57,6 +57,13 @@ Code excerpts that show you how to call individual service functions.
 - [Set the default settings for sending SMS messages](set_sms_type.cpp#L21) (`SetSMSAttributes`)
 - [Subscribe an email address to a topic](subscribe_email.cpp#L10) (`Subscribe`)
 
+### Scenarios
+
+Code examples that show you how to accomplish a specific task by calling multiple
+functions within the same service.
+
+- [Publish an SMS text message](publish_sms.cpp)
+
 ### Cross-service examples
 
 Sample applications that work across multiple AWS services.
@@ -92,6 +99,18 @@ folder.
 This example shows you how to get started using Amazon SNS.
 
 
+
+#### Publish an SMS text message
+
+This example shows you how to publish SMS messages using Amazon SNS.
+
+
+<!--custom.scenario_prereqs.sns_PublishTextSMS.start-->
+<!--custom.scenario_prereqs.sns_PublishTextSMS.end-->
+
+
+<!--custom.scenarios.sns_PublishTextSMS.start-->
+<!--custom.scenarios.sns_PublishTextSMS.end-->
 
 ### Tests
 

--- a/dotnetv3/SNS/README.md
+++ b/dotnetv3/SNS/README.md
@@ -48,6 +48,13 @@ Code excerpts that show you how to call individual service functions.
 - [Publish to a topic](PublishToSNSTopicExample/PublishToSNSTopicExample/PublishToSNSTopic.cs#L6) (`Publish`)
 - [Subscribe an email address to a topic](ManageTopicSubscriptionExample/ManageTopicSubscriptionExample/ManageTopicSubscription.cs#L38) (`Subscribe`)
 
+### Scenarios
+
+Code examples that show you how to accomplish a specific task by calling multiple
+functions within the same service.
+
+- [Publish an SMS text message](SNSMessageExample/SNSMessageExample/SNSMessage.cs)
+
 ### Cross-service examples
 
 Sample applications that work across multiple AWS services.
@@ -89,6 +96,18 @@ Alternatively, you can run the example from within your IDE.
 This example shows you how to get started using Amazon SNS.
 
 
+
+#### Publish an SMS text message
+
+This example shows you how to publish SMS messages using Amazon SNS.
+
+
+<!--custom.scenario_prereqs.sns_PublishTextSMS.start-->
+<!--custom.scenario_prereqs.sns_PublishTextSMS.end-->
+
+
+<!--custom.scenarios.sns_PublishTextSMS.start-->
+<!--custom.scenarios.sns_PublishTextSMS.end-->
 
 ### Tests
 

--- a/javav2/example_code/sns/Readme.md
+++ b/javav2/example_code/sns/Readme.md
@@ -49,15 +49,12 @@ Code excerpts that show you how to call individual service functions.
 - [List opted out phone numbers](src/main/java/com/example/sns/ListOptOut.java#L6) (`ListPhoneNumbersOptedOut`)
 - [List the subscribers of a topic](src/main/java/com/example/sns/ListSubscriptions.java#L6) (`ListSubscriptions`)
 - [List topics](src/main/java/com/example/sns/ListTopics.java#L6) (`ListTopics`)
-- [Publish an SMS text message](src/main/java/com/example/sns/PublishTextSMS.java#L6) (`Publish`)
 - [Publish to a topic](src/main/java/com/example/sns/PublishTopic.java#L6) (`Publish`)
 - [Set a dead-letter queue for a subscription](None) (`SetSubscriptionAttributesRedrivePolicy`)
 - [Set a filter policy](src/main/java/com/example/sns/UseMessageFilterPolicy.java#L6) (`SetSubscriptionAttributes`)
 - [Set the default settings for sending SMS messages](src/main/java/com/example/sns/SetSMSAttributes.java#L6) (`SetSMSAttributes`)
 - [Set topic attributes](src/main/java/com/example/sns/SetTopicAttributes.java#L6) (`SetTopicAttributes`)
-- [Subscribe a Lambda function to a topic](src/main/java/com/example/sns/SubscribeLambda.java#L6) (`Subscribe`)
-- [Subscribe an HTTP endpoint to a topic](src/main/java/com/example/sns/SubscribeHTTPS.java#L6) (`Subscribe`)
-- [Subscribe an email address to a topic](src/main/java/com/example/sns/SubscribeEmail.java#L6) (`Subscribe`)
+- [Subscribe an email address to a topic](None) (`Subscribe`)
 
 ### Scenarios
 
@@ -67,6 +64,7 @@ functions within the same service.
 - [Create a platform endpoint for push notifications](src/main/java/com/example/sns/RegistrationExample.java)
 - [Create and publish to a FIFO topic](src/main/java/com/example/sns/PriceUpdateExample.java)
 - [Publish SMS messages to a topic](src/main/java/com/example/sns/CreateTopic.java)
+- [Publish an SMS text message](src/main/java/com/example/sns/PublishTextSMS.java)
 
 
 <!--custom.examples.start-->
@@ -124,6 +122,18 @@ This example shows you how to do the following:
 
 <!--custom.scenarios.sns_UsageSmsTopic.start-->
 <!--custom.scenarios.sns_UsageSmsTopic.end-->
+
+#### Publish an SMS text message
+
+This example shows you how to publish SMS messages using Amazon SNS.
+
+
+<!--custom.scenario_prereqs.sns_PublishTextSMS.start-->
+<!--custom.scenario_prereqs.sns_PublishTextSMS.end-->
+
+
+<!--custom.scenarios.sns_PublishTextSMS.start-->
+<!--custom.scenarios.sns_PublishTextSMS.end-->
 
 ### Tests
 

--- a/kotlin/services/sns/Readme.md
+++ b/kotlin/services/sns/Readme.md
@@ -45,11 +45,16 @@ Code excerpts that show you how to call individual service functions.
 - [Get the properties of a topic](src/main/kotlin/com/kotlin/sns/GetTopicAttributes.kt#L39) (`GetTopicAttributes`)
 - [List the subscribers of a topic](src/main/kotlin/com/kotlin/sns/ListSubscriptions.kt#L22) (`ListSubscriptions`)
 - [List topics](src/main/kotlin/com/kotlin/sns/ListTopics.kt#L23) (`ListTopics`)
-- [Publish an SMS text message](src/main/kotlin/com/kotlin/sns/PublishTextSMS.kt#L41) (`Publish`)
 - [Publish to a topic](src/main/kotlin/com/kotlin/sns/PublishTopic.kt#L40) (`Publish`)
 - [Set topic attributes](src/main/kotlin/com/kotlin/sns/SetTopicAttributes.kt#L42) (`SetTopicAttributes`)
-- [Subscribe a Lambda function to a topic](src/main/kotlin/com/kotlin/sns/SubscribeLambda.kt#L40) (`Subscribe`)
 - [Subscribe an email address to a topic](src/main/kotlin/com/kotlin/sns/SubscribeEmail.kt#L41) (`Subscribe`)
+
+### Scenarios
+
+Code examples that show you how to accomplish a specific task by calling multiple
+functions within the same service.
+
+- [Publish an SMS text message](src/main/kotlin/com/kotlin/sns/PublishTextSMS.kt)
 
 
 <!--custom.examples.start-->
@@ -75,6 +80,18 @@ Code excerpts that show you how to call individual service functions.
 This example shows you how to get started using Amazon SNS.
 
 
+
+#### Publish an SMS text message
+
+This example shows you how to publish SMS messages using Amazon SNS.
+
+
+<!--custom.scenario_prereqs.sns_PublishTextSMS.start-->
+<!--custom.scenario_prereqs.sns_PublishTextSMS.end-->
+
+
+<!--custom.scenarios.sns_PublishTextSMS.start-->
+<!--custom.scenarios.sns_PublishTextSMS.end-->
 
 ### Tests
 

--- a/php/example_code/sns/README.md
+++ b/php/example_code/sns/README.md
@@ -48,6 +48,13 @@ Code excerpts that show you how to call individual service functions.
 - [Set topic attributes](SetTopicAttributes.php#L10) (`SetTopicAttributes`)
 - [Subscribe an email address to a topic](SubscribeEmail.php#L10) (`Subscribe`)
 
+### Scenarios
+
+Code examples that show you how to accomplish a specific task by calling multiple
+functions within the same service.
+
+- [Publish an SMS text message](PublishTextSMS.php)
+
 ### Cross-service examples
 
 Sample applications that work across multiple AWS services.
@@ -67,6 +74,18 @@ Sample applications that work across multiple AWS services.
 <!--custom.instructions.end-->
 
 
+
+#### Publish an SMS text message
+
+This example shows you how to publish SMS messages using Amazon SNS.
+
+
+<!--custom.scenario_prereqs.sns_PublishTextSMS.start-->
+<!--custom.scenario_prereqs.sns_PublishTextSMS.end-->
+
+
+<!--custom.scenarios.sns_PublishTextSMS.start-->
+<!--custom.scenarios.sns_PublishTextSMS.end-->
 
 ### Tests
 

--- a/python/example_code/sns/README.md
+++ b/python/example_code/sns/README.md
@@ -53,6 +53,7 @@ Code examples that show you how to accomplish a specific task by calling multipl
 functions within the same service.
 
 - [Create and publish to a FIFO topic](sns_fifo_topic.py)
+- [Publish an SMS text message](sns_basics.py)
 
 ### Cross-service examples
 
@@ -96,6 +97,24 @@ python sns_fifo_topic.py
 
 <!--custom.scenarios.sns_PublishFifoTopic.start-->
 <!--custom.scenarios.sns_PublishFifoTopic.end-->
+
+#### Publish an SMS text message
+
+This example shows you how to publish SMS messages using Amazon SNS.
+
+
+<!--custom.scenario_prereqs.sns_PublishTextSMS.start-->
+<!--custom.scenario_prereqs.sns_PublishTextSMS.end-->
+
+Start the example by running the following at a command prompt:
+
+```
+python sns_basics.py
+```
+
+
+<!--custom.scenarios.sns_PublishTextSMS.start-->
+<!--custom.scenarios.sns_PublishTextSMS.end-->
 
 ### Tests
 


### PR DESCRIPTION
Recent update consolidated an SNS PublishTextSMS example into a central Publish example, but the SMS example is linked from the the SNS guide.
This PR adds back the SMS example as a scenario to fix the SNS guide and accommodate the new rules for singe action examples.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
