### PR TITLE
Revert "Parse .xml snippet files in xi:include"

### DIFF
--- a/.doc_gen/templates/zonbook/example_language_template.xml
+++ b/.doc_gen/templates/zonbook/example_language_template.xml
@@ -53,7 +53,7 @@
                 {{- end}}
                 {{- if .SnippetTags}}
                 <!-- The following line break must be preserved and left-justified exactly as-is, to keep snippets looking good. -->
-                <programlisting language="{{.Syntax}}">{{range .SnippetTags}}<xi:include parse="{{- if hasSuffix . ".xml"}}xml{{- else}}text{{- end}}" href="{{$include_base}}snippets/{{.}}.txt"/>
+                <programlisting language="{{.Syntax}}">{{range .SnippetTags}}<xi:include parse="text" href="{{$include_base}}snippets/{{.}}.txt"/>
 {{end}}</programlisting>
                 {{- end}}
             </block>


### PR DESCRIPTION
Reverts awsdocs/aws-doc-sdk-examples#6661

Zonbook error: 
```
    [exec] 2024/07/17 18:37:44 Reading templates from aws-doc-sdk-examples/.doc_gen/templates/zonbook/*.*.
     [exec] panic: template: example_language_template.xml:56: function "hasSuffix" not defined
```