### PR TITLE
sap-abap: Remove UTF-8 BOM from ABAP code and fix licensing comment

### DIFF
--- a/sap-abap/services/bdr/zcl_aws1_bdr_actions.clas.abap
+++ b/sap-abap/services/bdr/zcl_aws1_bdr_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 CLASS zcl_aws1_bdr_actions DEFINITION
   PUBLIC
   FINAL

--- a/sap-abap/services/bdr/zcl_aws1_bdr_actions.clas.testclasses.abap
+++ b/sap-abap/services/bdr/zcl_aws1_bdr_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_bdr_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_bdr_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_bdr_actions.

--- a/sap-abap/services/bdr/zcl_aws1_bdr_actions.clas.testclasses.abap
+++ b/sap-abap/services/bdr/zcl_aws1_bdr_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_bdr_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_bdr_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_bdr_actions.

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.abap
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_CWT_ACTIONS definition
   public

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.abap
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_CWT_ACTIONS definition
   public

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.testclasses.abap
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_cwt_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.testclasses.abap
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_cwt_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.abap
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_CWT_SCENARIO definition
   public

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.abap
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_CWT_SCENARIO definition
   public

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.testclasses.abap
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_cwt_scenario DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.testclasses.abap
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_cwt_scenario DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/dyn/zcl_aws1_dyn_actions.clas.abap
+++ b/sap-abap/services/dyn/zcl_aws1_dyn_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS zcl_aws1_dyn_actions DEFINITION
   PUBLIC

--- a/sap-abap/services/dyn/zcl_aws1_dyn_actions.clas.abap
+++ b/sap-abap/services/dyn/zcl_aws1_dyn_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS zcl_aws1_dyn_actions DEFINITION
   PUBLIC

--- a/sap-abap/services/dyn/zcl_aws1_dyn_actions.clas.testclasses.abap
+++ b/sap-abap/services/dyn/zcl_aws1_dyn_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_dyn_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_dyn_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_dyn_actions.

--- a/sap-abap/services/dyn/zcl_aws1_dyn_actions.clas.testclasses.abap
+++ b/sap-abap/services/dyn/zcl_aws1_dyn_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_dyn_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_dyn_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_dyn_actions.

--- a/sap-abap/services/dyn/zcl_aws1_dyn_scenario.clas.abap
+++ b/sap-abap/services/dyn/zcl_aws1_dyn_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS zcl_aws1_dyn_scenario DEFINITION
   PUBLIC

--- a/sap-abap/services/dyn/zcl_aws1_dyn_scenario.clas.abap
+++ b/sap-abap/services/dyn/zcl_aws1_dyn_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS zcl_aws1_dyn_scenario DEFINITION
   PUBLIC

--- a/sap-abap/services/dyn/zcl_aws1_dyn_scenario.clas.testclasses.abap
+++ b/sap-abap/services/dyn/zcl_aws1_dyn_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_dyn_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_dyn_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_dyn_scenario.

--- a/sap-abap/services/dyn/zcl_aws1_dyn_scenario.clas.testclasses.abap
+++ b/sap-abap/services/dyn/zcl_aws1_dyn_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_dyn_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_dyn_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_dyn_scenario.

--- a/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.abap
+++ b/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_EC2_ACTIONS definition
   public

--- a/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.abap
+++ b/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_EC2_ACTIONS definition
   public

--- a/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.testclasses.abap
+++ b/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_ec2_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_ec2_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_ec2_actions.

--- a/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.testclasses.abap
+++ b/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_ec2_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_ec2_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_ec2_actions.

--- a/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_KNS_ACTIONS definition
   public

--- a/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_KNS_ACTIONS definition
   public

--- a/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.testclasses.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_kns_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.testclasses.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_kns_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_KNS_SCENARIO definition
   public

--- a/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_KNS_SCENARIO definition
   public

--- a/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.testclasses.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0""
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0""
 
 CLASS ltc_zcl_aws1_kns_scenario DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.testclasses.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0""
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0""
 
 CLASS ltc_zcl_aws1_kns_scenario DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.abap
+++ b/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_LMD_ACTIONS definition
   public

--- a/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.abap
+++ b/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_LMD_ACTIONS definition
   public

--- a/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.testclasses.abap
+++ b/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_lmd_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_lmd_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_lmd_actions.

--- a/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.testclasses.abap
+++ b/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_lmd_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_lmd_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_lmd_actions.

--- a/sap-abap/services/lambda/zcl_aws1_lmd_scenario.clas.abap
+++ b/sap-abap/services/lambda/zcl_aws1_lmd_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_LMD_SCENARIO definition
   public

--- a/sap-abap/services/lambda/zcl_aws1_lmd_scenario.clas.abap
+++ b/sap-abap/services/lambda/zcl_aws1_lmd_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_LMD_SCENARIO definition
   public

--- a/sap-abap/services/lambda/zcl_aws1_lmd_scenario.clas.testclasses.abap
+++ b/sap-abap/services/lambda/zcl_aws1_lmd_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_lmd_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_lmd_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_lmd_scenario.

--- a/sap-abap/services/lambda/zcl_aws1_lmd_scenario.clas.testclasses.abap
+++ b/sap-abap/services/lambda/zcl_aws1_lmd_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_lmd_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_lmd_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_lmd_scenario.

--- a/sap-abap/services/s3/zcl_aws1_s3_actions.clas.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 CLASS zcl_aws1_s3_actions DEFINITION
   PUBLIC
   FINAL

--- a/sap-abap/services/s3/zcl_aws1_s3_actions.clas.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 CLASS zcl_aws1_s3_actions DEFINITION
   PUBLIC
   FINAL

--- a/sap-abap/services/s3/zcl_aws1_s3_actions.clas.testclasses.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_s3_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_s3_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_s3_actions.

--- a/sap-abap/services/s3/zcl_aws1_s3_actions.clas.testclasses.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_s3_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_s3_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_s3_actions.

--- a/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_S3_SCENARIO definition
   public

--- a/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_S3_SCENARIO definition
   public

--- a/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.testclasses.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_s3_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_s3_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_s3_scenario.

--- a/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.testclasses.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_s3_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_s3_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_s3_scenario.

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_SGM_ACTIONS definition
   public

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_SGM_ACTIONS definition
   public

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.testclasses.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_sgm_actions DEFINITION FOR TESTING DURATION MEDIUM RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.testclasses.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_sgm_actions DEFINITION FOR TESTING DURATION MEDIUM RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_SGM_SCENARIO definition
   public

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_SGM_SCENARIO definition
   public

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.testclasses.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_sgm_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_sgm_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_sgm_scenario.

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.testclasses.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_sgm_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_sgm_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_sgm_scenario.

--- a/sap-abap/services/sns/zcl_aws1_sns_actions.clas.abap
+++ b/sap-abap/services/sns/zcl_aws1_sns_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_SNS_ACTIONS definition
   public

--- a/sap-abap/services/sns/zcl_aws1_sns_actions.clas.abap
+++ b/sap-abap/services/sns/zcl_aws1_sns_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_SNS_ACTIONS definition
   public

--- a/sap-abap/services/sns/zcl_aws1_sns_actions.clas.testclasses.abap
+++ b/sap-abap/services/sns/zcl_aws1_sns_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_sns_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_sns_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_sns_actions.

--- a/sap-abap/services/sns/zcl_aws1_sns_actions.clas.testclasses.abap
+++ b/sap-abap/services/sns/zcl_aws1_sns_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_sns_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_sns_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_sns_actions.

--- a/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.abap
+++ b/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_SNS_SCENARIO definition
   public

--- a/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.abap
+++ b/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_SNS_SCENARIO definition
   public

--- a/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.testclasses.abap
+++ b/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_sns_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_sns_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_sns_scenario.

--- a/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.testclasses.abap
+++ b/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_sns_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_sns_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_sns_scenario.

--- a/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.abap
+++ b/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_SQS_ACTIONS definition
   public

--- a/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.abap
+++ b/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_SQS_ACTIONS definition
   public

--- a/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.testclasses.abap
+++ b/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_sqs_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_sqs_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_sqs_actions.

--- a/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.testclasses.abap
+++ b/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_sqs_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_sqs_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_sqs_actions.

--- a/sap-abap/services/textract/zcl_aws1_tex_actions.clas.abap
+++ b/sap-abap/services/textract/zcl_aws1_tex_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 CLASS zcl_aws1_tex_actions DEFINITION
   PUBLIC
   FINAL

--- a/sap-abap/services/textract/zcl_aws1_tex_actions.clas.abap
+++ b/sap-abap/services/textract/zcl_aws1_tex_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 CLASS zcl_aws1_tex_actions DEFINITION
   PUBLIC
   FINAL

--- a/sap-abap/services/textract/zcl_aws1_tex_actions.clas.testclasses.abap
+++ b/sap-abap/services/textract/zcl_aws1_tex_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_tex_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/textract/zcl_aws1_tex_actions.clas.testclasses.abap
+++ b/sap-abap/services/textract/zcl_aws1_tex_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_tex_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.abap
+++ b/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 CLASS zcl_aws1_tex_scenario DEFINITION
   PUBLIC
   FINAL

--- a/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.abap
+++ b/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 CLASS zcl_aws1_tex_scenario DEFINITION
   PUBLIC
   FINAL

--- a/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.testclasses.abap
+++ b/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_tex_scenario DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.testclasses.abap
+++ b/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_tex_scenario DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.abap
+++ b/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_XL8_ACTIONS definition
   public

--- a/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.abap
+++ b/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_XL8_ACTIONS definition
   public

--- a/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.testclasses.abap
+++ b/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_xl8_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.testclasses.abap
+++ b/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_xl8_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.abap
+++ b/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_XL8_SCENARIO definition
   public

--- a/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.abap
+++ b/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 class ZCL_AWS1_XL8_SCENARIO definition
   public

--- a/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.testclasses.abap
+++ b/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-" SPDX-License-Identifier: Apache-2.0
+﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_xl8_scenario DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 

--- a/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.testclasses.abap
+++ b/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.testclasses.abap
@@ -1,5 +1,5 @@
-﻿* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-* SPDX-License-Identifier: Apache-2.0
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 
 CLASS ltc_zcl_aws1_xl8_scenario DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
 


### PR DESCRIPTION
This pull request does not change the example code but corrects a technical flaw in the files, where a UTF-8 BOM prevented abapGit from importing the ABAP code.  Also fixes an incorrect licensing comment.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
