### PR TITLE
JavaScript (v3): Glue - Make clean up more robust.

### DIFF
--- a/javascriptv3/example_code/glue/package.json
+++ b/javascriptv3/example_code/glue/package.json
@@ -1,26 +1,25 @@
 {
   "name": "@aws-doc-sdk-examples/glue",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "AWS SDK for JavaScript (v3) examples for AWS Glue",
   "type": "module",
-  "author": "corepyle@amazon.com",
+  "author": "Corey Pyle <corepyle@amazon.com>",
   "license": "Apache-2.0",
   "scripts": {
     "test": "vitest run **/*.unit.test.js",
     "integration-test": "vitest run **/*.integration.test.js --reporter=junit --outputFile=test_results/$npm_package_name.junit.xml"
   },
   "dependencies": {
-    "@aws-doc-sdk-examples/lib": "^1.0.0",
-    "@aws-sdk/client-glue": "^3.425.0",
+    "@aws-doc-sdk-examples/lib": "^1.0.1",
+    "@aws-sdk/client-glue": "^3.645.0",
     "chalk": "^5.3.0",
-    "dotenv": "^16.3.1",
-    "inquirer": "^9.2.11",
-    "open": "^9.1.0"
+    "dotenv": "^16.4.5",
+    "inquirer": "^10.2.0",
+    "open": "^10.1.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.204.0",
-    "@aws-sdk/client-s3": "^3.204.0",
-    "@vitest/coverage-c8": "^0.25.0",
-    "vitest": "^1.6.0"
+    "@aws-sdk/client-cloudformation": "^3.645.0",
+    "@aws-sdk/client-s3": "^3.645.0",
+    "vitest": "^2.0.5"
   }
 }

--- a/javascriptv3/example_code/glue/vite.config.js
+++ b/javascriptv3/example_code/glue/vite.config.js
@@ -7,8 +7,5 @@ export default defineConfig({
   test: {
     restoreMocks: true,
     cache: false,
-    coverage: {
-      reporter: ["text", "html"],
-    },
   },
 });


### PR DESCRIPTION
deleteDatabase wasn't being handled, leaving the test open to crashing before clean up was done. This handles that error.

There was also a potential for objects in the S3 Bucket to not be fully deleted before trying to delete the bucket. I suspect this was causing issues leading to N stacks being created every run and not being torn down.

<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
