### PR TITLE
Go: Added missing parameter in example usage of DynamoDB

### DIFF
--- a/go/dynamodb/README.md
+++ b/go/dynamodb/README.md
@@ -32,11 +32,12 @@ The table has two attributes:
 
 Creates a new item in a DynamoDB table.
 
-`go run CreateTableItem -d TABLE -y YEAR -t TITLE -r RATING`
+`go run CreateTableItem -d TABLE -y YEAR -t TITLE -p PLOT -r RATING`
 
 - _TABLE_ is the name of the table.
 - _YEAR_ is the year that the movie was released.
 - _TITLE_ is the title of the movie.
+- _PLOT_ is the plot of the movie.
 - _RATING_ is the rating, from 0.0 to 10.0, of the movie.
 
 The unit test accepts similar values in _config.json_.


### PR DESCRIPTION
PLOT was missing from the CreateTableItem example, causing the example to error if used as is. 

```
CreateTableItem git:(main) go run CreateTableItem.go -d test-dynamo-table -y 2024 -t TEST_MOVIE -r 2     
You must supply a database table name, year, title, plot and rating
```


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
