### PR TITLE
Bugfix: Typo in import leads to error

### DIFF
--- a/python/example_code/bedrock-runtime/models/ai21_labs_jurassic2/invoke_model.py
+++ b/python/example_code/bedrock-runtime/models/ai21_labs_jurassic2/invoke_model.py
@@ -7,7 +7,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/amazon_titan_text/invoke_model.py
+++ b/python/example_code/bedrock-runtime/models/amazon_titan_text/invoke_model.py
@@ -7,7 +7,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/anthropic_claude/invoke_model.py
+++ b/python/example_code/bedrock-runtime/models/anthropic_claude/invoke_model.py
@@ -7,7 +7,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/cohere_command/command_invoke_model.py
+++ b/python/example_code/bedrock-runtime/models/cohere_command/command_invoke_model.py
@@ -7,7 +7,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/cohere_command/command_invoke_model_with_response_stream.py
+++ b/python/example_code/bedrock-runtime/models/cohere_command/command_invoke_model_with_response_stream.py
@@ -8,7 +8,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/cohere_command/command_r_invoke_model.py
+++ b/python/example_code/bedrock-runtime/models/cohere_command/command_r_invoke_model.py
@@ -7,7 +7,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/cohere_command/command_r_invoke_model_with_response_stream.py
+++ b/python/example_code/bedrock-runtime/models/cohere_command/command_r_invoke_model_with_response_stream.py
@@ -8,7 +8,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/meta_llama/llama2_invoke_model.py
+++ b/python/example_code/bedrock-runtime/models/meta_llama/llama2_invoke_model.py
@@ -7,7 +7,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/meta_llama/llama2_invoke_model_with_response_stream.py
+++ b/python/example_code/bedrock-runtime/models/meta_llama/llama2_invoke_model_with_response_stream.py
@@ -8,7 +8,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/meta_llama/llama3_invoke_model.py
+++ b/python/example_code/bedrock-runtime/models/meta_llama/llama3_invoke_model.py
@@ -7,7 +7,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/meta_llama/llama3_invoke_model_with_response_stream.py
+++ b/python/example_code/bedrock-runtime/models/meta_llama/llama3_invoke_model_with_response_stream.py
@@ -8,7 +8,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/mistral_ai/invoke_model.py
+++ b/python/example_code/bedrock-runtime/models/mistral_ai/invoke_model.py
@@ -6,7 +6,7 @@
 
 import boto3
 import json
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/python/example_code/bedrock-runtime/models/mistral_ai/invoke_model_with_response_stream.py
+++ b/python/example_code/bedrock-runtime/models/mistral_ai/invoke_model_with_response_stream.py
@@ -8,7 +8,7 @@
 import boto3
 import json
 
-from botocore.Exceptions import ClientError
+from botocore.exceptions import ClientError
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
 client = boto3.client("bedrock-runtime", region_name="us-east-1")


### PR DESCRIPTION
This pull request fixes an import bug in all Python examples for the Bedrock InvokeModel API.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
