### PR TITLE
Javascript (v3): Bedrock Runtime Agent - added Invoke Flow

### DIFF
--- a/.doc_gen/metadata/bedrock-agent-runtime_metadata.yaml
+++ b/.doc_gen/metadata/bedrock-agent-runtime_metadata.yaml
@@ -18,5 +18,6 @@ bedrock-agent-runtime_InvokeAgent:
             - description:
               snippet_files:
                 - javascriptv3/example_code/bedrock-agent-runtime/actions/invoke-agent.js
+                - javascriptv3/example_code/bedrock-agent-runtime/actions/invoke-flow.js
   services:
     bedrock-agent-runtime: {InvokeAgent}

--- a/javascriptv3/example_code/bedrock-agent-runtime/README.md
+++ b/javascriptv3/example_code/bedrock-agent-runtime/README.md
@@ -34,6 +34,7 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `javas
 Code excerpts that show you how to call individual service functions.
 
 - [InvokeAgent](actions/invoke-agent.js)
+- [InvokeFlow](actions/invoke-agent.js)
 
 
 <!--custom.examples.start-->

--- a/javascriptv3/example_code/bedrock-agent-runtime/actions/invoke-flow.js
+++ b/javascriptv3/example_code/bedrock-agent-runtime/actions/invoke-flow.js
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  BedrockAgentRuntimeClient,
+  InvokeFlowCommand,
+} from "@aws-sdk/client-bedrock-agent-runtime";
+
+/**
+ * @typedef {Object} ResponseBody
+ * @returns {Object} flowResponse
+ */
+
+/**
+ * Invokes a Bedrock flow to run an inference using the input
+ * provided in the request body.
+ *
+ * @param {string} prompt - The prompt that you want the Agent to complete.
+ */
+export const invokeBedrockFlow = async (prompt) => {
+  const client = new BedrockAgentRuntimeClient({ region: "us-east-1" });
+  // const client = new BedrockAgentRuntimeClient({
+  //   region: "us-east-1",
+  //   credentials: {
+  //     accessKeyId: "accessKeyId", // permission to invoke flow
+  //     secretAccessKey: "accessKeySecret",
+  //   },
+  // });
+
+  const flowIdentifier = "AJBHXXILZN";
+  const flowAliasIdentifier = "AVKP1ITZAA";
+
+  const command = new InvokeFlowCommand({
+    flowIdentifier,
+    flowAliasIdentifier,
+    inputs: [
+      {
+        content: {
+          document: prompt,
+        },
+        nodeName: "FlowInputNode",
+        nodeOutputName: "document",
+      }
+    ]
+  });
+
+  try {
+    let flowResponse = {};
+    const response = await client.send(command);
+
+    if (response.responseStream === undefined) {
+      throw new Error("responseStream is undefined");
+    }
+
+    for await (let chunkEvent of response.responseStream) {
+      const { flowOutputEvent } = chunkEvent;
+      flowResponse = { ...flowResponse, ...flowOutputEvent };
+      console.log(flowOutputEvent);
+    }
+
+    return flowResponse;
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+// Call function if run directly
+import { fileURLToPath } from "url";
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const result = await invokeBedrockFlow("I need help.");
+  console.log(result);
+}

--- a/javascriptv3/example_code/bedrock-agent-runtime/tests/invoke-flow.unit.test.js
+++ b/javascriptv3/example_code/bedrock-agent-runtime/tests/invoke-flow.unit.test.js
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from "vitest";
+import { invokeBedrockFlow } from "../actions/invoke-flow.js";
+
+const mocks = vi.hoisted(() => ({
+  clientSendResolve: () =>
+    Promise.resolve({
+      responseStream: [
+        {
+          flowOutputEvent: {
+            content: {
+              document: 'Test prompt',
+            },
+          },
+        },
+      ],
+    }),
+  clientSendReject: () => Promise.reject(new Error("Mocked error")),
+  send: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-bedrock-agent-runtime", () => {
+  return {
+    BedrockAgentRuntimeClient: vi.fn(() => ({ send: mocks.send })),
+    InvokeFlowCommand: vi.fn(),
+  };
+});
+
+describe("invokeBedrockFlow", () => {
+  it("should return an object with responseStream", async () => {
+    const prompt = "Test prompt";
+    mocks.send.mockImplementationOnce(mocks.clientSendResolve);
+
+    const result = await invokeBedrockFlow(prompt);
+
+    expect(result).toEqual({
+      content: {
+        document: prompt,
+      },
+    });
+  });
+
+  it("should log errors", async () => {
+    mocks.send.mockImplementationOnce(mocks.clientSendReject);
+    const spy = vi.spyOn(console, "error");
+    const prompt = "Test prompt";
+
+    await invokeBedrockFlow(prompt);
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Mocked error" }),
+    );
+  });
+});


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request contains an example with @aws-sdk/client-bedrock-agent-runtime used to invoke an Prompt Flow. I have included a test case for the service function.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
