### PR TITLE
Python: Add log group argument to CloudWatchQuery. Addresses #7022

### DIFF
--- a/python/example_code/cloudwatch-logs/README.md
+++ b/python/example_code/cloudwatch-logs/README.md
@@ -38,8 +38,8 @@ python -m pip install -r requirements.txt
 
 Code excerpts that show you how to call individual service functions.
 
-- [GetQueryResults](scenarios/large-query/cloudwatch_query.py#L200)
-- [StartQuery](scenarios/large-query/cloudwatch_query.py#L126)
+- [GetQueryResults](scenarios/large-query/cloudwatch_query.py#L204)
+- [StartQuery](scenarios/large-query/cloudwatch_query.py#L130)
 
 ### Scenarios
 

--- a/python/example_code/cloudwatch-logs/scenarios/large-query/README.md
+++ b/python/example_code/cloudwatch-logs/scenarios/large-query/README.md
@@ -33,6 +33,7 @@ Use the following steps to create the necessary resources in AWS CloudFormation 
 1. Run `aws cloudformation deploy --template-file stack.yaml --stack-name CloudWatchLargeQuery`
 1. Run `./make-log-files.sh`. This will output two timestamps for use in the following step.
 1. Run `export QUERY_START_DATE=<QUERY_START_DATE>`. Replace `<QUERY_START_DATE>` with the output from the previous step. Repeat this for `QUERY_END_DATE`.
+1. Optional: Run `export QUERY_LOG_GROUP=<QUERY_LOG_GROUP>`. Replace `<QUERY_LOG_GROUP>` with your preferred log group.
 1. Run `./put-log-events.sh`.
 1. Wait five minutes for logs to settle and to make sure you're not querying for logs that exist in the future.
 

--- a/python/example_code/cloudwatch-logs/scenarios/large-query/exec.py
+++ b/python/example_code/cloudwatch-logs/scenarios/large-query/exec.py
@@ -85,6 +85,7 @@ class CloudWatchLogsQueryRunner:
         start_date_iso8601,
         end_date_iso8601,
         log_group="/workflows/cloudwatch-logs/large-query",
+        query="fields @timestamp, @message | sort @timestamp asc"
     ):
         """
         Creates a CloudWatchQuery instance and executes the query with provided date range.
@@ -97,7 +98,8 @@ class CloudWatchLogsQueryRunner:
         :type log_group: str
         """
         cloudwatch_query = CloudWatchQuery(
-            [start_date_iso8601, end_date_iso8601],
+            log_group=log_group,
+            query_string=query
         )
         cloudwatch_query.query_logs((start_date_iso8601, end_date_iso8601))
         logging.info("Query executed successfully.")


### PR DESCRIPTION
The CloudWatchQuery class now accepts log_group and query_string as arguments.