### PR TITLE
Java: Restore content accidentally removed in overzealous validation cleanup.

### DIFF
--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -2744,7 +2744,7 @@ s3_Scenario_PresignedUrl:
           sdkguide:
           excerpts:
             - description: >-
-                <para>The following shows three example of how to create presigned URLs and use the URLs with
+                The following shows three example of how to create presigned URLs and use the URLs with
                   HTTP client libraries:</para>
                 <itemizedlist>
                   <listitem>
@@ -2760,8 +2760,7 @@ s3_Scenario_PresignedUrl:
                   </listitem>
                 </itemizedlist>
                 <para>
-                  <emphasis role="bold">Generate a pre-signed URL for an object, then download it (GET request).</emphasis>
-                </para>
+                  Generate a pre-signed URL for an object, then download it (GET request).
             - description: Imports.
               snippet_tags:
                 - presigned.java2.generatepresignedgeturlandretrieve.import

--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -2743,7 +2743,25 @@ s3_Scenario_PresignedUrl:
           github: javav2/example_code/s3
           sdkguide:
           excerpts:
-            - description: Generate a pre-signed URL for an object, then download it (GET request).
+            - description: >-
+                <para>The following shows three example of how to create presigned URLs and use the URLs with
+                  HTTP client libraries:</para>
+                <itemizedlist>
+                  <listitem>
+                    <para>An HTTP GET request that uses the URL with three HTTP client libraries</para>
+                  </listitem>
+                  <listitem>
+                    <para>An HTTP PUT request with metadata in headers that uses the URL with three HTTP client
+                      libraries</para>
+                  </listitem>
+                  <listitem>
+                    <para>An HTTP PUT request with query parameters that uses the URL with one HTTP client
+                      library</para>
+                  </listitem>
+                </itemizedlist>
+                <para>
+                  <emphasis role="bold">Generate a pre-signed URL for an object, then download it (GET request).</emphasis>
+                </para>
             - description: Imports.
               snippet_tags:
                 - presigned.java2.generatepresignedgeturlandretrieve.import


### PR DESCRIPTION
While restoring the yamale validator and cleaning up invalid content, this content was accidentally removed.
This PR restores it!

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
