### PR TITLE
Swift: Fix ByteStream init in S3 code examples

### DIFF
--- a/swift/example_code/s3/DeleteObjects/Tests/DeleteObjectsTests/ServiceHandler_Ext.swift
+++ b/swift/example_code/s3/DeleteObjects/Tests/DeleteObjectsTests/ServiceHandler_Ext.swift
@@ -11,6 +11,7 @@ import AWSS3
 import AWSClientRuntime
 import ClientRuntime
 import SwiftUtilities
+import Smithy
 @testable import ServiceHandler
 
 public extension ServiceHandler {
@@ -47,7 +48,7 @@ public extension ServiceHandler {
     ///   - key: Name of the file to create.
     ///   - data: A `Data` object to write into the new file.
     func createFile(bucket: String, key: String, withData data: Data) async throws {
-        let dataStream = ByteStream.from(data: data)
+        let dataStream = ByteStream.data(data)
 
         let input = PutObjectInput(
             body: dataStream,

--- a/swift/example_code/s3/README.md
+++ b/swift/example_code/s3/README.md
@@ -33,15 +33,15 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `swift
 
 Code excerpts that show you how to call individual service functions.
 
-- [CopyObject](basics/Sources/ServiceHandler/ServiceHandler.swift#L164)
-- [CreateBucket](basics/Sources/ServiceHandler/ServiceHandler.swift#L41)
-- [DeleteBucket](basics/Sources/ServiceHandler/ServiceHandler.swift#L56)
-- [DeleteObject](basics/Sources/ServiceHandler/ServiceHandler.swift#L183)
+- [CopyObject](basics/Sources/ServiceHandler/ServiceHandler.swift#L165)
+- [CreateBucket](basics/Sources/ServiceHandler/ServiceHandler.swift#L42)
+- [DeleteBucket](basics/Sources/ServiceHandler/ServiceHandler.swift#L57)
+- [DeleteObject](basics/Sources/ServiceHandler/ServiceHandler.swift#L184)
 - [DeleteObjects](DeleteObjects/Sources/ServiceHandler/ServiceHandler.swift#L54)
-- [GetObject](basics/Sources/ServiceHandler/ServiceHandler.swift#L112)
+- [GetObject](basics/Sources/ServiceHandler/ServiceHandler.swift#L113)
 - [ListBuckets](ListBuckets/Sources/ListBuckets/S3Session.swift#L70)
-- [ListObjectsV2](basics/Sources/ServiceHandler/ServiceHandler.swift#L204)
-- [PutObject](basics/Sources/ServiceHandler/ServiceHandler.swift#L70)
+- [ListObjectsV2](basics/Sources/ServiceHandler/ServiceHandler.swift#L205)
+- [PutObject](basics/Sources/ServiceHandler/ServiceHandler.swift#L71)
 
 ### Scenarios
 

--- a/swift/example_code/s3/basics/Sources/ServiceHandler/ServiceHandler.swift
+++ b/swift/example_code/s3/basics/Sources/ServiceHandler/ServiceHandler.swift
@@ -11,6 +11,7 @@ import Foundation
 import AWSS3
 import ClientRuntime
 import AWSClientRuntime
+import Smithy
 // snippet-end:[s3.swift.basics.handler.imports]
 
 /// A class containing all the code that interacts with the AWS SDK for Swift.
@@ -71,7 +72,7 @@ public class ServiceHandler {
     public func uploadFile(bucket: String, key: String, file: String) async throws {
         let fileUrl = URL(fileURLWithPath: file)
         let fileData = try Data(contentsOf: fileUrl)
-        let dataStream = ByteStream.from(data: fileData)
+        let dataStream = ByteStream.data(fileData)
 
         let input = PutObjectInput(
             body: dataStream,
@@ -91,7 +92,7 @@ public class ServiceHandler {
     ///   - data: A `Data` object to write into the new file.
     // snippet-start:[s3.swift.basics.handler.createfile]
     public func createFile(bucket: String, key: String, withData data: Data) async throws {
-        let dataStream = ByteStream.from(data: data)
+        let dataStream = ByteStream.data(data)
 
         let input = PutObjectInput(
             body: dataStream,


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request fixes ByteStream initialization in Swift S3 code examples.

Closes #6626

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
