### PR TITLE
Add missing SoS tag to AssumeRole sample

### DIFF
--- a/swift/example_code/sts/AssumeRole/Sources/entry.swift
+++ b/swift/example_code/sts/AssumeRole/Sources/entry.swift
@@ -245,20 +245,23 @@ func getIdentityResolver(accessKey: String?, secretKey: String?,
     
     if accessKey == nil || secretKey == nil {
         return nil
-    }
+    }  
 
     guard let accessKey = accessKey,
           let secretKey = secretKey else {
         return nil
     }
 
+    // snippet-start:[swift.sts.AssumeRole.create-static-resolver]
     let credentials = AWSCredentialIdentity(
         accessKey: accessKey,
         secret: secretKey,
         sessionToken: sessionToken
     )
 
-    return try StaticAWSCredentialIdentityResolver(credentials)
+    let identityResolver = try StaticAWSCredentialIdentityResolver(credentials)
+    // snippet-end:[swift.sts.AssumeRole.create-static-resolver]
+    return identityResolver
 }
 
 /// The program's asynchronous entry point.


### PR DESCRIPTION
This PR adds a missing SoS tag to the example I just added for AssumeRole and static credential resolvers. Also broke one line into two to make the snippet slightly better in content.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
