### PR TITLE
Add new Swift example showing streamed binary data

### DIFF
--- a/swift/example_code/s3/binary-streaming/Package.swift
+++ b/swift/example_code/s3/binary-streaming/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version: 5.9
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// The swift-tools-version declares the minimum version of Swift required to
+// build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "streamup",
+    // Let Xcode know the minimum Apple platforms supported.
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v15)
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(
+            url: "https://github.com/awslabs/aws-sdk-swift",
+            from: "1.0.0"),
+        .package(
+            url: "https://github.com/apple/swift-argument-parser.git",
+            branch: "main"
+        )
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products
+        // from dependencies.
+        .executableTarget(
+            name: "streamup",
+            dependencies: [
+                .product(name: "AWSS3", package: "aws-sdk-swift"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Sources"),
+    ]
+)

--- a/swift/example_code/s3/binary-streaming/Sources/TransferError.swift
+++ b/swift/example_code/s3/binary-streaming/Sources/TransferError.swift
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Errors thrown by the example's functions.
+enum TransferError: Error {
+    /// The destination directory for a download is missing or inaccessible.
+    case directoryError
+    /// An error occurred while downloading a file from Amazon S3.
+    case downloadError(_ message: String = "")
+    /// An error occurred moving the file to its final destination.
+    case fileMoveError
+    /// An error occurred while reading the file's contents.
+    case readError
+    /// An error occurred while uploading a file to Amazon S3.
+    case uploadError(_ message: String = "")
+    /// An error occurred while writing the file's contents.
+    case writeError
+
+    var errorDescription: String? {
+        switch self {
+        case .directoryError:
+            return "The destination directory could not be located or created"
+        case .downloadError(message: let message):
+            return "An error occurred attempting to download the file: \(message)"
+        case .fileMoveError:
+            return "The file couldn't be moved to the destination directory"
+        case .readError:
+            return "An error occurred while reading the file data"
+        case .uploadError(message: let message):
+            return "An error occurred attempting to upload the file: \(message)"
+        case .writeError:
+            return "An error occurred while writing the file data"
+        }
+    }
+}

--- a/swift/example_code/s3/binary-streaming/Sources/entry.swift
+++ b/swift/example_code/s3/binary-streaming/Sources/entry.swift
@@ -13,11 +13,6 @@ import Smithy
 import SmithyHTTPAPI
 import SmithyStreams
 
-// Include FoundationNetworking on non-Apple platforms.
-
-#if canImport(FoundationNetworking)
-import FoundationNetworking
-#endif
 // snippet-end:[swift.s3.binary-streaming.imports]
 
 // -MARK: - Async command line tool

--- a/swift/example_code/s3/binary-streaming/Sources/entry.swift
+++ b/swift/example_code/s3/binary-streaming/Sources/entry.swift
@@ -1,0 +1,126 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+/// A simple example that shows how to use the AWS SDK for Swift to
+/// upload files using binary streaming.
+
+// snippet-start:[swift.s3.binary-streaming.imports]
+import ArgumentParser
+import AWSClientRuntime
+import AWSS3
+import Foundation
+import Smithy
+import SmithyHTTPAPI
+import SmithyStreams
+
+// Include FoundationNetworking on non-Apple platforms.
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+// snippet-end:[swift.s3.binary-streaming.imports]
+
+// -MARK: - Async command line tool
+
+struct ExampleCommand: ParsableCommand {
+    // -MARK: Command arguments
+    @Option(help: "Local file path of file to upload")
+    var source: String
+    @Option(help: "Name of the key to upload the data to")
+    var key: String?
+    @Option(help: "Name of the Amazon S3 bucket to upload to")
+    var bucket: String
+    @Option(help: "Name of the Amazon S3 Region to use (default: us-east-1)")
+    var region = "us-east-1"
+
+    static var configuration = CommandConfiguration(
+        commandName: "streamup",
+        abstract: """
+        This example shows how to use binary data streaming to upload a file
+        to Amazon S3.
+        """,
+        discussion: """
+        """
+    )
+
+    // snippet-start:[swift.s3.binary-streaming.upload-file]
+    /// Upload a file to the specified bucket.
+    ///
+    /// - Parameters:
+    ///   - bucket: The Amazon S3 bucket name to store the file into.
+    ///   - key: The name (or path) of the file to upload to in the `bucket`.
+    ///   - sourcePath: The pathname on the local filesystem at which to store
+    ///     the uploaded file.
+    func uploadFile(sourcePath: String, bucket: String, key: String?) async throws {
+        let fileURL: URL = URL(fileURLWithPath: sourcePath)
+        let fileName: String
+
+        // If no key was provided, use the last component of the filename.
+        
+        if key == nil {
+            fileName = fileURL.lastPathComponent
+        } else {
+            fileName = key!
+        }
+                
+        let s3Client = try await S3Client()
+
+        // Create a FileHandle for the source file.
+
+        let fileHandle = FileHandle(forReadingAtPath: sourcePath)
+        guard let fileHandle = fileHandle else {
+            throw TransferError.readError
+        }
+
+        // Create a byte stream to retrieve the file's contents. This uses the
+        // Smithy FileStream and ByteStream types.
+
+        let stream = FileStream(fileHandle: fileHandle)
+        let body = ByteStream.stream(stream)
+
+        // Create a `PutObjectInput` with the ByteStream as the body of the
+        // request's data. The AWS SDK for Swift will handle sending the
+        // entire file in chunks, regardless of its size.
+        
+        let putInput = PutObjectInput(
+            body: body,
+            bucket: bucket,
+            key: fileName
+        )
+
+        do {
+            _ = try await s3Client.putObject(input: putInput)
+        } catch {
+            throw TransferError.uploadError("Error uploading the file: \(error)")
+        }
+
+        print("File uploaded to \(fileURL.path).")
+    }
+    // snippet-end:[swift.s3.binary-streaming.upload-file]
+
+    // -MARK: - Asynchronous main code
+    
+    /// Called by ``main()`` to run the bulk of the example.
+    func runAsync() async throws {
+        try await uploadFile(sourcePath: source, bucket: bucket, key: key)
+    }
+}
+
+// -MARK: - Entry point
+
+/// The program's asynchronous entry point.
+@main
+struct Main {
+    static func main() async {
+        let args = Array(CommandLine.arguments.dropFirst())
+
+        do {
+            let command = try ExampleCommand.parse(args)
+            try await command.runAsync()
+        } catch let error as TransferError {
+            print("ERROR: \(error.errorDescription ?? "Unknown error")")
+        } catch {
+            ExampleCommand.exit(withError: error)
+        }
+    }    
+}

--- a/swift/example_code/s3/binary-streaming/test.sh
+++ b/swift/example_code/s3/binary-streaming/test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# A script that is run by `swiftbuild.py` instead of using `swiftc test` to
+# test this example, which does not have a standard Swift test available.
+#
+# A swiftbuild test script returns 0 on success, any other integer on fail.
+
+# There are no tests for this example, so always pass.
+exit 0


### PR DESCRIPTION
This pull request adds a new Swift example showing how to upload data using streaming. It's similar to other examples but written with describing this topic at front-of-mind.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
