### PR TITLE
Meta/tools: update to latest tools and update metadata & READMEs to match

### DIFF
--- a/.doc_gen/metadata/s3-control_metadata.yaml
+++ b/.doc_gen/metadata/s3-control_metadata.yaml
@@ -7,21 +7,21 @@ s3-control_Hello:
     Java:
       versions:
         - sdk_version: 2
-          github: javav2/example_code/s3
+          github: javav2/example_code/s3/src/main/java/com/example/s3/batch
           sdkguide:
           excerpts:
             - description:
               snippet_tags:
                 - s3control.java2.list_jobs.main
   services:
-    s3-control: {ListJobsPaginator}
+    s3-control: {ListJobs}
 
 s3-control_CreateJob:
   languages:
     Java:
       versions:
         - sdk_version: 2
-          github: javav2/example_code/s3
+          github: javav2/example_code/s3/src/main/java/com/example/s3/batch
           sdkguide:
           excerpts:
             - description: Create an asynchronous S3 job.
@@ -40,7 +40,7 @@ s3-control_PutJobTagging:
     Java:
       versions:
         - sdk_version: 2
-          github: javav2/example_code/s3
+          github: javav2/example_code/s3/src/main/java/com/example/s3/batch
           sdkguide:
           excerpts:
             - description:
@@ -53,7 +53,7 @@ s3-control_DescribeJob:
     Java:
       versions:
         - sdk_version: 2
-          github: javav2/example_code/s3
+          github: javav2/example_code/s3/src/main/java/com/example/s3/batch
           sdkguide:
           excerpts:
             - description:
@@ -66,7 +66,7 @@ s3-control_DeleteJobTagging:
     Java:
       versions:
         - sdk_version: 2
-          github: javav2/example_code/s3
+          github: javav2/example_code/s3/src/main/java/com/example/s3/batch
           sdkguide:
           excerpts:
             - description:
@@ -79,7 +79,7 @@ s3-control_GetJobTagging:
     Java:
       versions:
         - sdk_version: 2
-          github: javav2/example_code/s3
+          github: javav2/example_code/s3/src/main/java/com/example/s3/batch
           sdkguide:
           excerpts:
             - description:
@@ -92,7 +92,7 @@ s3-control_UpdateJobStatus:
     Java:
       versions:
         - sdk_version: 2
-          github: javav2/example_code/s3
+          github: javav2/example_code/s3/src/main/java/com/example/s3/batch
           sdkguide:
           excerpts:
             - description:
@@ -105,7 +105,7 @@ s3-control_UpdateJobPriority:
     Java:
       versions:
         - sdk_version: 2
-          github: javav2/example_code/s3
+          github: javav2/example_code/s3/src/main/java/com/example/s3/batch
           sdkguide:
           excerpts:
             - description:
@@ -120,7 +120,7 @@ s3-control_Basics:
     Java:
       versions:
         - sdk_version: 2
-          github: javav2/example_code/s3
+          github: javav2/example_code/s3/src/main/java/com/example/s3/batch
           sdkguide:
           excerpts:
             - description: Learn core operations.

--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -2988,7 +2988,7 @@ s3_Scenario_GettingStarted:
             - description: Define a struct that wraps bucket and object actions used by the scenario.
               snippet_tags:
                 - gov2.s3.BucketBasics.complete
-            - description: Run an interactive scenario that shows you how work with S3 buckets and objects.
+            - description: Run an interactive scenario that shows you how to work with S3 buckets and objects.
               snippet_tags:
                 - gov2.s3.Scenario_GetStarted
     Rust:

--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -2988,7 +2988,7 @@ s3_Scenario_GettingStarted:
             - description: Define a struct that wraps bucket and object actions used by the scenario.
               snippet_tags:
                 - gov2.s3.BucketBasics.complete
-            - description: Run an interactive scenario that shows you how to work with S3 buckets and objects.
+            - description: Run an interactive scenario that shows you how work with S3 buckets and objects.
               snippet_tags:
                 - gov2.s3.Scenario_GetStarted
     Rust:

--- a/.github/workflows/validate-doc-metadata.yml
+++ b/.github/workflows/validate-doc-metadata.yml
@@ -16,7 +16,7 @@ jobs:
       - name: checkout repo content
         uses: actions/checkout@v4
       - name: validate metadata
-        uses: awsdocs/aws-doc-sdk-examples-tools@2024.43.0
+        uses: awsdocs/aws-doc-sdk-examples-tools@2024.44.0
         with:
           doc_gen_only: "False"
           strict_titles: "True"

--- a/.tools/readmes/config.py
+++ b/.tools/readmes/config.py
@@ -53,6 +53,7 @@ language = {
             "service_folder": 'javav2/example_code/{{service["name"]}}',
             "sdk_api_ref": 'https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/{{service["name"]}}/package-summary.html',
             "service_folder_overrides": {
+                "s3-control": "javav2/example_code/s3/src/main/java/com/example/s3/batch",
                 "medical-imaging": "javav2/example_code/medicalimaging",
             },
         },

--- a/javav2/example_code/s3/src/main/java/com/example/s3/batch/README.md
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/batch/README.md
@@ -1,0 +1,112 @@
+# Amazon S3 Control code examples for the SDK for Java 2.x
+
+## Overview
+
+Shows how to use the AWS SDK for Java 2.x to work with Amazon S3 Control.
+
+<!--custom.overview.start-->
+<!--custom.overview.end-->
+
+_Amazon S3 Control _
+
+## ⚠ Important
+
+* Running this code might result in charges to your AWS account. For more details, see [AWS Pricing](https://aws.amazon.com/pricing/) and [Free Tier](https://aws.amazon.com/free/).
+* Running the tests might result in charges to your AWS account.
+* We recommend that you grant your code least privilege. At most, grant only the minimum permissions required to perform the task. For more information, see [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege).
+* This code is not tested in every AWS Region. For more information, see [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+
+<!--custom.important.start-->
+<!--custom.important.end-->
+
+## Code examples
+
+### Prerequisites
+
+For prerequisites, see the [README](../../../../../../../../../README.md#Prerequisites) in the `javav2` folder.
+
+
+<!--custom.prerequisites.start-->
+<!--custom.prerequisites.end-->
+
+### Get started
+
+- [Hello 'Amazon S3 Control'](HelloS3Batch.java#L5) (`ListJobs`)
+
+
+### Basics
+
+Code examples that show you how to perform the essential operations within a service.
+
+- [Learn the basics](S3BatchScenario.java)
+
+
+### Single actions
+
+Code excerpts that show you how to call individual service functions.
+
+- [CreateJob](S3BatchActions.java#L314)
+- [DeleteJobTagging](S3BatchActions.java#L238)
+- [DescribeJob](S3BatchActions.java#L263)
+- [GetJobTagging](S3BatchActions.java#L204)
+- [PutJobTagging](S3BatchActions.java#L434)
+- [UpdateJobPriority](S3BatchActions.java#L173)
+- [UpdateJobStatus](S3BatchActions.java#L146)
+
+
+<!--custom.examples.start-->
+<!--custom.examples.end-->
+
+## Run the examples
+
+### Instructions
+
+
+<!--custom.instructions.start-->
+<!--custom.instructions.end-->
+
+#### Hello 'Amazon S3 Control'
+
+This example shows you how to get started using 'Amazon S3 Control'
+
+
+#### Learn the basics
+
+This example shows you how to learn core operations for'Amazon S3 Control'.
+
+
+<!--custom.basic_prereqs.s3-control_Basics.start-->
+<!--custom.basic_prereqs.s3-control_Basics.end-->
+
+
+<!--custom.basics.s3-control_Basics.start-->
+<!--custom.basics.s3-control_Basics.end-->
+
+
+### Tests
+
+⚠ Running tests might result in charges to your AWS account.
+
+
+To find instructions for running these tests, see the [README](../../../../../../../../../README.md#Tests)
+in the `javav2` folder.
+
+
+
+<!--custom.tests.start-->
+<!--custom.tests.end-->
+
+## Additional resources
+
+- [Amazon S3 Control User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
+- [Amazon S3 Control API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html)
+- [SDK for Java 2.x Amazon S3 Control reference](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3-control/package-summary.html)
+
+<!--custom.resources.start-->
+<!--custom.resources.end-->
+
+---
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0

--- a/javav2/example_code/s3/src/main/java/com/example/s3/batch/README.md
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/batch/README.md
@@ -7,7 +7,7 @@ Shows how to use the AWS SDK for Java 2.x to work with Amazon S3 Control.
 <!--custom.overview.start-->
 <!--custom.overview.end-->
 
-_Amazon S3 Control _
+_Amazon S3 Control lets you manage S3 resources._
 
 ## ⚠ Important
 


### PR DESCRIPTION
This PR fixes some issues with S3 Control example metadata that were causing broken links:

* Update to latest tools release [2024.44.0](https://github.com/awsdocs/aws-doc-sdk-examples-tools/releases/tag/2024.44.0) to get updates services.yaml.
* Update S3 control metadata to point to the right places in the Java examples.
* Generate README for S3 Control.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
