### PR TITLE
WRITEME: `check` correctly when README is missing

### DIFF
--- a/.tools/readmes/render.py
+++ b/.tools/readmes/render.py
@@ -306,9 +306,12 @@ class Renderer:
             f.write(self.readme_text)
 
     def check(self):
-        with self.readme_filename.open("r", encoding="utf-8") as f:
-            readme_current = f.read()
-            return readme_current == self.readme_text
+        try:
+            with self.readme_filename.open("r", encoding="utf-8") as f:
+                readme_current = f.read()
+                return readme_current == self.readme_text
+        except FileNotFoundError:
+            return False
 
 
 def _transform_sdk(sdk: Sdk, sdk_ver):


### PR DESCRIPTION
This pull request updates the `check` method for when a README is missing when first created.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
