### PR TITLE
Swift: Rename duplicate snippet tag in Swift list buckets example.

### DIFF
--- a/swift/example_code/s3/ListBuckets-Simple/Sources/entry.swift
+++ b/swift/example_code/s3/ListBuckets-Simple/Sources/entry.swift
@@ -26,13 +26,13 @@ func getBucketNames() async throws -> [String] {
         let client = S3Client(config: configuration)
         // snippet-end:[s3.swift.intro.client-init]
 
-        // snippet-start:[s3.swift.intro.listbuckets]
+        // snippet-start:[s3.swift.intro.listbuckets_getnames]
         // Use "Paginated" to get all the buckets.
         // This lets the SDK handle the 'continuationToken' in "ListBucketsOutput".
         let pages = client.listBucketsPaginated(
             input: ListBucketsInput( maxBuckets: 10)
         )
-        // snippet-end:[s3.swift.intro.listbuckets]
+        // snippet-end:[s3.swift.intro.listbuckets_getnames]
 
         // Get the bucket names.
         var bucketNames: [String] = []


### PR DESCRIPTION
There are currently two snippets named `s3.swift.intro.listbuckets`.
This PR renames one of them to a different name to avoid a naming collision.
When two snippets exist with the same tag, the build output semi-randomly switches between them, causing commit churn.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
