### PR TITLE
Remove stray spaces in snippet tags

### DIFF
--- a/swift/example_code/identity-resolvers/sso-resolver/Sources/entry.swift
+++ b/swift/example_code/identity-resolvers/sso-resolver/Sources/entry.swift
@@ -35,13 +35,13 @@ struct ExampleCommand: ParsableCommand {
     /// example.
     func runAsync() async throws {
         do {
-            // snippet-start: [swift.identity.sso.create-resolver]
+            // snippet-start:[swift.identity.sso.create-resolver]
             let identityResolver = try SSOAWSCredentialIdentityResolver(
                 profileName: profile,
                 configFilePath: config,
                 credentialsFilePath: credentials
             )
-            // snippet-end: [swift.identity.sso.create-resolver]
+            // snippet-end:[swift.identity.sso.create-resolver]
 
             // Call the function that fetches the Amazon S3 bucket names, then
             // output the names.


### PR DESCRIPTION
The snippet tags for `swift.identity.sso.create-resolver` had a space after the colon. This may explain why this snippet is missing.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
