### PR TITLE
Swift: Add pagination example

### DIFF
--- a/swift/example_code/swift-sdk/pagination/Package.swift
+++ b/swift/example_code/swift-sdk/pagination/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:5.9
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// The swift-tools-version declares the minimum version of Swift required to
+// build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "pagination",
+    // Let Xcode know the minimum Apple platforms supported.
+    platforms: [
+        .macOS(.v11),
+        .iOS(.v13)
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(
+            url: "https://github.com/awslabs/aws-sdk-swift",
+            from: "1.0.0"
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "retry",
+            dependencies: [
+                .product(name: "AWSS3", package: "aws-sdk-swift"),
+            ],
+            path: "Sources"),
+    ]
+)

--- a/swift/example_code/swift-sdk/pagination/Sources/entry.swift
+++ b/swift/example_code/swift-sdk/pagination/Sources/entry.swift
@@ -13,6 +13,7 @@ struct PaginatorExample {
         let PAGE_SIZE = 10
         let client: S3Client
 
+        // snippet-start:[swift.pagination]
         do {
             client = try await S3Client()
         } catch {
@@ -24,13 +25,16 @@ struct PaginatorExample {
         // `listBuckets(input:)` function. Each page has up to 10 buckets in
         // it.
 
+        // snippet-start:[swift.create-paginator]
         let pages = client.listBucketsPaginated(
             input: ListBucketsInput(maxBuckets: PAGE_SIZE)
         )
+        // snippet-end:[swift.create-paginator]
 
         // Go through the pages, printing each page's buckets to the console.
         // The paginator handles the continuation tokens automatically.
 
+        // snippet-start:[swift.process-paginator]
         var pageNumber = 0
 
         do {
@@ -53,5 +57,7 @@ struct PaginatorExample {
         } catch {
             print("ERROR: Unable to process bucket list pages.")
         }
+        // snippet-end:[swift.process-paginator]
     }
+    // snippet-end:[swift.pagination]
 }

--- a/swift/example_code/swift-sdk/pagination/Sources/entry.swift
+++ b/swift/example_code/swift-sdk/pagination/Sources/entry.swift
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// An example to demonstrate the use of pagination with the AWS SDK
+// for Swift.
+
+import AWSS3
+import Foundation
+
+@main
+struct PaginatorExample {
+    static func main() async {
+        let PAGE_SIZE = 10
+        let client: S3Client
+
+        do {
+            client = try await S3Client()
+        } catch {
+            print("ERROR: Unable to create the Amazon S3 client.")
+            return
+        }
+
+        // Start pagination by using the `Paginated` version of the
+        // `listBuckets(input:)` function. Each page has up to 10 buckets in
+        // it.
+
+        let pages = client.listBucketsPaginated(
+            input: ListBucketsInput(maxBuckets: PAGE_SIZE)
+        )
+
+        // Go through the pages, printing each page's buckets to the console.
+        // The paginator handles the continuation tokens automatically.
+
+        var pageNumber = 0
+
+        do {
+            for try await page in pages {
+                pageNumber += 1
+
+                guard let pageBuckets = page.buckets else {
+                    print("ERROR: No buckets returned in page \(pageNumber)")
+                    continue
+                }
+
+                print("\nPage \(pageNumber):")
+
+                // Print this page's bucket names.
+
+                for bucket in pageBuckets {
+                    print("  " + (bucket.name ?? "<unknown>"))
+                }
+            }
+        } catch {
+            print("ERROR: Unable to process bucket list pages.")
+        }
+    }
+}

--- a/swift/example_code/swift-sdk/pagination/Sources/entry.swift
+++ b/swift/example_code/swift-sdk/pagination/Sources/entry.swift
@@ -10,10 +10,12 @@ import Foundation
 @main
 struct PaginatorExample {
     static func main() async {
+        // snippet-start:[swift.pagination]
         let PAGE_SIZE = 10
         let client: S3Client
 
-        // snippet-start:[swift.pagination]
+        // Create the Amazon S3 client.
+        
         do {
             client = try await S3Client()
         } catch {

--- a/swift/example_code/swift-sdk/pagination/test.sh
+++ b/swift/example_code/swift-sdk/pagination/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "No automated tests available."


### PR DESCRIPTION
This PR adds a new example for Swift demonstrating the use of a paginator. The example lists all S3 buckets with a page size of 10. The number of pages is counted, and each page is output as its own list, in order to more clearly call attention to the pagination feature.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
