### PR TITLE
Go: Update all bucket name uses to user input, env vars, or approved names.

### DIFF
--- a/gov2/cloudfront/CreateDistribution/CreateDistribution.go
+++ b/gov2/cloudfront/CreateDistribution/CreateDistribution.go
@@ -149,7 +149,7 @@ var (
 // and config files.
 func main() {
 
-	flag.StringVar(&bucketName, "bucket", "", "<EXAMPLE-BUCKET-NAME>")
+	flag.StringVar(&bucketName, "bucket", "", "amzn-s3-demo-bucket")
 	flag.StringVar(&certificateSSLArn, "cert", "", "<AWS CERTIFICATE MANGER ARN>")
 	flag.StringVar(&domain, "domain", "", "<YOUR DOMAIN>")
 	flag.Parse()

--- a/gov2/cloudfront/CreateDistribution/CreateDistribution_test.go
+++ b/gov2/cloudfront/CreateDistribution/CreateDistribution_test.go
@@ -68,7 +68,7 @@ func TestCreateDistribution(t *testing.T) {
 
 	mockCFDistribution := createMockCFDistribution(s3Client, cloudfrontClient)
 
-	bucketName := "example-com"
+	bucketName := "amzn-s3-demo-bucket"
 	certificateSSLArn := "arn:aws:acm:ap-northeast-2:123456789000:certificate/000000000-0000-0000-0000-000000000000"
 	domain := "example.com"
 

--- a/gov2/iam/scenarios/scenario_assume_role_test.go
+++ b/gov2/iam/scenarios/scenario_assume_role_test.go
@@ -60,7 +60,7 @@ func (scenTest *AssumeRoleScenarioTest) SetupDataAndStubs() []testtools.Stub {
 		&testtools.StubError{Err: &smithy.GenericAPIError{Code: "AccessDenied"}, ContinueAfter: true}))
 	stubList = append(stubList, stubs.StubAssumeRole(roleArn, "AssumeRoleExampleSession",
 		900, keyId, keySecret, token, nil))
-	stubList = append(stubList, stubs.StubListBuckets([]string{"test-bucket-1", "test-bucket-2"}, nil))
+	stubList = append(stubList, stubs.StubListBuckets([]string{"amzn-s3-demo-bucket-1", "amzn-s3-demo-bucket-2"}, nil))
 	stubList = append(stubList, stubs.StubListAttachedRolePolicies(roleName,
 		map[string]string{listBucketsPolicy: listBucketsPolicyArn}, nil))
 	stubList = append(stubList, stubs.StubDetachRolePolicy(roleName, listBucketsPolicyArn, nil))

--- a/gov2/s3/actions/bucket_basics_test.go
+++ b/gov2/s3/actions/bucket_basics_test.go
@@ -28,10 +28,10 @@ func TestBucketBasics_CopyToBucket(t *testing.T) {
 
 func CopyToBucket(raiseErr *testtools.StubError, t *testing.T) {
 	stubber, basics := enterTest()
-	stubber.Add(stubs.StubCopyObject("source-bucket", "object-key", "dest-bucket", "object-key", raiseErr))
+	stubber.Add(stubs.StubCopyObject("amzn-s3-demo-bucket-source", "object-key", "amzn-s3-demo-bucket-dest", "object-key", raiseErr))
 	ctx := context.Background()
 
-	err := basics.CopyToBucket(ctx, "source-bucket", "dest-bucket", "object-key")
+	err := basics.CopyToBucket(ctx, "amzn-s3-demo-bucket-source", "amzn-s3-demo-bucket-dest", "object-key")
 
 	testtools.VerifyError(err, raiseErr, t)
 	testtools.ExitTest(stubber, t)

--- a/gov2/s3/go.mod
+++ b/gov2/s3/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.22.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.7 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/term v0.24.0 // indirect
 )

--- a/gov2/s3/go.sum
+++ b/gov2/s3/go.sum
@@ -40,6 +40,8 @@ github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20240907001412-a93
 github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20240907001412-a9375541143b/go.mod h1:iBzksyiv5HVU+cymGDQbbvcecca+rsARJlDFL8np8oE=
 github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools v0.0.0-20240907001412-a9375541143b h1:UmPy4pArM7SIhTX2Xn5bhOkgI9onSUQ1Y9fxgDJ3pHU=
 github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools v0.0.0-20240907001412-a9375541143b/go.mod h1:9Oj/8PZn3D5Ftp/Z1QWrIEFE0daERMqfJawL9duHRfc=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.24.0 h1:Mh5cbb+Zk2hqqXNO7S1iTjEphVL+jb8ZWaqh/g+JWkM=

--- a/gov2/s3/scenarios/scenario_get_started_integ_test.go
+++ b/gov2/s3/scenarios/scenario_get_started_integ_test.go
@@ -3,8 +3,6 @@
 //go:build integration
 // +build integration
 
-// SPDX-License-Identifier: Apache-2.0
-
 // Integration test for the Amazon S3 get started scenario.
 
 package scenarios
@@ -12,6 +10,7 @@ package scenarios
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -19,13 +18,20 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools"
+	"github.com/google/uuid"
 )
 
 func TestGetStartedScenario_Integration(t *testing.T) {
+	bucket := os.Getenv("S3_BUCKET_NAME_PREFIX")
+	if bucket == "" {
+		bucket = "amzn-s3-demo-bucket"
+	} else {
+		bucket = fmt.Sprintf("%s-%s", bucket, uuid.New())
+	}
 	outFile := "integ-test.out"
 	mockQuestioner := &demotools.MockQuestioner{
 		Answers: []string{
-			"doc-example-go-test-bucket", "../README.md", "", outFile, "", "test-folder", "", "y",
+			bucket, "../README.md", "", outFile, "", "test-folder", "", "y",
 		},
 	}
 

--- a/gov2/s3/scenarios/scenario_get_started_test.go
+++ b/gov2/s3/scenarios/scenario_get_started_test.go
@@ -50,10 +50,10 @@ type GetStartedScenarioTest struct {
 // SetupDataAndStubs sets up test data and builds the stubs that are used to return
 // mocked data.
 func (scenTest *GetStartedScenarioTest) SetupDataAndStubs() []testtools.Stub {
-	bucketName := "test-bucket-1"
+	bucketName := "amzn-s3-demo-bucket-1"
 	objectKey := "doc-example-key"
 	largeKey := "doc-example-large"
-	bucketList := []types.Bucket{{Name: aws.String(bucketName)}, {Name: aws.String("test-bucket-2")}}
+	bucketList := []types.Bucket{{Name: aws.String(bucketName)}, {Name: aws.String("amzn-s3-demo-bucket-2")}}
 	testConfig, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		panic(err)

--- a/gov2/s3/scenarios/scenario_presigning_integ_test.go
+++ b/gov2/s3/scenarios/scenario_presigning_integ_test.go
@@ -12,6 +12,7 @@ package scenarios
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -19,12 +20,19 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools"
+	"github.com/google/uuid"
 )
 
 func TestRunPresigningScenario_Integration(t *testing.T) {
+	bucket := os.Getenv("S3_BUCKET_NAME_PREFIX")
+	if bucket == "" {
+		bucket = "amzn-s3-demo-bucket"
+	} else {
+		bucket = fmt.Sprintf("%s-%s", bucket, uuid.New())
+	}
 	mockQuestioner := &demotools.MockQuestioner{
 		Answers: []string{
-			"doc-example-go-test-bucket", "../README.md", "test-object", "", "", "",
+			bucket, "../README.md", "test-object", "", "", "",
 		},
 	}
 

--- a/gov2/s3/scenarios/scenario_presigning_test.go
+++ b/gov2/s3/scenarios/scenario_presigning_test.go
@@ -54,7 +54,7 @@ type PresigningScenarioTest struct {
 // SetupDataAndStubs sets up test data and builds the stubs that are used to return
 // mocked data.
 func (scenTest *PresigningScenarioTest) SetupDataAndStubs() []testtools.Stub {
-	bucketName := "test-bucket-1"
+	bucketName := "amzn-s3-demo-bucket-1"
 	testConfig, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		panic(err)

--- a/gov2/workflows/s3_object_lock/actions/s3_actions_test.go
+++ b/gov2/workflows/s3_object_lock/actions/s3_actions_test.go
@@ -40,8 +40,8 @@ func TestCreateBucketWithLock(t *testing.T) {
 	for _, expectedErr := range []error{&types.BucketAlreadyOwnedByYou{}, &types.BucketAlreadyExists{}} {
 		ctx, stubber, actor := enterTest()
 		_, stubErr := wrapErr(expectedErr)
-		stubber.Add(stubs.StubCreateBucket("test-bucket", "test-region", true, stubErr))
-		_, actualErr := actor.CreateBucketWithLock(ctx, "test-bucket", "test-region", true)
+		stubber.Add(stubs.StubCreateBucket("amzn-s3-demo-bucket", "test-region", true, stubErr))
+		_, actualErr := actor.CreateBucketWithLock(ctx, "amzn-s3-demo-bucket", "test-region", true)
 		verifyErr(expectedErr, actualErr, t)
 		testtools.ExitTest(stubber, t)
 	}
@@ -51,8 +51,8 @@ func TestGetObjectLegalHold(t *testing.T) {
 	for _, raisedErr := range []error{&types.NoSuchKey{}, &smithy.GenericAPIError{Code: "NoSuchObjectLockConfiguration"}, &smithy.GenericAPIError{Code: "InvalidRequest"}} {
 		ctx, stubber, actor := enterTest()
 		_, stubErr := wrapErr(raisedErr)
-		stubber.Add(stubs.StubGetObjectLegalHold("test-bucket", "test-region", "test-version", types.ObjectLockLegalHoldStatusOn, stubErr))
-		_, actualErr := actor.GetObjectLegalHold(ctx, "test-bucket", "test-region", "test-version")
+		stubber.Add(stubs.StubGetObjectLegalHold("amzn-s3-demo-bucket", "test-region", "test-version", types.ObjectLockLegalHoldStatusOn, stubErr))
+		_, actualErr := actor.GetObjectLegalHold(ctx, "amzn-s3-demo-bucket", "test-region", "test-version")
 		expectedErr := raisedErr
 		if _, ok := raisedErr.(*smithy.GenericAPIError); ok {
 			expectedErr = nil
@@ -66,8 +66,8 @@ func TestGetObjectLockConfiguration(t *testing.T) {
 	for _, raisedErr := range []error{&types.NoSuchBucket{}, &smithy.GenericAPIError{Code: "ObjectLockConfigurationNotFoundError"}} {
 		ctx, stubber, actor := enterTest()
 		_, stubErr := wrapErr(raisedErr)
-		stubber.Add(stubs.StubGetObjectLockConfiguration("test-bucket", types.ObjectLockEnabledEnabled, stubErr))
-		_, actualErr := actor.GetObjectLockConfiguration(ctx, "test-bucket")
+		stubber.Add(stubs.StubGetObjectLockConfiguration("amzn-s3-demo-bucket", types.ObjectLockEnabledEnabled, stubErr))
+		_, actualErr := actor.GetObjectLockConfiguration(ctx, "amzn-s3-demo-bucket")
 		expectedErr := raisedErr
 		if _, ok := raisedErr.(*smithy.GenericAPIError); ok {
 			expectedErr = nil
@@ -81,8 +81,8 @@ func TestGetObjectRetention(t *testing.T) {
 	for _, raisedErr := range []error{&types.NoSuchKey{}, &smithy.GenericAPIError{Code: "NoSuchObjectLockConfiguration"}, &smithy.GenericAPIError{Code: "InvalidRequest"}} {
 		ctx, stubber, actor := enterTest()
 		_, stubErr := wrapErr(raisedErr)
-		stubber.Add(stubs.StubGetObjectRetention("test-bucket", "test-key", types.ObjectLockRetentionModeGovernance, time.Now(), stubErr))
-		_, actualErr := actor.GetObjectRetention(ctx, "test-bucket", "test-key")
+		stubber.Add(stubs.StubGetObjectRetention("amzn-s3-demo-bucket", "test-key", types.ObjectLockRetentionModeGovernance, time.Now(), stubErr))
+		_, actualErr := actor.GetObjectRetention(ctx, "amzn-s3-demo-bucket", "test-key")
 		expectedErr := raisedErr
 		if _, ok := raisedErr.(*smithy.GenericAPIError); ok {
 			expectedErr = nil
@@ -97,8 +97,8 @@ func TestPutObjectLegalHold(t *testing.T) {
 	defer testtools.ExitTest(stubber, t)
 
 	expectedErr, stubErr := wrapErr(&types.NoSuchKey{})
-	stubber.Add(stubs.StubPutObjectLegalHold("test-bucket", "test-key", "test-version", types.ObjectLockLegalHoldStatusOn, stubErr))
-	actualErr := actor.PutObjectLegalHold(ctx, "test-bucket", "test-key", "test-version", types.ObjectLockLegalHoldStatusOn)
+	stubber.Add(stubs.StubPutObjectLegalHold("amzn-s3-demo-bucket", "test-key", "test-version", types.ObjectLockLegalHoldStatusOn, stubErr))
+	actualErr := actor.PutObjectLegalHold(ctx, "amzn-s3-demo-bucket", "test-key", "test-version", types.ObjectLockLegalHoldStatusOn)
 	verifyErr(expectedErr, actualErr, t)
 }
 
@@ -107,8 +107,8 @@ func TestModifyDefaultBucketRetention(t *testing.T) {
 	defer testtools.ExitTest(stubber, t)
 
 	expectedErr, stubErr := wrapErr(&types.NoSuchBucket{})
-	stubber.Add(stubs.StubPutObjectLockConfiguration("test-bucket", types.ObjectLockEnabledEnabled, 30, types.ObjectLockRetentionModeGovernance, stubErr))
-	actualErr := actor.ModifyDefaultBucketRetention(ctx, "test-bucket", types.ObjectLockEnabledEnabled, 30, types.ObjectLockRetentionModeGovernance)
+	stubber.Add(stubs.StubPutObjectLockConfiguration("amzn-s3-demo-bucket", types.ObjectLockEnabledEnabled, 30, types.ObjectLockRetentionModeGovernance, stubErr))
+	actualErr := actor.ModifyDefaultBucketRetention(ctx, "amzn-s3-demo-bucket", types.ObjectLockEnabledEnabled, 30, types.ObjectLockRetentionModeGovernance)
 	verifyErr(expectedErr, actualErr, t)
 }
 
@@ -117,14 +117,14 @@ func TestEnableObjectLockOnBucket(t *testing.T) {
 	defer testtools.ExitTest(stubber, t)
 
 	expectedErr, stubErr := wrapErr(&types.NoSuchBucket{})
-	stubber.Add(stubs.StubPutBucketVersioning("test-bucket", stubErr))
-	actualErr := actor.EnableObjectLockOnBucket(ctx, "test-bucket")
+	stubber.Add(stubs.StubPutBucketVersioning("amzn-s3-demo-bucket", stubErr))
+	actualErr := actor.EnableObjectLockOnBucket(ctx, "amzn-s3-demo-bucket")
 	verifyErr(expectedErr, actualErr, t)
 
 	expectedErr, stubErr = wrapErr(&types.NoSuchBucket{})
-	stubber.Add(stubs.StubPutBucketVersioning("test-bucket", nil))
-	stubber.Add(stubs.StubPutObjectLockConfiguration("test-bucket", types.ObjectLockEnabledEnabled, 0, types.ObjectLockRetentionModeGovernance, stubErr))
-	actualErr = actor.EnableObjectLockOnBucket(ctx, "test-bucket")
+	stubber.Add(stubs.StubPutBucketVersioning("amzn-s3-demo-bucket", nil))
+	stubber.Add(stubs.StubPutObjectLockConfiguration("amzn-s3-demo-bucket", types.ObjectLockEnabledEnabled, 0, types.ObjectLockRetentionModeGovernance, stubErr))
+	actualErr = actor.EnableObjectLockOnBucket(ctx, "amzn-s3-demo-bucket")
 	verifyErr(expectedErr, actualErr, t)
 }
 
@@ -133,8 +133,8 @@ func TestPutObjectRetention(t *testing.T) {
 	defer testtools.ExitTest(stubber, t)
 
 	expectedErr, stubErr := wrapErr(&types.NoSuchKey{})
-	stubber.Add(stubs.StubPutObjectRetention("test-bucket", "test-key", stubErr))
-	actualErr := actor.PutObjectRetention(ctx, "test-bucket", "test-key", types.ObjectLockRetentionModeGovernance, 30)
+	stubber.Add(stubs.StubPutObjectRetention("amzn-s3-demo-bucket", "test-key", stubErr))
+	actualErr := actor.PutObjectRetention(ctx, "amzn-s3-demo-bucket", "test-key", types.ObjectLockRetentionModeGovernance, 30)
 	verifyErr(expectedErr, actualErr, t)
 }
 
@@ -145,8 +145,8 @@ func TestUploadObject(t *testing.T) {
 	actor.S3Manager = manager.NewUploader(actor.S3Client)
 	expectedErr, stubErr := wrapErr(&types.NoSuchBucket{})
 	checksum := types.ChecksumAlgorithmSha256
-	stubber.Add(stubs.StubPutObject("test-bucket", "test-key", &checksum, stubErr))
-	_, actualErr := actor.UploadObject(ctx, "test-bucket", "test-key", "test-contents")
+	stubber.Add(stubs.StubPutObject("amzn-s3-demo-bucket", "test-key", &checksum, stubErr))
+	_, actualErr := actor.UploadObject(ctx, "amzn-s3-demo-bucket", "test-key", "test-contents")
 	verifyErr(expectedErr, actualErr, t)
 }
 
@@ -155,8 +155,8 @@ func TestListObjectVersions(t *testing.T) {
 	defer testtools.ExitTest(stubber, t)
 
 	expectedErr, stubErr := wrapErr(&types.NoSuchBucket{})
-	stubber.Add(stubs.StubListObjectVersions("test-bucket", []types.ObjectVersion{}, stubErr))
-	_, actualErr := actor.ListObjectVersions(ctx, "test-bucket")
+	stubber.Add(stubs.StubListObjectVersions("amzn-s3-demo-bucket", []types.ObjectVersion{}, stubErr))
+	_, actualErr := actor.ListObjectVersions(ctx, "amzn-s3-demo-bucket")
 	verifyErr(expectedErr, actualErr, t)
 }
 
@@ -164,8 +164,8 @@ func TestDeleteObject(t *testing.T) {
 	for _, raisedErr := range []error{&types.NoSuchKey{}, &smithy.GenericAPIError{Code: "AccessDenied"}, &smithy.GenericAPIError{Code: "InvalidArgument"}} {
 		ctx, stubber, actor := enterTest()
 		_, stubErr := wrapErr(raisedErr)
-		stubber.Add(stubs.StubDeleteObject("test-bucket", "test-key", "test-version", true, stubErr))
-		_, actualErr := actor.DeleteObject(ctx, "test-bucket", "test-key", "test-version", true)
+		stubber.Add(stubs.StubDeleteObject("amzn-s3-demo-bucket", "test-key", "test-version", true, stubErr))
+		_, actualErr := actor.DeleteObject(ctx, "amzn-s3-demo-bucket", "test-key", "test-version", true)
 		expectedErr := raisedErr
 		if _, ok := raisedErr.(*smithy.GenericAPIError); ok {
 			expectedErr = nil
@@ -180,7 +180,7 @@ func TestDeleteObjects(t *testing.T) {
 	defer testtools.ExitTest(stubber, t)
 
 	expectedErr, stubErr := wrapErr(&types.NoSuchBucket{})
-	stubber.Add(stubs.StubDeleteObjects("test-bucket", []types.ObjectVersion{{Key: aws.String("test-key"), VersionId: aws.String("test-version")}}, true, stubErr))
-	actualErr := actor.DeleteObjects(ctx, "test-bucket", []types.ObjectIdentifier{{Key: aws.String("test-key"), VersionId: aws.String("test-version")}}, true)
+	stubber.Add(stubs.StubDeleteObjects("amzn-s3-demo-bucket", []types.ObjectVersion{{Key: aws.String("test-key"), VersionId: aws.String("test-version")}}, true, stubErr))
+	actualErr := actor.DeleteObjects(ctx, "amzn-s3-demo-bucket", []types.ObjectIdentifier{{Key: aws.String("test-key"), VersionId: aws.String("test-version")}}, true)
 	verifyErr(expectedErr, actualErr, t)
 }

--- a/gov2/workflows/s3_object_lock/go.mod
+++ b/gov2/workflows/s3_object_lock/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.22.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.7 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/term v0.24.0 // indirect
 )

--- a/gov2/workflows/s3_object_lock/go.sum
+++ b/gov2/workflows/s3_object_lock/go.sum
@@ -40,6 +40,8 @@ github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20240907001412-a93
 github.com/awsdocs/aws-doc-sdk-examples/gov2/demotools v0.0.0-20240907001412-a9375541143b/go.mod h1:iBzksyiv5HVU+cymGDQbbvcecca+rsARJlDFL8np8oE=
 github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools v0.0.0-20240907001412-a9375541143b h1:UmPy4pArM7SIhTX2Xn5bhOkgI9onSUQ1Y9fxgDJ3pHU=
 github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools v0.0.0-20240907001412-a9375541143b/go.mod h1:9Oj/8PZn3D5Ftp/Z1QWrIEFE0daERMqfJawL9duHRfc=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.24.0 h1:Mh5cbb+Zk2hqqXNO7S1iTjEphVL+jb8ZWaqh/g+JWkM=

--- a/gov2/workflows/s3_object_lock/workflows/s3_object_lock.go
+++ b/gov2/workflows/s3_object_lock/workflows/s3_object_lock.go
@@ -61,6 +61,7 @@ func (scenario *ObjectLockScenario) CreateBuckets(ctx context.Context) {
 			"This example creates three buckets. Enter a prefix to name your buckets (remember bucket names must be globally unique):")
 
 		for _, info := range createInfo {
+			log.Println(fmt.Sprintf("%s.%s", prefix, info.name))
 			bucketName, err := scenario.s3Actions.CreateBucketWithLock(ctx, fmt.Sprintf("%s.%s", prefix, info.name), scenario.sdkConfig.Region, info.locked)
 			if err != nil {
 				switch err.(type) {

--- a/gov2/workflows/s3_object_lock/workflows/s3_object_lock_integ_test.go
+++ b/gov2/workflows/s3_object_lock/workflows/s3_object_lock_integ_test.go
@@ -22,7 +22,13 @@ import (
 )
 
 func TestObjectLockScenario_Integration(t *testing.T) {
-	bucketPrefix := fmt.Sprintf("test-bucket-%d", time.Now().Unix())
+	bucketPrefix := os.Getenv("S3_BUCKET_NAME_PREFIX")
+	if bucketPrefix == "" {
+		bucketPrefix = "amzn-s3-demo-bucket"
+	} else {
+		// Use Unix time instead of UUID to keep the name short enough when the scenario suffix is added.
+		bucketPrefix = fmt.Sprintf("%s-%d", bucketPrefix, time.Now().Unix())
+	}
 
 	mockQuestioner := demotools.MockQuestioner{
 		Answers: []string{

--- a/gov2/workflows/s3_object_lock/workflows/s3_object_lock_test.go
+++ b/gov2/workflows/s3_object_lock/workflows/s3_object_lock_test.go
@@ -31,7 +31,7 @@ func (scenTest *ObjectLockScenarioTest) SetupDataAndStubs() []testtools.Stub {
 	if err != nil {
 		panic(err)
 	}
-	bucketPrefix := "test-bucket"
+	bucketPrefix := "amzn-s3-demo-bucket"
 	standardBucket := fmt.Sprintf("%s.%s", bucketPrefix, createInfo[0].name)
 	lockBucket := fmt.Sprintf("%s.%s", bucketPrefix, createInfo[1].name)
 	retentionBucket := fmt.Sprintf("%s.%s", bucketPrefix, createInfo[2].name)


### PR DESCRIPTION
* All examples that use buckets ask for user input.
* All unit tests use the approved fictitious bucket name.
* All integration tests get the name for the environment or fall back to the approved name (in which case the test will fail as expected).

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
