### PR TITLE
python: Add ' us-gov-east-1' to SMTP_REGIONS in ses_generate_smtp_credentials.py

### DIFF
--- a/python/example_code/ses/ses_generate_smtp_credentials.py
+++ b/python/example_code/ses/ses_generate_smtp_credentials.py
@@ -34,6 +34,7 @@ SMTP_REGIONS = [
     "eu-north-1",  # Europe (Stockholm)
     "sa-east-1",  # South America (Sao Paulo)
     "us-gov-west-1",  # AWS GovCloud (US)
+    "us-gov-east-1",  # AWS GovCloud (US)
 ]
 
 # These values are required to calculate the signature. Do not change them.


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request adds "us-gov-east-1" to smtp regions to ses_generate_smtp_credentials.py

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
