### PR TITLE
JavaScript (v3): Tests: Ensure integ test exit code comes from tests not outputs.

### DIFF
--- a/javascriptv3/package.json
+++ b/javascriptv3/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "test": "npm run test --workspaces --if-present",
-    "integration-test": "npm run integration-test --workspaces --if-present -- --silent; npm run merge-test-results; npm run log-tests",
+    "integration-test": "npm run integration-test --workspaces --if-present -- --silent; exit_code=$?; npm run merge-test-results; npm run log-tests; exit ${exit_code:-99}",
     "merge-test-results": "jrm test-results.xml \"**/test_results/**/*.junit.xml\"",
     "log-tests": "cat test-results.xml",
     "lint": "lint-staged",


### PR DESCRIPTION

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
