### PR TITLE
Go: Improve error handling in CreateCustomMetric example (#6347))

### DIFF
--- a/go/cloudwatch/CreateCustomMetric/CreateCustomMetric.go
+++ b/go/cloudwatch/CreateCustomMetric/CreateCustomMetric.go
@@ -7,6 +7,7 @@ package main
 import (
 	"flag"
 	"fmt"
+        "log"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
@@ -85,7 +86,7 @@ func main() {
 
 	err := CreateCustomMetric(sess, namespace, metricName, unit, value, dimensionName, dimensionValue)
 	if err != nil {
-		fmt.Println()
+		log.Fatalf("Could not create custom metric: %v", err)
 	}
 }
 


### PR DESCRIPTION
Replace fmt.Println() with an actual error log in case of an error.

resolves: #6347

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
