### PR TITLE
Rust: Bump toolchain to 1.80.1

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
-          toolchain: "1.76.0"
+          toolchain: "1.80.1"
           components: clippy, rustfmt
       - name: Set Environment
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/rustv1/cross_service/rust-toolchain.toml
+++ b/rustv1/cross_service/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # This should be kept in sync with https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv
 [toolchain]
-channel = "1.76.0"
+channel = "1.80.1"

--- a/rustv1/examples/bedrock-runtime/src/bin/converse-stream.rs
+++ b/rustv1/examples/bedrock-runtime/src/bin/converse-stream.rs
@@ -125,10 +125,7 @@ fn get_converse_output_text(
 ) -> Result<String, BedrockConverseStreamError> {
     Ok(match output {
         ConverseStreamOutputType::ContentBlockDelta(event) => match event.delta() {
-            Some(delta) => delta
-                .as_text()
-                .map(|s| s.clone())
-                .unwrap_or_else(|_| "".into()),
+            Some(delta) => delta.as_text().cloned().unwrap_or_else(|_| "".into()),
             None => "".into(),
         },
         _ => "".into(),

--- a/rustv1/examples/bedrock-runtime/src/bin/tool-use.rs
+++ b/rustv1/examples/bedrock-runtime/src/bin/tool-use.rs
@@ -240,6 +240,8 @@ async fn fetch_weather_data(
 // snippet-end:[rust.bedrock-runtime.Converse_AnthropicClaude.tool-use.weather-tool]
 
 // snippet-start:[rust.bedrock-runtime.Converse_AnthropicClaude.tool-use]
+#[derive(Debug)]
+#[allow(dead_code)]
 struct InvokeToolResult(String, ToolResultBlock);
 struct ToolUseScenario {
     client: Client,

--- a/rustv1/examples/cloudwatchlogs/src/bin/large-query.rs
+++ b/rustv1/examples/cloudwatchlogs/src/bin/large-query.rs
@@ -27,7 +27,11 @@ use sdk_examples_test_utils::wait_on;
 #[derive(Debug)]
 enum LargeQueryError {
     DateOutOfBounds,
+    // Internal error is used in Debug output
+    #[allow(dead_code)]
     FromCloudwatchLogs(Error),
+    // Internal error is used in Debug output
+    #[allow(dead_code)]
     FromChronoParse(chrono::ParseError),
 }
 

--- a/rustv1/examples/eks/src/bin/create-cluster.rs
+++ b/rustv1/examples/eks/src/bin/create-cluster.rs
@@ -21,8 +21,7 @@ struct Opt {
     /// To create a role-arn:
     ///
     /// 1. Follow instructions to create an IAM role:
-    /// https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html
-    ///
+    ///     https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html
     /// 2. Copy role arn
     #[structopt(long)]
     role_arn: String,

--- a/rustv1/examples/lambda/src/actions.rs
+++ b/rustv1/examples/lambda/src/actions.rs
@@ -20,7 +20,7 @@ use aws_sdk_s3::{
 };
 use aws_smithy_types::Blob;
 use serde::{ser::SerializeMap, Serialize};
-use std::{path::PathBuf, str::FromStr, time::Duration};
+use std::{fmt::Display, path::PathBuf, str::FromStr, time::Duration};
 use tracing::{debug, info, warn};
 
 /* Operation describes  */
@@ -50,13 +50,13 @@ impl FromStr for Operation {
     }
 }
 
-impl ToString for Operation {
-    fn to_string(&self) -> String {
+impl Display for Operation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Operation::Plus => "plus".to_string(),
-            Operation::Minus => "minus".to_string(),
-            Operation::Times => "times".to_string(),
-            Operation::DividedBy => "divided-by".to_string(),
+            Operation::Plus => write!(f, "plus"),
+            Operation::Minus => write!(f, "minus"),
+            Operation::Times => write!(f, "times"),
+            Operation::DividedBy => write!(f, "divided-by"),
         }
     }
 }

--- a/rustv1/examples/rust-toolchain.toml
+++ b/rustv1/examples/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # This should be kept in sync with https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv
 [toolchain]
-channel = "1.76.0"
+channel = "1.80.1"

--- a/rustv1/examples/s3/src/bin/select-object-content.rs
+++ b/rustv1/examples/s3/src/bin/select-object-content.rs
@@ -51,8 +51,8 @@ pub struct Record {
     pub description: String,
 }
 
-fn is_valid_json(data: impl AsRef<str>) -> bool {
-    serde_json::from_str::<IgnoredAny>(data.as_ref()).is_ok()
+fn is_valid_json(data: &str) -> bool {
+    serde_json::from_str::<IgnoredAny>(data).is_ok()
 }
 
 // Get object content.
@@ -133,8 +133,8 @@ fn parse_line_buffered(buf: &mut String, line: &str) -> Result<Option<Record>, a
         Ok(Some(serde_json::from_str(line)?))
     } else {
         buf.push_str(line);
-        if is_valid_json(&buf) {
-            let result = serde_json::from_str(buf);
+        if is_valid_json(buf) {
+            let result = serde_json::from_str(buf.as_str());
             buf.clear();
             Ok(Some(result?))
         } else {

--- a/rustv1/tools/set_rust_version.py
+++ b/rustv1/tools/set_rust_version.py
@@ -36,7 +36,7 @@ def update_toolchains(root: pathlib.Path, channel: str, dry_run: bool):
 
 
 def update_actions(root: pathlib.Path, channel: str, dry_run: bool):
-    rust_yaml = root / ".github" / "workflows" / "rust.yml"
+    rust_yaml = root / ".github" / "workflows" / "lint-rust.yml"
     with open(rust_yaml, "rt") as file:
         action = file.readlines()
     found = None


### PR DESCRIPTION
Update patterns that are now Clippy violations.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
