### PR TITLE
Rewrite scanner to use -tools

### DIFF
--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -3,7 +3,7 @@ cross_MessageProcessingFrameworkTutorial:
   title: Use the &AWS; Message Processing Framework for .NET to publish and receive &SQS; messages
   title_abbrev: Use the &AWS; Message Processing Framework for .NET with &SQS;
   synopsis: create applications that publish and receive &SQS; messages using the &AWS; Message Processing Framework for .NET.
-  category: Cross
+  category: Cross-service examples
   languages:
     .NET:
       versions:
@@ -521,7 +521,7 @@ cross_RekognitionVideoDetection:
   title: Detect people and objects in a video with &REK; using an &AWS; SDK
   title_abbrev: Detect people and objects in a video
   synopsis: detect people and objects in a video with &REK;.
-  category: Cross
+  category: Cross-service examples
   languages:
     Java:
       versions:
@@ -780,7 +780,7 @@ cross_ServerlessS3DataTransformation:
   title: Transform data for your application with S3 Object Lambda
   title_abbrev: Transform data with S3 Object Lambda
   synopsis: transform data for your application with S3 Object Lambda.
-  category: Cross
+  category: Cross-service examples
   languages:
     .NET:
       versions:

--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -3,7 +3,7 @@ cross_MessageProcessingFrameworkTutorial:
   title: Use the &AWS; Message Processing Framework for .NET to publish and receive &SQS; messages
   title_abbrev: Use the &AWS; Message Processing Framework for .NET with &SQS;
   synopsis: create applications that publish and receive &SQS; messages using the &AWS; Message Processing Framework for .NET.
-  category: Cross-service examples
+  category: Cross
   languages:
     .NET:
       versions:
@@ -521,7 +521,7 @@ cross_RekognitionVideoDetection:
   title: Detect people and objects in a video with &REK; using an &AWS; SDK
   title_abbrev: Detect people and objects in a video
   synopsis: detect people and objects in a video with &REK;.
-  category: Cross-service examples
+  category: Cross
   languages:
     Java:
       versions:
@@ -780,7 +780,7 @@ cross_ServerlessS3DataTransformation:
   title: Transform data for your application with S3 Object Lambda
   title_abbrev: Transform data with S3 Object Lambda
   synopsis: transform data for your application with S3 Object Lambda.
-  category: Cross-service examples
+  category: Cross
   languages:
     .NET:
       versions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.egg-info
 *.exe
 *.swp
 .*~

--- a/.tools/readmes/config.py
+++ b/.tools/readmes/config.py
@@ -7,6 +7,8 @@ doc_base_url = "https://docs.aws.amazon.com"
 categories = {
     "hello": "Hello",
     "scenarios": "Scenarios",
+    "actions": "Api",
+    "cross": "Cross",
 }
 entities = {
     "&AWS;": "AWS",

--- a/.tools/readmes/config.py
+++ b/.tools/readmes/config.py
@@ -8,7 +8,7 @@ categories = {
     "hello": "Hello",
     "scenarios": "Scenarios",
     "actions": "Api",
-    "cross": "Cross",
+    "cross": "Cross-service examples",
 }
 entities = {
     "&AWS;": "AWS",

--- a/.tools/readmes/render.py
+++ b/.tools/readmes/render.py
@@ -174,10 +174,11 @@ class Renderer:
 
         sorted_cats = {}
         for key in sorted(post_cats.keys()):
-            # sorted_cats[key] = sorted(post_cats[key], key=itemgetter("title_abbrev"))
-            sorted_cats[key] = post_cats[key]
+            if len(post_cats[key]) == 0:
+                del sorted_cats[key]
+            else:
+                sorted_cats[key] = post_cats[key]
         return sorted_cats
-        # return post_cats
 
     def _expand_entities(self, readme_text):
         entities = set(re.findall(r"&[\dA-Za-z-_]+;", readme_text))

--- a/.tools/readmes/render.py
+++ b/.tools/readmes/render.py
@@ -87,7 +87,7 @@ class Renderer:
         post_examples: List[Dict[str, str]] = []
         for pre in pre_examples.values():
             try:
-                api = next(iter(pre.services[self.scanner.svc_name]))
+                api = sorted(pre.services[self.scanner.svc_name])[0]
             except Exception:
                 api = ""
 

--- a/.tools/readmes/render.py
+++ b/.tools/readmes/render.py
@@ -10,6 +10,7 @@ from dataclasses import asdict
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from operator import itemgetter
 from pathlib import Path
+from typing import Dict
 
 from aws_doc_sdk_examples_tools.metadata import Example
 
@@ -103,7 +104,7 @@ class Renderer:
         post_svc["guide"]["url"] = self._doc_link(post_svc["guide"]["url"])
         return post_svc
 
-    def _transform_hello(self, pre_hello: dict[str, Example]):
+    def _transform_hello(self, pre_hello: Dict[str, Example]):
         post_hello = []
         for _, pre in pre_hello.items():
             try:

--- a/.tools/readmes/requirements.txt
+++ b/.tools/readmes/requirements.txt
@@ -1,2 +1,3 @@
 jinja2>=3.0.3
 pyyaml>=5.3.1
+aws-doc-sdk-examples-tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools

--- a/.tools/readmes/scanner.py
+++ b/.tools/readmes/scanner.py
@@ -3,8 +3,9 @@
 
 import config
 import logging
-import os
+from os.path import relpath
 from pathlib import Path
+from typing import Dict, List
 
 from aws_doc_sdk_examples_tools.doc_gen import DocGen
 from aws_doc_sdk_examples_tools.metadata import Example
@@ -21,7 +22,7 @@ class Scanner:
         self.sdk_ver = None
         self.svc_name = None
         self.example_meta = None
-        self.cross_meta = {}
+        self.cross_meta: Dict[None, None] = {}
         self.snippets = None
 
     def _contains_language_version(self, example):
@@ -40,16 +41,16 @@ class Scanner:
     def sdk(self) -> Sdk:
         return self.doc_gen.sdks[self.lang_name]
 
-    def sdks(self) -> dict[str, Sdk]:
+    def sdks(self) -> Dict[str, Sdk]:
         return self.doc_gen.sdks
 
     def service(self) -> Service:
         return self.doc_gen.services[self.svc_name]
 
-    def services(self) -> dict[str, Service]:
+    def services(self) -> Dict[str, Service]:
         return self.doc_gen.services
 
-    def examples(self) -> list[Example]:
+    def examples(self) -> List[Example]:
         return [
             example
             for example in self.doc_gen.examples.values()
@@ -65,7 +66,7 @@ class Scanner:
             elif entity in config.entities:
                 return config.entities[entity]
 
-    def hello(self) -> dict[str, Example]:
+    def hello(self) -> Dict[str, Example]:
         return {
             example.id: example
             for example in self.examples()
@@ -73,7 +74,7 @@ class Scanner:
             and self.lang_name in example.languages
         }
 
-    def actions(self) -> dict[str, Example]:
+    def actions(self) -> Dict[str, Example]:
         return {
             example.id: example
             for example in self.examples()
@@ -81,7 +82,7 @@ class Scanner:
             and self.lang_name in example.languages
         }
 
-    def scenarios(self) -> dict[str, Example]:
+    def scenarios(self) -> Dict[str, Example]:
         return {
             example.id: example
             for example in self.examples()
@@ -138,12 +139,13 @@ class Scanner:
                                     tag_path = "../cross-services/" + tag_path
                         elif ex_ver.block_content:
                             tag_path = github
-        if github is not None and tag_path is None:
+        if tag and github is not None and tag_path is None:
             snippet = self.doc_gen.snippets[tag]
             if snippet is not None:
-                snippet_path = Path(snippet.file)
+                snippet_path = self.doc_gen.root / Path(snippet.file)
                 readme_path = Path(__file__).parent.parent.parent / readme_folder
-                tag_path = snippet_path.relative_to(readme_path)
+                # tag_path = snippet_path.relative_to(readme_path)  # Must be subpaths, no ..
+                tag_path = relpath(snippet_path, readme_path)
                 tag_path = str(tag_path).replace("\\", "/")
                 if api_name != "":
                     tag_path += f"#L{snippet.line_start + 1}"

--- a/.tools/readmes/scanner.py
+++ b/.tools/readmes/scanner.py
@@ -24,11 +24,14 @@ class Scanner:
         self.example_meta = None
         self.cross_meta: Dict[str, Example] = {}
         self.snippets = None
-        self.entities: Dict[str, str] = {e: en for e, en in config.entities.items()}
+        self.entities: Dict[str, str] = {}
         for svc in self.services().values():
             if svc.expanded:
                 self.entities[svc.long] = svc.expanded.long
                 self.entities[svc.short] = svc.expanded.short
+        # config entities override
+        for entity, expanded in config.entities.items():
+            self.entities[entity] = expanded
 
     def load_crosses(self):
         self.doc_gen.process_metadata(

--- a/.tools/readmes/scanner.py
+++ b/.tools/readmes/scanner.py
@@ -24,6 +24,11 @@ class Scanner:
         self.example_meta = None
         self.cross_meta: Dict[str, Example] = {}
         self.snippets = None
+        self.entities: Dict[str, str] = {e: en for e, en in config.entities.items()}
+        for svc in self.services().values():
+            if svc.expanded:
+                self.entities[svc.long] = svc.expanded.long
+                self.entities[svc.short] = svc.expanded.short
 
     def load_crosses(self):
         self.doc_gen.process_metadata(
@@ -67,13 +72,7 @@ class Scanner:
         ]
 
     def expand_entity(self, entity):
-        for svc in self.services().values():
-            if svc.long == entity:
-                return svc.expanded.long
-            elif svc.short == entity:
-                return svc.expanded.short
-            elif entity in config.entities:
-                return config.entities[entity]
+        return self.entities[entity]
 
     def hello(self) -> Dict[str, Example]:
         return {

--- a/.tools/readmes/scanner.py
+++ b/.tools/readmes/scanner.py
@@ -26,6 +26,7 @@ class Scanner:
         self.entities: Dict[str, str] = {}
         self._prepare_entities()
         self.examples: Dict[str, List[Example]] = {}
+        self._build_examples()
         self.hellos: Dict[str, Example] = {}
         self.actions: Dict[str, Example] = {}
         self.scenarios: Dict[str, Example] = {}
@@ -49,15 +50,10 @@ class Scanner:
 
     def set_service(self, service):
         self.svc_name = service
-        self.doc_gen.process_metadata(
-            Path(__file__).parent.parent.parent
-            / ".doc_gen"
-            / "metadata"
-            / f"{service}_metadata.yaml"
-        )
 
+    def _build_examples(self):
         # Kinda sucks to rebuild this every round. Should building it get moved into DocGen?
-        self.examples: Dict[str, List[Example]] = defaultdict(list)
+        self.examples = defaultdict(list)
         for example in self.doc_gen.examples.values():
             for lang_name, language in example.languages.items():
                 for sdk_version in language.versions:

--- a/.tools/readmes/scanner.py
+++ b/.tools/readmes/scanner.py
@@ -48,9 +48,6 @@ class Scanner:
             self.doc_gen.root / ".doc_gen" / "metadata" / "cross_metadata.yaml"
         )
 
-    def set_service(self, service):
-        self.svc_name = service
-
     def _build_examples(self):
         self.examples = defaultdict(list)
         for example in self.doc_gen.examples.values():
@@ -64,7 +61,8 @@ class Scanner:
     def _example_key(self):
         return f"{self.lang_name}:{self.sdk_ver}:{self.svc_name}"
 
-    def set_example(self, language, sdk_ver):
+    def set_example(self, svc_name: str, language: str, sdk_ver: int):
+        self.svc_name = svc_name
         self.lang_name = language
         self.sdk_ver = sdk_ver
 
@@ -107,13 +105,13 @@ class Scanner:
     def expand_entity(self, entity):
         return self.entities[entity]
 
-    def snippet(self, example: Example, sdk_ver, readme_folder, api_name: str):
+    def snippet(self, example: Example, readme_folder, api_name: str):
         github = None
         tag = None
         tag_path = None
         if self.lang_name in example.languages:
             for ex_ver in example.languages[self.lang_name].versions:
-                if ex_ver.sdk_version == sdk_ver:
+                if ex_ver.sdk_version == self.sdk_ver:
                     github = ex_ver.github
                     if github is not None:
                         if ex_ver.excerpts:

--- a/.tools/readmes/scanner.py
+++ b/.tools/readmes/scanner.py
@@ -4,10 +4,9 @@
 import config
 import logging
 import os
-import re
 import yaml
 
-from snippets import Snippet, scan_for_snippets
+from snippets import scan_for_snippets
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +52,12 @@ class Scanner:
                     return True
         return False
 
+    def _custom_categories_set(self):
+        return {
+            config.categories["scenarios"],
+            config.categories["hello"],
+        }
+
     def set_example(self, language, sdk_ver, service):
         self.lang_name = language
         self.sdk_ver = sdk_ver
@@ -88,57 +93,61 @@ class Scanner:
     def hello(self):
         self._load_examples()
         hello = {}
-        for example_name, example in self.example_meta.items():
-            if example.get("category", "") == config.categories[
-                "hello"
-            ] and self._contains_language_version(example):
-                hello[example_name] = example
+        for name, example in self.example_meta.items():
+            if (
+                self._contains_language_version(example)
+                and example.get("category", "") == config.categories["hello"]
+            ):
+                hello[name] = example
         return hello
 
     def actions(self):
         self._load_examples()
         actions = {}
-        for example_name, example in self.example_meta.items():
-            if not example.get("category") and self._contains_language_version(example):
-                actions[example_name] = example
+        for name, example in self.example_meta.items():
+            if (
+                self._contains_language_version(example)
+                and example.get("category", None) is None
+            ):
+                actions[name] = example
         return actions
 
     def scenarios(self):
         self._load_examples()
         scenarios = {}
-        for example_name, example in self.example_meta.items():
-            if example.get("category", "") == config.categories[
-                "scenarios"
-            ] and self._contains_language_version(example):
-                scenarios[example_name] = example
+        for name, example in self.example_meta.items():
+            if (
+                self._contains_language_version(example)
+                and example.get("category", "") == config.categories["scenarios"]
+            ):
+                scenarios[name] = example
         return scenarios
 
     def custom_categories(self):
         self._load_examples()
         custom_cats = {}
-        for example_name, example in self.example_meta.items():
+        for name, example in self.example_meta.items():
+            category = example.get("category", "")
             if (
-                example.get("category", "")
-                and example.get("category", "")
-                not in {config.categories["scenarios"], config.categories["hello"]}
-                and self._contains_language_version(example)
+                self._contains_language_version(example)
+                and category not in self._custom_categories_set()
             ):
-                custom_cats[example_name] = example
+                custom_cats[name] = example
         return custom_cats
 
     def crosses(self):
         self._load_cross()
         crosses = {}
         scenarios = {}
-        for example_name, example in self.cross_meta.items():
+        for name, example in self.cross_meta.items():
             if (
                 self._contains_language_version(example)
                 and self.svc_name in example["services"]
             ):
                 if example.get("category", "") == config.categories["scenarios"]:
-                    scenarios[example_name] = example
+                    scenarios[name] = example
                 else:
-                    crosses[example_name] = example
+                    crosses[name] = example
         return crosses, scenarios
 
     def snippet(self, example, sdk_ver, readme_folder, api_name):

--- a/.tools/readmes/scanner.py
+++ b/.tools/readmes/scanner.py
@@ -52,7 +52,6 @@ class Scanner:
         self.svc_name = service
 
     def _build_examples(self):
-        # Kinda sucks to rebuild this every round. Should building it get moved into DocGen?
         self.examples = defaultdict(list)
         for example in self.doc_gen.examples.values():
             for lang_name, language in example.languages.items():
@@ -146,13 +145,3 @@ class Scanner:
                 if api_name != "":
                     tag_path += f"#L{snippet.line_start + 1}"
         return tag_path
-
-
-def _contains_language_version(example: Example, lang_name: str, sdk_ver: int):
-    return (
-        lang_name in example.languages
-        and next(
-            v.sdk_version == sdk_ver for v in example.languages[lang_name].versions
-        )
-        is not None
-    )

--- a/.tools/readmes/setup.py
+++ b/.tools/readmes/setup.py
@@ -17,6 +17,7 @@ setup(
     install_requires=[
         "jinja2>=3.1.4",
         "pyyaml>=5.3.1",
-        "aws-doc-sdk-examples-tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools",
+        # "aws-doc-sdk-examples-tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools",
+        "aws-doc-sdk-examples-tools @ file:///Users/dpsouth/devel/aws/aws-doc-sdk-examples-tools",
     ],
 )

--- a/.tools/readmes/setup.py
+++ b/.tools/readmes/setup.py
@@ -17,7 +17,6 @@ setup(
     install_requires=[
         "jinja2>=3.1.4",
         "pyyaml>=5.3.1",
-        # "aws-doc-sdk-examples-tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools",
-        "aws-doc-sdk-examples-tools @ file:///Users/dpsouth/devel/aws/aws-doc-sdk-examples-tools",
+        "aws-doc-sdk-examples-tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools",
     ],
 )

--- a/.tools/readmes/setup.py
+++ b/.tools/readmes/setup.py
@@ -9,7 +9,6 @@ setup(
     entry_points={
         "console_scripts": ["writeme=writeme:main"],
     },
-    python_requires=">=3.8,<3.9",
     build_requires=[
         "setuptools>=40.8.0",
         "wheel",

--- a/.tools/readmes/setup.py
+++ b/.tools/readmes/setup.py
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from setuptools import setup
+
+setup(
+    name="aws_doc_sdk_examples_readmes",
+    version="0.0.1",
+    entry_points={
+        "console_scripts": ["writeme=writeme:main"],
+    },
+    python_requires=">=3.8,<3.9",
+    build_requires=[
+        "setuptools>=40.8.0",
+        "wheel",
+    ],
+    install_requires=[
+        "jinja2>=3.1.4",
+        "pyyaml>=5.3.1",
+        "aws-doc-sdk-examples-tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools",
+    ],
+)

--- a/.tools/readmes/update.py
+++ b/.tools/readmes/update.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+from subprocess import check_call
+from sys import executable
+
+check_call([executable, "-m", "pip", "install", "-e", Path(__file__).parent])

--- a/.tools/readmes/update.py
+++ b/.tools/readmes/update.py
@@ -1,7 +1,12 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
 from pathlib import Path
 from subprocess import run, DEVNULL, PIPE, CalledProcessError
 from sys import executable
 
+logging.info("Updating WRITEME environment")
 try:
     run(
         [executable, "-m", "pip", "install", "-e", Path(__file__).parent],

--- a/.tools/readmes/update.py
+++ b/.tools/readmes/update.py
@@ -1,5 +1,9 @@
 from pathlib import Path
-from subprocess import check_call
+from subprocess import run
 from sys import executable
 
-check_call([executable, "-m", "pip", "install", "-e", Path(__file__).parent])
+run(
+    [executable, "-m", "pip", "install", "-e", Path(__file__).parent],
+    check=True,
+    capture_output=False,
+)

--- a/.tools/readmes/update.py
+++ b/.tools/readmes/update.py
@@ -1,9 +1,14 @@
 from pathlib import Path
-from subprocess import run
+from subprocess import run, DEVNULL, PIPE, CalledProcessError
 from sys import executable
 
-run(
-    [executable, "-m", "pip", "install", "-e", Path(__file__).parent],
-    check=True,
-    capture_output=False,
-)
+try:
+    run(
+        [executable, "-m", "pip", "install", "-e", Path(__file__).parent],
+        check=True,
+        stderr=PIPE,
+        stdin=DEVNULL,
+        stdout=DEVNULL,
+    )
+except CalledProcessError as _cpe:
+    raise RuntimeError(f"Update failed: {_cpe.stderr}")

--- a/.tools/readmes/writeme.py
+++ b/.tools/readmes/writeme.py
@@ -2,6 +2,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import update  # for side effects
+
 import argparse
 import config
 import logging

--- a/.tools/readmes/writeme.py
+++ b/.tools/readmes/writeme.py
@@ -19,7 +19,8 @@ from aws_doc_sdk_examples_tools.doc_gen import DocGen
 
 
 def main():
-    doc_gen = DocGen.from_root(Path(__file__).parent.parent.parent, incremental=True)
+    # Load all examples immediately for cross references. Trades correctness for speed
+    doc_gen = DocGen.from_root(Path(__file__).parent.parent.parent, incremental=False)
     doc_gen.collect_snippets()
     doc_gen.validate()
     if doc_gen.errors:

--- a/.tools/readmes/writeme.py
+++ b/.tools/readmes/writeme.py
@@ -2,7 +2,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import update  # for side effects
+# flake8: noqa: F401 for side effects
+import update
 
 import argparse
 import config
@@ -18,7 +19,7 @@ from aws_doc_sdk_examples_tools.doc_gen import DocGen
 
 
 def main():
-    doc_gen = DocGen.from_root(Path(__file__).parent.parent.parent)
+    doc_gen = DocGen.from_root(Path(__file__).parent.parent.parent, incremental=True)
     doc_gen.collect_snippets()
     doc_gen.validate()
     if doc_gen.errors:
@@ -83,37 +84,41 @@ def main():
     failed = []
     written = []
 
-    for language_and_version in args.languages:
-        if language_and_version not in languages:
-            logging.debug(f"Skipping {language_and_version}")
-        else:
-            (language, version) = language_and_version.split(":")
-            for service in args.services:
-                id = f"{language}:{version}:{service}"
-                try:
-                    scanner.set_example(language, int(version), service)
-                    logging.debug("Rendering %s", id)
-                    renderer = Renderer(scanner, int(version), args.safe)
+    # Preload cross-content examples
+    scanner.load_crosses()
 
-                    result, _readme_updated = renderer.render()
-                    if result is None:
-                        logging.info("Render returned empty for %s", id)
-                        skipped.append(id)
-                        continue
-                    if args.dry_run:
-                        if not renderer.check():
-                            failed.append(id)
-                    else:
-                        renderer.write()
-                        written.append(id)
-                except FileNotFoundError:
+    for service in args.services:
+        for language_and_version in args.languages:
+            if language_and_version not in languages:
+                logging.debug(f"Skipping {language_and_version}")
+                continue
+
+            (language, version) = language_and_version.split(":")
+            id = f"{language}:{version}:{service}"
+            try:
+                scanner.set_example(language, int(version), service)
+                logging.debug("Rendering %s", id)
+                renderer = Renderer(scanner, int(version), args.safe)
+                result, _readme_updated = renderer.render()
+
+                if result is None:
+                    logging.info("Render returned empty for %s", id)
                     skipped.append(id)
-                except MissingMetadataError as mme:
-                    logging.error(mme)
-                    failed.append(id)
-                except Exception:
-                    logging.exception("Exception rendering %s", id)
-                    failed.append(id)
+                    continue
+                if args.dry_run:
+                    if not renderer.check():
+                        failed.append(id)
+                else:
+                    renderer.write()
+                    written.append(id)
+            except FileNotFoundError:
+                skipped.append(id)
+            except MissingMetadataError as mme:
+                logging.error(mme)
+                failed.append(id)
+            except Exception:
+                logging.exception("Exception rendering %s", id)
+                failed.append(id)
 
     done_list = "\n\t".join(written)
     skip_list = "\n\t".join(skipped)

--- a/.tools/readmes/writeme.py
+++ b/.tools/readmes/writeme.py
@@ -88,6 +88,10 @@ def main():
     scanner.load_crosses()
 
     for service in args.services:
+        try:
+            scanner.set_service(service)
+        except FileNotFoundError:
+            continue
         for language_and_version in args.languages:
             if language_and_version not in languages:
                 logging.debug(f"Skipping {language_and_version}")
@@ -96,7 +100,7 @@ def main():
             (language, version) = language_and_version.split(":")
             id = f"{language}:{version}:{service}"
             try:
-                scanner.set_example(language, int(version), service)
+                scanner.set_example(language, int(version))
                 logging.debug("Rendering %s", id)
                 renderer = Renderer(scanner, int(version), args.safe)
                 result, _readme_updated = renderer.render()

--- a/.tools/readmes/writeme.py
+++ b/.tools/readmes/writeme.py
@@ -94,10 +94,7 @@ def main():
     scanner.load_crosses()
 
     for service in args.services:
-        try:
-            scanner.set_service(service)
-        except FileNotFoundError:
-            continue
+        scanner.set_service(service)
         for language_and_version in args.languages:
             (language, version) = language_and_version.split(":")
             id = f"{language}:{version}:{service}"

--- a/.tools/readmes/writeme.py
+++ b/.tools/readmes/writeme.py
@@ -93,22 +93,27 @@ def main():
     # Preload cross-content examples
     scanner.load_crosses()
 
+    renderer = Renderer(scanner)
     for service in args.services:
-        scanner.set_service(service)
         for language_and_version in args.languages:
             (language, version) = language_and_version.split(":")
             id = f"{language}:{version}:{service}"
             try:
-                scanner.set_example(language, int(version))
-                logging.debug("Rendering %s", id)
-                renderer = Renderer(scanner, int(version), args.safe)
+                renderer.set_example(service, language, int(version), args.safe)
                 if renderer.lang_config is None:
                     continue
 
+                logging.debug("Rendering %s", id)
                 result, updated = renderer.render()
 
                 if result is None:
-                    if renderer.readme_filename.exists():
+                    if (
+                        renderer.lang_config["service_folder"]
+                        not in renderer.lang_config.get(
+                            "service_folder_overrides", {}
+                        ).values()
+                        and renderer.readme_filename.exists()
+                    ):
                         non_writeme.append(id)
                     else:
                         skipped.append(id)

--- a/cpp/example_code/sns/README.md
+++ b/cpp/example_code/sns/README.md
@@ -63,6 +63,7 @@ Code examples that show you how to accomplish a specific task by calling multipl
 functions within the same service.
 
 - [Publish an SMS text message](publish_sms.cpp)
+- [Publish messages to queues](../cross-service/topics_and_queues/messaging_with_topics_and_queues.cpp)
 
 ### Cross-service examples
 
@@ -111,6 +112,22 @@ This example shows you how to publish SMS messages using Amazon SNS.
 
 <!--custom.scenarios.sns_PublishTextSMS.start-->
 <!--custom.scenarios.sns_PublishTextSMS.end-->
+
+#### Publish messages to queues
+
+This example shows you how to do the following:
+
+- Create topic (FIFO or non-FIFO).
+- Subscribe several queues to the topic with an option to apply a filter.
+- Publish messages to the topic.
+- Poll the queues for messages received.
+
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.end-->
+
+
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.end-->
 
 ### Tests
 

--- a/dotnetv3/SNS/README.md
+++ b/dotnetv3/SNS/README.md
@@ -54,6 +54,7 @@ Code examples that show you how to accomplish a specific task by calling multipl
 functions within the same service.
 
 - [Publish an SMS text message](SNSMessageExample/SNSMessageExample/SNSMessage.cs)
+- [Publish messages to queues](../cross-service/TopicsAndQueues/Scenarios/TopicsAndQueuesScenario/TopicsAndQueues.cs)
 
 ### Cross-service examples
 
@@ -108,6 +109,22 @@ This example shows you how to publish SMS messages using Amazon SNS.
 
 <!--custom.scenarios.sns_PublishTextSMS.start-->
 <!--custom.scenarios.sns_PublishTextSMS.end-->
+
+#### Publish messages to queues
+
+This example shows you how to do the following:
+
+- Create topic (FIFO or non-FIFO).
+- Subscribe several queues to the topic with an option to apply a filter.
+- Publish messages to the topic.
+- Poll the queues for messages received.
+
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.end-->
+
+
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.end-->
 
 ### Tests
 

--- a/gov2/sns/README.md
+++ b/gov2/sns/README.md
@@ -44,6 +44,13 @@ Code excerpts that show you how to call individual service functions.
 - [Publish](../workflows/topics_and_queues/actions/sns_actions.go#L105)
 - [Subscribe](../workflows/topics_and_queues/actions/sns_actions.go#L70)
 
+### Scenarios
+
+Code examples that show you how to accomplish a specific task by calling multiple
+functions within the same service.
+
+- [Publish messages to queues](../workflows/topics_and_queues/workflows/scenario_topics_and_queues.go)
+
 
 <!--custom.examples.start-->
 ### Workflows
@@ -87,6 +94,22 @@ and to get help for running a scenario, use the following command:
 ```
 go run ./cmd -h
 ```
+
+#### Publish messages to queues
+
+This example shows you how to do the following:
+
+- Create topic (FIFO or non-FIFO).
+- Subscribe several queues to the topic with an option to apply a filter.
+- Publish messages to the topic.
+- Poll the queues for messages received.
+
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.end-->
+
+
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.end-->
 
 ### Tests
 

--- a/javascriptv3/example_code/bedrock-agent/README.md
+++ b/javascriptv3/example_code/bedrock-agent/README.md
@@ -34,7 +34,7 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `javas
 
 ### Get started
 
-- [Hello Agents for Amazon Bedrock](hello.js) (`ListAgents`)
+- [Hello Agents for Amazon Bedrock](hello.js) (`GetAgent`)
 
 
 ### Single actions

--- a/javascriptv3/example_code/sns/README.md
+++ b/javascriptv3/example_code/sns/README.md
@@ -52,6 +52,13 @@ Code excerpts that show you how to call individual service functions.
 - [Subscribe](libs/snsClient.js#L4)
 - [Unsubscribe](libs/snsClient.js#L4)
 
+### Scenarios
+
+Code examples that show you how to accomplish a specific task by calling multiple
+functions within the same service.
+
+- [Publish messages to queues](../cross-services/wkflw-topics-queues/index.js)
+
 
 <!--custom.examples.start-->
 <!--custom.examples.end-->
@@ -86,6 +93,22 @@ This example shows you how to get started using Amazon SNS.
 node ./hello.js
 ```
 
+
+#### Publish messages to queues
+
+This example shows you how to do the following:
+
+- Create topic (FIFO or non-FIFO).
+- Subscribe several queues to the topic with an option to apply a filter.
+- Publish messages to the topic.
+- Poll the queues for messages received.
+
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.end-->
+
+
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.end-->
 
 ### Tests
 

--- a/javav2/example_code/sns/README.md
+++ b/javav2/example_code/sns/README.md
@@ -63,6 +63,7 @@ functions within the same service.
 - [Create and publish to a FIFO topic](src/main/java/com/example/sns/PriceUpdateExample.java)
 - [Publish SMS messages to a topic](src/main/java/com/example/sns/CreateTopic.java)
 - [Publish an SMS text message](src/main/java/com/example/sns/PublishTextSMS.java)
+- [Publish messages to queues](../../usecases/topics_and_queues/src/main/java/com/example/sns/SNSWorkflow.java)
 
 
 <!--custom.examples.start-->
@@ -132,6 +133,22 @@ This example shows you how to publish SMS messages using Amazon SNS.
 
 <!--custom.scenarios.sns_PublishTextSMS.start-->
 <!--custom.scenarios.sns_PublishTextSMS.end-->
+
+#### Publish messages to queues
+
+This example shows you how to do the following:
+
+- Create topic (FIFO or non-FIFO).
+- Subscribe several queues to the topic with an option to apply a filter.
+- Publish messages to the topic.
+- Poll the queues for messages received.
+
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.end-->
+
+
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.end-->
 
 ### Tests
 

--- a/javav2/example_code/sns/README.md
+++ b/javav2/example_code/sns/README.md
@@ -51,7 +51,6 @@ Code excerpts that show you how to call individual service functions.
 - [SetSMSAttributes](src/main/java/com/example/sns/SetSMSAttributes.java#L6)
 - [SetSubscriptionAttributes](src/main/java/com/example/sns/UseMessageFilterPolicy.java#L6)
 - [SetTopicAttributes](src/main/java/com/example/sns/SetTopicAttributes.java#L6)
-- [Subscribe](None)
 - [TagResource](src/main/java/com/example/sns/AddTags.java#L6)
 - [Unsubscribe](src/main/java/com/example/sns/Unsubscribe.java#L6)
 

--- a/javav2/example_code/sqs/README.md
+++ b/javav2/example_code/sqs/README.md
@@ -52,7 +52,6 @@ Code excerpts that show you how to call individual service functions.
 Code examples that show you how to accomplish a specific task by calling multiple
 functions within the same service.
 
-- [Create and publish to a FIFO topic](../sns/src/main/java/com/example/sns/PriceUpdateExample.java)
 - [Publish messages to queues](../../usecases/topics_and_queues/src/main/java/com/example/sns/SNSWorkflow.java)
 
 
@@ -72,18 +71,6 @@ functions within the same service.
 This example shows you how to get started using Amazon SQS.
 
 
-
-#### Create and publish to a FIFO topic
-
-This example shows you how to create and publish to a FIFO Amazon SNS topic.
-
-
-<!--custom.scenario_prereqs.sns_PublishFifoTopic.start-->
-<!--custom.scenario_prereqs.sns_PublishFifoTopic.end-->
-
-
-<!--custom.scenarios.sns_PublishFifoTopic.start-->
-<!--custom.scenarios.sns_PublishFifoTopic.end-->
 
 #### Publish messages to queues
 

--- a/javav2/example_code/sqs/README.md
+++ b/javav2/example_code/sqs/README.md
@@ -52,6 +52,7 @@ Code excerpts that show you how to call individual service functions.
 Code examples that show you how to accomplish a specific task by calling multiple
 functions within the same service.
 
+- [Create and publish to a FIFO topic](../sns/src/main/java/com/example/sns/PriceUpdateExample.java)
 - [Publish messages to queues](../../usecases/topics_and_queues/src/main/java/com/example/sns/SNSWorkflow.java)
 
 
@@ -71,6 +72,18 @@ functions within the same service.
 This example shows you how to get started using Amazon SQS.
 
 
+
+#### Create and publish to a FIFO topic
+
+This example shows you how to create and publish to a FIFO Amazon SNS topic.
+
+
+<!--custom.scenario_prereqs.sns_PublishFifoTopic.start-->
+<!--custom.scenario_prereqs.sns_PublishFifoTopic.end-->
+
+
+<!--custom.scenarios.sns_PublishFifoTopic.start-->
+<!--custom.scenarios.sns_PublishFifoTopic.end-->
 
 #### Publish messages to queues
 

--- a/kotlin/services/sns/README.md
+++ b/kotlin/services/sns/README.md
@@ -55,6 +55,7 @@ Code examples that show you how to accomplish a specific task by calling multipl
 functions within the same service.
 
 - [Publish an SMS text message](src/main/kotlin/com/kotlin/sns/PublishTextSMS.kt)
+- [Publish messages to queues](../../usecases/topics_and_queues/src/main/kotlin/com/example/sns/SNSWorkflow.kt)
 
 
 <!--custom.examples.start-->
@@ -92,6 +93,22 @@ This example shows you how to publish SMS messages using Amazon SNS.
 
 <!--custom.scenarios.sns_PublishTextSMS.start-->
 <!--custom.scenarios.sns_PublishTextSMS.end-->
+
+#### Publish messages to queues
+
+This example shows you how to do the following:
+
+- Create topic (FIFO or non-FIFO).
+- Subscribe several queues to the topic with an option to apply a filter.
+- Publish messages to the topic.
+- Poll the queues for messages received.
+
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenario_prereqs.sqs_Scenario_TopicsAndQueues.end-->
+
+
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.start-->
+<!--custom.scenarios.sqs_Scenario_TopicsAndQueues.end-->
 
 ### Tests
 

--- a/python/example_code/sqs/README.md
+++ b/python/example_code/sqs/README.md
@@ -53,6 +53,7 @@ Code excerpts that show you how to call individual service functions.
 Code examples that show you how to accomplish a specific task by calling multiple
 functions within the same service.
 
+- [Create and publish to a FIFO topic](../sns/sns_fifo_topic.py)
 - [Send and receive batches of messages](message_wrapper.py)
 
 ### Cross-service examples
@@ -75,6 +76,24 @@ Sample applications that work across multiple AWS services.
 <!--custom.instructions.end-->
 
 
+
+#### Create and publish to a FIFO topic
+
+This example shows you how to create and publish to a FIFO Amazon SNS topic.
+
+
+<!--custom.scenario_prereqs.sns_PublishFifoTopic.start-->
+<!--custom.scenario_prereqs.sns_PublishFifoTopic.end-->
+
+Start the example by running the following at a command prompt:
+
+```
+python ../sns/sns_fifo_topic.py
+```
+
+
+<!--custom.scenarios.sns_PublishFifoTopic.start-->
+<!--custom.scenarios.sns_PublishFifoTopic.end-->
 
 #### Send and receive batches of messages
 

--- a/sap-abap/services/sqs/README.md
+++ b/sap-abap/services/sqs/README.md
@@ -40,6 +40,13 @@ Code excerpts that show you how to call individual service functions.
 - [ReceiveMessage](zcl_aws1_sqs_actions.clas.abap#L179)
 - [SendMessage](zcl_aws1_sqs_actions.clas.abap#L197)
 
+### Scenarios
+
+Code examples that show you how to accomplish a specific task by calling multiple
+functions within the same service.
+
+- [Create and publish to a FIFO topic](../sns/zcl_aws1_sns_scenario.clas.abap)
+
 
 <!--custom.examples.start-->
 <!--custom.examples.end-->
@@ -53,6 +60,18 @@ Code excerpts that show you how to call individual service functions.
 <!--custom.instructions.end-->
 
 
+
+#### Create and publish to a FIFO topic
+
+This example shows you how to create and publish to a FIFO Amazon SNS topic.
+
+
+<!--custom.scenario_prereqs.sns_PublishFifoTopic.start-->
+<!--custom.scenario_prereqs.sns_PublishFifoTopic.end-->
+
+
+<!--custom.scenarios.sns_PublishFifoTopic.start-->
+<!--custom.scenarios.sns_PublishFifoTopic.end-->
 
 ### Tests
 

--- a/sap-abap/services/sqs/README.md
+++ b/sap-abap/services/sqs/README.md
@@ -40,13 +40,6 @@ Code excerpts that show you how to call individual service functions.
 - [ReceiveMessage](zcl_aws1_sqs_actions.clas.abap#L179)
 - [SendMessage](zcl_aws1_sqs_actions.clas.abap#L197)
 
-### Scenarios
-
-Code examples that show you how to accomplish a specific task by calling multiple
-functions within the same service.
-
-- [Create and publish to a FIFO topic](../sns/zcl_aws1_sns_scenario.clas.abap)
-
 
 <!--custom.examples.start-->
 <!--custom.examples.end-->
@@ -60,18 +53,6 @@ functions within the same service.
 <!--custom.instructions.end-->
 
 
-
-#### Create and publish to a FIFO topic
-
-This example shows you how to create and publish to a FIFO Amazon SNS topic.
-
-
-<!--custom.scenario_prereqs.sns_PublishFifoTopic.start-->
-<!--custom.scenario_prereqs.sns_PublishFifoTopic.end-->
-
-
-<!--custom.scenarios.sns_PublishFifoTopic.start-->
-<!--custom.scenarios.sns_PublishFifoTopic.end-->
 
 ### Tests
 


### PR DESCRIPTION
Part I: Rewrite scanner generally. This has 90% match to existing scanner, but is slow.

~TODO: Meet parity, around cross services especially.~
~TODO: Don't load the entire metadata on start, but rather progressively load services as needed.~
~TODO: Build Scanner lookup structures automatically~
~TODO: Remove Scanner and have Renderer just look up structs as it needs them~

Part II: Refactor Renderer to remove duplicate code and normalize configs for templates.

Baseline: python .tools/readmes/writeme.py  36.90s user 2.40s system 92% cpu 42.694 total
Full run: python .tools/readmes/writeme.py  15.07s user 2.03s system 87% cpu 19.589 total
Single service: python .tools/readmes/writeme.py --services sqs  7.13s user 1.05s system 85% cpu 9.523 total

Loading the entire metadata set sucks but is necessary for correctness

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
