### PR TITLE
-tools 2024-04-30-A Test for doc_gen_only tools update

### DIFF
--- a/.github/workflows/validate-doc-metadata.yml
+++ b/.github/workflows/validate-doc-metadata.yml
@@ -18,4 +18,6 @@ jobs:
       - name: checkout repo content
         uses: actions/checkout@v4
       - name: validate metadata
-        uses: awsdocs/aws-doc-sdk-examples-tools@2024-04-19-A
+        uses: awsdocs/aws-doc-sdk-examples-tools@2024-04-30-A
+        with:
+          doc_gen_only: "False"

--- a/cpp/example_code/cloudtrail/tests/cloudtrail_gtests.cpp
+++ b/cpp/example_code/cloudtrail/tests/cloudtrail_gtests.cpp
@@ -1,7 +1,5 @@
-/*
-   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-   SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "cloudtrail_gtests.h"
 #include <fstream>

--- a/cpp/example_code/cloudtrail/tests/test_main.cpp
+++ b/cpp/example_code/cloudtrail/tests/test_main.cpp
@@ -1,7 +1,5 @@
-/*
-   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-   SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
https://github.com/awsdocs/aws-doc-sdk-examples-tools/pull/22

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
