### PR TITLE
Normalize adding (and allowing missing) trailing newlines for READMEs.

### DIFF
--- a/.tools/readmes/render.py
+++ b/.tools/readmes/render.py
@@ -304,6 +304,7 @@ class Renderer:
             customs=customs,
             unsupported=unsupported,
         )
+        self.readme_text += "\n" # Jinja is the worst and strips trailing new lines
         [text, errors] = expand_all_entities(self.readme_text, self.scanner.doc_gen.entities)
         if errors:
             raise errors

--- a/.tools/readmes/runner.py
+++ b/.tools/readmes/runner.py
@@ -173,6 +173,12 @@ def main():
 
 def make_diff(renderer, id):
     current = renderer.read_current().split("\n")
+    if current[-1] != "":
+        # Ensure final "last" line
+        current += [""]
     expected = renderer.readme_text.split("\n")
+    if expected[-1] != "":
+        # Ensure final "last" line
+        expected += [""]
     diff = unified_diff(current, expected, f"{id}/current", f"{id}/expected")
     return "\n".join(diff)


### PR DESCRIPTION


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
