### PR TITLE
Workflow: Update cdk folder name to .cdk in READMEs to match the actual folder name.

### DIFF
--- a/gov2/workflows/user_pools_and_lambda_triggers/README.md
+++ b/gov2/workflows/user_pools_and_lambda_triggers/README.md
@@ -67,7 +67,7 @@ The AWS resources for this example are deployed by using the AWS Cloud Developme
 To install the AWS CDK, follow the instructions in the
 [Developer Guide](https://docs.aws.amazon.com/cdk/v2/guide/home.html).
 
-Deploy resources at a command prompt from the [cdk](cdk) folder:
+Deploy resources at a command prompt from the [.cdk](.cdk) folder:
 
 ```
 npm install
@@ -86,7 +86,7 @@ go run ./cmd -scenario [auto_confirm migrate_user activity_log]
 
 Delete resources deployed for this example by deleting the stack.
 
-Delete the stack at a command prompt from the [cdk](cdk) folder:
+Delete the stack at a command prompt from the [.cdk](.cdk) folder:
 
 ```
 cdk destroy

--- a/workflows/user_pools_and_lambda_triggers/SPECIFICATION.md
+++ b/workflows/user_pools_and_lambda_triggers/SPECIFICATION.md
@@ -30,7 +30,7 @@ can be used as a reference for writing this example in other languages.
 ### Create AWS resources
 
 The `PoolsAndTriggersBase` CDK construct in the  
-[reference implementation for Go](../../gov2/workflows/user_pools_and_lambda_triggers/cdk/lib/pools-and-triggers-base.ts) 
+[reference implementation for Go](../../gov2/workflows/user_pools_and_lambda_triggers/.cdk/lib/pools-and-triggers-base.ts) 
 folder creates all of the common AWS resources you need for this example:
 
 * Amazon DynamoDB table with a `UserEmail` primary key.
@@ -40,7 +40,7 @@ folder creates all of the common AWS resources you need for this example:
 
 This construct is intended as a base script that you copy to your implementation and include in a stack that 
 deploys Lambda handlers in the way that works best for your language. 
-For an example, see the [reference implementation for Go](../../gov2/workflows/user_pools_and_lambda_triggers/cdk/lib/pools-and-triggers-stack.ts).
+For an example, see the [reference implementation for Go](../../gov2/workflows/user_pools_and_lambda_triggers/.cdk/lib/pools-and-triggers-stack.ts).
 
 Because most languages require a bootstrap environment that contains an S3 bucket for staging Lambda handlers,
 it's recommended that you use `cdk deploy` to deploy resources, but if your language supports it you can use 


### PR DESCRIPTION
The underlying folder name was changed from `cdk` to `.cdk` but the READMEs were missed. This fixes that.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
