### PR TITLE
Tools/meta: Add s3 only entity and udpate tools release to 2024.47.0

### DIFF
--- a/.doc_gen/cross-content/phrases-code-examples.ent
+++ b/.doc_gen/cross-content/phrases-code-examples.ent
@@ -162,3 +162,6 @@
 <!ENTITY CFJS10 'JavaScript runtime 1.0 for &CF; Functions'>
 <!ENTITY CFJS20long 'JavaScript runtime 2.0 for &CFlong; Functions'>
 <!ENTITY CFJS20 'JavaScript runtime 2.0 for &CF; Functions'>
+
+<!-- S3 only entity to account for super-short usage -->
+<!ENTITY S3only 'S3'>

--- a/.github/workflows/validate-doc-metadata.yml
+++ b/.github/workflows/validate-doc-metadata.yml
@@ -16,7 +16,7 @@ jobs:
       - name: checkout repo content
         uses: actions/checkout@v4
       - name: validate metadata
-        uses: awsdocs/aws-doc-sdk-examples-tools@2024.45.0
+        uses: awsdocs/aws-doc-sdk-examples-tools@2024.47.0
         with:
           doc_gen_only: "False"
           strict_titles: "True"


### PR DESCRIPTION
* Update tools release to https://github.com/awsdocs/aws-doc-sdk-examples-tools/releases/tag/2024.47.0 to pull in services.yaml that contains S3 directory bucket subservice.
* Add an `S3only` entity for use when we need it.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
