### PR TITLE
Tools - Weathertop: Add clarification to README

### DIFF
--- a/.tools/test/stacks/config/targets.yaml
+++ b/.tools/test/stacks/config/targets.yaml
@@ -11,7 +11,7 @@ gov2:
   status: "enabled"
 javascriptv3:
   account_id: "875008041426"
-  status: "enabled"
+  status: "disabled"
 javav2:
   account_id: "667348412466"  # back-up "814548047983"
   status: "enabled"

--- a/.tools/test/stacks/config/targets.yaml
+++ b/.tools/test/stacks/config/targets.yaml
@@ -11,7 +11,7 @@ gov2:
   status: "enabled"
 javascriptv3:
   account_id: "875008041426"
-  status: "disabled"
+  status: "enabled"
 javav2:
   account_id: "667348412466"  # back-up "814548047983"
   status: "enabled"

--- a/.tools/test/stacks/plugin/README.md
+++ b/.tools/test/stacks/plugin/README.md
@@ -23,8 +23,6 @@ Specifically, it consumes images from a Simple Notification Service (SNS) topic,
 
 Before you get started, update [config/resources.yaml](../config/resources.yaml) and [config/targets.yaml](../config/targets.yaml) to include logical names representing test targets and their corresponding AWS Account ID and enabled status.
 
-This PR disabled JS tests runs, as this language does not support test automation within our engineering constraints.
-
 If you need to disable a plugin stack, use this configuration file and perform an [admin stack deployment](../../DEPLOYMENT.md#usage).
 
 ---

--- a/.tools/test/stacks/plugin/README.md
+++ b/.tools/test/stacks/plugin/README.md
@@ -23,7 +23,7 @@ Specifically, it consumes images from a Simple Notification Service (SNS) topic,
 
 Before you get started, update [config/resources.yaml](../config/resources.yaml) and [config/targets.yaml](../config/targets.yaml) to include logical names representing test targets and their corresponding AWS Account ID and enabled status.
 
-If you need to disable a plugin stack, use the [config/targets.yaml](../config/targets.yaml) configuration file and perform an [admin stack deployment](../../DEPLOYMENT.md#usage).
+If you need to disable a plugin stack, update [config/targets.yaml](../config/targets.yaml) accordingly and perform an [admin stack deployment](../../DEPLOYMENT.md#usage).
 
 ---
 

--- a/.tools/test/stacks/plugin/README.md
+++ b/.tools/test/stacks/plugin/README.md
@@ -23,7 +23,7 @@ Specifically, it consumes images from a Simple Notification Service (SNS) topic,
 
 Before you get started, update [config/resources.yaml](../config/resources.yaml) and [config/targets.yaml](../config/targets.yaml) to include logical names representing test targets and their corresponding AWS Account ID and enabled status.
 
-If you need to disable a plugin stack, use this configuration file and perform an [admin stack deployment](../../DEPLOYMENT.md#usage).
+If you need to disable a plugin stack, use the [config/targets.yaml](../config/targets.yaml) configuration file and perform an [admin stack deployment](../../DEPLOYMENT.md#usage).
 
 ---
 

--- a/.tools/test/stacks/plugin/README.md
+++ b/.tools/test/stacks/plugin/README.md
@@ -23,6 +23,10 @@ Specifically, it consumes images from a Simple Notification Service (SNS) topic,
 
 Before you get started, update [config/resources.yaml](../config/resources.yaml) and [config/targets.yaml](../config/targets.yaml) to include logical names representing test targets and their corresponding AWS Account ID and enabled status.
 
+This PR disabled JS tests runs, as this language does not support test automation within our engineering constraints.
+
+If you need to disable a plugin stack, use this configuration file and perform an [admin stack deployment](../../DEPLOYMENT.md#usage).
+
 ---
 
 ## AWS CDK setup and deployment


### PR DESCRIPTION
This PR adds clarification to a README for how to disable test runs for a specific language.