### PR TITLE
Update rust api link_template.

### DIFF
--- a/.doc_gen/metadata/sdks.yaml
+++ b/.doc_gen/metadata/sdks.yaml
@@ -279,7 +279,8 @@ Rust:
       api_ref:
         uid: "SdkForRustV1"
         name: "&guide-rust-api;"
-        link_template: "https://docs.rs/releases/search?query=aws-sdk"
+        # https://docs.rs/aws-sdk-apigateway/latest/aws_sdk_apigateway/client/struct.Client.html#method.get_rest_apis
+        link_template: "https://docs.rs/aws-sdk-{{.ServiceCollapsed}}/latest/aws_sdk_{{.ServiceCollapsed}}/client/struct.Client.html#method.{{.ActionSnake}}"
   guide: "&guide-rust-dev;"
 Swift:
   property: swift


### PR DESCRIPTION
This pull request updates Rust API links to point to the specific API page for the action.


Relies on internal commit 139264199

Closes #6281



---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
