### PR TITLE
Rust: bump msrv to 1.76.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
-          toolchain: "1.75.0"
+          toolchain: "1.76.0"
           components: clippy, rustfmt
       - name: Set Environment
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/rustv1/Dockerfile
+++ b/rustv1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG MSRV=1.75.0
+ARG MSRV=1.76.0
 FROM rust:$MSRV
 
 # Update image

--- a/rustv1/cross_service/photo_asset_management/src/uploader.rs
+++ b/rustv1/cross_service/photo_asset_management/src/uploader.rs
@@ -77,7 +77,7 @@ impl<'a> ZipUpload<'a> {
         let key = self.key;
 
         let body = ByteStream::read_from()
-            .file(zip.try_into()?)
+            .file(zip.into())
             .buffer_size(4096 * 16)
             .build()
             .await?;

--- a/rustv1/cross_service/rest_ses/src/work_item/repository.rs
+++ b/rustv1/cross_service/rest_ses/src/work_item/repository.rs
@@ -82,7 +82,7 @@ pub async fn retrieve(id: String, client: &RdsClient) -> Result<WorkItem, WorkIt
     }
 
     // Last chance for something to go wrong!
-    let item = match items.get(0) {
+    let item = match items.first() {
         Some(item) => Ok(item),
         None => Err(WorkItemError::Other(
             "Somehow len() == 1 but get(0) is None".to_string(),

--- a/rustv1/cross_service/rust-toolchain.toml
+++ b/rustv1/cross_service/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # This should be kept in sync with https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"

--- a/rustv1/examples/glue/src/run.rs
+++ b/rustv1/examples/glue/src/run.rs
@@ -44,7 +44,7 @@ impl GlueScenario {
             .arguments(
                 "--input_table",
                 self.tables
-                    .get(0)
+                    .first()
                     .ok_or_else(|| GlueMvpError::Unknown("Missing crawler table".into()))?
                     .name(),
             )

--- a/rustv1/examples/rust-toolchain.toml
+++ b/rustv1/examples/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # This should be kept in sync with https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"


### PR DESCRIPTION


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
