### PR TITLE
Adjust snippet for Swift multipart upload sample

### DIFF
--- a/swift/example_code/s3/presigned-urls/Sources/presigned-upload/entry.swift
+++ b/swift/example_code/s3/presigned-urls/Sources/presigned-upload/entry.swift
@@ -171,7 +171,6 @@ struct ExampleCommand: ParsableCommand {
         } catch {
             throw TransferError.signingError
         }
-        // snippet-end:[swift.s3.presigned.presign-PutObject-advanced]
 
         // Send the HTTP request and upload the file to Amazon S3.
 
@@ -180,6 +179,7 @@ struct ExampleCommand: ParsableCommand {
         request.body = .bytes(fileData)
 
         _ = try await HTTPClient.shared.execute(request, timeout: .seconds(5*60))
+        // snippet-end:[swift.s3.presigned.presign-PutObject-advanced]
 
         print("Uploaded (presigned) \(sourcePath) to \(bucket)/\(fileName).")
     }


### PR DESCRIPTION
This pull request just moves the end tag for a snippet a few lines down to include the code that handles sending the presigned request to S3. That's it.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
