### PR TITLE
Revert "Revert "Parse .xml snippet files in xi:include""

### DIFF
--- a/.doc_gen/templates/zonbook/example_language_template.xml
+++ b/.doc_gen/templates/zonbook/example_language_template.xml
@@ -53,7 +53,7 @@
                 {{- end}}
                 {{- if .SnippetTags}}
                 <!-- The following line break must be preserved and left-justified exactly as-is, to keep snippets looking good. -->
-                <programlisting language="{{.Syntax}}">{{range .SnippetTags}}<xi:include parse="text" href="{{$include_base}}snippets/{{.}}.txt"/>
+                <programlisting language="{{.Syntax}}">{{range .SnippetTags}}<xi:include parse="{{- if hasSuffix . ".xml"}}xml{{- else}}text{{- end}}" href="{{$include_base}}snippets/{{.}}.txt"/>
 {{end}}</programlisting>
                 {{- end}}
             </block>


### PR DESCRIPTION
Reverts awsdocs/aws-doc-sdk-examples#6668

This change is required to render the CLI examples correctly in the documentation.
The "missing hasSuffix" error you saw on 6668 was caused by your workspace being out of sync on the backend. If you sync everything and build with this unrevert, it should build correctly.