### PR TITLE
Update GH action to publish monthly issue metrics

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -8,9 +8,13 @@
 name: Monthly issue metrics
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
-  schedule:
-    - cron: '3 2 1 * *'
-
+    inputs:
+      report_date_start:
+        description: "Report date start(01/01/2024)"
+        required: false
+      report_date_end:
+        description: "Report date end(11/07/2024)"
+        required: false
 permissions:
   issues: write
   pull-requests: read
@@ -24,13 +28,10 @@ jobs:
         shell: bash
         run: |
           # Calculate the first day of the previous month
-          first_day=$(date -d "last month" +%Y-%m-01)
+          first_day=${{ inputs.report_date_start }}
 
           # Calculate the last day of the previous month
-          last_day=$(date -d "$first_day +1 month -1 day" +%Y-%m-%d)
-
-          # Set an environment variable with the date range
-          echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
+          last_day=${{ inputs.report_date_end }}
 
       - name: Run issue-metrics tool
         uses: github/issue-metrics@v2


### PR DESCRIPTION
This pull request updates the GH action to publish monthly issue metrics, enabling it to be triggered for any period of time on request.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
