### PR TITLE
Rust: Rework lambda getting started create_role logic to align with other examples.

### DIFF
--- a/rustv1/examples/lambda/README.md
+++ b/rustv1/examples/lambda/README.md
@@ -36,13 +36,13 @@ Additionally, to compile Lambda functions written in the Rust programming langua
 
 Code excerpts that show you how to call individual service functions.
 
-- [CreateFunction](src/actions.rs#L231)
-- [DeleteFunction](src/actions.rs#L469)
-- [GetFunction](src/actions.rs#L377)
-- [Invoke](src/actions.rs#L402)
-- [ListFunctions](src/actions.rs#L390)
-- [UpdateFunctionCode](src/actions.rs#L418)
-- [UpdateFunctionConfiguration](src/actions.rs#L444)
+- [CreateFunction](src/actions.rs#L232)
+- [DeleteFunction](src/actions.rs#L474)
+- [GetFunction](src/actions.rs#L382)
+- [Invoke](src/actions.rs#L407)
+- [ListFunctions](src/actions.rs#L395)
+- [UpdateFunctionCode](src/actions.rs#L423)
+- [UpdateFunctionConfiguration](src/actions.rs#L449)
 
 ### Scenarios
 


### PR DESCRIPTION
This fixes an issue reported through the internal docs tracker.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
