### PR TITLE
Update retry example for latest SDK (Prep for GA)

### DIFF
--- a/swift/example_code/swift-sdk/retry/Package.swift
+++ b/swift/example_code/swift-sdk/retry/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.6
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -18,7 +18,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "0.36.0"
+            from: "0.75.0"
         ),
     ],
     targets: [

--- a/swift/example_code/swift-sdk/retry/Sources/entry.swift
+++ b/swift/example_code/swift-sdk/retry/Sources/entry.swift
@@ -6,8 +6,9 @@
 // AWS service.
 
 import Foundation
-import ClientRuntime
 import AWSS3
+import SmithyRetries
+import SmithyRetriesAPI
 
 @main
 struct RetryExample {
@@ -16,12 +17,14 @@ struct RetryExample {
         let config: S3Client.S3ClientConfiguration
 
         // Create an Amazon S3 client configuration object that specifies the
-        // adaptive retry mode and the base maximum number of retries as 5.
+        // standard exponential backoff strategy, adaptive retry mode and the
+        // base maximum number of retries as 5.
 
         do {
             // snippet-start:[retry.swift.configure]
             config = try await S3Client.S3ClientConfiguration(
                 retryStrategyOptions: RetryStrategyOptions(
+                    backoffStrategy: SmithyRetries.ExponentialBackoffStrategy(),
                     maxRetriesBase: 5,
                     rateLimitingMode: .adaptive
                 )


### PR DESCRIPTION
This patch brings the example for retry up to working on the latest version of the SDK for Swift.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
