### PR TITLE
Rust: Bedrock Examples

### DIFF
--- a/.doc_gen/metadata/bedrock-runtime_metadata.yaml
+++ b/.doc_gen/metadata/bedrock-runtime_metadata.yaml
@@ -154,6 +154,14 @@ bedrock-runtime_Converse_AnthropicClaude:
             - description: Send a text message to Anthropic Claude, using Bedrock's Converse API.
               snippet_tags:
                 - javascript.v3.bedrock-runtime.Converse_AnthropicClaude
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/bedrock-runtime
+          excerpts:
+            - description: Send a text message to Anthropic Claude, using Bedrock's Converse API.
+              snippet_tags:
+                - rust.bedrock-runtime.Converse_AnthropicClaude
   services:
     bedrock-runtime: {Converse}
 

--- a/.doc_gen/metadata/bedrock-runtime_metadata.yaml
+++ b/.doc_gen/metadata/bedrock-runtime_metadata.yaml
@@ -1304,7 +1304,7 @@ bedrock-runtime_Scenario_ToolUseDemo_AnthropicClaude:
           github: rustv1/examples/bedrock-runtime
           excerpts:
             - description: "The primary scenario and logic for the demo. This orchestrates the conversation between the user, the &BR; Converse API, and a weather tool."
-              snippet-tags:
+              snippet_tags:
                 - rust.bedrock-runtime.Converse_AnthropicClaude.tool-use
             - description: "The weather tool used by the demo. This script defines the tool specification and implements the logic to retrieve weather data using from the Open-Meteo API."
               snippet_tags:

--- a/.doc_gen/metadata/bedrock-runtime_metadata.yaml
+++ b/.doc_gen/metadata/bedrock-runtime_metadata.yaml
@@ -162,6 +162,9 @@ bedrock-runtime_Converse_AnthropicClaude:
             - description: Send a text message to Anthropic Claude, using Bedrock's Converse API.
               snippet_tags:
                 - rust.bedrock-runtime.Converse_AnthropicClaude
+            - description: Use statements, Error utility, and constants.
+              snippet_tags:
+                - rust.bedrock-runtime.Converse_AnthropicClaude.supporting
   services:
     bedrock-runtime: {Converse}
 
@@ -377,6 +380,17 @@ bedrock-runtime_ConverseStream_AnthropicClaude:
             - description: Send a text message to Anthropic Claude, using Bedrock's Converse API and process the response stream in real-time.
               snippet_tags:
                 - javascript.v3.bedrock-runtime.ConverseStream_AnthropicClaude
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/bedrock-runtime
+          excerpts:
+            - description: Send a text message to Anthropic Claude and stream reply tokens, using Bedrock's ConverseStream API.
+              snippet_tags:
+                - rust.bedrock-runtime.ConverseStream_AnthropicClaude
+            - description: Use statements, Error utility, and constants.
+              snippet_tags:
+                - rust.bedrock-runtime.ConverseStream_AnthropicClaude.supporting
   services:
     bedrock-runtime: {ConverseStream}
 
@@ -1284,6 +1298,24 @@ bedrock-runtime_Scenario_ToolUseDemo_AnthropicClaude:
             - description: "The weather tool used by the demo. This script defines the tool specification and implements the logic to retrieve weather data using from the Open-Meteo API."
               snippet_files:
                 - python/example_code/bedrock-runtime/cross-model-scenarios/tool_use_demo/weather_tool.py
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/bedrock-runtime
+          excerpts:
+            - description: "The primary scenario and logic for the demo. This orchestrates the conversation between the user, the &BR; Converse API, and a weather tool."
+              snippet-tags:
+                - rust.bedrock-runtime.Converse_AnthropicClaude.tool-use
+            - description: "The weather tool used by the demo. This script defines the tool specification and implements the logic to retrieve weather data using from the Open-Meteo API."
+              snippet_tags:
+                - rust.bedrock-runtime.Converse_AnthropicClaude.tool-use.weather-tool
+            - description: "Utilities to print the Message Content Blocks"
+              snippet_tags:
+                - rust.bedrock-runtime.Converse_AnthropicClaude.tool-use.user-interface
+            - description: "Use statements, Error utility, and constants."
+              snippet_tags:
+                - rust.bedrock-runtime.Converse_AnthropicClaude.tool-use.supporting
+
   services:
     bedrock-runtime: {Converse}
 

--- a/rustv1/examples/Cargo.toml
+++ b/rustv1/examples/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "auto-scaling",
     "autoscalingplans",
     "batch",
+    "bedrock-runtime",
     "cloudformation",
     "cloudwatch",
     "cloudwatchlogs",

--- a/rustv1/examples/bedrock-runtime/Cargo.toml
+++ b/rustv1/examples/bedrock-runtime/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bedrock-runtime"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aws-config = "1.5.4"
+aws-sdk-bedrockruntime = "1.40.0"
+tokio = { version = "1.38.1", features = ["full"] }
+tracing-subscriber = "0.3.18"

--- a/rustv1/examples/bedrock-runtime/Cargo.toml
+++ b/rustv1/examples/bedrock-runtime/Cargo.toml
@@ -8,5 +8,10 @@ edition = "2021"
 [dependencies]
 aws-config = "1.5.4"
 aws-sdk-bedrockruntime = "1.40.0"
+aws-smithy-runtime-api = "1.7.1"
+aws-smithy-types = "1.2.0"
+reqwest = "0.12.5"
+serde = "1.0.204"
+serde_json = "1.0.120"
 tokio = { version = "1.38.1", features = ["full"] }
 tracing-subscriber = "0.3.18"

--- a/rustv1/examples/bedrock-runtime/Cargo.toml
+++ b/rustv1/examples/bedrock-runtime/Cargo.toml
@@ -14,4 +14,5 @@ reqwest = "0.12.5"
 serde = "1.0.204"
 serde_json = "1.0.120"
 tokio = { version = "1.38.1", features = ["full"] }
+tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/rustv1/examples/bedrock-runtime/README.md
+++ b/rustv1/examples/bedrock-runtime/README.md
@@ -1,0 +1,77 @@
+# Amazon Bedrock Runtime code examples for the SDK for Rust
+
+## Overview
+
+Shows how to use the AWS SDK for Rust to work with Amazon Bedrock Runtime.
+
+<!--custom.overview.start-->
+<!--custom.overview.end-->
+
+_Amazon Bedrock Runtime is a fully managed service that makes it easy to use foundation models from third-party providers and Amazon._
+
+## ⚠ Important
+
+* Running this code might result in charges to your AWS account. For more details, see [AWS Pricing](https://aws.amazon.com/pricing/) and [Free Tier](https://aws.amazon.com/free/).
+* Running the tests might result in charges to your AWS account.
+* We recommend that you grant your code least privilege. At most, grant only the minimum permissions required to perform the task. For more information, see [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege).
+* This code is not tested in every AWS Region. For more information, see [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+
+<!--custom.important.start-->
+<!--custom.important.end-->
+
+## Code examples
+
+### Prerequisites
+
+For prerequisites, see the [README](../../README.md#Prerequisites) in the `rustv1` folder.
+
+
+<!--custom.prerequisites.start-->
+<!--custom.prerequisites.end-->
+### Anthropic Claude
+
+- [Converse](src/bin/converse.rs#L43)
+- [ConverseStream](src/bin/converse-stream.rs#L70)
+- [Scenario: Tool use with the Converse API](src/bin/tool-use.rs#L244)
+
+
+<!--custom.examples.start-->
+<!--custom.examples.end-->
+
+## Run the examples
+
+### Instructions
+
+
+<!--custom.instructions.start-->
+<!--custom.instructions.end-->
+
+
+
+### Tests
+
+⚠ Running tests might result in charges to your AWS account.
+
+
+To find instructions for running these tests, see the [README](../../README.md#Tests)
+in the `rustv1` folder.
+
+
+
+<!--custom.tests.start-->
+<!--custom.tests.end-->
+
+## Additional resources
+
+- [Amazon Bedrock Runtime User Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html)
+- [Amazon Bedrock Runtime API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/welcome.html)
+- [SDK for Rust Amazon Bedrock Runtime reference](https://docs.rs/aws-sdk-bedrock-runtime/latest/aws_sdk_bedrock-runtime/)
+
+<!--custom.resources.start-->
+<!--custom.resources.end-->
+
+---
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0

--- a/rustv1/examples/bedrock-runtime/README.md
+++ b/rustv1/examples/bedrock-runtime/README.md
@@ -32,7 +32,7 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `rustv
 
 - [Converse](src/bin/converse.rs#L43)
 - [ConverseStream](src/bin/converse-stream.rs#L70)
-- [Scenario: Tool use with the Converse API](src/bin/tool-use.rs#L244)
+- [Scenario: Tool use with the Converse API](src/bin/tool-use.rs#L242)
 
 
 <!--custom.examples.start-->

--- a/rustv1/examples/bedrock-runtime/src/bin/converse-stream.rs
+++ b/rustv1/examples/bedrock-runtime/src/bin/converse-stream.rs
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// snippet-start:[rust.bedrock-runtime.ConverseStream_AnthropicClaude]
+use aws_config::BehaviorVersion;
+use aws_sdk_bedrockruntime::{
+    error::ProvideErrorMetadata,
+    operation::converse_stream::ConverseStreamError,
+    types::{
+        error::ConverseStreamOutputError, ContentBlock, ConversationRole,
+        ConverseStreamOutput as ConverseStreamOutputType, Message,
+    },
+    Client,
+};
+
+// Set the model ID, e.g., Claude 3 Haiku.
+const MODEL_ID: &str = "anthropic.claude-3-haiku-20240307-v1:0";
+const CLAUDE_REGION: &str = "us-east-1";
+
+// Start a conversation with the user message.
+const USER_MESSAGE: &str = "Describe the purpose of a 'hello world' program in one line.";
+
+#[tokio::main]
+async fn main() -> Result<(), BedrockConverseStreamError> {
+    tracing_subscriber::fmt::init();
+    let sdk_config = aws_config::defaults(BehaviorVersion::latest())
+        .region(CLAUDE_REGION)
+        .load()
+        .await;
+    let client = Client::new(&sdk_config);
+
+    let response = client
+        .converse_stream()
+        .model_id(MODEL_ID)
+        .messages(
+            Message::builder()
+                .role(ConversationRole::User)
+                .content(ContentBlock::Text(USER_MESSAGE.to_string()))
+                .build()
+                .map_err(|_| "failed to build message")?,
+        )
+        .send()
+        .await;
+
+    let mut stream = match response {
+        Ok(output) => Ok(output.stream),
+        Err(e) => Err(BedrockConverseStreamError::from(
+            e.as_service_error().unwrap(),
+        )),
+    }?;
+
+    loop {
+        let token = stream.recv().await;
+        match token {
+            Ok(Some(text)) => {
+                let next = get_converse_output_text(text)?;
+                print!("{}", next);
+                Ok(())
+            }
+            Ok(None) => break,
+            Err(e) => Err(e
+                .as_service_error()
+                .map(BedrockConverseStreamError::from)
+                .unwrap_or(BedrockConverseStreamError(
+                    "Unknown error receiving stream".into(),
+                ))),
+        }?
+    }
+
+    println!();
+
+    Ok(())
+}
+
+fn get_converse_output_text(
+    output: ConverseStreamOutputType,
+) -> Result<String, BedrockConverseStreamError> {
+    Ok(match output {
+        ConverseStreamOutputType::ContentBlockDelta(event) => match event.delta() {
+            Some(delta) => delta
+                .as_text()
+                .map(|s| s.clone())
+                .unwrap_or_else(|_| "".into()),
+            None => "".into(),
+        },
+        _ => "".into(),
+    })
+}
+
+#[derive(Debug)]
+struct BedrockConverseStreamError(String);
+impl std::fmt::Display for BedrockConverseStreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Can't invoke '{}'. Reason: {}", MODEL_ID, self.0)
+    }
+}
+impl std::error::Error for BedrockConverseStreamError {}
+impl From<&str> for BedrockConverseStreamError {
+    fn from(value: &str) -> Self {
+        BedrockConverseStreamError(value.into())
+    }
+}
+
+impl From<&ConverseStreamError> for BedrockConverseStreamError {
+    fn from(value: &ConverseStreamError) -> Self {
+        BedrockConverseStreamError(
+            match value {
+                ConverseStreamError::ModelTimeoutException(_) => "Model took too long",
+                ConverseStreamError::ModelNotReadyException(_) => "Model is not ready",
+                _ => "Unknown",
+            }
+            .into(),
+        )
+    }
+}
+
+impl From<&ConverseStreamOutputError> for BedrockConverseStreamError {
+    fn from(value: &ConverseStreamOutputError) -> Self {
+        match value {
+            ConverseStreamOutputError::ValidationException(ve) => BedrockConverseStreamError(
+                ve.message().unwrap_or("Unknown ValidationException").into(),
+            ),
+            ConverseStreamOutputError::ThrottlingException(te) => BedrockConverseStreamError(
+                te.message().unwrap_or("Unknown ThrottlingException").into(),
+            ),
+            value => BedrockConverseStreamError(
+                value
+                    .message()
+                    .unwrap_or("Unknown StreamOutput exception")
+                    .into(),
+            ),
+        }
+    }
+}
+// snippet-end:[rust.bedrock-runtime.ConverseStream_AnthropicClaude]

--- a/rustv1/examples/bedrock-runtime/src/bin/converse.rs
+++ b/rustv1/examples/bedrock-runtime/src/bin/converse.rs
@@ -40,7 +40,6 @@ impl From<&ConverseError> for BedrockConverseError {
 }
 // snippet-end:[rust.bedrock-runtime.Converse_AnthropicClaude.supporting]
 
-
 // snippet-start:[rust.bedrock-runtime.Converse_AnthropicClaude]
 #[tokio::main]
 async fn main() -> Result<(), BedrockConverseError> {

--- a/rustv1/examples/bedrock-runtime/src/bin/converse.rs
+++ b/rustv1/examples/bedrock-runtime/src/bin/converse.rs
@@ -1,0 +1,97 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// snippet-start:[rust.bedrock-runtime.Converse_AnthropicClaude]
+use aws_config::BehaviorVersion;
+use aws_sdk_bedrockruntime::{
+    operation::converse::{ConverseError, ConverseOutput},
+    types::{ContentBlock, ConversationRole, Message},
+    Client,
+};
+
+// Set the model ID, e.g., Claude 3 Haiku.
+const MODEL_ID: &str = "anthropic.claude-3-haiku-20240307-v1:0";
+const CLAUDE_REGION: &str = "us-east-1";
+
+// Start a conversation with the user message.
+const USER_MESSAGE: &str = "Describe the purpose of a 'hello world' program in one line.";
+// conversation = [
+//     {
+//         "role": "user",
+//         "content": [{"text": user_message}],
+//     }
+// ]
+
+#[tokio::main]
+async fn main() -> Result<(), BedrockConverseError> {
+    tracing_subscriber::fmt::init();
+    let sdk_config = aws_config::defaults(BehaviorVersion::latest())
+        .region(CLAUDE_REGION)
+        .load()
+        .await;
+    let client = Client::new(&sdk_config);
+
+    let response = client
+        .converse()
+        .model_id(MODEL_ID)
+        .messages(
+            Message::builder()
+                .role(ConversationRole::User)
+                .content(ContentBlock::Text(USER_MESSAGE.to_string()))
+                .build()
+                .map_err(|_| "failed to build message")?,
+        )
+        .send()
+        .await;
+
+    match response {
+        Ok(output) => {
+            let text = get_converse_output_text(output)?;
+            println!("{}", text);
+            Ok(())
+        }
+        Err(e) => Err(BedrockConverseError(
+            MODEL_ID.to_string(),
+            e.as_service_error()
+                .map(|e| {
+                    match e {
+                        ConverseError::ModelTimeoutException(_) => "Model took too long",
+                        ConverseError::ModelNotReadyException(_) => "Model is not ready",
+                        _ => "Unknown",
+                    }
+                    .to_string()
+                })
+                .unwrap_or(String::from("Unknown")),
+        )),
+    }
+}
+
+fn get_converse_output_text(output: ConverseOutput) -> Result<String, BedrockConverseError> {
+    let text = output
+        .output()
+        .ok_or("no output")?
+        .as_message()
+        .map_err(|_| "output not a message")?
+        .content()
+        .first()
+        .ok_or("no content in message")?
+        .as_text()
+        .map_err(|_| "content is not text")?
+        .to_string();
+    Ok(text)
+}
+
+#[derive(Debug)]
+struct BedrockConverseError(String, String);
+impl std::fmt::Display for BedrockConverseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Can't invoke '{}'. Reason: {}", self.0, self.1)
+    }
+}
+impl std::error::Error for BedrockConverseError {}
+impl From<&str> for BedrockConverseError {
+    fn from(value: &str) -> Self {
+        BedrockConverseError(MODEL_ID.to_string(), value.to_string())
+    }
+}
+// snippet-end:[rust.bedrock-runtime.Converse_AnthropicClaude]

--- a/rustv1/examples/bedrock-runtime/src/bin/tool-use.rs
+++ b/rustv1/examples/bedrock-runtime/src/bin/tool-use.rs
@@ -131,7 +131,6 @@ fn print_model_response(block: &ContentBlock) -> Result<(), ToolUseScenarioError
 }
 // snippet-end:[rust.bedrock-runtime.Converse_AnthropicClaude.tool-use.user-interface]
 
-
 async fn get_input() -> Result<Option<String>, ToolUseScenarioError> {
     let mut line = String::new();
     let mut first = true;
@@ -149,7 +148,7 @@ async fn get_input() -> Result<Option<String>, ToolUseScenarioError> {
             .read_line(&mut line)
             .map_err(|e| ToolUseScenarioError(format!("Failed to read line from stdin: {e:?}")))?;
 
-        if line.trim().to_ascii_lowercase().starts_with("x") {
+        if line.trim().to_ascii_lowercase().starts_with('x') {
             return Ok(None);
         }
     }
@@ -398,8 +397,6 @@ impl ToolUseScenario {
         }
     }
 }
-
-
 
 #[tokio::main]
 async fn main() {

--- a/rustv1/examples/bedrock-runtime/src/bin/tool-use.rs
+++ b/rustv1/examples/bedrock-runtime/src/bin/tool-use.rs
@@ -20,7 +20,7 @@ use aws_smithy_types::Document;
 use tracing::debug;
 
 /// This demo illustrates a tool use scenario using Amazon Bedrock's Converse API and a weather tool.
-/// The script interacts with a foundation model on Amazon Bedrock to provide weather debugrmation based on user
+/// The script interacts with a foundation model on Amazon Bedrock to provide weather information based on user
 /// input. It uses the Open-Meteo API (https://open-meteo.com) to retrieve current weather data for a given location.
 
 // Set the model ID, e.g., Claude 3 Haiku.
@@ -33,7 +33,7 @@ If the user provides coordinates, infer the approximate location and refer to it
 To use the tool, you strictly apply the provided tool specification.
 
 - Explain your step-by-step process, and give brief updates before each step.
-- Only use the Weather_Tool for data. Never guess or make up debugrmation. 
+- Only use the Weather_Tool for data. Never guess or make up information. 
 - Repeat the tool use for subsequent requests if necessary.
 - If the tool errors, apologize, explain weather is unavailable, and suggest other options.
 - Report temperatures in °C (°F) and wind in km/h (mph). Keep weather reports concise. Sparingly use
@@ -136,11 +136,9 @@ async fn get_input() -> Result<Option<String>, ToolUseScenarioError> {
     let mut first = true;
     while line.is_empty() {
         if first {
-            println!("Your weather debug request (x to exit):")
+            println!("Your weather request (x to exit):")
         } else {
-            println!(
-                "Please enter your weather debug request, e.g. the name of a city (x to exit):"
-            )
+            println!("Please enter your weather request, e.g. the name of a city (x to exit):")
         }
         first = false;
 
@@ -160,7 +158,7 @@ fn header() {
         "================================================================================
 Welcome to the Amazon Bedrock Tool Use demo!
 ================================================================================
-This assistant provides current weather debugrmation for user-specified locations.
+This assistant provides current weather information for user-specified locations.
 You can ask for weather details by providing the location name or coordinates.
 
 Example queries:

--- a/rustv1/examples/bedrock-runtime/src/bin/tool-use.rs
+++ b/rustv1/examples/bedrock-runtime/src/bin/tool-use.rs
@@ -1,0 +1,333 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use aws_config::BehaviorVersion;
+use aws_sdk_bedrockruntime::{
+    error::{BuildError, SdkError},
+    operation::converse::{ConverseError, ConverseOutput},
+    types::{
+        ContentBlock, ConversationRole::User, DocumentBlock, Message, StopReason,
+        SystemContentBlock, Tool, ToolConfiguration, ToolInputSchema, ToolSpecification,
+        ToolUseBlock,
+    },
+    Client,
+};
+use aws_smithy_runtime_api::http::Response;
+use aws_smithy_types::Document;
+
+/// This demo illustrates a tool use scenario using Amazon Bedrock's Converse API and a weather tool.
+/// The script interacts with a foundation model on Amazon Bedrock to provide weather information based on user
+/// input. It uses the Open-Meteo API (https://open-meteo.com) to retrieve current weather data for a given location.
+
+// Set the model ID, e.g., Claude 3 Haiku.
+const MODEL_ID: &str = "anthropic.claude-3-haiku-20240307-v1:0";
+const CLAUDE_REGION: &str = "us-east-1";
+
+const SYSTEM_PROMPT: &str = "You are a weather assistant that provides current weather data for user-specified locations using only
+the Weather_Tool, which expects latitude and longitude. Infer the coordinates from the location yourself.
+If the user provides coordinates, infer the approximate location and refer to it in your response.
+To use the tool, you strictly apply the provided tool specification.
+
+- Explain your step-by-step process, and give brief updates before each step.
+- Only use the Weather_Tool for data. Never guess or make up information. 
+- Repeat the tool use for subsequent requests if necessary.
+- If the tool errors, apologize, explain weather is unavailable, and suggest other options.
+- Report temperatures in °C (°F) and wind in km/h (mph). Keep weather reports concise. Sparingly use
+  emojis where appropriate.
+- Only respond to weather queries. Remind off-topic users of your purpose. 
+- Never claim to search online, access external data, or use tools besides Weather_Tool.
+- Complete the entire process until you have all required data before sending the complete response.
+";
+
+// The maximum number of recursive calls allowed in the tool_use_demo function.
+// This helps prevent infinite loops and potential performance issues.
+const MAX_RECURSIONS: i8 = 5;
+
+const TOOL_NAME: &str = "Weather_Tool";
+const TOOL_DESCRIPTION: &str =
+    "Get the current weather for a given location, based on its WGS84 coordinates.";
+fn make_tool_schema() -> Document {
+    Document::Object(HashMap::<String, Document>::from([
+        ("type".into(), Document::String("object".into())),
+        (
+            "properties".into(),
+            Document::Object(HashMap::from([
+                (
+                    "latitude".into(),
+                    Document::Object(HashMap::from([
+                        ("type".into(), Document::String("string".into())),
+                        (
+                            "description".into(),
+                            Document::String("Geographical WGS84 latitude of the location.".into()),
+                        ),
+                    ])),
+                ),
+                (
+                    "longitude".into(),
+                    Document::Object(HashMap::from([
+                        ("type".into(), Document::String("string".into())),
+                        (
+                            "description".into(),
+                            Document::String(
+                                "Geographical WGS84 longitude of the location.".into(),
+                            ),
+                        ),
+                    ])),
+                ),
+            ])),
+        ),
+        (
+            "required".into(),
+            Document::Array(vec![
+                Document::String("latitude".into()),
+                Document::String("longitude".into()),
+            ]),
+        ),
+    ]))
+}
+
+struct ToolUseScenario {
+    client: Client,
+    conversation: Vec<Message>,
+    system_prompt: SystemContentBlock,
+    tool_config: ToolConfiguration,
+}
+
+impl ToolUseScenario {
+    fn new(client: Client) -> Self {
+        let system_prompt = SystemContentBlock::Text(SYSTEM_PROMPT.into());
+        let tool_config = ToolConfiguration::builder()
+            .tools(Tool::ToolSpec(
+                ToolSpecification::builder()
+                    .name(TOOL_NAME)
+                    .description(TOOL_DESCRIPTION)
+                    .input_schema(ToolInputSchema::Json(make_tool_schema()))
+                    .build()
+                    .unwrap(),
+            ))
+            .build()
+            .unwrap();
+
+        ToolUseScenario {
+            client,
+            conversation: vec![],
+            system_prompt,
+            tool_config,
+        }
+    }
+
+    async fn run(&mut self) -> Result<(), ToolUseScenarioError> {
+        loop {
+            let input = get_input().await;
+            if input.is_empty() {
+                break;
+            }
+
+            let message = Message::builder()
+                .role(User)
+                .content(ContentBlock::Text(input))
+                .build()
+                .map_err(ToolUseScenarioError::from)?;
+            self.conversation.push(message);
+
+            let response = self.send_to_bedrock().await?;
+
+            self.process_model_response(response, MAX_RECURSIONS)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn send_to_bedrock(&mut self) -> Result<ConverseOutput, ToolUseScenarioError> {
+        self.client
+            .converse()
+            .model_id(MODEL_ID)
+            .set_messages(Some(self.conversation.clone()))
+            .system(self.system_prompt.clone())
+            .tool_config(self.tool_config.clone())
+            .send()
+            .await
+            .map_err(ToolUseScenarioError::from)
+    }
+
+    async fn process_model_response(
+        &mut self,
+        response: ConverseOutput,
+        max_recursion: i8,
+    ) -> Result<(), ToolUseScenarioError> {
+        if max_recursion <= 0 {
+            return Err(ToolUseScenarioError(
+                "Too many recursions when performing tool use".into(),
+            ));
+        }
+
+        let message = if let Some(output) = response.output {
+            if output.is_message() {
+                Ok(output.as_message().unwrap().clone())
+            } else {
+                Err(ToolUseScenarioError(
+                    "Converse Output is not a message".into(),
+                ))
+            }
+        } else {
+            Err(ToolUseScenarioError("Missing Converse Output".into()))
+        }?;
+
+        self.conversation.push(message.clone());
+
+        match response.stop_reason {
+            StopReason::ToolUse => self.handle_tool_use(&message, max_recursion).await,
+            StopReason::EndTurn => print_model_response(&message.content[0]),
+            _ => Ok(()),
+        }
+    }
+
+    async fn handle_tool_use(
+        &mut self,
+        message: &Message,
+        max_recursion: i8,
+    ) -> Result<(), ToolUseScenarioError> {
+        let mut tool_results: String = String::new();
+
+        for block in &message.content {
+            match block {
+                ContentBlock::Text(_) => print_model_response(block)?,
+                ContentBlock::ToolUse(tool) => {
+                    let tool_response = self.invoke_tool(tool).await;
+                    match tool_response {
+                        Ok(results) => {
+                            tool_results = format!("{tool_results}\n{}", results.1);
+                        }
+                        Err(_) => todo!(),
+                    }
+                }
+                _ => (),
+            };
+        }
+
+        let message = Message::builder()
+            .role(User)
+            .content(ContentBlock::Text(tool_results))
+            .build()?;
+        self.conversation.push(message);
+
+        let response = self.send_to_bedrock().await?;
+        self.process_model_response(response, max_recursion - 1)
+            .await
+    }
+
+    async fn invoke_tool(
+        &mut self,
+        tool: &ToolUseBlock,
+    ) -> Result<InvokeToolResult, ToolUseScenarioError> {
+        match tool.name() {
+            TOOL_NAME => {
+                println!("Calling {TOOL_NAME} with {:?}", tool.input());
+                let content = fetch_weather_data(tool.input()).await?;
+                Ok(InvokeToolResult(tool.tool_use_id.clone(), content))
+            }
+            _ => Err(ToolUseScenarioError(format!(
+                "The requested tool with name {} does not exist",
+                tool.name()
+            ))),
+        }
+    }
+}
+
+fn print_model_response(block: &ContentBlock) -> Result<(), ToolUseScenarioError> {
+    if block.is_text() {
+        let text = block.as_text().unwrap();
+        println!("{text}");
+        Ok(())
+    } else {
+        Err(ToolUseScenarioError(format!(
+            "Content block is not text ({block:?})"
+        )))
+    }
+}
+
+const ENDPOINT: &str = "https://api.open-meteo.com/v1/forecast";
+async fn fetch_weather_data(input: &Document) -> Result<String, ToolUseScenarioError> {
+    let latitude = input
+        .as_object()
+        .unwrap()
+        .get("latitude")
+        .unwrap()
+        .as_string()
+        .unwrap();
+    let longitude = input
+        .as_object()
+        .unwrap()
+        .get("longitude")
+        .unwrap()
+        .as_string()
+        .unwrap();
+    let params =
+        format!(r#"{{"latitude":"{latitude}","longitude":"{longitude}","current_weather":true}}"#);
+
+    let response = reqwest::Client::new()
+        .get(ENDPOINT)
+        .body(params)
+        .send()
+        .await
+        .map_err(|e| ToolUseScenarioError(format!("Error requesting weather: {e:?}")))?
+        .error_for_status()
+        .map_err(|e| ToolUseScenarioError(format!("Failed to request weather: {e:?}")))?;
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| ToolUseScenarioError(format!("Error reading response: {e:?}")))?;
+
+    String::from_utf8(bytes.to_vec())
+        .map_err(|_| ToolUseScenarioError("Response was not utf8".into()))
+}
+
+struct InvokeToolResult(String, String);
+
+#[derive(Debug)]
+struct ToolUseScenarioError(String);
+impl std::fmt::Display for ToolUseScenarioError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Tool use error with '{}'. Reason: {}", MODEL_ID, self.0)
+    }
+}
+impl From<&str> for ToolUseScenarioError {
+    fn from(value: &str) -> Self {
+        ToolUseScenarioError(value.into())
+    }
+}
+impl From<BuildError> for ToolUseScenarioError {
+    fn from(value: BuildError) -> Self {
+        ToolUseScenarioError(value.to_string().clone())
+    }
+}
+impl From<SdkError<ConverseError, Response>> for ToolUseScenarioError {
+    fn from(value: SdkError<ConverseError, Response>) -> Self {
+        ToolUseScenarioError(match value.as_service_error() {
+            Some(value) => value.meta().message().unwrap_or("Unknown").into(),
+            None => "Unknown".into(),
+        })
+    }
+}
+
+async fn get_input() -> String {
+    return "".into();
+}
+
+#[tokio::main]
+async fn main() -> Result<(), ToolUseScenarioError> {
+    tracing_subscriber::fmt::init();
+    let sdk_config = aws_config::defaults(BehaviorVersion::latest())
+        .region(CLAUDE_REGION)
+        .load()
+        .await;
+    let client = Client::new(&sdk_config);
+
+    let mut scenario = ToolUseScenario::new(client);
+
+    scenario.run().await
+}


### PR DESCRIPTION
This pull request adds Rust examples for Bedrock Converse API, as well as Tool Use.

1. Converse - sends a hard coded query to Haiku.
2. ConverseStream - sends a hard coded query to Haiku, and reads blocks of replies.
3. ToolUse - sends user queries to Haiku in a conversation with a weather tool enabled.

Closes #6681

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
