### PR TITLE
Tools: writeme handles missing readmes

### DIFF
--- a/.tools/readmes/render.py
+++ b/.tools/readmes/render.py
@@ -306,9 +306,12 @@ class Renderer:
             f.write(self.readme_text)
 
     def check(self):
-        with self.readme_filename.open("r", encoding="utf-8") as f:
-            readme_current = f.read()
-            return readme_current == self.readme_text
+        try:
+            with self.readme_filename.open("r", encoding="utf-8") as f:
+                readme_current = f.read()
+                return readme_current == self.readme_text
+        except FileNotFoundError:
+            return False
 
 
 def _transform_sdk(sdk: Sdk, sdk_ver):

--- a/.tools/readmes/render.py
+++ b/.tools/readmes/render.py
@@ -7,10 +7,11 @@ import logging
 import os
 import re
 from dataclasses import asdict
+from enum import Enum
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from operator import itemgetter
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from aws_doc_sdk_examples_tools.metadata import Example
 from aws_doc_sdk_examples_tools.sdks import Sdk
@@ -20,6 +21,15 @@ import config
 from scanner import Scanner
 
 logger = logging.getLogger(__name__)
+
+
+class RenderStatus(Enum):
+    UNCHANGED = 0
+    NO_EXAMPLES = 1
+    UNIMPLEMENTED = 2
+    UPDATED = 3
+    UNMANAGED = 4
+    NO_FOLDER = 5
 
 
 class MissingMetadataError(Exception):
@@ -241,9 +251,9 @@ class Renderer:
                             self.lang_config["sdk_api_ref"] = href
         return customs
 
-    def render(self) -> Tuple[Optional["Renderer"], bool]:
+    def render(self) -> RenderStatus:
         if self.lang_config is None:
-            return None, False  # Return False to indicate no update
+            return RenderStatus.UNIMPLEMENTED
 
         sdk = _transform_sdk(self.scanner.sdk(), self.scanner.sdk_ver)
         svc = _transform_service(self.scanner.service())
@@ -257,7 +267,10 @@ class Renderer:
             len(hello) + len(actions) + len(scenarios) + len(custom_cats) + len(crosses)
             == 0
         ):
-            return None, False
+            return RenderStatus.NO_EXAMPLES
+
+        if not self.readme_filename.parent.exists():
+            return RenderStatus.NO_FOLDER
 
         self.lang_config["name"] = self.scanner.lang_name
         self.lang_config["sdk_ver"] = self.scanner.sdk_ver
@@ -287,10 +300,17 @@ class Renderer:
         self.readme_text = self._expand_entities(self.readme_text)
 
         # Check if the rendered text is different from the existing file
-        readme_updated = not self.check()
-        return self, readme_updated
-
-        # return self, True
+        if self.read_current() == self.readme_text:
+            return RenderStatus.UNCHANGED
+        else:
+            if (
+                self.lang_config["service_folder"]
+                not in self.lang_config.get("service_folder_overrides", {}).values()
+                and self.readme_filename.exists()
+            ):
+                return RenderStatus.UNMANAGED
+            else:
+                return RenderStatus.UPDATED
 
     def write(self):
         if self.readme_filename.exists():
@@ -298,20 +318,20 @@ class Renderer:
                 self.readme_filename.rename(
                     self.readme_filename.parent / config.saved_readme
                 )
-
+            logging.debug("Removing existing file %s", self.readme_filename)
             # Do this so that new files are always updated to the correct case (README.md).
             self.readme_filename.unlink(missing_ok=True)
 
         with self.readme_filename.open("w", encoding="utf-8") as f:
+            logging.debug("Writing file %s", self.readme_filename)
             f.write(self.readme_text)
 
-    def check(self):
+    def read_current(self):
         try:
             with self.readme_filename.open("r", encoding="utf-8") as f:
-                readme_current = f.read()
-                return readme_current == self.readme_text
+                return f.read()
         except FileNotFoundError:
-            return False
+            return ""
 
 
 def _transform_sdk(sdk: Sdk, sdk_ver):

--- a/.tools/readmes/writeme.py
+++ b/.tools/readmes/writeme.py
@@ -138,10 +138,7 @@ def main():
                 else:
                     renderer.write()
                     written.append(id)
-            except FileNotFoundError as e:
-                from traceback import print_exception
-
-                print_exception(e)
+            except FileNotFoundError:
                 skipped.append(id)
             except MissingMetadataError as mme:
                 logging.error(mme)

--- a/.tools/readmes/writeme.py
+++ b/.tools/readmes/writeme.py
@@ -29,8 +29,8 @@ def prepare_scanner(doc_gen: DocGen) -> Optional[Scanner]:
     doc_gen.validate()
     if doc_gen.errors:
         error_strings = [str(error) for error in doc_gen.errors]
-        failed_list = "\n\t".join(error_strings)
-        logging.error(f"Metadata errors encountered:\n\t{failed_list}")
+        failed_list = "\n".join(f"DocGen Error: {e}" for e in error_strings)
+        print(f"Metadata errors encountered:\n\t{failed_list}")
         return None
     scanner = Scanner(doc_gen)
 
@@ -155,11 +155,15 @@ def main():
         unchanged_list = "\n".join(f"Unchanged {f}" for f in sorted(unchanged))
         print(unchanged_list)
     if non_writeme:
-        non_writeme_list = "\n\t".join(sorted(non_writeme))
-        print(f"Non-WRITEME READMES:\n\t{non_writeme_list}")
+        non_writeme_list = "\n".join(
+            f"Non-WRITEME README: {f}" for f in sorted(non_writeme)
+        )
+        print(non_writeme_list)
     if failed:
-        failed_list = "\n\t".join(failed)
-        print(f"READMEs with incorrect formatting:\n\t{failed_list}")
+        failed_list = "\n".join(
+            f"README with incorrect formatting: {f}" for f in sorted(non_writeme)
+        )
+        print(failed_list)
         print("Rerun writeme.py to update README links and sections.")
     print("WRITEME Run completed.")
     return len(failed)

--- a/.tools/readmes/writeme.py
+++ b/.tools/readmes/writeme.py
@@ -10,10 +10,11 @@ import config
 import logging
 import os
 import sys
+from difflib import unified_diff
 from pathlib import Path
 from typing import Optional
 
-from render import Renderer, MissingMetadataError
+from render import Renderer, MissingMetadataError, RenderStatus
 from scanner import Scanner
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO").upper(), force=True)
@@ -80,6 +81,7 @@ def main():
     )
     parser.add_argument("--no-dry-run", dest="dry_run", action="store_false")
     parser.add_argument("--check", dest="dry_run", action="store_true")
+    parser.add_argument("--diff", action="store_true", default=False)
     args = parser.parse_args()
 
     if "all" in args.languages:
@@ -94,13 +96,14 @@ def main():
     logging.debug(f"Args configuration: {args}")
 
     if args.dry_run:
-        logging.info("Dry run, no changes will be made.")
+        print("Dry run, no changes will be made.")
 
     skipped = []
     failed = []
     written = []
     non_writeme = []
     unchanged = []
+    no_folder = []
 
     scanner = prepare_scanner(doc_gen)
     if scanner is None:
@@ -113,60 +116,66 @@ def main():
             id = f"{language}:{version}:{service}"
             try:
                 renderer.set_example(service, language, int(version), args.safe)
-                if renderer.lang_config is None:
-                    continue
 
                 logging.debug("Rendering %s", id)
-                result, updated = renderer.render()
+                render_status = renderer.render()
+                logging.debug("Status %s", render_status)
 
-                if result is None:
-                    if (
-                        renderer.lang_config["service_folder"]
-                        not in renderer.lang_config.get(
-                            "service_folder_overrides", {}
-                        ).values()
-                        and renderer.readme_filename.exists()
-                    ):
-                        non_writeme.append(id)
-                    else:
-                        skipped.append(id)
-                elif args.dry_run:
-                    if not renderer.check():
+                if render_status == RenderStatus.UPDATED:
+                    if args.dry_run:
                         failed.append(id)
-                elif not updated:
+                        if args.diff:
+                            print_diff(renderer, id)
+                    else:
+                        renderer.write()
+                        written.append(id)
+                elif render_status == RenderStatus.UNCHANGED:
                     unchanged.append(id)
-                else:
-                    renderer.write()
-                    written.append(id)
-            except FileNotFoundError:
+                elif render_status == RenderStatus.UNMANAGED:
+                    non_writeme.append(id)
+                elif render_status == RenderStatus.NO_EXAMPLES:
+                    skipped.append(id)
+                elif render_status == RenderStatus.NO_FOLDER:
+                    no_folder.append(id)
+                elif render_status == RenderStatus.UNIMPLEMENTED:
+                    pass
+            except FileNotFoundError as fnfe:
+                logging.debug(fnfe, exc_info=True)
                 skipped.append(id)
             except MissingMetadataError as mme:
-                logging.error(mme)
+                logging.debug(mme, exc_info=True)
                 failed.append(id)
-            except Exception:
-                logging.exception("Exception rendering %s", id)
+            except Exception as e:
+                logging.error(e, exc_info=True)
                 failed.append(id)
 
-    done_list = "\n".join(f"Wrote {f}" for f in sorted(written))
     skip_list = "\n".join(f"Skipped {f}" for f in sorted(skipped))
-    print(skip_list or "(None Skipped)")
-    print(done_list or "(None Written)")
+    logging.debug(skip_list or "(None Skipped)")
     if unchanged:
         unchanged_list = "\n".join(f"Unchanged {f}" for f in sorted(unchanged))
         print(unchanged_list)
     if non_writeme:
-        non_writeme_list = "\n".join(
-            f"Non-WRITEME README: {f}" for f in sorted(non_writeme)
-        )
+        non_writeme_list = "\n".join(f"Non-WRITEME: {f}" for f in sorted(non_writeme))
         print(non_writeme_list)
+    if no_folder:
+        no_folder_list = "\n".join(f"No folder: {f}" for f in sorted(no_folder))
+        print(no_folder_list)
+    if not args.dry_run:
+        done_list = "\n".join(f"Wrote {f}" for f in sorted(written))
+        print(done_list or "(None Written)")
     if failed:
-        failed_list = "\n".join(
-            f"README with incorrect formatting: {f}" for f in sorted(non_writeme)
-        )
+        failed_list = "\n".join(f"Incorrect: {f}" for f in sorted(failed))
         print(failed_list)
         print("Rerun writeme.py to update README links and sections.")
     print("WRITEME Run completed.")
     return len(failed)
+
+
+def print_diff(renderer, id):
+    current = renderer.read_current().split("\n")
+    expected = renderer.readme_text.split("\n")
+    diff = unified_diff(current, expected, f"{id}/current", f"{id}/expected")
+    print("\n".join(diff))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #6715 

Treats missing READMEs as empty during render unchanged check, which prevents skipping the file for not being found.
Improves error handling a bit, now looks like this:

```
$ python3.11 .tools/readmes/writeme.py --languages Rust:1 --services ec2
(None Skipped)
(None Written)
Unchanged Rust:1:ec2
WRITEME Run completed.
```

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
