### PR TITLE
Add another set of SoS tags to Swift example

### DIFF
--- a/swift/example_code/s3/presigned-urls/Sources/entry.swift
+++ b/swift/example_code/s3/presigned-urls/Sources/entry.swift
@@ -378,6 +378,7 @@ struct ExampleCommand: ParsableCommand {
 
         // Create a presigned URLRequest with the `GetObject` action.
         
+        // snippet-start:[swift.s3.presigned.getobject]
         let getInput = GetObjectInput(
             bucket: bucket,
             key: key
@@ -392,6 +393,7 @@ struct ExampleCommand: ParsableCommand {
         } catch {
             throw TransferError.signingError
         }
+        // snippet-end:[swift.s3.presigned.getobject]
 
         // Use the presigned request to fetch the file from Amazon S3 and
         // store it at the location given by the `destPath` parameter.


### PR DESCRIPTION
This pull request adds SoS tags for a bit of code I want to inline in docs. That's it.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
