### PR TITLE
Rust: EC2 Getting Started scenario

### DIFF
--- a/.doc_gen/metadata/ec2_metadata.yaml
+++ b/.doc_gen/metadata/ec2_metadata.yaml
@@ -68,6 +68,13 @@ ec2_Hello:
             - description:
               snippet_tags:
                 - ec2.ruby.hello_ec2
+    Rust:
+        versions:
+        - sdk_version: 1
+          github: rust/examples/ec2
+          excerpts:
+            - snippet_tags:
+                - ec2.rust.ec2-helloworld
   services:
     ec2: {DescribeSecurityGroups}
 ec2_GetPasswordData:
@@ -168,6 +175,17 @@ ec2_CreateKeyPair:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - description: Rust implementation that calls the EC2 Client's create_key_pair and extracts the returned material.
+              snippet_tags:
+                - ec2.rust.create_key.impl
+            - description: A function that calls the create_key impl and securely saves the PEM private key.
+              snippet_tags:
+                - ec2.rust.create_key.wrapper
   services:
     ec2: {CreateKeyPair}
 ec2_DescribeKeyPairs:
@@ -246,6 +264,13 @@ ec2_DescribeKeyPairs:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - snippet_tags:
+                - ec2.rust.list_keys.impl
   services:
     ec2: {DescribeKeyPairs}
 
@@ -297,7 +322,6 @@ ec2_CreateSecurityGroup:
             - description:
               snippet_tags:
                 - ec2.Ruby.exampleSecurityGroup
-
     JavaScript:
       versions:
         - sdk_version: 3
@@ -335,6 +359,13 @@ ec2_CreateSecurityGroup:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - snippet_tags:
+                - ec2.rust.create_security_group.impl
   services:
     ec2: {CreateSecurityGroup}
 ec2_RunInstances:
@@ -397,6 +428,7 @@ ec2_RunInstances:
       versions:
         - sdk_version: 1
           github: cpp/example_code/ec2
+          sdkguide:
           excerpts:
             - description:
               snippet_tags:
@@ -413,6 +445,13 @@ ec2_RunInstances:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - snippet_tags:
+                - ec2.rust.create_instance.impl
   services:
     ec2: {RunInstances}
 ec2_StartInstances:
@@ -477,9 +516,12 @@ ec2_StartInstances:
         - sdk_version: 1
           github: rustv1/examples/ec2
           excerpts:
-            - description:
+            - description: Start an EC2 Instance by instance ID.
               snippet_tags:
-                - ec2.rust.start-instance
+                - ec2.rust.start_instance.impl
+            - description:  Wait for an instance to be in the ready and status ok states, using the Waiters API. Using the Waiters API requires `use aws_sdk_ec2::client::Waiters` in the rust file.
+              snippet_tags:
+                - ec2.rust.wait_for_instance_ready.impl
     SAP ABAP:
       versions:
         - sdk_version: 1
@@ -572,9 +614,11 @@ ec2_StopInstances:
         - sdk_version: 1
           github: rustv1/examples/ec2
           excerpts:
-            - description:
+            - snippet_tags:
+                - ec2.rust.stop_instance.impl
+            - description: Wait for an instance to be in the stopped state, using the Waiters API. Using the Waiters API requires `use aws_sdk_ec2::client::Waiters` in the rust file.
               snippet_tags:
-                - ec2.rust.stop-instance
+                - ec2.rust.stop_instance.impl
     SAP ABAP:
       versions:
         - sdk_version: 1
@@ -691,6 +735,13 @@ ec2_AllocateAddress:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - snippet_tags:
+                - ec2.rust.allocate_address.impl
   services:
     ec2: {AllocateAddress}
 ec2_AssociateAddress:
@@ -765,6 +816,7 @@ ec2_AssociateAddress:
           excerpts:
             - description:
               snippet_tags:
+                - cpp.example_code.ec2.allocate_address.client
                 - cpp.example_code.ec2.AssociateAddress
     Bash:
       versions:
@@ -778,6 +830,13 @@ ec2_AssociateAddress:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - snippet_tags:
+                - ec2.rust.associate_address.impl
   services:
     ec2: {AssociateAddress}
 ec2_DisassociateAddress:
@@ -840,6 +899,13 @@ ec2_DisassociateAddress:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - snippet_tags:
+                - ec2.rust.disassociate_address.impl
   services:
     ec2: {DisassociateAddress}
 ec2_ReleaseAddress:
@@ -927,6 +993,13 @@ ec2_ReleaseAddress:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - snippet_tags:
+                - ec2.rust.deallocate_address.impl
   services:
     ec2: {ReleaseAddress}
 ec2_AuthorizeSecurityGroupIngress:
@@ -1000,6 +1073,13 @@ ec2_AuthorizeSecurityGroupIngress:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - snippet_tags:
+                - ec2.rust.authorize_security_group_ssh_ingress.impl
   services:
     ec2: {AuthorizeSecurityGroupIngress}
 ec2_DeleteKeyPair:
@@ -1078,6 +1158,16 @@ ec2_DeleteKeyPair:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - description: Wrapper around delete_key that also removes the backing private PEM key.
+              snippet_tags:
+                - ec2.rust.delete_key.wrapper
+            - snippet_tags:
+                - ec2.rust.delete_key.impl
   services:
     ec2: {DeleteKeyPair}
 ec2_DescribeSecurityGroups:
@@ -1156,6 +1246,13 @@ ec2_DescribeSecurityGroups:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+        versions:
+        - sdk_version: 1
+          github: rust/examples/ec2
+          excerpts:
+            - snippet_tags:
+                - ec2.rust.ec2-helloworld
   services:
     ec2: {DescribeSecurityGroups}
 ec2_DeleteSecurityGroup:
@@ -1234,6 +1331,13 @@ ec2_DeleteSecurityGroup:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+        versions:
+        - sdk_version: 1
+          github: rust/examples/ec2
+          excerpts:
+            - snippet_tags:
+              - ec2.rust.delete_security_group.impl
   services:
     ec2: {DeleteSecurityGroup}
 ec2_DeleteSnapshot:
@@ -1340,6 +1444,16 @@ ec2_TerminateInstances:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+        versions:
+        - sdk_version: 1
+          github: rust/examples/ec2
+          excerpts:
+            - snippet_tags:
+              - ec2.rust.delete_instance.impl
+            - description: Wait for an instance to be in the terminted state, using the Waiters API. Using the Waiters API requires `use aws_sdk_ec2::client::Waiters` in the rust file.
+              snippet_tags:
+              - ec2.rust.wait_for_instance_terminated.impl
   services:
     ec2: {TerminateInstances}
 ec2_DescribeInstances:
@@ -1401,9 +1515,12 @@ ec2_DescribeInstances:
         - sdk_version: 1
           github: rustv1/examples/ec2
           excerpts:
-            - description:
+            - description: Retrieve details for an EC2 Instance.
               snippet_tags:
-                - ec2.rust.describe-instances
+                - ec2.rust.describe_instance.impl
+            - description: After creating an EC2 instance, retrieve and store its details.
+              snippet_tags:
+                - ec2.rust.create_instance.wrapper
     SAP ABAP:
       versions:
         - sdk_version: 1
@@ -1443,7 +1560,7 @@ ec2_DescribeRegions:
           excerpts:
             - description:
               snippet_tags:
-                - ec2.rust.ec2-helloworld
+                - ec2.rust.describe-regions
     JavaScript:
       versions:
         - sdk_version: 3
@@ -1560,9 +1677,14 @@ ec2_RebootInstances:
         - sdk_version: 1
           github: rustv1/examples/ec2
           excerpts:
-            - description:
+            - snippet_tags:
+                - ec2.rust.reboot_instance.wrapper
+            - snippet_tags:
+                - ec2.rust.reboot_instance.impl
+            - description: Waiters for instance to be in the stopped and ready states, using the Waiters API. Using the Waiters API requires `use aws_sdk_ec2::client::Waiters` in the rust file.
               snippet_tags:
-                - ec2.rust.reboot-instance
+                - ec2.rust.wait_for_instance_ready.impl
+                - ec2.rust.wait_for_instance_stopped.impl
     JavaScript:
       versions:
         - sdk_version: 3
@@ -1625,9 +1747,11 @@ ec2_DescribeImages:
         - sdk_version: 1
           github: rustv1/examples/ec2
           excerpts:
-            - genai: some
-              snippet_tags:
-                - ec2.rust.describe-images
+              - snippet_tags:
+                - ec2.rust.list_images.impl
+              - description: Using the list_images function with &SSM; to limit based on your environment. For more details on SSM, see https://docs.aws.amazon.com/systems-manager/latest/userguide/example_ssm_GetParameters_section.html.
+                snippet_tags:
+                - ec2.rust.find_image.scenario
     Bash:
       versions:
         - sdk_version: 2
@@ -1702,6 +1826,13 @@ ec2_DescribeInstanceTypes:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+              - snippet_tags:
+                - ec2.rust.list_instance_types.impl
   services:
     ec2: {DescribeInstanceTypes}
 ec2_DescribeAddresses:
@@ -1780,6 +1911,14 @@ ec2_CreateTags:
             - description:
               snippet_tags:
                 - cpp.example_code.ec2.CreateTags
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - description: This example applies the Name tag After creating an instance.
+              snippet_tags:
+              - ec2.rust.create_instance.impl
   services:
     ec2: {CreateTags}
 ec2_CreateRouteTable:
@@ -1868,7 +2007,8 @@ ec2_ReplaceIamInstanceProfileAssociation:
           github: python/example_code/ec2
           sdkguide:
           excerpts:
-            - description: This example replaces the instance profile of a running instance, reboots the instance, and sends
+            - description:
+                This example replaces the instance profile of a running instance, reboots the instance, and sends
                 a command to the instance after it starts.
               snippet_tags:
                 - python.cross_service.resilient_service.AutoScaler.decl
@@ -2112,7 +2252,49 @@ ec2_Scenario_GetStartedInstances:
               snippet_tags:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/examples/ec2
+          excerpts:
+            - description: The EC2InstanceScenario implementation contains logic to run the example as a whole.
+              snippet_files:
+                - rustv1/examples/ec2/src/getting_started/scenario.rs
+            - description: The EC2Impl struct serves as a an automock point for testing, and its functions wrap the EC2 SDK calls.
+              snippet_files:
+                - rustv1/examples/ec2/src/ec2.rs
+            - description: The SSM struct serves as a an automock point for testing, and its functions wraps SSM SDK calls.
+              snippet_files:
+                - rustv1/examples/ec2/src/ssm.rs
+            - description: The scenario uses several "Manager"-style structs to handle access to resources that are created and deleted throughout the scenario.
+              snippet_files:
+                - rustv1/examples/ec2/src/getting_started/elastic_ip.rs
+                - rustv1/examples/ec2/src/getting_started/instance.rs
+                - rustv1/examples/ec2/src/getting_started/key_pair.rs
+                - rustv1/examples/ec2/src/getting_started/security_group.rs
+            - description: The main entry point for the scenario.
+              snippet_files:
+                - rustv1/examples/ec2/src/bin/getting-started.rs
   services:
-    ec2: {AllocateAddress, AssociateAddress, AuthorizeSecurityGroupIngress, CreateKeyPair, CreateSecurityGroup, DeleteKeyPair,
-          DeleteSecurityGroup, DescribeImages, DescribeInstanceTypes, DescribeInstances, DescribeKeyPairs, DescribeSecurityGroups,
-          DisassociateAddress, ReleaseAddress, RunInstances, StartInstances, StopInstances, TerminateInstances, UnmonitorInstances}
+    ec2:
+      {
+        AllocateAddress,
+        AssociateAddress,
+        AuthorizeSecurityGroupIngress,
+        CreateKeyPair,
+        CreateSecurityGroup,
+        DeleteKeyPair,
+        DeleteSecurityGroup,
+        DescribeImages,
+        DescribeInstanceTypes,
+        DescribeInstances,
+        DescribeKeyPairs,
+        DescribeSecurityGroups,
+        DisassociateAddress,
+        ReleaseAddress,
+        RunInstances,
+        StartInstances,
+        StopInstances,
+        TerminateInstances,
+        UnmonitorInstances,
+      }

--- a/.doc_gen/metadata/ec2_metadata.yaml
+++ b/.doc_gen/metadata/ec2_metadata.yaml
@@ -69,7 +69,7 @@ ec2_Hello:
               snippet_tags:
                 - ec2.ruby.hello_ec2
     Rust:
-        versions:
+      versions:
         - sdk_version: 1
           github: rust/examples/ec2
           excerpts:
@@ -519,7 +519,7 @@ ec2_StartInstances:
             - description: Start an EC2 Instance by instance ID.
               snippet_tags:
                 - ec2.rust.start_instance.impl
-            - description:  Wait for an instance to be in the ready and status ok states, using the Waiters API. Using the Waiters API requires `use aws_sdk_ec2::client::Waiters` in the rust file.
+            - description: Wait for an instance to be in the ready and status ok states, using the Waiters API. Using the Waiters API requires `use aws_sdk_ec2::client::Waiters` in the rust file.
               snippet_tags:
                 - ec2.rust.wait_for_instance_ready.impl
     SAP ABAP:
@@ -1247,7 +1247,7 @@ ec2_DescribeSecurityGroups:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
     Rust:
-        versions:
+      versions:
         - sdk_version: 1
           github: rust/examples/ec2
           excerpts:
@@ -1332,12 +1332,12 @@ ec2_DeleteSecurityGroup:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
     Rust:
-        versions:
+      versions:
         - sdk_version: 1
           github: rust/examples/ec2
           excerpts:
             - snippet_tags:
-              - ec2.rust.delete_security_group.impl
+                - ec2.rust.delete_security_group.impl
   services:
     ec2: {DeleteSecurityGroup}
 ec2_DeleteSnapshot:
@@ -1445,15 +1445,15 @@ ec2_TerminateInstances:
                 - aws-cli.bash-linux.ec2.errecho
                 - aws-cli.bash-linux.ec2.aws_cli_error_log
     Rust:
-        versions:
+      versions:
         - sdk_version: 1
           github: rust/examples/ec2
           excerpts:
             - snippet_tags:
-              - ec2.rust.delete_instance.impl
+                - ec2.rust.delete_instance.impl
             - description: Wait for an instance to be in the terminted state, using the Waiters API. Using the Waiters API requires `use aws_sdk_ec2::client::Waiters` in the rust file.
               snippet_tags:
-              - ec2.rust.wait_for_instance_terminated.impl
+                - ec2.rust.wait_for_instance_terminated.impl
   services:
     ec2: {TerminateInstances}
 ec2_DescribeInstances:
@@ -1747,10 +1747,10 @@ ec2_DescribeImages:
         - sdk_version: 1
           github: rustv1/examples/ec2
           excerpts:
-              - snippet_tags:
+            - snippet_tags:
                 - ec2.rust.list_images.impl
-              - description: Using the list_images function with &SSM; to limit based on your environment. For more details on SSM, see https://docs.aws.amazon.com/systems-manager/latest/userguide/example_ssm_GetParameters_section.html.
-                snippet_tags:
+            - description: Using the list_images function with &SSM; to limit based on your environment. For more details on SSM, see https://docs.aws.amazon.com/systems-manager/latest/userguide/example_ssm_GetParameters_section.html.
+              snippet_tags:
                 - ec2.rust.find_image.scenario
     Bash:
       versions:
@@ -1831,7 +1831,7 @@ ec2_DescribeInstanceTypes:
         - sdk_version: 1
           github: rustv1/examples/ec2
           excerpts:
-              - snippet_tags:
+            - snippet_tags:
                 - ec2.rust.list_instance_types.impl
   services:
     ec2: {DescribeInstanceTypes}
@@ -1918,7 +1918,7 @@ ec2_CreateTags:
           excerpts:
             - description: This example applies the Name tag After creating an instance.
               snippet_tags:
-              - ec2.rust.create_instance.impl
+                - ec2.rust.create_instance.impl
   services:
     ec2: {CreateTags}
 ec2_CreateRouteTable:

--- a/.doc_gen/metadata/ssm_metadata.yaml
+++ b/.doc_gen/metadata/ssm_metadata.yaml
@@ -45,6 +45,17 @@ ssm_DescribeParameters:
                 - ssm.rust.describe-parameters
   services:
     ssm: {DescribeParameters}
+ssm_GetParameter:
+  languages:
+    Rust:
+      versions:
+        - sdk_version: 1
+          github: rustv1/example_code/ssm
+          excerpts:
+            - snippet_tags:
+              - ec2.rust.ssm_list_path.impl
+  services:
+    ssm: {GetParameter}
 ssm_PutParameter:
   languages:
     Java:

--- a/.doc_gen/metadata/ssm_metadata.yaml
+++ b/.doc_gen/metadata/ssm_metadata.yaml
@@ -53,7 +53,7 @@ ssm_GetParameter:
           github: rustv1/example_code/ssm
           excerpts:
             - snippet_tags:
-              - ec2.rust.ssm_list_path.impl
+                - ec2.rust.ssm_list_path.impl
   services:
     ssm: {GetParameter}
 ssm_PutParameter:

--- a/rustv1/examples/ec2/Cargo.toml
+++ b/rustv1/examples/ec2/Cargo.toml
@@ -19,3 +19,8 @@ clap = { version = "~4.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 tracing = "0.1.40"
 aws-smithy-runtime-api = "1.6.2"
+mockall = "0.13.0"
+inquire = "0.7.5"
+reqwest = "0.12.5"
+aws-sdk-ssm = "1.40.0"
+aws-smithy-async = "1.2.1"

--- a/rustv1/examples/ec2/README.md
+++ b/rustv1/examples/ec2/README.md
@@ -44,7 +44,7 @@ Code excerpts that show you how to call individual service functions.
 - [CreateKeyPair](src/ec2.rs#L41)
 - [CreateSecurityGroup](src/ec2.rs#L77)
 - [CreateTags](src/ec2.rs#L233)
-- [DeleteKeyPair](src/getting_started/key_pair.rs#L75)
+- [DeleteKeyPair](src/getting_started/key_pair.rs#L66)
 - [DeleteSecurityGroup](src/ec2.rs#L167)
 - [DeleteSnapshot](../ebs/src/bin/delete-snapshot.rs#L26)
 - [DescribeImages](src/ec2.rs#L179)

--- a/rustv1/examples/ec2/README.md
+++ b/rustv1/examples/ec2/README.md
@@ -29,19 +29,46 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `rustv
 <!--custom.prerequisites.start-->
 <!--custom.prerequisites.end-->
 
+### Get started
+
+- [Hello Amazon EC2](src/bin/ec2-helloworld.rs#L22) (`DescribeSecurityGroups`)
+
+
 ### Single actions
 
 Code excerpts that show you how to call individual service functions.
 
+- [AllocateAddress](src/ec2.rs#L443)
+- [AssociateAddress](src/ec2.rs#L465)
+- [AuthorizeSecurityGroupIngress](src/ec2.rs#L136)
+- [CreateKeyPair](src/ec2.rs#L41)
+- [CreateSecurityGroup](src/ec2.rs#L77)
+- [CreateTags](src/ec2.rs#L233)
+- [DeleteKeyPair](src/getting_started/key_pair.rs#L75)
+- [DeleteSecurityGroup](src/ec2.rs#L167)
 - [DeleteSnapshot](../ebs/src/bin/delete-snapshot.rs#L26)
-- [DescribeImages](src/bin/describe-images.rs#L6)
+- [DescribeImages](src/ec2.rs#L179)
 - [DescribeInstanceStatus](src/bin/list-all-instance-events.rs#L22)
-- [DescribeInstances](src/bin/describe-instance.rs#L26)
-- [DescribeRegions](src/bin/ec2-helloworld.rs#L22)
+- [DescribeInstanceTypes](src/ec2.rs#L198)
+- [DescribeInstances](src/ec2.rs#L317)
+- [DescribeKeyPairs](src/ec2.rs#L57)
+- [DescribeRegions](src/bin/describe-regions.rs#L22)
+- [DescribeSecurityGroups](src/bin/ec2-helloworld.rs#L22)
 - [DescribeSnapshots](../ebs/src/bin/get-snapshot-state.rs#L27)
-- [RebootInstances](src/bin/reboot-instance.rs#L28)
-- [StartInstances](src/bin/start-instance.rs#L29)
-- [StopInstances](src/bin/stop-instance.rs#L29)
+- [DisassociateAddress](src/ec2.rs#L482)
+- [RebootInstances](src/getting_started/instance.rs#L86)
+- [ReleaseAddress](src/ec2.rs#L454)
+- [RunInstances](src/ec2.rs#L233)
+- [StartInstances](src/ec2.rs#L340)
+- [StopInstances](src/ec2.rs#L356)
+- [TerminateInstances](src/ec2.rs#L410)
+
+### Scenarios
+
+Code examples that show you how to accomplish a specific task by calling multiple
+functions within the same service.
+
+- [Get started with instances](src/getting_started/scenario.rs)
 
 
 <!--custom.examples.start-->
@@ -55,7 +82,28 @@ Code excerpts that show you how to call individual service functions.
 <!--custom.instructions.start-->
 <!--custom.instructions.end-->
 
+#### Hello Amazon EC2
 
+This example shows you how to get started using Amazon EC2.
+
+
+
+#### Get started with instances
+
+This example shows you how to do the following:
+
+- Create a key pair and security group.
+- Select an Amazon Machine Image (AMI) and compatible instance type, then create an instance.
+- Stop and restart the instance.
+- Associate an Elastic IP address with your instance.
+- Connect to your instance with SSH, then clean up resources.
+
+<!--custom.scenario_prereqs.ec2_Scenario_GetStartedInstances.start-->
+<!--custom.scenario_prereqs.ec2_Scenario_GetStartedInstances.end-->
+
+
+<!--custom.scenarios.ec2_Scenario_GetStartedInstances.start-->
+<!--custom.scenarios.ec2_Scenario_GetStartedInstances.end-->
 
 ### Tests
 

--- a/rustv1/examples/ec2/src/bin/describe-regions.rs
+++ b/rustv1/examples/ec2/src/bin/describe-regions.rs
@@ -19,36 +19,18 @@ struct Opt {
 }
 
 // Describes the regions.
-// snippet-start:[ec2.rust.ec2-helloworld]
-async fn show_security_groups(client: &aws_sdk_ec2::Client, group_ids: Vec<String>) {
-    let response = client
-        .describe_security_groups()
-        .set_group_ids(Some(group_ids))
-        .send()
-        .await;
+// snippet-start:[ec2.rust.describe-regions]
+async fn show_regions(client: &Client) -> Result<(), Error> {
+    let rsp = client.describe_regions().send().await?;
 
-    match response {
-        Ok(output) => {
-            for group in output.security_groups() {
-                println!(
-                    "Found Security Group {} ({}), vpc id {} and description {}",
-                    group.group_name().unwrap_or("unknown"),
-                    group.group_id().unwrap_or("id-unknown"),
-                    group.vpc_id().unwrap_or("vpcid-unknown"),
-                    group.description().unwrap_or("(none)")
-                );
-            }
-        }
-        Err(err) => {
-            let err = err.into_service_error();
-            let meta = err.meta();
-            let message = meta.message().unwrap_or("unknown");
-            let code = meta.code().unwrap_or("unknown");
-            eprintln!("Error listing EC2 Security Groups: ({code}) {message}");
-        }
+    println!("Regions:");
+    for region in rsp.regions() {
+        println!("  {}", region.region_name().unwrap());
     }
+
+    Ok(())
 }
-// snippet-end:[ec2.rust.ec2-helloworld]
+// snippet-end:[ec2.rust.describe-regions]
 
 /// Describes the AWS Regions that are enabled for your account.
 /// # Arguments
@@ -79,7 +61,5 @@ async fn main() -> Result<(), Error> {
     let shared_config = aws_config::from_env().region(region_provider).load().await;
     let client = Client::new(&shared_config);
 
-    show_security_groups(&client, vec![]).await;
-
-    Ok(())
+    show_regions(&client).await
 }

--- a/rustv1/examples/ec2/src/bin/getting-started.rs
+++ b/rustv1/examples/ec2/src/bin/getting-started.rs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use ec2_code_examples::{ec2::EC2, getting_started::scenario, ssm::SSM};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    let sdk_config = aws_config::load_from_env().await;
+    let ec2 = EC2::new(aws_sdk_ec2::Client::new(&sdk_config));
+    let ssm = SSM::new(aws_sdk_ssm::Client::new(&sdk_config));
+    let mut scenario = crate::scenario::Ec2InstanceScenario::new(ec2, ssm);
+
+    println!("--------------------------------------------------------------------------------");
+    println!(
+        "Welcome to the Amazon Elastic Compute Cloud (Amazon EC2) get started with instances demo."
+    );
+    println!("--------------------------------------------------------------------------------");
+
+    if let Err(err) = scenario.run().await {
+        eprintln!("There was an error running the scenario: {err}")
+    }
+
+    println!("--------------------------------------------------------------------------------");
+
+    scenario.clean_up().await;
+
+    println!("Thanks for running!");
+    println!("--------------------------------------------------------------------------------");
+}

--- a/rustv1/examples/ec2/src/bin/getting-started.rs
+++ b/rustv1/examples/ec2/src/bin/getting-started.rs
@@ -1,7 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use ec2_code_examples::{ec2::EC2, getting_started::scenario, ssm::SSM};
+use ec2_code_examples::{
+    ec2::EC2,
+    getting_started::{
+        scenario::{run, Ec2InstanceScenario},
+        util::UtilImpl,
+    },
+    ssm::SSM,
+};
 
 #[tokio::main]
 async fn main() {
@@ -9,22 +16,7 @@ async fn main() {
     let sdk_config = aws_config::load_from_env().await;
     let ec2 = EC2::new(aws_sdk_ec2::Client::new(&sdk_config));
     let ssm = SSM::new(aws_sdk_ssm::Client::new(&sdk_config));
-    let mut scenario = crate::scenario::Ec2InstanceScenario::new(ec2, ssm);
-
-    println!("--------------------------------------------------------------------------------");
-    println!(
-        "Welcome to the Amazon Elastic Compute Cloud (Amazon EC2) get started with instances demo."
-    );
-    println!("--------------------------------------------------------------------------------");
-
-    if let Err(err) = scenario.run().await {
-        eprintln!("There was an error running the scenario: {err}")
-    }
-
-    println!("--------------------------------------------------------------------------------");
-
-    scenario.clean_up().await;
-
-    println!("Thanks for running!");
-    println!("--------------------------------------------------------------------------------");
+    let util = UtilImpl {};
+    let scenario = Ec2InstanceScenario::new(ec2, ssm, util);
+    run(scenario).await;
 }

--- a/rustv1/examples/ec2/src/ec2.rs
+++ b/rustv1/examples/ec2/src/ec2.rs
@@ -77,14 +77,14 @@ impl EC2Impl {
     // snippet-start:[ec2.rust.create_security_group.impl]
     pub async fn create_security_group(
         &self,
-        name: String,
-        description: String,
+        name: &str,
+        description: &str,
     ) -> Result<SecurityGroup, EC2Error> {
         tracing::info!("Creating security group {name}");
         let create_output = self
             .client
             .create_security_group()
-            .group_name(&name)
+            .group_name(name)
             .description(description)
             .send()
             .await
@@ -138,7 +138,7 @@ impl EC2Impl {
     /// as {ip}/32 over TCP port 22.
     pub async fn authorize_security_group_ssh_ingress(
         &self,
-        group_id: String,
+        group_id: &str,
         ingress_ips: Vec<Ipv4Addr>,
     ) -> Result<(), EC2Error> {
         tracing::info!("Authorizing ingress for security group {group_id}");
@@ -165,7 +165,7 @@ impl EC2Impl {
     // snippet-end:[ec2.rust.authorize_security_group_ssh_ingress.impl]
 
     // snippet-start:[ec2.rust.delete_security_group.impl]
-    pub async fn delete_security_group(&self, group_id: String) -> Result<(), EC2Error> {
+    pub async fn delete_security_group(&self, group_id: &str) -> Result<(), EC2Error> {
         tracing::info!("Deleting security group {group_id}");
         self.client
             .delete_security_group()

--- a/rustv1/examples/ec2/src/ec2.rs
+++ b/rustv1/examples/ec2/src/ec2.rs
@@ -1,0 +1,530 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{net::Ipv4Addr, time::Duration};
+
+use aws_sdk_ec2::{
+    client::Waiters,
+    error::ProvideErrorMetadata,
+    operation::{
+        allocate_address::AllocateAddressOutput, associate_address::AssociateAddressOutput,
+    },
+    types::{
+        DomainType, Filter, Image, Instance, InstanceType, IpPermission, IpRange, KeyPairInfo,
+        SecurityGroup, Tag,
+    },
+    Client as EC2Client,
+};
+use aws_sdk_ssm::types::Parameter;
+use aws_smithy_runtime_api::client::waiters::error::WaiterError;
+
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg(not(test))]
+pub use EC2Impl as EC2;
+
+#[cfg(test)]
+pub use MockEC2Impl as EC2;
+
+#[derive(Clone)]
+pub struct EC2Impl {
+    pub client: EC2Client,
+}
+
+#[cfg_attr(test, automock)]
+impl EC2Impl {
+    pub fn new(client: EC2Client) -> Self {
+        EC2Impl { client }
+    }
+
+    // snippet-start:[ec2.rust.create_key.impl]
+    pub async fn create_key_pair(&self, name: String) -> Result<(KeyPairInfo, String), EC2Error> {
+        tracing::info!("Creating key pair {name}");
+        let output = self.client.create_key_pair().key_name(name).send().await?;
+        let info = KeyPairInfo::builder()
+            .set_key_name(output.key_name)
+            .set_key_fingerprint(output.key_fingerprint)
+            .set_key_pair_id(output.key_pair_id)
+            .build();
+        let material = output
+            .key_material
+            .ok_or_else(|| EC2Error::new("Create Key Pair has no key material"))?;
+        Ok((info, material))
+    }
+    // snippet-end:[ec2.rust.create_key.impl]
+
+    // snippet-start:[ec2.rust.list_keys.impl]
+    pub async fn list_key_pair(&self) -> Result<Vec<KeyPairInfo>, EC2Error> {
+        let output = self.client.describe_key_pairs().send().await?;
+        Ok(output.key_pairs.unwrap_or_default())
+    }
+    // snippet-end:[ec2.rust.list_keys.impl]
+
+    // snippet-start:[ec2.rust.delete_key.impl]
+    pub async fn delete_key_pair(&self, key_pair_id: &str) -> Result<(), EC2Error> {
+        let key_pair_id: String = key_pair_id.into();
+        tracing::info!("Deleting key pair {key_pair_id}");
+        self.client
+            .delete_key_pair()
+            .key_pair_id(key_pair_id)
+            .send()
+            .await?;
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.delete_key.impl]
+
+    // snippet-start:[ec2.rust.create_security_group.impl]
+    pub async fn create_security_group(
+        &self,
+        name: String,
+        description: String,
+    ) -> Result<SecurityGroup, EC2Error> {
+        tracing::info!("Creating security group {name}");
+        let create_output = self
+            .client
+            .create_security_group()
+            .group_name(&name)
+            .description(description)
+            .send()
+            .await
+            .map_err(EC2Error::from)?;
+
+        let group_id = create_output
+            .group_id
+            .ok_or_else(|| EC2Error::new("Missing security group id after creation"))?;
+
+        let group = self
+            .describe_security_group(&group_id)
+            .await?
+            .ok_or_else(|| {
+                EC2Error::new(format!("Could not find security group with id {group_id}"))
+            })?;
+
+        tracing::info!("Created security group {name} as {group_id}");
+
+        Ok(group)
+    }
+    // snippet-end:[ec2.rust.create_security_group.impl]
+
+    // snippet-start:[ec2.rust.describe_security_group.impl]
+    /// Find a single security group, by ID. Returns Err if multiple groups are found.
+    pub async fn describe_security_group(
+        &self,
+        group_id: &str,
+    ) -> Result<Option<SecurityGroup>, EC2Error> {
+        let group_id: String = group_id.into();
+        let describe_output = self
+            .client
+            .describe_security_groups()
+            .group_ids(&group_id)
+            .send()
+            .await?;
+
+        let mut groups = describe_output.security_groups.unwrap_or_default();
+
+        match groups.len() {
+            0 => Ok(None),
+            1 => Ok(Some(groups.remove(0))),
+            _ => Err(EC2Error::new(format!(
+                "Expected single group for {group_id}"
+            ))),
+        }
+    }
+    // snippet-end:[ec2.rust.describe_security_group.impl]
+
+    // snippet-start:[ec2.rust.authorize_security_group_ssh_ingress.impl]
+    /// Add an ingress rule to a security group explicitly allowing IPv4 address
+    /// as {ip}/32 over TCP port 22.
+    pub async fn authorize_security_group_ssh_ingress(
+        &self,
+        group_id: String,
+        ingress_ips: Vec<Ipv4Addr>,
+    ) -> Result<(), EC2Error> {
+        tracing::info!("Authorizing ingress for security group {group_id}");
+        self.client
+            .authorize_security_group_ingress()
+            .group_id(group_id)
+            .set_ip_permissions(Some(
+                ingress_ips
+                    .into_iter()
+                    .map(|ip| {
+                        IpPermission::builder()
+                            .ip_protocol("tcp")
+                            .from_port(22)
+                            .to_port(22)
+                            .ip_ranges(IpRange::builder().cidr_ip(format!("{ip}/32")).build())
+                            .build()
+                    })
+                    .collect(),
+            ))
+            .send()
+            .await?;
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.authorize_security_group_ssh_ingress.impl]
+
+    // snippet-start:[ec2.rust.delete_security_group.impl]
+    pub async fn delete_security_group(&self, group_id: String) -> Result<(), EC2Error> {
+        tracing::info!("Deleting security group {group_id}");
+        self.client
+            .delete_security_group()
+            .group_id(group_id)
+            .send()
+            .await?;
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.delete_security_group.impl]
+
+    // snippet-start:[ec2.rust.list_images.impl]
+    pub async fn list_images(&self, ids: Vec<Parameter>) -> Result<Vec<Image>, EC2Error> {
+        let image_ids = ids.into_iter().filter_map(|p| p.value).collect();
+        let output = self
+            .client
+            .describe_images()
+            .set_image_ids(Some(image_ids))
+            .send()
+            .await?;
+
+        let images = output.images.unwrap_or_default();
+        if images.is_empty() {
+            Err(EC2Error::new("No images for selected AMIs"))
+        } else {
+            Ok(images)
+        }
+    }
+    // snippet-end:[ec2.rust.list_images.impl]
+
+    // snippet-start:[ec2.rust.list_instance_types.impl]
+    /// List instance types that match an image's architecture and are free tier eligible.
+    pub async fn list_instance_types(&self, image: &Image) -> Result<Vec<InstanceType>, EC2Error> {
+        let architecture = format!(
+            "{}",
+            image.architecture().ok_or_else(|| EC2Error::new(format!(
+                "Image {:?} does not have a listed architecture",
+                image.image_id()
+            )))?
+        );
+        let free_tier_eligible_filter = Filter::builder()
+            .name("free-tier-eligible")
+            .values("false")
+            .build();
+        let supported_architecture_filter = Filter::builder()
+            .name("processor-info.supported-architecture")
+            .values(architecture)
+            .build();
+        let response = self
+            .client
+            .describe_instance_types()
+            .filters(free_tier_eligible_filter)
+            .filters(supported_architecture_filter)
+            .send()
+            .await?;
+
+        Ok(response
+            .instance_types
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|iti| iti.instance_type)
+            .collect())
+    }
+    // snippet-end:[ec2.rust.list_instance_types.impl]
+
+    // snippet-start:[ec2.rust.create_instance.impl]
+    pub async fn create_instance<'a>(
+        &self,
+        image_id: &'a str,
+        instance_type: InstanceType,
+        key_pair: &'a KeyPairInfo,
+        security_groups: Vec<&'a SecurityGroup>,
+    ) -> Result<String, EC2Error> {
+        let run_instances = self
+            .client
+            .run_instances()
+            .image_id(image_id)
+            .instance_type(instance_type)
+            .key_name(
+                key_pair
+                    .key_name()
+                    .ok_or_else(|| EC2Error::new("Missing key name when launching instance"))?,
+            )
+            .set_security_group_ids(Some(
+                security_groups
+                    .iter()
+                    .filter_map(|sg| sg.group_id.clone())
+                    .collect(),
+            ))
+            .min_count(1)
+            .max_count(1)
+            .send()
+            .await?;
+
+        if run_instances.instances().is_empty() {
+            return Err(EC2Error::new("Failed to create instance"));
+        }
+
+        let instance_id = run_instances.instances()[0].instance_id().unwrap();
+        let response = self
+            .client
+            .create_tags()
+            .resources(instance_id)
+            .tags(
+                Tag::builder()
+                    .key("Name")
+                    .value("From SDK Examples")
+                    .build(),
+            )
+            .send()
+            .await;
+
+        match response {
+            Ok(_) => tracing::info!("Created {instance_id} and applied tags."),
+            Err(err) => {
+                tracing::info!("Error applying tags to {instance_id}: {err:?}");
+                return Err(err.into());
+            }
+        }
+
+        tracing::info!("Instance is created.");
+
+        Ok(instance_id.to_string())
+    }
+    // snippet-end:[ec2.rust.create_instance.impl]
+
+    // snippet-start:[ec2.rust.wait_for_instance_ready.impl]
+    /// Wait for an instance to be ready and status ok (default wait 60 seconds)
+    pub async fn wait_for_instance_ready(
+        &self,
+        instance_id: &str,
+        duration: Option<Duration>,
+    ) -> Result<(), EC2Error> {
+        self.client
+            .wait_until_instance_status_ok()
+            .instance_ids(instance_id)
+            .wait(duration.unwrap_or(Duration::from_secs(60)))
+            .await
+            .map_err(|err| match err {
+                WaiterError::ExceededMaxWait(exceeded) => EC2Error(format!(
+                    "Exceeded max time ({}s) waiting for instance to start.",
+                    exceeded.max_wait().as_secs()
+                )),
+                _ => EC2Error::from(err),
+            })?;
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.wait_for_instance_ready.impl]
+
+    // snippet-start:[ec2.rust.describe_instance.impl]
+    pub async fn describe_instance(&self, instance_id: &str) -> Result<Instance, EC2Error> {
+        let response = self
+            .client
+            .describe_instances()
+            .instance_ids(instance_id)
+            .send()
+            .await?;
+
+        let instance = response
+            .reservations()
+            .first()
+            .ok_or_else(|| EC2Error::new(format!("No instance reservations for {instance_id}")))?
+            .instances()
+            .first()
+            .ok_or_else(|| {
+                EC2Error::new(format!("No instances in reservation for {instance_id}"))
+            })?;
+
+        Ok(instance.clone())
+    }
+    // snippet-end:[ec2.rust.describe_instance.impl]
+
+    // snippet-start:[ec2.rust.start_instance.impl]
+    pub async fn start_instance(&self, instance_id: &str) -> Result<(), EC2Error> {
+        tracing::info!("Starting instance {instance_id}");
+
+        self.client
+            .start_instances()
+            .instance_ids(instance_id)
+            .send()
+            .await?;
+
+        tracing::info!("Started instance.");
+
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.start_instance.impl]
+
+    // snippet-start:[ec2.rust.stop_instance.impl]
+    pub async fn stop_instance(&self, instance_id: &str) -> Result<(), EC2Error> {
+        tracing::info!("Stopping instance {instance_id}");
+
+        self.client
+            .stop_instances()
+            .instance_ids(instance_id)
+            .send()
+            .await?;
+
+        self.wait_for_instance_stopped(instance_id, None).await?;
+
+        tracing::info!("Stopped instance.");
+
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.stop_instance.impl]
+
+    // snippet-start:[ec2.rust.reboot_instance.impl]
+    pub async fn reboot_instance(&self, instance_id: &str) -> Result<(), EC2Error> {
+        tracing::info!("Rebooting instance {instance_id}");
+
+        self.client
+            .reboot_instances()
+            .instance_ids(instance_id)
+            .send()
+            .await?;
+
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.reboot_instance.impl]
+
+    // snippet-start:[ec2.rust.wait_for_instance_stopped.impl]
+    pub async fn wait_for_instance_stopped(
+        &self,
+        instance_id: &str,
+        duration: Option<Duration>,
+    ) -> Result<(), EC2Error> {
+        self.client
+            .wait_until_instance_stopped()
+            .instance_ids(instance_id)
+            .wait(duration.unwrap_or(Duration::from_secs(60)))
+            .await
+            .map_err(|err| match err {
+                WaiterError::ExceededMaxWait(exceeded) => EC2Error(format!(
+                    "Exceeded max time ({}s) waiting for instance to stop.",
+                    exceeded.max_wait().as_secs(),
+                )),
+                _ => EC2Error::from(err),
+            })?;
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.wait_for_instance_stopped.impl]
+
+    // snippet-start:[ec2.rust.delete_instance.impl]
+    pub async fn delete_instance(&self, instance_id: &str) -> Result<(), EC2Error> {
+        tracing::info!("Deleting instance with id {instance_id}");
+        self.stop_instance(instance_id).await?;
+        self.client
+            .terminate_instances()
+            .instance_ids(instance_id)
+            .send()
+            .await?;
+        self.wait_for_instance_terminated(instance_id).await?;
+        tracing::info!("Terminated instance with id {instance_id}");
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.delete_instance.impl]
+
+    // snippet-start:[ec2.rust.wait_for_instance_terminated.impl]
+    async fn wait_for_instance_terminated(&self, instance_id: &str) -> Result<(), EC2Error> {
+        self.client
+            .wait_until_instance_terminated()
+            .instance_ids(instance_id)
+            .wait(Duration::from_secs(60))
+            .await
+            .map_err(|err| match err {
+                WaiterError::ExceededMaxWait(exceeded) => EC2Error(format!(
+                    "Exceeded max time ({}s) waiting for instance to terminate.",
+                    exceeded.max_wait().as_secs(),
+                )),
+                _ => EC2Error::from(err),
+            })?;
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.wait_for_instance_terminated.impl]
+
+    // snippet-start:[ec2.rust.allocate_address.impl]
+    pub async fn allocate_ip_address(&self) -> Result<AllocateAddressOutput, EC2Error> {
+        self.client
+            .allocate_address()
+            .domain(DomainType::Vpc)
+            .send()
+            .await
+            .map_err(EC2Error::from)
+    }
+    // snippet-end:[ec2.rust.allocate_address.impl]
+
+    // snippet-start:[ec2.rust.deallocate_address.impl]
+    pub async fn deallocate_ip_address(&self, allocation_id: &str) -> Result<(), EC2Error> {
+        self.client
+            .release_address()
+            .allocation_id(allocation_id)
+            .send()
+            .await?;
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.deallocate_address.impl]
+
+    // snippet-start:[ec2.rust.associate_address.impl]
+    pub async fn associate_ip_address(
+        &self,
+        allocation_id: &str,
+        instance_id: &str,
+    ) -> Result<AssociateAddressOutput, EC2Error> {
+        let response = self
+            .client
+            .associate_address()
+            .allocation_id(allocation_id)
+            .instance_id(instance_id)
+            .send()
+            .await?;
+        Ok(response)
+    }
+    // snippet-end:[ec2.rust.associate_address.impl]
+
+    // snippet-start:[ec2.rust.disassociate_address.impl]
+    pub async fn disassociate_ip_address(&self, association_id: &str) -> Result<(), EC2Error> {
+        self.client
+            .disassociate_address()
+            .association_id(association_id)
+            .send()
+            .await?;
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.disassociate_address.impl]
+}
+
+// snippet-start:[ec2.rust.ec2error.impl]
+#[derive(Debug)]
+pub struct EC2Error(String);
+impl EC2Error {
+    pub fn new(value: impl Into<String>) -> Self {
+        EC2Error(value.into())
+    }
+
+    pub fn add_message(self, message: impl Into<String>) -> Self {
+        EC2Error(format!("{}: {}", message.into(), self.0))
+    }
+}
+
+impl<T: ProvideErrorMetadata> From<T> for EC2Error {
+    fn from(value: T) -> Self {
+        EC2Error(format!(
+            "{}: {}",
+            value
+                .code()
+                .map(String::from)
+                .unwrap_or("unknown code".into()),
+            value
+                .message()
+                .map(String::from)
+                .unwrap_or("missing reason".into()),
+        ))
+    }
+}
+
+impl std::error::Error for EC2Error {}
+
+impl std::fmt::Display for EC2Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+// snippet-end:[ec2.rust.ec2error.impl]

--- a/rustv1/examples/ec2/src/getting_started/elastic_ip.rs
+++ b/rustv1/examples/ec2/src/getting_started/elastic_ip.rs
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use aws_sdk_ec2::operation::{
+    allocate_address::AllocateAddressOutput, associate_address::AssociateAddressOutput,
+};
+
+use crate::ec2::{EC2Error, EC2};
+
+/// ElasticIpManager tracks the lifecycle of a public IP address, including its
+/// allocation from the global pool and association with a specific instance.
+#[derive(Debug, Default)]
+pub struct ElasticIpManager {
+    elastic_ip: Option<AllocateAddressOutput>,
+    association: Option<AssociateAddressOutput>,
+}
+
+impl ElasticIpManager {
+    pub fn has_allocation(&self) -> bool {
+        self.elastic_ip.is_some()
+    }
+
+    pub fn public_ip(&self) -> &str {
+        if let Some(allocation) = &self.elastic_ip {
+            if let Some(addr) = allocation.public_ip() {
+                return addr;
+            }
+        }
+        "0.0.0.0"
+    }
+
+    pub async fn allocate(&mut self, ec2: &EC2) -> Result<(), EC2Error> {
+        let allocation = ec2.allocate_ip_address().await?;
+        self.elastic_ip = Some(allocation);
+        Ok(())
+    }
+
+    pub async fn associate(&mut self, ec2: &EC2, instance_id: &str) -> Result<(), EC2Error> {
+        if let Some(allocation) = &self.elastic_ip {
+            if let Some(allocation_id) = allocation.allocation_id() {
+                let association = ec2.associate_ip_address(allocation_id, instance_id).await?;
+                self.association = Some(association);
+                return Ok(());
+            }
+        }
+        Err(EC2Error::new("No ip address allocation to associate"))
+    }
+
+    pub async fn remove(mut self, ec2: &EC2) -> Result<(), EC2Error> {
+        if let Some(association) = &self.association {
+            if let Some(association_id) = association.association_id() {
+                ec2.disassociate_ip_address(association_id).await?;
+            }
+        }
+        self.association = None;
+        if let Some(allocation) = &self.elastic_ip {
+            if let Some(allocation_id) = allocation.allocation_id() {
+                ec2.deallocate_ip_address(allocation_id).await?;
+            }
+        }
+        self.elastic_ip = None;
+        Ok(())
+    }
+}

--- a/rustv1/examples/ec2/src/getting_started/instance.rs
+++ b/rustv1/examples/ec2/src/getting_started/instance.rs
@@ -1,0 +1,151 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Display;
+
+use aws_sdk_ec2::types::{Instance, InstanceType, KeyPairInfo, SecurityGroup};
+
+use crate::ec2::{EC2Error, EC2};
+
+/// InstanceManager wraps the lifecycle of an EC2 Instance.
+#[derive(Debug, Default)]
+pub struct InstanceManager {
+    instance: Option<Instance>,
+}
+
+impl InstanceManager {
+    pub fn instance_id(&self) -> &str {
+        if let Some(instance) = &self.instance {
+            if let Some(id) = instance.instance_id() {
+                return id;
+            }
+        }
+        "Unknown"
+    }
+
+    pub fn instance_name(&self) -> &str {
+        if let Some(instance) = &self.instance {
+            if let Some(tag) = instance.tags().iter().find(|e| e.key() == Some("Name")) {
+                if let Some(value) = tag.value() {
+                    return value;
+                }
+            }
+        }
+        "Unknown"
+    }
+
+    pub fn instance_ip(&self) -> &str {
+        if let Some(instance) = &self.instance {
+            if let Some(public_ip_address) = instance.public_ip_address() {
+                return public_ip_address;
+            }
+        }
+        "0.0.0.0"
+    }
+
+    pub fn instance_display_name(&self) -> String {
+        format!("{} ({})", self.instance_name(), self.instance_id())
+    }
+
+    // snippet-start:[ec2.rust.create_instance.wrapper]
+    /// Create an EC2 instance with the given ID on a given type, using a
+    /// generated KeyPair and applying a list of security groups.
+    pub async fn create(
+        &mut self,
+        ec2: &EC2,
+        image_id: &str,
+        instance_type: InstanceType,
+        key_pair: &KeyPairInfo,
+        security_groups: Vec<&SecurityGroup>,
+    ) -> Result<(), EC2Error> {
+        let instance_id = ec2
+            .create_instance(image_id, instance_type, key_pair, security_groups)
+            .await?;
+        let instance = ec2.describe_instance(&instance_id).await?;
+        self.instance = Some(instance);
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.create_instance.wrapper]
+
+    /// Start the managed EC2 instance, if present.
+    pub async fn start(&self, ec2: &EC2) -> Result<(), EC2Error> {
+        if self.instance.is_some() {
+            ec2.start_instance(self.instance_id()).await?;
+        }
+        Ok(())
+    }
+
+    /// Stop the managed EC2 instance, if present.
+    pub async fn stop(&self, ec2: &EC2) -> Result<(), EC2Error> {
+        if self.instance.is_some() {
+            ec2.stop_instance(self.instance_id()).await?;
+        }
+        Ok(())
+    }
+
+    // snippet-start:[ec2.rust.reboot_instance.wrapper]
+    pub async fn reboot(&self, ec2: &EC2) -> Result<(), EC2Error> {
+        if self.instance.is_some() {
+            ec2.reboot_instance(self.instance_id()).await?;
+            ec2.wait_for_instance_stopped(self.instance_id(), None)
+                .await?;
+            ec2.wait_for_instance_ready(self.instance_id(), None)
+                .await?;
+        }
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.reboot_instance.wrapper]
+
+    /// Terminate and delete the managed EC2 instance, if present.
+    pub async fn delete(self, ec2: &EC2) -> Result<(), EC2Error> {
+        if self.instance.is_some() {
+            ec2.delete_instance(self.instance_id()).await?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for InstanceManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(instance) = &self.instance {
+            writeln!(f, "\tID: {}", instance.instance_id().unwrap_or("(Unknown)"))?;
+            writeln!(
+                f,
+                "\tImage ID: {}",
+                instance.image_id().unwrap_or("(Unknown)")
+            )?;
+            writeln!(
+                f,
+                "\tInstance type: {}",
+                instance
+                    .instance_type()
+                    .map(|it| format!("{it}"))
+                    .unwrap_or("(Unknown)".to_string())
+            )?;
+            writeln!(
+                f,
+                "\tKey name: {}",
+                instance.key_name().unwrap_or("(Unknown)")
+            )?;
+            writeln!(f, "\tVPC ID: {}", instance.vpc_id().unwrap_or("(Unknown)"))?;
+            writeln!(
+                f,
+                "\tPublic IP: {}",
+                instance.public_ip_address().unwrap_or("(Unknown)")
+            )?;
+            let instance_state = instance
+                .state
+                .as_ref()
+                .map(|is| {
+                    is.name()
+                        .map(|isn| format!("{isn}"))
+                        .unwrap_or("(Unknown)".to_string())
+                })
+                .unwrap_or("(Unknown)".to_string());
+            writeln!(f, "\tState: {instance_state}")?;
+        } else {
+            writeln!(f, "\tNo loaded instance")?;
+        }
+        Ok(())
+    }
+}

--- a/rustv1/examples/ec2/src/getting_started/key_pair.rs
+++ b/rustv1/examples/ec2/src/getting_started/key_pair.rs
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{env, fs::OpenOptions, io::Write, path::PathBuf};
+
+use aws_sdk_ec2::types::KeyPairInfo;
+
+use crate::ec2::{EC2Error, EC2};
+
+/// KeyPairManager tracks a KeyPairInfo and the path the private key has been
+/// written to, if it's been created.
+#[derive(Debug)]
+pub struct KeyPairManager {
+    key_pair: KeyPairInfo,
+    key_file_path: Option<PathBuf>,
+    key_file_dir: PathBuf,
+}
+
+impl KeyPairManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn key_pair(&self) -> &KeyPairInfo {
+        &self.key_pair
+    }
+
+    pub fn key_file_path(&self) -> Option<&PathBuf> {
+        self.key_file_path.as_ref()
+    }
+
+    pub fn key_file_dir(&self) -> &PathBuf {
+        &self.key_file_dir
+    }
+
+    // snippet-start:[ec2.rust.create_key.wrapper]
+    /// Creates a key pair that can be used to securely connect to an EC2 instance.
+    /// The returned key pair contains private key information that cannot be retrieved
+    /// again. The private key data is stored as a .pem file.
+    ///
+    /// :param key_name: The name of the key pair to create.
+    pub async fn create(&mut self, ec2: &EC2, key_name: String) -> Result<KeyPairInfo, EC2Error> {
+        let (key_pair, material) = ec2
+            .create_key_pair(key_name.clone())
+            .await
+            .map_err(|e| e.add_message(format!("Couldn't create key {key_name}")))?;
+
+        let path = self.key_file_dir.join(format!("{key_name}.pem"));
+
+        #[cfg(unix)]
+        let mut file = {
+            use std::os::unix::fs::OpenOptionsExt;
+            OpenOptions::new()
+                .mode(0o600)
+                .open(path.clone())
+                .map_err(|e| EC2Error::new(format!("Failed to create {path:?} ({e:?})")))?
+        };
+        #[cfg(not(unix))]
+        let mut file = {
+            fs::File::create(path.clone())
+                .map_err(|e| EC2Error::new(format!("Failed to create {path:?} ({e:?})")))?
+        };
+
+        file.write(material.as_bytes()).map_err(|e| {
+            EC2Error::new(format!("Failed to write {key_name} to {path:?} ({e:?})"))
+        })?;
+
+        self.key_file_path = Some(path);
+        self.key_pair = key_pair.clone();
+
+        Ok(key_pair)
+    }
+    // snippet-end:[ec2.rust.create_key.wrapper]
+
+    // snippet-start:[ec2.rust.delete_key.wrapper]
+    pub async fn delete(self, ec2: &EC2) -> Result<(), EC2Error> {
+        if let Some(key_pair_id) = self.key_pair.key_pair_id() {
+            ec2.delete_key_pair(key_pair_id).await?;
+            if let Some(key_path) = self.key_file_path() {
+                if let Err(err) = std::fs::remove_file(key_path) {
+                    eprintln!("Failed to remove {key_path:?} ({err:?})");
+                }
+            }
+        }
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.delete_key.wrapper]
+
+    pub async fn list(&self, ec2: &EC2) -> Result<Vec<KeyPairInfo>, EC2Error> {
+        ec2.list_key_pair().await
+    }
+}
+
+impl Default for KeyPairManager {
+    fn default() -> Self {
+        KeyPairManager {
+            key_pair: KeyPairInfo::builder().build(),
+            key_file_path: Default::default(),
+            key_file_dir: env::temp_dir(),
+        }
+    }
+}

--- a/rustv1/examples/ec2/src/getting_started/mod.rs
+++ b/rustv1/examples/ec2/src/getting_started/mod.rs
@@ -6,3 +6,6 @@ pub mod instance;
 pub mod key_pair;
 pub mod scenario;
 pub mod security_group;
+
+pub mod tests;
+pub mod util;

--- a/rustv1/examples/ec2/src/getting_started/mod.rs
+++ b/rustv1/examples/ec2/src/getting_started/mod.rs
@@ -7,5 +7,7 @@ pub mod key_pair;
 pub mod scenario;
 pub mod security_group;
 
-pub mod tests;
 pub mod util;
+
+#[cfg(test)]
+pub mod tests;

--- a/rustv1/examples/ec2/src/getting_started/mod.rs
+++ b/rustv1/examples/ec2/src/getting_started/mod.rs
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod elastic_ip;
+pub mod instance;
+pub mod key_pair;
+pub mod scenario;
+pub mod security_group;

--- a/rustv1/examples/ec2/src/getting_started/scenario.rs
+++ b/rustv1/examples/ec2/src/getting_started/scenario.rs
@@ -1,0 +1,404 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Scenario that uses the AWS SDK for Rust (the SDK) with Amazon Elastic Compute Cloud
+//! (Amazon EC2) to do the following:
+//!
+//! * Create a key pair that is used to secure SSH communication between your computer and
+//!   an EC2 instance.
+//! * Create a security group that acts as a virtual firewall for your EC2 instances to
+//!   control incoming and outgoing traffic.
+//! * Find an Amazon Machine Image (AMI) and a compatible instance type.
+//! * Create an instance that is created from the instance type and AMI you select, and
+//!   is configured to use the security group and key pair created in this example.
+//! * Stop and restart the instance.
+//! * Create an Elastic IP address and associate it as a consistent IP address for your instance.
+//! * Connect to your instance with SSH, using both its public IP address and your Elastic IP
+//!   address.
+//! * Clean up all of the resources created by this example.
+
+use std::{fmt::Display, net::Ipv4Addr};
+
+use crate::{
+    ec2::{EC2Error, EC2},
+    getting_started::key_pair::KeyPairManager,
+    ssm::SSM,
+};
+use aws_sdk_ec2::types::Image;
+use aws_sdk_ssm::types::Parameter;
+use inquire::{validator::ValueRequiredValidator, InquireError};
+
+use super::{
+    elastic_ip::ElasticIpManager, instance::InstanceManager, security_group::SecurityGroupManager,
+};
+
+pub struct Ec2InstanceScenario {
+    ec2: EC2,
+    ssm: SSM,
+    key_pair_manager: KeyPairManager,
+    security_group_manager: SecurityGroupManager,
+    instance_manager: InstanceManager,
+    elastic_ip_manager: ElasticIpManager,
+}
+
+impl Ec2InstanceScenario {
+    pub fn new(ec2: EC2, ssm: SSM) -> Self {
+        Ec2InstanceScenario {
+            ec2,
+            ssm,
+            key_pair_manager: Default::default(),
+            security_group_manager: Default::default(),
+            instance_manager: Default::default(),
+            elastic_ip_manager: Default::default(),
+        }
+    }
+
+    pub async fn run(&mut self) -> Result<(), EC2Error> {
+        self.create_and_list_key_pairs().await?;
+        self.create_security_group().await?;
+        self.create_instance().await?;
+        self.stop_and_start_instance().await?;
+        self.associate_elastic_ip().await?;
+        self.stop_and_start_instance().await?;
+        Ok(())
+    }
+
+    /// 1. Creates an RSA key pair and saves its private key data as a .pem file in secure
+    ///    temporary storage. The private key data is deleted after the example completes.
+    /// 2. Optionally, lists the first five key pairs for the current account.
+    pub async fn create_and_list_key_pairs(&mut self) -> Result<(), EC2Error> {
+        println!( "Let's create an RSA key pair that you can be use to securely connect to your EC2 instance.");
+
+        let key_name = inquire::Text::new("Enter a unique name for your key: ")
+            .with_validator(ValueRequiredValidator::default())
+            .with_default("my_key")
+            .prompt()
+            .map_err(|e| EC2Error::new(format!("Failed to get name for key pair. {e:?}")))?;
+
+        self.key_pair_manager.create(&self.ec2, key_name).await?;
+
+        println!(
+            "Created a key pair {} and saved the private key to {:?}.",
+            self.key_pair_manager
+                .key_pair()
+                .key_name()
+                .ok_or_else(|| EC2Error::new("No key name after creating key"))?,
+            self.key_pair_manager
+                .key_file_path()
+                .ok_or_else(|| EC2Error::new("No key file after creating key"))?
+        );
+
+        if inquire::Confirm::new("Do you want to list some of your key pairs?")
+            .with_default(false)
+            .prompt()
+            .or(Ok(false))
+            .map_err(|e: InquireError| EC2Error::new(format!("Failed to ask question. {e:?}")))?
+        {
+            for pair in self.key_pair_manager.list(&self.ec2).await? {
+                println!(
+                    "Found {:?} key {} with fingerprint:\t{:?}",
+                    pair.key_type(),
+                    pair.key_name().unwrap_or("Unknown"),
+                    pair.key_fingerprint()
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// 1. Creates a security group for the default VPC.
+    /// 2. Adds an inbound rule to allow SSH. The SSH rule allows only
+    ///    inbound traffic from the current computer’s public IPv4 address.
+    /// 3. Displays information about the security group.
+    ///
+    /// This function uses <http://checkip.amazonaws.com> to get the current public IP
+    /// address of the computer that is running the example. This method works in most
+    /// cases. However, depending on how your computer connects to the internet, you
+    /// might have to manually add your public IP address to the security group by using
+    /// the AWS Management Console.
+    pub async fn create_security_group(&mut self) -> Result<(), EC2Error> {
+        println!("Let's create a security group to manage access to your instance.");
+        let group_name = inquire::Text::new("Enter a unique name for your security group: ")
+            .with_validator(ValueRequiredValidator::default())
+            .with_default("my_group")
+            .prompt()
+            .map_err(|e| EC2Error::new(format!("Failed to get name for security group! {e:?}")))?;
+
+        self.security_group_manager
+            .create(
+                &self.ec2,
+                group_name,
+                "Security group for example: get started with instances.",
+            )
+            .await?;
+
+        println!(
+            "Created security group {} in your default VPC {}.",
+            self.security_group_manager.group_name(),
+            self.security_group_manager
+                .vpc_id()
+                .unwrap_or("(unknown vpc)")
+        );
+
+        let check_ip = do_get("https://checkip.amazonaws.com").await?;
+        let current_ip_address: Ipv4Addr = check_ip.trim().parse().map_err(|e| {
+            EC2Error::new(format!(
+                "Failed to convert response {} to IP Address: {e:?}",
+                check_ip
+            ))
+        })?;
+
+        println!("Your public IP address seems to be {current_ip_address}");
+        if inquire::Confirm::new("Add this rule to your security group?")
+            .with_default(true)
+            .prompt()
+            .unwrap_or(true)
+        {
+            match self
+                .security_group_manager
+                .authorize_ingress(&self.ec2, current_ip_address)
+                .await
+            {
+                Ok(_) => println!("Security group rules updated"),
+                Err(err) => eprintln!("Couldn't update security group rules: {err:?}"),
+            }
+        }
+        println!("{}", self.security_group_manager);
+
+        Ok(())
+    }
+
+    // snippet-start:[ec2.rust.create_instance.scenario]
+    /// 1. Gets a list of Amazon Linux 2 AMIs from AWS Systems Manager. Specifying the
+    ///    '/aws/service/ami-amazon-linux-latest' path returns only the latest AMIs.
+    /// 2. Gets and displays information about the available AMIs and lets you select one.
+    /// 3. Gets a list of instance types that are compatible with the selected AMI and
+    ///    lets you select one.
+    /// 4. Creates an instance with the previously created key pair and security group,
+    ///    and the selected AMI and instance type.
+    /// 5. Waits for the instance to be running and then displays its information.
+    pub async fn create_instance(&mut self) -> Result<(), EC2Error> {
+        let ami = self.find_image().await?;
+
+        let instance_types = self
+            .ec2
+            .list_instance_types(&ami.0)
+            .await
+            .map_err(|e| e.add_message("Could not find instance types"))?;
+        println!(
+            "There are several instance types that support the {} architecture of the image.",
+            ami.0
+                .architecture
+                .as_ref()
+                .ok_or_else(|| EC2Error::new(format!("Missing architecture in {:?}", ami.0)))?
+        );
+        let instance_type =
+            inquire::Select::new("Select an instance type for this instance:", instance_types)
+                .prompt()
+                .map_err(|e| {
+                    EC2Error::new(format!(
+                        "Could not determine the desired instance type ({e:?})"
+                    ))
+                })?;
+
+        println!("Creating your instance and waiting for it to start...");
+        self.instance_manager
+            .create(
+                &self.ec2,
+                ami.0
+                    .image_id()
+                    .ok_or_else(|| EC2Error::new("Could not find image ID"))?,
+                instance_type,
+                self.key_pair_manager.key_pair(),
+                self.security_group_manager
+                    .security_group()
+                    .map(|sg| vec![sg])
+                    .ok_or_else(|| EC2Error::new("Could not find security group"))?,
+            )
+            .await
+            .map_err(|e| e.add_message("Scenario failed to create instance"))?;
+
+        while let Err(err) = self
+            .ec2
+            .wait_for_instance_ready(self.instance_manager.instance_id(), None)
+            .await
+        {
+            println!("{err}");
+            if !inquire::Confirm::new("Continue waiting?")
+                .with_default(true)
+                .prompt()
+                .map_err(|_| err)?
+            {
+                break;
+            }
+        }
+
+        println!("Your instance is ready:\n{}", self.instance_manager);
+
+        self.display_ssh_info();
+
+        Ok(())
+    }
+    // snippet-end:[ec2.rust.create_instance.scenario]
+
+    // snippet-start:[ec2.rust.find_image.scenario]
+    async fn find_image(&mut self) -> Result<ScenarioImage, EC2Error> {
+        let params: Vec<Parameter> = self
+            .ssm
+            .list_path("/aws/service/ami-amazon-linux-latest")
+            .await
+            .map_err(|e| e.add_message("Could not find parameters for available images"))?
+            .into_iter()
+            .filter(|param| param.name().is_some_and(|name| name.contains("amzn2")))
+            .collect();
+        let amzn2_images: Vec<ScenarioImage> = self
+            .ec2
+            .list_images(params)
+            .await
+            .map_err(|e| e.add_message("Could not find images"))?
+            .into_iter()
+            .map(ScenarioImage::from)
+            .collect();
+        println!("We will now create an instance from an Amazon Linux 2 AMI");
+        let ami = inquire::Select::new(
+            "Select an Amazon Linux 2 AMI for this instance",
+            amzn2_images,
+        )
+        .prompt()
+        .map_err(|e| EC2Error::new(format!("Could not determine desired AMI ({e:?})")))?;
+        Ok(ami)
+    }
+    // snippet-end:[ec2.rust.find_image.scenario]
+
+    // 1. Stops the instance and waits for it to stop.
+    // 2. Starts the instance and waits for it to start.
+    // 3. Displays information about the instance.
+    // 4. Displays an SSH connection string. When an Elastic IP address is associated
+    //    with the instance, the IP address stays consistent when the instance stops
+    //    and starts.
+    pub async fn stop_and_start_instance(&self) -> Result<(), EC2Error> {
+        println!("Let's stop and start your instance to see what changes.");
+        println!("Stopping your instance and waiting until it's stopped...");
+        self.instance_manager.stop(&self.ec2).await?;
+        println!("Your instance is stopped. Restarting...");
+        self.instance_manager.start(&self.ec2).await?;
+        println!("Your instance is running.");
+        println!("{}", self.instance_manager);
+        if self.elastic_ip_manager.public_ip() == "0.0.0.0" {
+            println!("Every time your instance is restarted, its public IP address changes.");
+        } else {
+            println!(
+                "Because you have associated an Elastic IP with your instance, you can connect by using a consistent IP address after the instance restarts."
+            );
+        }
+        self.display_ssh_info();
+        Ok(())
+    }
+
+    /// 1. Allocates an Elastic IP address and associates it with the instance.
+    /// 2. Displays an SSH connection string that uses the Elastic IP address.
+    async fn associate_elastic_ip(&mut self) -> Result<(), EC2Error> {
+        self.elastic_ip_manager.allocate(&self.ec2).await?;
+        println!(
+            "Allocated static Elastic IP address: {}",
+            self.elastic_ip_manager.public_ip()
+        );
+
+        self.elastic_ip_manager
+            .associate(&self.ec2, self.instance_manager.instance_id())
+            .await?;
+        println!("Associated your Elastic IP with your instance.");
+        println!("You can now use SSH to connect to your instance by using the Elastic IP.");
+        self.display_ssh_info();
+        Ok(())
+    }
+
+    /// Displays an SSH connection string that can be used to connect to a running
+    /// instance.
+    fn display_ssh_info(&self) {
+        let ip_addr = if self.elastic_ip_manager.has_allocation() {
+            self.elastic_ip_manager.public_ip()
+        } else {
+            self.instance_manager.instance_ip()
+        };
+        let key_file_path = self.key_pair_manager.key_file_path().unwrap();
+        println!("To connect, open another command prompt and run the following command:");
+        println!("\nssh -i {} ec2-user@{ip_addr}\n", key_file_path.display());
+        let _ = inquire::Text::new("Press Enter when you're ready to continue the demo.").prompt();
+    }
+
+    /// 1. Disassociate and delete the previously created Elastic IP.
+    /// 2. Terminate the previously created instance.
+    /// 3. Delete the previously created security group.
+    /// 4. Delete the previously created key pair.
+    pub async fn clean_up(self) {
+        println!("Let's clean everything up. This example created these resources:");
+        println!(
+            "\tKey pair: {}",
+            self.key_pair_manager
+                .key_pair()
+                .key_name()
+                .unwrap_or("(unknown key pair)")
+        );
+        println!(
+            "\tSecurity group: {}",
+            self.security_group_manager.group_name()
+        );
+        println!(
+            "\tInstance: {}",
+            self.instance_manager.instance_display_name()
+        );
+        if inquire::Confirm::new("Clean up resources?")
+            .with_default(true)
+            .prompt()
+            .unwrap_or(false)
+        {
+            if let Err(err) = self.elastic_ip_manager.remove(&self.ec2).await {
+                eprintln!("{err}")
+            }
+            if let Err(err) = self.instance_manager.delete(&self.ec2).await {
+                eprintln!("{err}")
+            }
+            if let Err(err) = self.security_group_manager.delete(&self.ec2).await {
+                eprintln!("{err}");
+            }
+            if let Err(err) = self.key_pair_manager.delete(&self.ec2).await {
+                eprintln!("{err}");
+            }
+        } else {
+            println!("Ok, not cleaning up any resources!");
+        }
+    }
+}
+
+/// Utility to perform a GET request and return the body as UTF-8, or an appropriate EC2Error.
+async fn do_get(url: &str) -> Result<String, EC2Error> {
+    reqwest::get(url)
+        .await
+        .map_err(|e| EC2Error::new(format!("Could not request ip from {url}: {e:?}")))?
+        .error_for_status()
+        .map_err(|e| EC2Error::new(format!("Failure status from {url}: {e:?}")))?
+        .text_with_charset("utf-8")
+        .await
+        .map_err(|e| EC2Error::new(format!("Failed to read response from {url}: {e:?}")))
+}
+
+/// Image doesn't impl Display, which is necessary for inquire to use it in a Select.
+/// This wraps Image and provides a Display impl.
+struct ScenarioImage(Image);
+impl From<Image> for ScenarioImage {
+    fn from(value: Image) -> Self {
+        ScenarioImage(value)
+    }
+}
+impl Display for ScenarioImage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}: {}",
+            self.0.name().unwrap_or("(unknown)"),
+            self.0.description().unwrap_or("unknown")
+        )
+    }
+}

--- a/rustv1/examples/ec2/src/getting_started/security_group.rs
+++ b/rustv1/examples/ec2/src/getting_started/security_group.rs
@@ -20,14 +20,14 @@ impl SecurityGroupManager {
     pub async fn create(
         &mut self,
         ec2: &EC2,
-        group_name: impl Into<String>,
-        group_description: impl Into<String>,
+        group_name: &str,
+        group_description: &str,
     ) -> Result<(), EC2Error> {
         self.group_name = group_name.into();
         self.group_description = group_description.into();
 
         self.security_group = Some(
-            ec2.create_security_group(self.group_name.clone(), self.group_description.clone())
+            ec2.create_security_group(group_name, group_description)
                 .await
                 .map_err(|e| e.add_message("Couldn't create security group"))?,
         );
@@ -39,8 +39,7 @@ impl SecurityGroupManager {
         if let Some(sg) = &self.security_group {
             ec2.authorize_security_group_ssh_ingress(
                 sg.group_id()
-                    .ok_or_else(|| EC2Error::new("Missing security group ID"))?
-                    .to_string(),
+                    .ok_or_else(|| EC2Error::new("Missing security group ID"))?,
                 vec![ip_address],
             )
             .await?;
@@ -53,8 +52,7 @@ impl SecurityGroupManager {
         if let Some(sg) = &self.security_group {
             ec2.delete_security_group(
                 sg.group_id()
-                    .ok_or_else(|| EC2Error::new("Missing security group ID"))?
-                    .to_string(),
+                    .ok_or_else(|| EC2Error::new("Missing security group ID"))?,
             )
             .await?;
         };

--- a/rustv1/examples/ec2/src/getting_started/security_group.rs
+++ b/rustv1/examples/ec2/src/getting_started/security_group.rs
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::Ipv4Addr;
+
+use aws_sdk_ec2::types::SecurityGroup;
+
+use crate::ec2::{EC2Error, EC2};
+
+/// SecurityGroupManager tracks the lifecycle of a SecurityGroup for an instance,
+/// including adding a rule to allow SSH from a public IP address.
+#[derive(Debug, Default)]
+pub struct SecurityGroupManager {
+    group_name: String,
+    group_description: String,
+    security_group: Option<SecurityGroup>,
+}
+
+impl SecurityGroupManager {
+    pub async fn create(
+        &mut self,
+        ec2: &EC2,
+        group_name: impl Into<String>,
+        group_description: impl Into<String>,
+    ) -> Result<(), EC2Error> {
+        self.group_name = group_name.into();
+        self.group_description = group_description.into();
+
+        self.security_group = Some(
+            ec2.create_security_group(self.group_name.clone(), self.group_description.clone())
+                .await
+                .map_err(|e| e.add_message("Couldn't create security group"))?,
+        );
+
+        Ok(())
+    }
+
+    pub async fn authorize_ingress(&self, ec2: &EC2, ip_address: Ipv4Addr) -> Result<(), EC2Error> {
+        if let Some(sg) = &self.security_group {
+            ec2.authorize_security_group_ssh_ingress(
+                sg.group_id()
+                    .ok_or_else(|| EC2Error::new("Missing security group ID"))?
+                    .to_string(),
+                vec![ip_address],
+            )
+            .await?;
+        };
+
+        Ok(())
+    }
+
+    pub async fn delete(self, ec2: &EC2) -> Result<(), EC2Error> {
+        if let Some(sg) = &self.security_group {
+            ec2.delete_security_group(
+                sg.group_id()
+                    .ok_or_else(|| EC2Error::new("Missing security group ID"))?
+                    .to_string(),
+            )
+            .await?;
+        };
+
+        Ok(())
+    }
+
+    pub fn group_name(&self) -> &str {
+        &self.group_name
+    }
+
+    pub fn vpc_id(&self) -> Option<&str> {
+        self.security_group.as_ref().and_then(|sg| sg.vpc_id())
+    }
+
+    pub fn security_group(&self) -> Option<&SecurityGroup> {
+        self.security_group.as_ref()
+    }
+}
+
+impl std::fmt::Display for SecurityGroupManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.security_group {
+            Some(sg) => {
+                writeln!(
+                    f,
+                    "Security group: {}",
+                    sg.group_name().unwrap_or("(unknown group)")
+                )?;
+                writeln!(f, "\tID: {}", sg.group_id().unwrap_or("(unknown group id)"))?;
+                writeln!(f, "\tVPC: {}", sg.vpc_id().unwrap_or("(unknown group vpc)"))?;
+                if !sg.ip_permissions().is_empty() {
+                    writeln!(f, "\tInbound Permissions:")?;
+                    for permission in sg.ip_permissions() {
+                        writeln!(f, "\t\t{permission:?}")?;
+                    }
+                }
+                Ok(())
+            }
+            None => writeln!(f, "No security group loaded."),
+        }
+    }
+}

--- a/rustv1/examples/ec2/src/getting_started/tests/mod.rs
+++ b/rustv1/examples/ec2/src/getting_started/tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod scenario_with_mocks;

--- a/rustv1/examples/ec2/src/getting_started/tests/mod.rs
+++ b/rustv1/examples/ec2/src/getting_started/tests/mod.rs
@@ -1,1 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// List test modules here. This mod.rs is gated by #[cfg(test)] in the crate mod.rs.
 pub mod scenario_with_mocks;

--- a/rustv1/examples/ec2/src/getting_started/tests/scenario_with_mocks.rs
+++ b/rustv1/examples/ec2/src/getting_started/tests/scenario_with_mocks.rs
@@ -1,475 +1,116 @@
-#[cfg(test)]
-mod test {
-    use std::{net::Ipv4Addr, path::PathBuf};
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
-    use aws_sdk_ec2::{
-        operation::{
-            allocate_address::AllocateAddressOutput, associate_address::AssociateAddressOutput,
-        },
-        types::{ArchitectureValues, Image, Instance, InstanceType, KeyPairInfo, SecurityGroup},
-    };
-    use aws_sdk_ssm::types::Parameter;
-    use mockall::predicate::{self, eq};
+use std::{net::Ipv4Addr, path::PathBuf};
 
-    use crate::{
-        ec2::{EC2Error, MockEC2Impl},
-        getting_started::{
-            scenario::{run, Ec2InstanceScenario},
-            util::MockUtilImpl,
-        },
-        ssm::MockSSMImpl,
-    };
+use aws_sdk_ec2::{
+    operation::{
+        allocate_address::AllocateAddressOutput, associate_address::AssociateAddressOutput,
+    },
+    types::{ArchitectureValues, Image, Instance, InstanceType, KeyPairInfo, SecurityGroup},
+};
+use aws_sdk_ssm::types::Parameter;
+use mockall::predicate::{self, eq};
 
-    #[tokio::test]
-    async fn test_happy_path() {
-        let mut mock_ec2 = MockEC2Impl::default();
-        let mut mock_ssm = MockSSMImpl::default();
-        let mut mock_util = MockUtilImpl::default();
+use crate::{
+    ec2::{EC2Error, MockEC2Impl},
+    getting_started::{
+        scenario::{run, Ec2InstanceScenario},
+        util::MockUtilImpl,
+    },
+    ssm::MockSSMImpl,
+};
 
-        // create_and_list_key_pairs
+#[tokio::test]
+async fn test_happy_path() {
+    let mut mock_ec2 = MockEC2Impl::default();
+    let mut mock_ssm = MockSSMImpl::default();
+    let mut mock_util = MockUtilImpl::default();
+
+    // create_and_list_key_pairs
+    {
+        mock_util
+            .expect_prompt_key_name()
+            .returning(|| Ok("test_key".into()));
+
+        // create
         {
-            mock_util
-                .expect_prompt_key_name()
-                .returning(|| Ok("test_key".into()));
-
-            // create
-            {
-                mock_ec2
-                    .expect_create_key_pair()
-                    .with(eq("test_key".to_string()))
-                    .returning(|_| {
-                        Ok((
-                            KeyPairInfo::builder()
-                                .key_name("test_key")
-                                .key_pair_id("kp-12345")
-                                .build(),
-                            "PEM MATERIAL".into(),
-                        ))
-                    });
-
-                mock_util
-                    .expect_write_secure()
-                    .with(
-                        eq("test_key"),
-                        predicate::function(|path: &PathBuf| path.ends_with("test_key.pem")),
-                        eq("PEM MATERIAL".to_string()),
-                    )
-                    .returning(|_, _, _| Ok(()));
-            }
-
-            mock_util
-                .expect_should_list_key_pairs()
-                .returning(|| Ok(false));
-        }
-        // create_security_group
-        {
-            mock_util
-                .expect_prompt_security_group_name()
-                .returning(|| Ok("test_group".into()));
-
-            // security_group_manager.create
-            {
-                mock_ec2
-                    .expect_create_security_group()
-                    .with(
-                        eq("test_group"),
-                        eq("Security group for example: get started with instances."),
-                    )
-                    .returning(|_, _| {
-                        Ok(SecurityGroup::builder()
-                            .group_id("sg-0123")
-                            .group_name("test_group")
-                            .build())
-                    });
-            }
-
-            mock_util
-                .expect_do_get()
-                .with(eq("https://checkip.amazonaws.com"))
-                .returning(|_| Ok("192.168.0.1".into()));
-
-            mock_util
-                .expect_should_add_to_security_group()
-                .returning(|| true);
-
-            // security_group_manager.authorize_ingress
-            {
-                mock_ec2
-                    .expect_authorize_security_group_ssh_ingress()
-                    .with(eq("sg-0123"), eq(vec![Ipv4Addr::new(192, 168, 0, 1)]))
-                    .returning(|_, _| Ok(()));
-            }
-        }
-
-        // create_instance
-        {
-            // find_image
-            {
-                mock_ssm
-                    .expect_list_path()
-                    .with(eq("/aws/service/ami-amazon-linux-latest"))
-                    .returning(|_| {
-                        Ok(vec![
-                            Parameter::builder()
-                                .name("amzn2-ami1")
-                                .value("amzn2-ami1")
-                                .build(),
-                            Parameter::builder()
-                                .name("amzn2-ami2")
-                                .value("amzn2-ami2")
-                                .build(),
-                        ])
-                    });
-                mock_ec2
-                    .expect_list_images()
-                    .with(eq(vec![
-                        Parameter::builder()
-                            .name("amzn2-ami1")
-                            .value("amzn2-ami1")
-                            .build(),
-                        Parameter::builder()
-                            .name("amzn2-ami2")
-                            .value("amzn2-ami2")
-                            .build(),
-                    ]))
-                    .returning(|_| {
-                        Ok(vec![
-                            aws_sdk_ec2::types::Image::builder()
-                                .architecture(ArchitectureValues::X8664)
-                                .image_id("img-1234_x64")
-                                .build(),
-                            aws_sdk_ec2::types::Image::builder()
-                                .architecture(ArchitectureValues::Arm64)
-                                .image_id("img-1234_arm")
-                                .build(),
-                        ])
-                    });
-
-                mock_util
-                    .expect_select_scenario_image()
-                    .with(eq(vec![
-                        Image::builder()
-                            .architecture(ArchitectureValues::X8664)
-                            .image_id("img-1234_x64")
-                            .build()
-                            .into(),
-                        Image::builder()
-                            .architecture(ArchitectureValues::Arm64)
-                            .image_id("img-1234_arm")
-                            .build()
-                            .into(),
-                    ]))
-                    .returning(|_| {
-                        Ok(Image::builder()
-                            .architecture(ArchitectureValues::Arm64)
-                            .image_id("img-1234_arm")
-                            .build()
-                            .into())
-                    });
-            }
-
             mock_ec2
-                .expect_list_instance_types()
-                .withf(|image| {
-                    image.architecture == Some(ArchitectureValues::Arm64)
-                        && image.image_id() == Some("img-1234_arm")
-                })
-                .returning(|_| Ok(vec![InstanceType::T1Micro, InstanceType::A1Medium]));
-
-            mock_util
-                .expect_select_instance_type()
-                .with(eq(vec![InstanceType::T1Micro, InstanceType::A1Medium]))
-                .returning(|_| Ok(InstanceType::T1Micro));
-
-            // instance_manager.create
-            {
-                mock_ec2
-                    .expect_create_instance()
-                    .withf(|image_id, instance_type, keypair_info, sgs| {
-                        image_id == "img-1234_arm"
-                            && *instance_type == InstanceType::T1Micro
-                            && keypair_info.key_name() == Some("test_key")
-                            && sgs[0].group_id() == Some("sg-0123")
-                    })
-                    .returning(|_, _, _, _| Ok("i-01234567".into()));
-
-                mock_ec2
-                    .expect_describe_instance()
-                    .with(eq("i-01234567"))
-                    .returning(|_| {
-                        Ok(Instance::builder()
-                            .architecture(ArchitectureValues::Arm64)
-                            .instance_id("i-01234567")
-                            .build())
-                    });
-            }
-
-            mock_ec2
-                .expect_wait_for_instance_ready()
-                .times(1)
-                .with(eq("i-01234567"), eq(None))
-                .returning(|_, _| {
-                    Err(EC2Error::new(
-                        "Exceeded max time (60s) waiting for instance to start.",
+                .expect_create_key_pair()
+                .with(eq("test_key".to_string()))
+                .returning(|_| {
+                    Ok((
+                        KeyPairInfo::builder()
+                            .key_name("test_key")
+                            .key_pair_id("kp-12345")
+                            .build(),
+                        "PEM MATERIAL".into(),
                     ))
                 });
 
             mock_util
-                .expect_should_continue_waiting()
-                .returning(|| true);
+                .expect_write_secure()
+                .with(
+                    eq("test_key"),
+                    predicate::function(|path: &PathBuf| path.ends_with("test_key.pem")),
+                    eq("PEM MATERIAL".to_string()),
+                )
+                .returning(|_, _, _| Ok(()));
+        }
 
+        mock_util
+            .expect_should_list_key_pairs()
+            .returning(|| Ok(false));
+    }
+    // create_security_group
+    {
+        mock_util
+            .expect_prompt_security_group_name()
+            .returning(|| Ok("test_group".into()));
+
+        // security_group_manager.create
+        {
             mock_ec2
-                .expect_wait_for_instance_ready()
-                .times(1)
-                .with(eq("i-01234567"), eq(None))
-                .returning(|_, _| Ok(()));
-
-            // display_ssh_info
-            {
-                mock_util
-                    .expect_enter_to_continue()
-                    .returning(|| Ok("".into()));
-            }
-        }
-
-        // stop_and_start_instance 1
-        {
-            // stop
-            {
-                mock_ec2
-                    .expect_stop_instance()
-                    .with(eq("i-01234567"))
-                    .returning(|_| Ok(()));
-            }
-
-            // start
-            {
-                mock_ec2
-                    .expect_start_instance()
-                    .with(eq("i-01234567"))
-                    .returning(|_| Ok(()));
-            }
-
-            // display_ssh_info
-            {
-                mock_util
-                    .expect_enter_to_continue()
-                    .returning(|| Ok("".into()));
-            }
-        }
-
-        // associate_elastic_ip
-        {
-            // elastic_ip_manager.allocate
-            {
-                mock_ec2.expect_allocate_ip_address().returning(|| {
-                    Ok(AllocateAddressOutput::builder()
-                        .allocation_id("eip-1234567")
+                .expect_create_security_group()
+                .with(
+                    eq("test_group"),
+                    eq("Security group for example: get started with instances."),
+                )
+                .returning(|_, _| {
+                    Ok(SecurityGroup::builder()
+                        .group_id("sg-0123")
+                        .group_name("test_group")
                         .build())
                 });
-            }
-
-            // elastic_ip_manager.associate
-            {
-                mock_ec2
-                    .expect_associate_ip_address()
-                    .with(eq("eip-1234567"), eq("i-01234567"))
-                    .returning(|_, _| {
-                        Ok(AssociateAddressOutput::builder()
-                            .association_id("aid-01234567")
-                            .build())
-                    });
-            }
-
-            // display_ssh_info
-            {
-                mock_util
-                    .expect_enter_to_continue()
-                    .returning(|| Ok("".into()));
-            }
         }
 
-        // stop_and_start_instance 2
+        mock_util
+            .expect_do_get()
+            .with(eq("https://checkip.amazonaws.com"))
+            .returning(|_| Ok("192.168.0.1".into()));
+
+        mock_util
+            .expect_should_add_to_security_group()
+            .returning(|| true);
+
+        // security_group_manager.authorize_ingress
         {
-            // stop
-            {
-                mock_ec2
-                    .expect_stop_instance()
-                    .with(eq("i-01234567"))
-                    .returning(|_| Ok(()));
-            }
-
-            // start
-            {
-                mock_ec2
-                    .expect_start_instance()
-                    .with(eq("i-01234567"))
-                    .returning(|_| Ok(()));
-            }
-
-            // display_ssh_info
-            {
-                mock_util
-                    .expect_enter_to_continue()
-                    .returning(|| Ok("".into()));
-            }
+            mock_ec2
+                .expect_authorize_security_group_ssh_ingress()
+                .with(eq("sg-0123"), eq(vec![Ipv4Addr::new(192, 168, 0, 1)]))
+                .returning(|_, _| Ok(()));
         }
-
-        // clean_up
-        {
-            mock_util.expect_should_clean_resources().returning(|| true);
-
-            // elastic_ip_manager.remove
-            {
-                mock_ec2
-                    .expect_disassociate_ip_address()
-                    .with(eq("aid-01234567"))
-                    .returning(|_| Ok(()));
-
-                mock_ec2
-                    .expect_deallocate_ip_address()
-                    .with(eq("eip-1234567"))
-                    .returning(|_| Ok(()));
-            }
-
-            // instance_manager.delete
-            {
-                mock_ec2
-                    .expect_delete_instance()
-                    .with(eq("i-01234567"))
-                    .returning(|_| Ok(()));
-            }
-
-            // security_group_manager.delete
-            {
-                mock_ec2
-                    .expect_delete_security_group()
-                    .with(eq("sg-0123"))
-                    .returning(|_| Ok(()));
-            }
-
-            // key_pair_manager.delete
-            {
-                mock_ec2
-                    .expect_delete_key_pair()
-                    .with(eq("kp-12345"))
-                    .returning(|_| Ok(()));
-
-                mock_util
-                    .expect_remove()
-                    .withf(|p| format!("{p:?}").contains("test_key.pem"))
-                    .returning(|_| Ok(()));
-            }
-        }
-
-        let scenario = Ec2InstanceScenario::new(mock_ec2, mock_ssm, mock_util);
-
-        run(scenario).await;
     }
 
-    #[tokio::test]
-    async fn test_unhappy_path_instance_takes_too_long() {
-        let mut mock_ec2 = MockEC2Impl::default();
-        let mut mock_ssm = MockSSMImpl::default();
-        let mut mock_util = MockUtilImpl::default();
-
-        // create_and_list_key_pairs
+    // create_instance
+    {
+        // find_image
         {
-            mock_util
-                .expect_prompt_key_name()
-                .returning(|| Ok("test_key".into()));
-
-            // create
-            {
-                mock_ec2
-                    .expect_create_key_pair()
-                    .with(eq("test_key".to_string()))
-                    .returning(|_| {
-                        Ok((
-                            KeyPairInfo::builder()
-                                .key_name("test_key")
-                                .key_pair_id("kp-12345")
-                                .build(),
-                            "PEM MATERIAL".into(),
-                        ))
-                    });
-
-                mock_util
-                    .expect_write_secure()
-                    .with(
-                        eq("test_key"),
-                        predicate::function(|path: &PathBuf| path.ends_with("test_key.pem")),
-                        eq("PEM MATERIAL".to_string()),
-                    )
-                    .returning(|_, _, _| Ok(()));
-            }
-
-            mock_util
-                .expect_should_list_key_pairs()
-                .returning(|| Ok(false));
-        }
-        // create_security_group
-        {
-            mock_util
-                .expect_prompt_security_group_name()
-                .returning(|| Ok("test_group".into()));
-
-            // security_group_manager.create
-            {
-                mock_ec2
-                    .expect_create_security_group()
-                    .with(
-                        eq("test_group"),
-                        eq("Security group for example: get started with instances."),
-                    )
-                    .returning(|_, _| {
-                        Ok(SecurityGroup::builder()
-                            .group_id("sg-0123")
-                            .group_name("test_group")
-                            .build())
-                    });
-            }
-
-            mock_util
-                .expect_do_get()
-                .with(eq("https://checkip.amazonaws.com"))
-                .returning(|_| Ok("192.168.0.1".into()));
-
-            mock_util
-                .expect_should_add_to_security_group()
-                .returning(|| true);
-
-            // security_group_manager.authorize_ingress
-            {
-                mock_ec2
-                    .expect_authorize_security_group_ssh_ingress()
-                    .with(eq("sg-0123"), eq(vec![Ipv4Addr::new(192, 168, 0, 1)]))
-                    .returning(|_, _| Ok(()));
-            }
-        }
-
-        // create_instance
-        {
-            // find_image
-            {
-                mock_ssm
-                    .expect_list_path()
-                    .with(eq("/aws/service/ami-amazon-linux-latest"))
-                    .returning(|_| {
-                        Ok(vec![
-                            Parameter::builder()
-                                .name("amzn2-ami1")
-                                .value("amzn2-ami1")
-                                .build(),
-                            Parameter::builder()
-                                .name("amzn2-ami2")
-                                .value("amzn2-ami2")
-                                .build(),
-                        ])
-                    });
-                mock_ec2
-                    .expect_list_images()
-                    .with(eq(vec![
+            mock_ssm
+                .expect_list_path()
+                .with(eq("/aws/service/ami-amazon-linux-latest"))
+                .returning(|_| {
+                    Ok(vec![
                         Parameter::builder()
                             .name("amzn2-ami1")
                             .value("amzn2-ami1")
@@ -478,130 +119,489 @@ mod test {
                             .name("amzn2-ami2")
                             .value("amzn2-ami2")
                             .build(),
-                    ]))
-                    .returning(|_| {
-                        Ok(vec![
-                            aws_sdk_ec2::types::Image::builder()
-                                .architecture(ArchitectureValues::X8664)
-                                .image_id("img-1234_x64")
-                                .build(),
-                            aws_sdk_ec2::types::Image::builder()
-                                .architecture(ArchitectureValues::Arm64)
-                                .image_id("img-1234_arm")
-                                .build(),
-                        ])
-                    });
-
-                mock_util
-                    .expect_select_scenario_image()
-                    .with(eq(vec![
-                        Image::builder()
+                    ])
+                });
+            mock_ec2
+                .expect_list_images()
+                .with(eq(vec![
+                    Parameter::builder()
+                        .name("amzn2-ami1")
+                        .value("amzn2-ami1")
+                        .build(),
+                    Parameter::builder()
+                        .name("amzn2-ami2")
+                        .value("amzn2-ami2")
+                        .build(),
+                ]))
+                .returning(|_| {
+                    Ok(vec![
+                        aws_sdk_ec2::types::Image::builder()
                             .architecture(ArchitectureValues::X8664)
                             .image_id("img-1234_x64")
-                            .build()
-                            .into(),
-                        Image::builder()
+                            .build(),
+                        aws_sdk_ec2::types::Image::builder()
                             .architecture(ArchitectureValues::Arm64)
                             .image_id("img-1234_arm")
-                            .build()
-                            .into(),
-                    ]))
-                    .returning(|_| {
-                        Ok(Image::builder()
-                            .architecture(ArchitectureValues::Arm64)
-                            .image_id("img-1234_arm")
-                            .build()
-                            .into())
-                    });
-            }
-
-            mock_ec2
-                .expect_list_instance_types()
-                .withf(|image| {
-                    image.architecture == Some(ArchitectureValues::Arm64)
-                        && image.image_id() == Some("img-1234_arm")
-                })
-                .returning(|_| Ok(vec![InstanceType::T1Micro, InstanceType::A1Medium]));
+                            .build(),
+                    ])
+                });
 
             mock_util
-                .expect_select_instance_type()
-                .with(eq(vec![InstanceType::T1Micro, InstanceType::A1Medium]))
-                .returning(|_| Ok(InstanceType::T1Micro));
+                .expect_select_scenario_image()
+                .with(eq(vec![
+                    Image::builder()
+                        .architecture(ArchitectureValues::X8664)
+                        .image_id("img-1234_x64")
+                        .build()
+                        .into(),
+                    Image::builder()
+                        .architecture(ArchitectureValues::Arm64)
+                        .image_id("img-1234_arm")
+                        .build()
+                        .into(),
+                ]))
+                .returning(|_| {
+                    Ok(Image::builder()
+                        .architecture(ArchitectureValues::Arm64)
+                        .image_id("img-1234_arm")
+                        .build()
+                        .into())
+                });
+        }
 
-            // instance_manager.create
-            {
-                mock_ec2
-                    .expect_create_instance()
-                    .withf(|image_id, instance_type, keypair_info, sgs| {
-                        image_id == "img-1234_arm"
-                            && *instance_type == InstanceType::T1Micro
-                            && keypair_info.key_name() == Some("test_key")
-                            && sgs[0].group_id() == Some("sg-0123")
-                    })
-                    .returning(|_, _, _, _| Ok("i-01234567".into()));
+        mock_ec2
+            .expect_list_instance_types()
+            .withf(|image| {
+                image.architecture == Some(ArchitectureValues::Arm64)
+                    && image.image_id() == Some("img-1234_arm")
+            })
+            .returning(|_| Ok(vec![InstanceType::T1Micro, InstanceType::A1Medium]));
 
-                mock_ec2
-                    .expect_describe_instance()
-                    .with(eq("i-01234567"))
-                    .returning(|_| {
-                        Ok(Instance::builder()
-                            .architecture(ArchitectureValues::Arm64)
-                            .instance_id("i-01234567")
-                            .build())
-                    });
-            }
+        mock_util
+            .expect_select_instance_type()
+            .with(eq(vec![InstanceType::T1Micro, InstanceType::A1Medium]))
+            .returning(|_| Ok(InstanceType::T1Micro));
+
+        // instance_manager.create
+        {
+            mock_ec2
+                .expect_create_instance()
+                .withf(|image_id, instance_type, keypair_info, sgs| {
+                    image_id == "img-1234_arm"
+                        && *instance_type == InstanceType::T1Micro
+                        && keypair_info.key_name() == Some("test_key")
+                        && sgs[0].group_id() == Some("sg-0123")
+                })
+                .returning(|_, _, _, _| Ok("i-01234567".into()));
 
             mock_ec2
-                .expect_wait_for_instance_ready()
-                .times(1)
-                .with(eq("i-01234567"), eq(None))
+                .expect_describe_instance()
+                .with(eq("i-01234567"))
+                .returning(|_| {
+                    Ok(Instance::builder()
+                        .architecture(ArchitectureValues::Arm64)
+                        .instance_id("i-01234567")
+                        .build())
+                });
+        }
+
+        mock_ec2
+            .expect_wait_for_instance_ready()
+            .times(1)
+            .with(eq("i-01234567"), eq(None))
+            .returning(|_, _| {
+                Err(EC2Error::new(
+                    "Exceeded max time (60s) waiting for instance to start.",
+                ))
+            });
+
+        mock_util
+            .expect_should_continue_waiting()
+            .returning(|| true);
+
+        mock_ec2
+            .expect_wait_for_instance_ready()
+            .times(1)
+            .with(eq("i-01234567"), eq(None))
+            .returning(|_, _| Ok(()));
+
+        // display_ssh_info
+        {
+            mock_util
+                .expect_enter_to_continue()
+                .returning(|| Ok("".into()));
+        }
+    }
+
+    // stop_and_start_instance 1
+    {
+        // stop
+        {
+            mock_ec2
+                .expect_stop_instance()
+                .with(eq("i-01234567"))
+                .returning(|_| Ok(()));
+        }
+
+        // start
+        {
+            mock_ec2
+                .expect_start_instance()
+                .with(eq("i-01234567"))
+                .returning(|_| Ok(()));
+        }
+
+        // display_ssh_info
+        {
+            mock_util
+                .expect_enter_to_continue()
+                .returning(|| Ok("".into()));
+        }
+    }
+
+    // associate_elastic_ip
+    {
+        // elastic_ip_manager.allocate
+        {
+            mock_ec2.expect_allocate_ip_address().returning(|| {
+                Ok(AllocateAddressOutput::builder()
+                    .allocation_id("eip-1234567")
+                    .build())
+            });
+        }
+
+        // elastic_ip_manager.associate
+        {
+            mock_ec2
+                .expect_associate_ip_address()
+                .with(eq("eip-1234567"), eq("i-01234567"))
                 .returning(|_, _| {
-                    Err(EC2Error::new(
-                        "Exceeded max time (60s) waiting for instance to start.",
+                    Ok(AssociateAddressOutput::builder()
+                        .association_id("aid-01234567")
+                        .build())
+                });
+        }
+
+        // display_ssh_info
+        {
+            mock_util
+                .expect_enter_to_continue()
+                .returning(|| Ok("".into()));
+        }
+    }
+
+    // stop_and_start_instance 2
+    {
+        // stop
+        {
+            mock_ec2
+                .expect_stop_instance()
+                .with(eq("i-01234567"))
+                .returning(|_| Ok(()));
+        }
+
+        // start
+        {
+            mock_ec2
+                .expect_start_instance()
+                .with(eq("i-01234567"))
+                .returning(|_| Ok(()));
+        }
+
+        // display_ssh_info
+        {
+            mock_util
+                .expect_enter_to_continue()
+                .returning(|| Ok("".into()));
+        }
+    }
+
+    // clean_up
+    {
+        mock_util.expect_should_clean_resources().returning(|| true);
+
+        // elastic_ip_manager.remove
+        {
+            mock_ec2
+                .expect_disassociate_ip_address()
+                .with(eq("aid-01234567"))
+                .returning(|_| Ok(()));
+
+            mock_ec2
+                .expect_deallocate_ip_address()
+                .with(eq("eip-1234567"))
+                .returning(|_| Ok(()));
+        }
+
+        // instance_manager.delete
+        {
+            mock_ec2
+                .expect_delete_instance()
+                .with(eq("i-01234567"))
+                .returning(|_| Ok(()));
+        }
+
+        // security_group_manager.delete
+        {
+            mock_ec2
+                .expect_delete_security_group()
+                .with(eq("sg-0123"))
+                .returning(|_| Ok(()));
+        }
+
+        // key_pair_manager.delete
+        {
+            mock_ec2
+                .expect_delete_key_pair()
+                .with(eq("kp-12345"))
+                .returning(|_| Ok(()));
+
+            mock_util
+                .expect_remove()
+                .withf(|p| format!("{p:?}").contains("test_key.pem"))
+                .returning(|_| Ok(()));
+        }
+    }
+
+    let scenario = Ec2InstanceScenario::new(mock_ec2, mock_ssm, mock_util);
+
+    run(scenario).await;
+}
+
+#[tokio::test]
+async fn test_unhappy_path_instance_takes_too_long() {
+    let mut mock_ec2 = MockEC2Impl::default();
+    let mut mock_ssm = MockSSMImpl::default();
+    let mut mock_util = MockUtilImpl::default();
+
+    // create_and_list_key_pairs
+    {
+        mock_util
+            .expect_prompt_key_name()
+            .returning(|| Ok("test_key".into()));
+
+        // create
+        {
+            mock_ec2
+                .expect_create_key_pair()
+                .with(eq("test_key".to_string()))
+                .returning(|_| {
+                    Ok((
+                        KeyPairInfo::builder()
+                            .key_name("test_key")
+                            .key_pair_id("kp-12345")
+                            .build(),
+                        "PEM MATERIAL".into(),
                     ))
                 });
 
             mock_util
-                .expect_should_continue_waiting()
-                .returning(|| false);
+                .expect_write_secure()
+                .with(
+                    eq("test_key"),
+                    predicate::function(|path: &PathBuf| path.ends_with("test_key.pem")),
+                    eq("PEM MATERIAL".to_string()),
+                )
+                .returning(|_, _, _| Ok(()));
         }
 
-        // clean_up
-        {
-            mock_util.expect_should_clean_resources().returning(|| true);
-
-            // instance_manager.delete
-            {
-                mock_ec2
-                    .expect_delete_instance()
-                    .with(eq("i-01234567"))
-                    .returning(|_| Ok(()));
-            }
-
-            // security_group_manager.delete
-            {
-                mock_ec2
-                    .expect_delete_security_group()
-                    .with(eq("sg-0123"))
-                    .returning(|_| Ok(()));
-            }
-
-            // key_pair_manager.delete
-            {
-                mock_ec2
-                    .expect_delete_key_pair()
-                    .with(eq("kp-12345"))
-                    .returning(|_| Ok(()));
-
-                mock_util
-                    .expect_remove()
-                    .withf(|p| format!("{p:?}").contains("test_key.pem"))
-                    .returning(|_| Ok(()));
-            }
-        }
-
-        let scenario = Ec2InstanceScenario::new(mock_ec2, mock_ssm, mock_util);
-
-        run(scenario).await;
+        mock_util
+            .expect_should_list_key_pairs()
+            .returning(|| Ok(false));
     }
+    // create_security_group
+    {
+        mock_util
+            .expect_prompt_security_group_name()
+            .returning(|| Ok("test_group".into()));
+
+        // security_group_manager.create
+        {
+            mock_ec2
+                .expect_create_security_group()
+                .with(
+                    eq("test_group"),
+                    eq("Security group for example: get started with instances."),
+                )
+                .returning(|_, _| {
+                    Ok(SecurityGroup::builder()
+                        .group_id("sg-0123")
+                        .group_name("test_group")
+                        .build())
+                });
+        }
+
+        mock_util
+            .expect_do_get()
+            .with(eq("https://checkip.amazonaws.com"))
+            .returning(|_| Ok("192.168.0.1".into()));
+
+        mock_util
+            .expect_should_add_to_security_group()
+            .returning(|| true);
+
+        // security_group_manager.authorize_ingress
+        {
+            mock_ec2
+                .expect_authorize_security_group_ssh_ingress()
+                .with(eq("sg-0123"), eq(vec![Ipv4Addr::new(192, 168, 0, 1)]))
+                .returning(|_, _| Ok(()));
+        }
+    }
+
+    // create_instance
+    {
+        // find_image
+        {
+            mock_ssm
+                .expect_list_path()
+                .with(eq("/aws/service/ami-amazon-linux-latest"))
+                .returning(|_| {
+                    Ok(vec![
+                        Parameter::builder()
+                            .name("amzn2-ami1")
+                            .value("amzn2-ami1")
+                            .build(),
+                        Parameter::builder()
+                            .name("amzn2-ami2")
+                            .value("amzn2-ami2")
+                            .build(),
+                    ])
+                });
+            mock_ec2
+                .expect_list_images()
+                .with(eq(vec![
+                    Parameter::builder()
+                        .name("amzn2-ami1")
+                        .value("amzn2-ami1")
+                        .build(),
+                    Parameter::builder()
+                        .name("amzn2-ami2")
+                        .value("amzn2-ami2")
+                        .build(),
+                ]))
+                .returning(|_| {
+                    Ok(vec![
+                        aws_sdk_ec2::types::Image::builder()
+                            .architecture(ArchitectureValues::X8664)
+                            .image_id("img-1234_x64")
+                            .build(),
+                        aws_sdk_ec2::types::Image::builder()
+                            .architecture(ArchitectureValues::Arm64)
+                            .image_id("img-1234_arm")
+                            .build(),
+                    ])
+                });
+
+            mock_util
+                .expect_select_scenario_image()
+                .with(eq(vec![
+                    Image::builder()
+                        .architecture(ArchitectureValues::X8664)
+                        .image_id("img-1234_x64")
+                        .build()
+                        .into(),
+                    Image::builder()
+                        .architecture(ArchitectureValues::Arm64)
+                        .image_id("img-1234_arm")
+                        .build()
+                        .into(),
+                ]))
+                .returning(|_| {
+                    Ok(Image::builder()
+                        .architecture(ArchitectureValues::Arm64)
+                        .image_id("img-1234_arm")
+                        .build()
+                        .into())
+                });
+        }
+
+        mock_ec2
+            .expect_list_instance_types()
+            .withf(|image| {
+                image.architecture == Some(ArchitectureValues::Arm64)
+                    && image.image_id() == Some("img-1234_arm")
+            })
+            .returning(|_| Ok(vec![InstanceType::T1Micro, InstanceType::A1Medium]));
+
+        mock_util
+            .expect_select_instance_type()
+            .with(eq(vec![InstanceType::T1Micro, InstanceType::A1Medium]))
+            .returning(|_| Ok(InstanceType::T1Micro));
+
+        // instance_manager.create
+        {
+            mock_ec2
+                .expect_create_instance()
+                .withf(|image_id, instance_type, keypair_info, sgs| {
+                    image_id == "img-1234_arm"
+                        && *instance_type == InstanceType::T1Micro
+                        && keypair_info.key_name() == Some("test_key")
+                        && sgs[0].group_id() == Some("sg-0123")
+                })
+                .returning(|_, _, _, _| Ok("i-01234567".into()));
+
+            mock_ec2
+                .expect_describe_instance()
+                .with(eq("i-01234567"))
+                .returning(|_| {
+                    Ok(Instance::builder()
+                        .architecture(ArchitectureValues::Arm64)
+                        .instance_id("i-01234567")
+                        .build())
+                });
+        }
+
+        mock_ec2
+            .expect_wait_for_instance_ready()
+            .times(1)
+            .with(eq("i-01234567"), eq(None))
+            .returning(|_, _| {
+                Err(EC2Error::new(
+                    "Exceeded max time (60s) waiting for instance to start.",
+                ))
+            });
+
+        mock_util
+            .expect_should_continue_waiting()
+            .returning(|| false);
+    }
+
+    // clean_up
+    {
+        mock_util.expect_should_clean_resources().returning(|| true);
+
+        // instance_manager.delete
+        {
+            mock_ec2
+                .expect_delete_instance()
+                .with(eq("i-01234567"))
+                .returning(|_| Ok(()));
+        }
+
+        // security_group_manager.delete
+        {
+            mock_ec2
+                .expect_delete_security_group()
+                .with(eq("sg-0123"))
+                .returning(|_| Ok(()));
+        }
+
+        // key_pair_manager.delete
+        {
+            mock_ec2
+                .expect_delete_key_pair()
+                .with(eq("kp-12345"))
+                .returning(|_| Ok(()));
+
+            mock_util
+                .expect_remove()
+                .withf(|p| format!("{p:?}").contains("test_key.pem"))
+                .returning(|_| Ok(()));
+        }
+    }
+
+    let scenario = Ec2InstanceScenario::new(mock_ec2, mock_ssm, mock_util);
+
+    run(scenario).await;
 }

--- a/rustv1/examples/ec2/src/getting_started/tests/scenario_with_mocks.rs
+++ b/rustv1/examples/ec2/src/getting_started/tests/scenario_with_mocks.rs
@@ -1,0 +1,607 @@
+#[cfg(test)]
+mod test {
+    use std::{net::Ipv4Addr, path::PathBuf};
+
+    use aws_sdk_ec2::{
+        operation::{
+            allocate_address::AllocateAddressOutput, associate_address::AssociateAddressOutput,
+        },
+        types::{ArchitectureValues, Image, Instance, InstanceType, KeyPairInfo, SecurityGroup},
+    };
+    use aws_sdk_ssm::types::Parameter;
+    use mockall::predicate::{self, eq};
+
+    use crate::{
+        ec2::{EC2Error, MockEC2Impl},
+        getting_started::{
+            scenario::{run, Ec2InstanceScenario},
+            util::MockUtilImpl,
+        },
+        ssm::MockSSMImpl,
+    };
+
+    #[tokio::test]
+    async fn test_happy_path() {
+        let mut mock_ec2 = MockEC2Impl::default();
+        let mut mock_ssm = MockSSMImpl::default();
+        let mut mock_util = MockUtilImpl::default();
+
+        // create_and_list_key_pairs
+        {
+            mock_util
+                .expect_prompt_key_name()
+                .returning(|| Ok("test_key".into()));
+
+            // create
+            {
+                mock_ec2
+                    .expect_create_key_pair()
+                    .with(eq("test_key".to_string()))
+                    .returning(|_| {
+                        Ok((
+                            KeyPairInfo::builder()
+                                .key_name("test_key")
+                                .key_pair_id("kp-12345")
+                                .build(),
+                            "PEM MATERIAL".into(),
+                        ))
+                    });
+
+                mock_util
+                    .expect_write_secure()
+                    .with(
+                        eq("test_key"),
+                        predicate::function(|path: &PathBuf| path.ends_with("test_key.pem")),
+                        eq("PEM MATERIAL".to_string()),
+                    )
+                    .returning(|_, _, _| Ok(()));
+            }
+
+            mock_util
+                .expect_should_list_key_pairs()
+                .returning(|| Ok(false));
+        }
+        // create_security_group
+        {
+            mock_util
+                .expect_prompt_security_group_name()
+                .returning(|| Ok("test_group".into()));
+
+            // security_group_manager.create
+            {
+                mock_ec2
+                    .expect_create_security_group()
+                    .with(
+                        eq("test_group"),
+                        eq("Security group for example: get started with instances."),
+                    )
+                    .returning(|_, _| {
+                        Ok(SecurityGroup::builder()
+                            .group_id("sg-0123")
+                            .group_name("test_group")
+                            .build())
+                    });
+            }
+
+            mock_util
+                .expect_do_get()
+                .with(eq("https://checkip.amazonaws.com"))
+                .returning(|_| Ok("192.168.0.1".into()));
+
+            mock_util
+                .expect_should_add_to_security_group()
+                .returning(|| true);
+
+            // security_group_manager.authorize_ingress
+            {
+                mock_ec2
+                    .expect_authorize_security_group_ssh_ingress()
+                    .with(eq("sg-0123"), eq(vec![Ipv4Addr::new(192, 168, 0, 1)]))
+                    .returning(|_, _| Ok(()));
+            }
+        }
+
+        // create_instance
+        {
+            // find_image
+            {
+                mock_ssm
+                    .expect_list_path()
+                    .with(eq("/aws/service/ami-amazon-linux-latest"))
+                    .returning(|_| {
+                        Ok(vec![
+                            Parameter::builder()
+                                .name("amzn2-ami1")
+                                .value("amzn2-ami1")
+                                .build(),
+                            Parameter::builder()
+                                .name("amzn2-ami2")
+                                .value("amzn2-ami2")
+                                .build(),
+                        ])
+                    });
+                mock_ec2
+                    .expect_list_images()
+                    .with(eq(vec![
+                        Parameter::builder()
+                            .name("amzn2-ami1")
+                            .value("amzn2-ami1")
+                            .build(),
+                        Parameter::builder()
+                            .name("amzn2-ami2")
+                            .value("amzn2-ami2")
+                            .build(),
+                    ]))
+                    .returning(|_| {
+                        Ok(vec![
+                            aws_sdk_ec2::types::Image::builder()
+                                .architecture(ArchitectureValues::X8664)
+                                .image_id("img-1234_x64")
+                                .build(),
+                            aws_sdk_ec2::types::Image::builder()
+                                .architecture(ArchitectureValues::Arm64)
+                                .image_id("img-1234_arm")
+                                .build(),
+                        ])
+                    });
+
+                mock_util
+                    .expect_select_scenario_image()
+                    .with(eq(vec![
+                        Image::builder()
+                            .architecture(ArchitectureValues::X8664)
+                            .image_id("img-1234_x64")
+                            .build()
+                            .into(),
+                        Image::builder()
+                            .architecture(ArchitectureValues::Arm64)
+                            .image_id("img-1234_arm")
+                            .build()
+                            .into(),
+                    ]))
+                    .returning(|_| {
+                        Ok(Image::builder()
+                            .architecture(ArchitectureValues::Arm64)
+                            .image_id("img-1234_arm")
+                            .build()
+                            .into())
+                    });
+            }
+
+            mock_ec2
+                .expect_list_instance_types()
+                .withf(|image| {
+                    image.architecture == Some(ArchitectureValues::Arm64)
+                        && image.image_id() == Some("img-1234_arm")
+                })
+                .returning(|_| Ok(vec![InstanceType::T1Micro, InstanceType::A1Medium]));
+
+            mock_util
+                .expect_select_instance_type()
+                .with(eq(vec![InstanceType::T1Micro, InstanceType::A1Medium]))
+                .returning(|_| Ok(InstanceType::T1Micro));
+
+            // instance_manager.create
+            {
+                mock_ec2
+                    .expect_create_instance()
+                    .withf(|image_id, instance_type, keypair_info, sgs| {
+                        image_id == "img-1234_arm"
+                            && *instance_type == InstanceType::T1Micro
+                            && keypair_info.key_name() == Some("test_key")
+                            && sgs[0].group_id() == Some("sg-0123")
+                    })
+                    .returning(|_, _, _, _| Ok("i-01234567".into()));
+
+                mock_ec2
+                    .expect_describe_instance()
+                    .with(eq("i-01234567"))
+                    .returning(|_| {
+                        Ok(Instance::builder()
+                            .architecture(ArchitectureValues::Arm64)
+                            .instance_id("i-01234567")
+                            .build())
+                    });
+            }
+
+            mock_ec2
+                .expect_wait_for_instance_ready()
+                .times(1)
+                .with(eq("i-01234567"), eq(None))
+                .returning(|_, _| {
+                    Err(EC2Error::new(
+                        "Exceeded max time (60s) waiting for instance to start.",
+                    ))
+                });
+
+            mock_util
+                .expect_should_continue_waiting()
+                .returning(|| true);
+
+            mock_ec2
+                .expect_wait_for_instance_ready()
+                .times(1)
+                .with(eq("i-01234567"), eq(None))
+                .returning(|_, _| Ok(()));
+
+            // display_ssh_info
+            {
+                mock_util
+                    .expect_enter_to_continue()
+                    .returning(|| Ok("".into()));
+            }
+        }
+
+        // stop_and_start_instance 1
+        {
+            // stop
+            {
+                mock_ec2
+                    .expect_stop_instance()
+                    .with(eq("i-01234567"))
+                    .returning(|_| Ok(()));
+            }
+
+            // start
+            {
+                mock_ec2
+                    .expect_start_instance()
+                    .with(eq("i-01234567"))
+                    .returning(|_| Ok(()));
+            }
+
+            // display_ssh_info
+            {
+                mock_util
+                    .expect_enter_to_continue()
+                    .returning(|| Ok("".into()));
+            }
+        }
+
+        // associate_elastic_ip
+        {
+            // elastic_ip_manager.allocate
+            {
+                mock_ec2.expect_allocate_ip_address().returning(|| {
+                    Ok(AllocateAddressOutput::builder()
+                        .allocation_id("eip-1234567")
+                        .build())
+                });
+            }
+
+            // elastic_ip_manager.associate
+            {
+                mock_ec2
+                    .expect_associate_ip_address()
+                    .with(eq("eip-1234567"), eq("i-01234567"))
+                    .returning(|_, _| {
+                        Ok(AssociateAddressOutput::builder()
+                            .association_id("aid-01234567")
+                            .build())
+                    });
+            }
+
+            // display_ssh_info
+            {
+                mock_util
+                    .expect_enter_to_continue()
+                    .returning(|| Ok("".into()));
+            }
+        }
+
+        // stop_and_start_instance 2
+        {
+            // stop
+            {
+                mock_ec2
+                    .expect_stop_instance()
+                    .with(eq("i-01234567"))
+                    .returning(|_| Ok(()));
+            }
+
+            // start
+            {
+                mock_ec2
+                    .expect_start_instance()
+                    .with(eq("i-01234567"))
+                    .returning(|_| Ok(()));
+            }
+
+            // display_ssh_info
+            {
+                mock_util
+                    .expect_enter_to_continue()
+                    .returning(|| Ok("".into()));
+            }
+        }
+
+        // clean_up
+        {
+            mock_util.expect_should_clean_resources().returning(|| true);
+
+            // elastic_ip_manager.remove
+            {
+                mock_ec2
+                    .expect_disassociate_ip_address()
+                    .with(eq("aid-01234567"))
+                    .returning(|_| Ok(()));
+
+                mock_ec2
+                    .expect_deallocate_ip_address()
+                    .with(eq("eip-1234567"))
+                    .returning(|_| Ok(()));
+            }
+
+            // instance_manager.delete
+            {
+                mock_ec2
+                    .expect_delete_instance()
+                    .with(eq("i-01234567"))
+                    .returning(|_| Ok(()));
+            }
+
+            // security_group_manager.delete
+            {
+                mock_ec2
+                    .expect_delete_security_group()
+                    .with(eq("sg-0123"))
+                    .returning(|_| Ok(()));
+            }
+
+            // key_pair_manager.delete
+            {
+                mock_ec2
+                    .expect_delete_key_pair()
+                    .with(eq("kp-12345"))
+                    .returning(|_| Ok(()));
+
+                mock_util
+                    .expect_remove()
+                    .withf(|p| format!("{p:?}").contains("test_key.pem"))
+                    .returning(|_| Ok(()));
+            }
+        }
+
+        let scenario = Ec2InstanceScenario::new(mock_ec2, mock_ssm, mock_util);
+
+        run(scenario).await;
+    }
+
+    #[tokio::test]
+    async fn test_unhappy_path_instance_takes_too_long() {
+        let mut mock_ec2 = MockEC2Impl::default();
+        let mut mock_ssm = MockSSMImpl::default();
+        let mut mock_util = MockUtilImpl::default();
+
+        // create_and_list_key_pairs
+        {
+            mock_util
+                .expect_prompt_key_name()
+                .returning(|| Ok("test_key".into()));
+
+            // create
+            {
+                mock_ec2
+                    .expect_create_key_pair()
+                    .with(eq("test_key".to_string()))
+                    .returning(|_| {
+                        Ok((
+                            KeyPairInfo::builder()
+                                .key_name("test_key")
+                                .key_pair_id("kp-12345")
+                                .build(),
+                            "PEM MATERIAL".into(),
+                        ))
+                    });
+
+                mock_util
+                    .expect_write_secure()
+                    .with(
+                        eq("test_key"),
+                        predicate::function(|path: &PathBuf| path.ends_with("test_key.pem")),
+                        eq("PEM MATERIAL".to_string()),
+                    )
+                    .returning(|_, _, _| Ok(()));
+            }
+
+            mock_util
+                .expect_should_list_key_pairs()
+                .returning(|| Ok(false));
+        }
+        // create_security_group
+        {
+            mock_util
+                .expect_prompt_security_group_name()
+                .returning(|| Ok("test_group".into()));
+
+            // security_group_manager.create
+            {
+                mock_ec2
+                    .expect_create_security_group()
+                    .with(
+                        eq("test_group"),
+                        eq("Security group for example: get started with instances."),
+                    )
+                    .returning(|_, _| {
+                        Ok(SecurityGroup::builder()
+                            .group_id("sg-0123")
+                            .group_name("test_group")
+                            .build())
+                    });
+            }
+
+            mock_util
+                .expect_do_get()
+                .with(eq("https://checkip.amazonaws.com"))
+                .returning(|_| Ok("192.168.0.1".into()));
+
+            mock_util
+                .expect_should_add_to_security_group()
+                .returning(|| true);
+
+            // security_group_manager.authorize_ingress
+            {
+                mock_ec2
+                    .expect_authorize_security_group_ssh_ingress()
+                    .with(eq("sg-0123"), eq(vec![Ipv4Addr::new(192, 168, 0, 1)]))
+                    .returning(|_, _| Ok(()));
+            }
+        }
+
+        // create_instance
+        {
+            // find_image
+            {
+                mock_ssm
+                    .expect_list_path()
+                    .with(eq("/aws/service/ami-amazon-linux-latest"))
+                    .returning(|_| {
+                        Ok(vec![
+                            Parameter::builder()
+                                .name("amzn2-ami1")
+                                .value("amzn2-ami1")
+                                .build(),
+                            Parameter::builder()
+                                .name("amzn2-ami2")
+                                .value("amzn2-ami2")
+                                .build(),
+                        ])
+                    });
+                mock_ec2
+                    .expect_list_images()
+                    .with(eq(vec![
+                        Parameter::builder()
+                            .name("amzn2-ami1")
+                            .value("amzn2-ami1")
+                            .build(),
+                        Parameter::builder()
+                            .name("amzn2-ami2")
+                            .value("amzn2-ami2")
+                            .build(),
+                    ]))
+                    .returning(|_| {
+                        Ok(vec![
+                            aws_sdk_ec2::types::Image::builder()
+                                .architecture(ArchitectureValues::X8664)
+                                .image_id("img-1234_x64")
+                                .build(),
+                            aws_sdk_ec2::types::Image::builder()
+                                .architecture(ArchitectureValues::Arm64)
+                                .image_id("img-1234_arm")
+                                .build(),
+                        ])
+                    });
+
+                mock_util
+                    .expect_select_scenario_image()
+                    .with(eq(vec![
+                        Image::builder()
+                            .architecture(ArchitectureValues::X8664)
+                            .image_id("img-1234_x64")
+                            .build()
+                            .into(),
+                        Image::builder()
+                            .architecture(ArchitectureValues::Arm64)
+                            .image_id("img-1234_arm")
+                            .build()
+                            .into(),
+                    ]))
+                    .returning(|_| {
+                        Ok(Image::builder()
+                            .architecture(ArchitectureValues::Arm64)
+                            .image_id("img-1234_arm")
+                            .build()
+                            .into())
+                    });
+            }
+
+            mock_ec2
+                .expect_list_instance_types()
+                .withf(|image| {
+                    image.architecture == Some(ArchitectureValues::Arm64)
+                        && image.image_id() == Some("img-1234_arm")
+                })
+                .returning(|_| Ok(vec![InstanceType::T1Micro, InstanceType::A1Medium]));
+
+            mock_util
+                .expect_select_instance_type()
+                .with(eq(vec![InstanceType::T1Micro, InstanceType::A1Medium]))
+                .returning(|_| Ok(InstanceType::T1Micro));
+
+            // instance_manager.create
+            {
+                mock_ec2
+                    .expect_create_instance()
+                    .withf(|image_id, instance_type, keypair_info, sgs| {
+                        image_id == "img-1234_arm"
+                            && *instance_type == InstanceType::T1Micro
+                            && keypair_info.key_name() == Some("test_key")
+                            && sgs[0].group_id() == Some("sg-0123")
+                    })
+                    .returning(|_, _, _, _| Ok("i-01234567".into()));
+
+                mock_ec2
+                    .expect_describe_instance()
+                    .with(eq("i-01234567"))
+                    .returning(|_| {
+                        Ok(Instance::builder()
+                            .architecture(ArchitectureValues::Arm64)
+                            .instance_id("i-01234567")
+                            .build())
+                    });
+            }
+
+            mock_ec2
+                .expect_wait_for_instance_ready()
+                .times(1)
+                .with(eq("i-01234567"), eq(None))
+                .returning(|_, _| {
+                    Err(EC2Error::new(
+                        "Exceeded max time (60s) waiting for instance to start.",
+                    ))
+                });
+
+            mock_util
+                .expect_should_continue_waiting()
+                .returning(|| false);
+        }
+
+        // clean_up
+        {
+            mock_util.expect_should_clean_resources().returning(|| true);
+
+            // instance_manager.delete
+            {
+                mock_ec2
+                    .expect_delete_instance()
+                    .with(eq("i-01234567"))
+                    .returning(|_| Ok(()));
+            }
+
+            // security_group_manager.delete
+            {
+                mock_ec2
+                    .expect_delete_security_group()
+                    .with(eq("sg-0123"))
+                    .returning(|_| Ok(()));
+            }
+
+            // key_pair_manager.delete
+            {
+                mock_ec2
+                    .expect_delete_key_pair()
+                    .with(eq("kp-12345"))
+                    .returning(|_| Ok(()));
+
+                mock_util
+                    .expect_remove()
+                    .withf(|p| format!("{p:?}").contains("test_key.pem"))
+                    .returning(|_| Ok(()));
+            }
+        }
+
+        let scenario = Ec2InstanceScenario::new(mock_ec2, mock_ssm, mock_util);
+
+        run(scenario).await;
+    }
+}

--- a/rustv1/examples/ec2/src/getting_started/util.rs
+++ b/rustv1/examples/ec2/src/getting_started/util.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! IO Utilities wrapper to allow automock for requests and user input prompts.
 
 use std::{fmt::Display, io::Write, path::PathBuf};

--- a/rustv1/examples/ec2/src/getting_started/util.rs
+++ b/rustv1/examples/ec2/src/getting_started/util.rs
@@ -1,0 +1,161 @@
+//! IO Utilities wrapper to allow automock for requests and user input prompts.
+
+use std::{fmt::Display, io::Write, path::PathBuf};
+
+use inquire::{validator::ValueRequiredValidator, InquireError};
+
+use aws_sdk_ec2::types::Image;
+
+use crate::ec2::EC2Error;
+
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg(not(test))]
+pub use UtilImpl as Util;
+
+#[cfg(test)]
+pub use MockUtilImpl as Util;
+
+#[derive(Default)]
+pub struct UtilImpl;
+
+#[cfg_attr(test, automock)]
+impl UtilImpl {
+    pub fn prompt_key_name(&self) -> Result<String, EC2Error> {
+        inquire::Text::new("Enter a unique name for your key: ")
+            .with_validator(ValueRequiredValidator::default())
+            .with_default("my_key")
+            .prompt()
+            .map_err(|e| EC2Error::new(format!("Failed to get name for key pair. {e:?}")))
+    }
+    pub fn should_clean_resources(&self) -> bool {
+        inquire::Confirm::new("Clean up resources?")
+            .with_default(true)
+            .prompt()
+            .unwrap_or(false)
+    }
+
+    pub fn enter_to_continue(&self) -> Result<String, InquireError> {
+        inquire::Text::new("Press Enter when you're ready to continue the demo.").prompt()
+    }
+
+    pub fn select_scenario_image(
+        &self,
+        amzn2_images: Vec<ScenarioImage>,
+    ) -> Result<ScenarioImage, EC2Error> {
+        inquire::Select::new(
+            "Select an Amazon Linux 2 AMI for this instance",
+            amzn2_images,
+        )
+        .prompt()
+        .map_err(|e| EC2Error::new(format!("Could not determine desired AMI ({e:?})")))
+    }
+
+    pub fn should_continue_waiting(&self) -> bool {
+        inquire::Confirm::new("Continue waiting?")
+            .with_default(true)
+            .prompt()
+            .unwrap_or(false)
+    }
+
+    pub fn select_instance_type(
+        &self,
+        instance_types: Vec<aws_sdk_ec2::types::InstanceType>,
+    ) -> Result<aws_sdk_ec2::types::InstanceType, EC2Error> {
+        inquire::Select::new("Select an instance type for this instance:", instance_types)
+            .prompt()
+            .map_err(|e| {
+                EC2Error::new(format!(
+                    "Could not determine the desired instance type ({e:?})"
+                ))
+            })
+    }
+
+    pub fn should_add_to_security_group(&self) -> bool {
+        inquire::Confirm::new("Add this rule to your security group?")
+            .with_default(true)
+            .prompt()
+            .unwrap_or(true)
+    }
+
+    pub fn prompt_security_group_name(&self) -> Result<String, EC2Error> {
+        inquire::Text::new("Enter a unique name for your security group: ")
+            .with_validator(ValueRequiredValidator::default())
+            .with_default("my_group")
+            .prompt()
+            .map_err(|e| EC2Error::new(format!("Failed to get name for security group! {e:?}")))
+    }
+
+    pub fn should_list_key_pairs(&self) -> Result<bool, EC2Error> {
+        inquire::Confirm::new("Do you want to list some of your key pairs?")
+            .with_default(false)
+            .prompt()
+            .or(Ok(false))
+            .map_err(|e: InquireError| EC2Error::new(format!("Failed to ask question. {e:?}")))
+    }
+
+    /// Utility to perform a GET request and return the body as UTF-8, or an appropriate EC2Error.
+    pub async fn do_get(&self, url: &str) -> Result<String, EC2Error> {
+        reqwest::get(url)
+            .await
+            .map_err(|e| EC2Error::new(format!("Could not request ip from {url}: {e:?}")))?
+            .error_for_status()
+            .map_err(|e| EC2Error::new(format!("Failure status from {url}: {e:?}")))?
+            .text_with_charset("utf-8")
+            .await
+            .map_err(|e| EC2Error::new(format!("Failed to read response from {url}: {e:?}")))
+    }
+
+    pub fn write_secure(
+        &self,
+        key_name: &str,
+        path: &PathBuf,
+        material: String,
+    ) -> Result<(), EC2Error> {
+        let mut file = open_file_0600(path)?;
+        file.write(material.as_bytes()).map_err(|e| {
+            EC2Error::new(format!("Failed to write {key_name} to {path:?} ({e:?})"))
+        })?;
+        Ok(())
+    }
+
+    pub fn remove(&self, path: &PathBuf) -> std::io::Result<()> {
+        std::fs::remove_file(path)
+    }
+}
+
+#[cfg(unix)]
+fn open_file_0600(path: &PathBuf) -> Result<std::fs::File, EC2Error> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .mode(0o600)
+        .open(path.clone())
+        .map_err(|e| EC2Error::new(format!("Failed to create {path:?} ({e:?})")))
+}
+
+#[cfg(not(unix))]
+fn open_file(path: &PathBuf) -> Result<File, EC2Error> {
+    fs::File::create(path.clone())
+        .map_err(|e| EC2Error::new(format!("Failed to create {path:?} ({e:?})")))?
+}
+
+/// Image doesn't impl Display, which is necessary for inquire to use it in a Select.
+/// This wraps Image and provides a Display impl.
+#[derive(PartialEq, Debug)]
+pub struct ScenarioImage(pub Image);
+impl From<Image> for ScenarioImage {
+    fn from(value: Image) -> Self {
+        ScenarioImage(value)
+    }
+}
+impl Display for ScenarioImage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}: {}",
+            self.0.name().unwrap_or("(unknown)"),
+            self.0.description().unwrap_or("unknown")
+        )
+    }
+}

--- a/rustv1/examples/ec2/src/lib.rs
+++ b/rustv1/examples/ec2/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod ec2;
+pub mod getting_started;
+pub mod ssm;

--- a/rustv1/examples/ec2/src/lib.rs
+++ b/rustv1/examples/ec2/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod ec2;
 pub mod getting_started;
 pub mod ssm;

--- a/rustv1/examples/ec2/src/ssm.rs
+++ b/rustv1/examples/ec2/src/ssm.rs
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use aws_sdk_ssm::{types::Parameter, Client};
+use aws_smithy_async::future::pagination_stream::TryFlatMap;
+
+use crate::ec2::EC2Error;
+
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg(not(test))]
+pub use SSMImpl as SSM;
+
+#[cfg(test)]
+pub use MockSSMImpl as SSM;
+
+pub struct SSMImpl {
+    inner: Client,
+}
+
+#[cfg_attr(test, automock)]
+impl SSMImpl {
+    pub fn new(inner: Client) -> Self {
+        SSMImpl { inner }
+    }
+
+    // snippet-start:[ec2.rust.ssm_list_path.impl]
+    pub async fn list_path(&self, path: &str) -> Result<Vec<Parameter>, EC2Error> {
+        let maybe_params: Vec<Result<Parameter, _>> = TryFlatMap::new(
+            self.inner
+                .get_parameters_by_path()
+                .path(path)
+                .into_paginator()
+                .send(),
+        )
+        .flat_map(|item| item.parameters.unwrap_or_default())
+        .collect()
+        .await;
+        // Fail on the first error
+        let params = maybe_params
+            .into_iter()
+            .collect::<Result<Vec<Parameter>, _>>()?;
+        Ok(params)
+    }
+    // snippet-end:[ec2.rust.ssm_list_path.impl]
+}

--- a/rustv1/examples/ssm/README.md
+++ b/rustv1/examples/ssm/README.md
@@ -34,6 +34,7 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `rustv
 Code excerpts that show you how to call individual service functions.
 
 - [DescribeParameters](src/bin/describe-parameters.rs#L22)
+- [GetParameter](../ec2/src/ssm.rs#L19)
 - [PutParameter](src/bin/create-parameter.rs#L35)
 
 

--- a/rustv1/examples/ssm/README.md
+++ b/rustv1/examples/ssm/README.md
@@ -34,7 +34,7 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `rustv
 Code excerpts that show you how to call individual service functions.
 
 - [DescribeParameters](src/bin/describe-parameters.rs#L22)
-- [GetParameter](../ec2/src/ssm.rs#L19)
+- [GetParameter](../ec2/src/ssm.rs#L28)
 - [PutParameter](src/bin/create-parameter.rs#L35)
 
 


### PR DESCRIPTION
This PR updates rust EC2 examples to follow 2024 best practices, using the EC2 Getting Started scenario spec in lieu of single-action action examples.

Closes #6621

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
