### PR TITLE
English: Updated callIndex for awsm_stubber for testtools 

### DIFF
--- a/gov2/testtools/awsm_stubber.go
+++ b/gov2/testtools/awsm_stubber.go
@@ -150,15 +150,19 @@ func (stubber *AwsmStubber) Next() *Stub {
 // Clear removes all stubs from the stubber.
 func (stubber *AwsmStubber) Clear() {
 	stubber.stubs = nil
+	stubber.callIndex = 0	
 }
 
 // VerifyAllStubsCalled returns an error if there are stubs in the slice that were not
 // called. In this way, you can verify that your test made all the calls that you expected.
+// Also reset callIndex so that next() call when stubs is lesser then existing call will not fail
 func (stubber *AwsmStubber) VerifyAllStubsCalled() error {
 	var err error
 	next := stubber.Next()
 	if next != nil {
 		err = fmt.Errorf("Remaining stub %v was never called.", next.OperationName)
+	}else{
+	stubber.callIndex = 0	
 	}
 	return err
 }

--- a/gov2/testtools/awsm_stubber.go
+++ b/gov2/testtools/awsm_stubber.go
@@ -155,14 +155,13 @@ func (stubber *AwsmStubber) Clear() {
 
 // VerifyAllStubsCalled returns an error if there are stubs in the slice that were not
 // called. In this way, you can verify that your test made all the calls that you expected.
-// Also reset callIndex so that next() call when stubs is lesser then existing call will not fail
 func (stubber *AwsmStubber) VerifyAllStubsCalled() error {
 	var err error
 	next := stubber.Next()
 	if next != nil {
 		err = fmt.Errorf("Remaining stub %v was never called.", next.OperationName)
-	}else{
-	stubber.callIndex = 0	
+	} else {
+	        stubber.callIndex = 0	
 	}
 	return err
 }


### PR DESCRIPTION
Currently if we use stubs in a single test func multiple times the callIndex will increase while the stubs decrease. If we run a for loop for the doing multiple tests, and stub twice for a loop, the call index will eventually become 3 while the stubs available is lesser then 3 throwing an error out. 

```
E.G
tests := []struct {
		Input string
		Prefunc func()
		Err     error
	}{
            {
             Input:"test1",
             Prefunc: func(){ stubsomething here twice},
            },.... multiple more tests
          }
for each tests{
   test.Prefunc()
   some test here
   if err != nil {
      err will show no more stubs available but in reality there is 2 stubs but callIndex will be > 3
   }
}

```
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->



---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
