### PR TITLE
Weathertop: set Rust ephemeralStorage override at 30GiB

### DIFF
--- a/.tools/test/stacks/config/targets.yaml
+++ b/.tools/test/stacks/config/targets.yaml
@@ -30,6 +30,7 @@ ruby:
 rustv1:
   account_id: "050288538048"
   status: "enabled"
+  storage: "30"
 sapabap:
   account_id: "099736152523"
   status: "enabled"


### PR DESCRIPTION


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
