### PR TITLE
JavaScript (v3): Kinesis - Update CDK/CFN deletion policy to delete stream on stack deletion.

### DIFF
--- a/javascriptv3/example_code/kinesis/kinesis-cdk/lib/kinesis-cdk-stack.ts
+++ b/javascriptv3/example_code/kinesis/kinesis-cdk/lib/kinesis-cdk-stack.ts
@@ -12,6 +12,7 @@ export class KinesisCdkStack extends cdk.Stack {
     const stream = new kinesis.Stream(this, "ExampleStream", {
       streamName: "example-stream",
       encryption: kinesis.StreamEncryption.KMS,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
     new cdk.CfnOutput(this, "ExampleStreamName", {

--- a/javascriptv3/example_code/kinesis/stack.yaml
+++ b/javascriptv3/example_code/kinesis/stack.yaml
@@ -34,8 +34,8 @@ Resources:
           Fn::GetAtt:
             - ExampleStreamKeyBB67426B
             - Arn
-    UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
     Metadata:
       aws:cdk:path: KinesisCdkStack/ExampleStream/Resource
   CDKMetadata:


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

Kinesis streams were being retained during integ test runs and breaking the suite. This updates the deletion policy to prevent that.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
