### PR TITLE
Rust: Bump ephemeral storage to 60GiB  in weathertop.

### DIFF
--- a/.tools/test/stacks/config/targets.yaml
+++ b/.tools/test/stacks/config/targets.yaml
@@ -30,7 +30,7 @@ ruby:
 rustv1:
   account_id: "050288538048"
   status: "enabled"
-  storage: "30"
+  storage: 60
 sapabap:
   account_id: "099736152523"
   status: "enabled"

--- a/.tools/test/stacks/plugin/typescript/plugin_stack.ts
+++ b/.tools/test/stacks/plugin/typescript/plugin_stack.ts
@@ -141,7 +141,7 @@ class PluginStack extends cdk.Stack {
           },
         ],
         ephemeralStorage: {
-          sizeInGib: this.batchStorage,
+          sizeInGiB: this.batchStorage,
         },
         environment: variableConfigJson,
       },


### PR DESCRIPTION


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
