### PR TITLE
Tools: Update tools release to 2024.43.0

### DIFF
--- a/.github/workflows/validate-doc-metadata.yml
+++ b/.github/workflows/validate-doc-metadata.yml
@@ -16,7 +16,7 @@ jobs:
       - name: checkout repo content
         uses: actions/checkout@v4
       - name: validate metadata
-        uses: awsdocs/aws-doc-sdk-examples-tools@2024.42.2
+        uses: awsdocs/aws-doc-sdk-examples-tools@2024.43.0
         with:
           doc_gen_only: "False"
           strict_titles: "True"


### PR DESCRIPTION
Tools release: https://github.com/awsdocs/aws-doc-sdk-examples-tools/releases/tag/2024.43.0

3P internal release has also been deployed.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
