### PR TITLE
JavaScript: Added link to DDB dev guide

### DIFF
--- a/.doc_gen/metadata/dynamodb_metadata.yaml
+++ b/.doc_gen/metadata/dynamodb_metadata.yaml
@@ -28,7 +28,9 @@ dynamodb_Hello:
           github: javascriptv3/example_code/dynamodb
           sdkguide:
           excerpts:
-            - description:
+            - description: >-
+                For more details on working with &DDB; in &JSBlong;, 
+                see <ulink url="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/programming-with-javascript.html">Programming &DDB; with JavaScript</ulink>.
               snippet_tags:
                 - javascript.v3.dynamodb.hello
     C++:


### PR DESCRIPTION
This pull request adds a link to the page "Programming Amazon DynamoDB with JavaScript" in the DynamoDB developer guide. This should help customers that need more context when using the SDK for JavaScript v3 with DDB.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
