### PR TITLE
Meta: Remove duplicate S3 legal hold scenario example.

### DIFF
--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -1002,32 +1002,6 @@ s3_GetObjectLegalHold:
             - description: Put an object legal hold.
               snippet_tags:
                 - python.example_code.s3.GetObjectLegalHold
-  services:
-    s3: {GetObjectLegalHold}
-s3_GetObjectLegalHoldConfiguration:
-  title: Get the legal hold configuration of an &S3; object using an &AWS; SDK
-  title_abbrev: Get the legal hold configuration of an object
-  synopsis: get the legal hold configuration of an S3 bucket.
-  category: Scenarios
-  languages:
-    Java:
-      versions:
-        - sdk_version: 2
-          github: javav2/example_code/s3
-          sdkguide:
-          excerpts:
-            - description:
-              snippet_tags:
-                - S3LockWorkflow.javav2.GetObjectLegalHold.main
-    .NET:
-      versions:
-        - sdk_version: 3
-          github: dotnetv3/S3/scenarios/S3ObjectLockScenario
-          sdkguide:
-          excerpts:
-            - description:
-              snippet_tags:
-                - S3LockWorkflow.dotnetv3.GetObjectLegalHold
     JavaScript:
       versions:
         - sdk_version: 3

--- a/dotnetv3/S3/README.md
+++ b/dotnetv3/S3/README.md
@@ -84,7 +84,6 @@ functions within the same service.
 - [Detect objects in images](../cross-service/PhotoAnalyzerApp)
 - [Get started with encryption](SSEClientEncryptionExample/SSEClientEncryption.cs)
 - [Get started with tags](ObjectTagExample/ObjectTag.cs)
-- [Get the legal hold configuration of an object](scenarios/S3ObjectLockScenario/S3ObjectLockWorkflow/S3ActionsWrapper.cs)
 - [Lock Amazon S3 objects](scenarios/S3ObjectLockScenario/S3ObjectLockWorkflow/S3ObjectLockWorkflow.cs)
 - [Manage access control lists (ACLs)](ManageACLsExample/ManageACLs.cs)
 - [Perform a multipart copy](MPUapiCopyObjExample/MPUapiCopyObj.cs)
@@ -198,18 +197,6 @@ This example shows you how to get started with tags for Amazon S3 objects.
 
 <!--custom.scenarios.s3_Scenario_Tagging.start-->
 <!--custom.scenarios.s3_Scenario_Tagging.end-->
-
-#### Get the legal hold configuration of an object
-
-This example shows you how to get the legal hold configuration of an S3 bucket.
-
-
-<!--custom.scenario_prereqs.s3_GetObjectLegalHoldConfiguration.start-->
-<!--custom.scenario_prereqs.s3_GetObjectLegalHoldConfiguration.end-->
-
-
-<!--custom.scenarios.s3_GetObjectLegalHoldConfiguration.start-->
-<!--custom.scenarios.s3_GetObjectLegalHoldConfiguration.end-->
 
 #### Lock Amazon S3 objects
 

--- a/javascriptv3/example_code/s3/README.md
+++ b/javascriptv3/example_code/s3/README.md
@@ -57,6 +57,7 @@ Code excerpts that show you how to call individual service functions.
 - [GetBucketPolicy](actions/get-bucket-policy.js#L6)
 - [GetBucketWebsite](actions/get-bucket-website.js#L6)
 - [GetObject](actions/get-object.js#L6)
+- [GetObjectLegalHold](actions/get-object-legal-hold.js)
 - [GetObjectLockConfiguration](actions/get-object-lock-configuration.js)
 - [GetObjectRetention](actions/get-object-retention.js)
 - [ListBuckets](actions/list-buckets.js#L6)
@@ -78,7 +79,6 @@ functions within the same service.
 - [Create a presigned URL](scenarios/presigned-url-upload.js)
 - [Create a web page that lists Amazon S3 objects](../web/s3/list-objects/src/App.tsx)
 - [Delete all objects in a bucket](scenarios/delete-all-objects.js)
-- [Get the legal hold configuration of an object](actions/get-object-legal-hold.js)
 - [Lock Amazon S3 objects](scenarios/object-locking/index.js)
 - [Upload or download large files](scenarios/multipart-upload.js)
 
@@ -187,18 +187,6 @@ This example shows you how to delete all of the objects in an Amazon S3 bucket.
 
 <!--custom.scenarios.s3_Scenario_DeleteAllObjects.start-->
 <!--custom.scenarios.s3_Scenario_DeleteAllObjects.end-->
-
-#### Get the legal hold configuration of an object
-
-This example shows you how to get the legal hold configuration of an S3 bucket.
-
-
-<!--custom.scenario_prereqs.s3_GetObjectLegalHoldConfiguration.start-->
-<!--custom.scenario_prereqs.s3_GetObjectLegalHoldConfiguration.end-->
-
-
-<!--custom.scenarios.s3_GetObjectLegalHoldConfiguration.start-->
-<!--custom.scenarios.s3_GetObjectLegalHoldConfiguration.end-->
 
 #### Lock Amazon S3 objects
 

--- a/javav2/example_code/s3/README.md
+++ b/javav2/example_code/s3/README.md
@@ -81,7 +81,6 @@ functions within the same service.
 
 - [Delete incomplete multipart uploads](src/main/java/com/example/s3/AbortMultipartUploadExamples.java)
 - [Download objects to a local directory](src/main/java/com/example/s3/transfermanager/DownloadToDirectory.java)
-- [Get the legal hold configuration of an object](src/main/java/com/example/s3/lockscenario/S3LockActions.java)
 - [Lock Amazon S3 objects](src/main/java/com/example/s3/lockscenario/S3ObjectLockWorkflow.java)
 - [Parse URIs](src/main/java/com/example/s3/ParseUri.java)
 - [Perform a multipart upload](src/main/java/com/example/s3/PerformMultiPartUpload.java)
@@ -153,18 +152,6 @@ This example shows you how to download all objects in an Amazon Simple Storage S
 
 <!--custom.scenarios.s3_DownloadBucketToDirectory.start-->
 <!--custom.scenarios.s3_DownloadBucketToDirectory.end-->
-
-#### Get the legal hold configuration of an object
-
-This example shows you how to get the legal hold configuration of an S3 bucket.
-
-
-<!--custom.scenario_prereqs.s3_GetObjectLegalHoldConfiguration.start-->
-<!--custom.scenario_prereqs.s3_GetObjectLegalHoldConfiguration.end-->
-
-
-<!--custom.scenarios.s3_GetObjectLegalHoldConfiguration.start-->
-<!--custom.scenarios.s3_GetObjectLegalHoldConfiguration.end-->
 
 #### Lock Amazon S3 objects
 


### PR DESCRIPTION
Remove duplicate "Scenario" for `GetObjectLegalHold`. This was kept during a previous refactor to avoid a broken reference in the S3 guide. The guide reference has been updated so we can now remove this duplicate example.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
