### PR TITLE
Update Package.swift files

### DIFF
--- a/swift/example_code/swift-sdk/Waiters/Package.swift
+++ b/swift/example_code/swift-sdk/Waiters/Package.swift
@@ -9,6 +9,11 @@ import PackageDescription
 
 let package = Package(
     name: "Waiters",
+    // Let Xcode know the minimum Apple platforms supported.
+    platforms: [
+        .macOS(.v11),
+        .iOS(.v13)
+    ],
     dependencies: [
         // This project requires the AWS SDK for Swift.
         .package(

--- a/swift/example_code/swift-sdk/mocking/Package.swift
+++ b/swift/example_code/swift-sdk/mocking/Package.swift
@@ -9,6 +9,11 @@ import PackageDescription
 
 let package = Package(
     name: "mocking",
+    // Let Xcode know the minimum Apple platforms supported.
+    platforms: [
+        .macOS(.v11),
+        .iOS(.v13)
+    ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(

--- a/swift/modules/SwiftUtilities/Package.swift
+++ b/swift/modules/SwiftUtilities/Package.swift
@@ -7,6 +7,11 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftUtilities",
+    // Let Xcode know the minimum Apple platforms supported.
+    platforms: [
+        .macOS(.v11),
+        .iOS(.v13)
+    ],
     products: [
         // Products define the executables and libraries a package produces.
         // They also make their own executables and libraries visible to other


### PR DESCRIPTION
This commit updates `Package.swift` files that were missing the platform specification that indicates that the targets can be built for iOS and macOS. This was preventing the examples from working on these platforms.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
