### PR TITLE
JavaScript: Cognito - Add type annotation on authService.ts

### DIFF
--- a/javascriptv3/example_code/cognito-identity-provider/scenarios/cognito-developer-guide-react-example/frontend-client/src/authService.ts
+++ b/javascriptv3/example_code/cognito-identity-provider/scenarios/cognito-developer-guide-react-example/frontend-client/src/authService.ts
@@ -6,6 +6,9 @@ import {
   InitiateAuthCommand,
   SignUpCommand,
   ConfirmSignUpCommand,
+  type InitiateAuthCommandInput,
+  type SignUpCommandInput,
+  type ConfirmSignUpCommandInput,
 } from "@aws-sdk/client-cognito-identity-provider";
 import config from "./config.json";
 
@@ -14,7 +17,7 @@ export const cognitoClient = new CognitoIdentityProviderClient({
 });
 
 export const signIn = async (username: string, password: string) => {
-  const params = {
+  const params: InitiateAuthCommandInput = {
     AuthFlow: "USER_PASSWORD_AUTH",
     ClientId: config.clientId,
     AuthParameters: {
@@ -44,7 +47,7 @@ export const signIn = async (username: string, password: string) => {
 };
 
 export const signUp = async (email: string, password: string) => {
-  const params = {
+  const params: SignUpCommandInput = {
     ClientId: config.clientId,
     Username: email,
     Password: password,
@@ -67,7 +70,7 @@ export const signUp = async (email: string, password: string) => {
 };
 
 export const confirmSignUp = async (username: string, code: string) => {
-  const params = {
+  const params: ConfirmSignUpCommandInput = {
     ClientId: config.clientId,
     Username: username,
     ConfirmationCode: code,


### PR DESCRIPTION
When running `npm run build` on the project, the build fails due to the following error:
```
src/authService.ts:26:45 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(input: InitiateAuthCommandInput): InitiateAuthCommand', gave the following error.
    Argument of type '{ AuthFlow: string; ClientId: string; AuthParameters: { USERNAME: string; PASSWORD: string; }; }' is not assignable to parameter of type 'InitiateAuthCommandInput'.
      Types of property 'AuthFlow' are incompatible.
        Type 'string' is not assignable to type 'AuthFlowType'.
  Overload 2 of 2, '(__0_0: InitiateAuthCommandInput): InitiateAuthCommand', gave the following error.
    Argument of type '{ AuthFlow: string; ClientId: string; AuthParameters: { USERNAME: string; PASSWORD: string; }; }' is not assignable to parameter of type 'InitiateAuthCommandInput'.
      Types of property 'AuthFlow' are incompatible.
        Type 'string' is not assignable to type 'AuthFlowType'.

26     const command = new InitiateAuthCommand(params);
```

By adding type annotations, TypeScript does not complain on the line. Added annotations on every other API call as well for consistency. 