### PR TITLE
Go: Fixed an off-by-one bug in the mock questioner AskChoice

### DIFF
--- a/gov2/demotools/filesystem.go
+++ b/gov2/demotools/filesystem.go
@@ -42,7 +42,7 @@ func (filesystem FileSystem) OpenFile(filename string) (io.ReadWriteCloser, erro
 
 // CloseFile closes the provided file.
 func (filesystem FileSystem) CloseFile(file io.ReadWriteCloser) {
-	defer file.Close()
+	file.Close()
 }
 
 // MockFileSystem is a mock version of IFileSystem for testing.
@@ -69,5 +69,5 @@ func (filesystem MockFileSystem) OpenFile(_ string) (io.ReadWriteCloser, error) 
 
 // CloseFile closes the io.ReadWriteCloser provided on object creation.
 func (filesystem MockFileSystem) CloseFile(_ io.ReadWriteCloser) {
-	defer filesystem.mockfile.Close()
+	filesystem.mockfile.Close()
 }

--- a/gov2/demotools/filesystem_test.go
+++ b/gov2/demotools/filesystem_test.go
@@ -20,12 +20,13 @@ func TestNewStandardFileSystemGwd(t *testing.T) {
 func TestNewStandardFileSystemFileIO(t *testing.T) {
 	filesystem := NewStandardFileSystem()
 	filename := "test.txt"
-	os.Create(filename)
-	file, err := filesystem.OpenFile(filename)
+	file, err := os.Create(filename)
+	fsFile, err := filesystem.OpenFile(filename)
 	if err != nil {
 		t.Errorf("NewStandardFileSystemFileInteraction(): error opening file: %v", err)
 	}
-	filesystem.CloseFile(file)
+	filesystem.CloseFile(fsFile)
+	file.Close()
 	err = os.Remove(filename)
 	if err != nil {
 		t.Errorf("NewStandardFileSystemFileInteraction(): error removing file: %v", err)
@@ -48,6 +49,7 @@ func TestNewMockFileSystem(t *testing.T) {
 		t.Errorf("NewMockFileSystem(): error opening file: %v", fErr)
 	}
 	filesystem.CloseFile(mockFile)
+	file.Close()
 	err = os.Remove(filename)
 	if err != nil {
 		t.Errorf("NewMockFileSystem(): error removing file: %v", err)

--- a/gov2/demotools/mocks.go
+++ b/gov2/demotools/mocks.go
@@ -47,7 +47,7 @@ func (mock *MockQuestioner) AskFloat64(question string, validators ...IAnswerVal
 
 func (mock *MockQuestioner) AskChoice(question string, choices []string) int {
 	answerInt, _ := strconv.Atoi(mock.Next(question))
-	return answerInt
+	return answerInt - 1
 }
 
 func (mock *MockQuestioner) AskPassword(question string, minLength int) string {


### PR DESCRIPTION
* Mock questioner was returning the specified choice, but it should subtract one from it to match the real implementation.
* Updated the FileSystem tests to close both references to the file to avoid a "file in use" error in Windows.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
