### PR TITLE
Fix typo in retry sample code

### DIFF
--- a/swift/example_code/swift-sdk/retry/Sources/entry.swift
+++ b/swift/example_code/swift-sdk/retry/Sources/entry.swift
@@ -16,7 +16,7 @@ struct RetryExample {
         let config: S3Client.S3ClientConfiguration
 
         // Create an Amazon S3 client configuration object that specifies the
-        // the adaptive retry mode and the base maximum number of retries as 5.
+        // adaptive retry mode and the base maximum number of retries as 5.
 
         do {
             // snippet-start:[retry.swift.configure]


### PR DESCRIPTION
Removed a stray "the" in a comment in the Swift retry example. Oops.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
