### PR TITLE
Fix AWSK SDK typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # AWS SDK Code Examples
 
-This repository contains code examples that demonstrate how to use the [AWSK SDKs](https://aws.amazon.com/developer/tools/) to interact with [AWS services](https://aws.amazon.com/products).
+This repository contains code examples that demonstrate how to use the [AWS SDKs](https://aws.amazon.com/developer/tools/) to interact with [AWS services](https://aws.amazon.com/products).
 
 Many examples are injected into the [AWS Documentation](https://docs.aws.amazon.com).
 


### PR DESCRIPTION
This PR fixes a small typo in the `README.md`, AWSK SDK should be AWS SDK.
