### PR TITLE
Swift AssumeRole: Add region command line option

### DIFF
--- a/swift/example_code/sts/AssumeRole/Sources/AssumeRoleExampleError.swift
+++ b/swift/example_code/sts/AssumeRole/Sources/AssumeRoleExampleError.swift
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// An `Error` type used to return errors from the
+/// `assumeRole(identityResolver: roleArn:)` function.
+enum AssumeRoleExampleError: Error {
+    /// An error indicating that the STS `AssumeRole` request failed.
+    case assumeRoleFailed
+    /// An error indicating that the returned credentials were missing
+    /// required information.
+    case incompleteCredentials
+    /// An error indicating that no credentials were returned by `AssumeRole`.
+    case missingCredentials
+
+    /// Return a human-readable explanation of the error.
+    var errorDescription: String? {
+        switch self {
+        case .assumeRoleFailed:
+            return "Unable to assume the specified role."
+        case .incompleteCredentials:
+            return "AWS STS returned incomplete credentials."
+        case .missingCredentials:
+            return "AWS STS did not return any credentials for the specified role."
+        }
+    }
+}


### PR DESCRIPTION
Add a command line option to specify a Region. Default is us-east-1. This change is being made because it's [been reported](https://github.com/awsdocs/aws-doc-sdk-examples/issues/6992) that this example errors if people don't have the region set in their environment. Since this example is intended not to rely on the environment, adding the option will resolve that issue.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
