### PR TITLE
Fixes two broken links for SSM scenarios.

### DIFF
--- a/.doc_gen/metadata/ssm_metadata.yaml
+++ b/.doc_gen/metadata/ssm_metadata.yaml
@@ -32,7 +32,7 @@ ssm_Hello:
               snippet_tags:
                 - python.example_code.ssm.Hello
   services:
-    ssm: {listThings}
+    ssm: {ListDocuments}
 ssm_DescribeParameters:
   languages:
     Java:
@@ -456,5 +456,5 @@ ssm_Scenario:
               snippet_tags:
                 - python.example_code.ssm.MaintenanceWindowWrapper.class
   services:
-    ssm: {CreateOpsItem, CreateMaintenanceWindow, CreateDocument, SendCommand, CommandInvocations, DeleteMaintenanceWindow,
+    ssm: {CreateOpsItem, CreateMaintenanceWindow, CreateDocument, SendCommand, ListCommandInvocations, DeleteMaintenanceWindow,
           UpdateOpsItem}

--- a/javascriptv3/example_code/ssm/README.md
+++ b/javascriptv3/example_code/ssm/README.md
@@ -31,7 +31,7 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `javas
 
 ### Get started
 
-- [Hello Systems Manager](hello.js#L4) (`listThings`)
+- [Hello Systems Manager](hello.js#L4) (`ListDocuments`)
 
 
 ### Basics

--- a/javav2/example_code/ssm/README.md
+++ b/javav2/example_code/ssm/README.md
@@ -31,7 +31,7 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `javav
 
 ### Get started
 
-- [Hello Systems Manager](src/main/java/com/example/ssm/HelloSSM.java#L6) (`listThings`)
+- [Hello Systems Manager](src/main/java/com/example/ssm/HelloSSM.java#L6) (`ListDocuments`)
 
 
 ### Basics

--- a/python/example_code/ssm/README.md
+++ b/python/example_code/ssm/README.md
@@ -36,7 +36,7 @@ python -m pip install -r requirements.txt
 
 ### Get started
 
-- [Hello Systems Manager](hello.py#L4) (`listThings`)
+- [Hello Systems Manager](hello.py#L4) (`ListDocuments`)
 
 
 ### Basics


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This fixes some broken metadata for Javav2, Python, and JavaScriptv3 for the ListDocuments link on the Hello Systems Manager page as well as the ListCommandInvocations link on the Basics page.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
