### PR TITLE
Added a Transcribe streaming example for Swift

### DIFF
--- a/swift/example_code/transcribe/transcribe-events/Package.swift
+++ b/swift/example_code/transcribe/transcribe-events/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version: 5.9
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// The swift-tools-version declares the minimum version of Swift required to
+// build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "tsevents",
+    // Let Xcode know the minimum Apple platforms supported.
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v15)
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(
+            url: "https://github.com/awslabs/aws-sdk-swift",
+            from: "1.0.0"),
+        .package(
+            url: "https://github.com/apple/swift-argument-parser.git",
+            branch: "main"
+        )
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products
+        // from dependencies.
+        .executableTarget(
+            name: "tsevents",
+            dependencies: [
+                .product(name: "AWSTranscribeStreaming", package: "aws-sdk-swift"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Sources"),
+    ]
+)

--- a/swift/example_code/transcribe/transcribe-events/Sources/TranscribeError.swift
+++ b/swift/example_code/transcribe/transcribe-events/Sources/TranscribeError.swift
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Errors thrown by the example's functions.
+enum TranscribeError: Error {
+    /// No transcription stream available.
+    case noTranscriptionStream
+    /// The source media file couldn't be read.
+    case readError
+
+    var errorDescription: String? {
+        switch self {
+        case .noTranscriptionStream:
+            return "No transcription stream returned by Amazon Transcribe."
+        case .readError:
+            return "Unable to read the source audio file."
+        }
+    }
+}

--- a/swift/example_code/transcribe/transcribe-events/Sources/entry.swift
+++ b/swift/example_code/transcribe/transcribe-events/Sources/entry.swift
@@ -99,7 +99,7 @@ struct ExampleCommand: ParsableCommand {
             }
         }
 
-        // Start the transcription running.
+        // Start the transcription running on the audio stream.
 
         let output = try await client.startStreamTranscription(
             input: StartStreamTranscriptionInput(
@@ -109,10 +109,6 @@ struct ExampleCommand: ParsableCommand {
                 mediaSampleRateHertz: sampleRate
             )
         )
-
-        // A variable to receive the complete text.
-
-        var text = ""
 
         // Iterate over the events in the transcript result stream. Each
         // `transcriptevent` contains a list of result fragments which need
@@ -125,20 +121,19 @@ struct ExampleCommand: ParsableCommand {
                     continue
                 }
 
+                // When the complete fragment of transcribed text is ready,
+                // print it. This could just as easily be used to draw the
+                // text as a subtitle over a playing video, though timing
+                // would need to be managed.
+
                 if !result.isPartial {
                     print(transcript)
-                    text.append(transcript + "\n")
                 }
             }
             default:
                 print("Error: Unexpected message from Amazon Transcribe:")
             }
         }
-
-        print("Transcription complete.")
-        print("-----------------------")
-        print(text)
-        print("-----------------------")
     }
 }
 

--- a/swift/example_code/transcribe/transcribe-events/Sources/entry.swift
+++ b/swift/example_code/transcribe/transcribe-events/Sources/entry.swift
@@ -1,0 +1,162 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+/// An example that demonstrates how to watch an transcribe event stream.
+
+// snippet-start:[swift.s3.binary-streaming.imports]
+import ArgumentParser
+import AWSClientRuntime
+import AWSTranscribeStreaming
+import Foundation
+import Smithy
+//import SmithyHTTPAPI
+import SmithyStreams
+
+// snippet-end:[swift.s3.binary-streaming.imports]
+
+// -MARK: - Async command line tool
+
+struct ExampleCommand: ParsableCommand {
+    enum MediaFormat: String, ExpressibleByArgument {
+        case ogg = "ogg"
+        case pcm = "pcm"
+        case flac = "flac"
+    }
+
+    // -MARK: Command arguments
+    @Option(help: "Language code to transcribe into")
+    var lang: String = "en-US"
+    @Option(help: "Format of the source audio file")
+    var format: MediaFormat
+    @Option(help: "Sample rate of the source audio file in Hertz")
+    var sampleRate: Int = 16000
+    @Option(help: "Path of the source audio file")
+    var path: String
+    @Option(help: "Name of the Amazon S3 Region to use (default: us-east-1)")
+    var region = "us-east-1"
+
+    static var configuration = CommandConfiguration(
+        commandName: "tsevents",
+        abstract: """
+        This example shows how to use event streaming with Amazon Transcribe.
+        """,
+        discussion: """
+        """
+    )
+
+    func transcribe() async throws {
+        let config = try await TranscribeStreamingClient.TranscribeStreamingClientConfiguration(
+            region: region
+        )
+        let client = TranscribeStreamingClient(config: config)
+
+        let mediaEncoding: TranscribeStreamingClientTypes.MediaEncoding
+        switch format {
+        case .flac:
+            mediaEncoding = .flac
+        case .ogg:
+            mediaEncoding = .oggOpus
+        case .pcm:
+            mediaEncoding = .pcm
+        }
+
+        // Create the source audio stream.
+
+        let fileURL: URL = URL(fileURLWithPath: path)
+        let audioData = try Data(contentsOf: fileURL)
+
+        print("Processing file...")
+
+        // Properties defining the size of audio chunks and the total size of
+        // the audio file in bytes.
+
+        let chunkSize = 16384
+        let audioDataSize = audioData.count
+
+        // Create an audio stream from the source data. The stream's job is
+        // to send the audio in chunks to Amazon Transcribe as
+        // `AudioStream.audioevent` events.
+
+        let audioStream = AsyncThrowingStream<TranscribeStreamingClientTypes.AudioStream,
+                                Error> { continuation in
+            Task {
+                var currentStart = 0
+                var currentEnd = min(chunkSize, audioDataSize - currentStart)
+
+                while currentStart < audioDataSize {
+                    let dataChunk = audioData[currentStart ..< currentEnd]
+                    
+                    let audioEvent = TranscribeStreamingClientTypes.AudioStream.audioevent(
+                        .init(audioChunk: dataChunk)
+                    )
+                    continuation.yield(audioEvent)
+
+                    currentStart = currentEnd
+                    currentEnd = min(currentStart + chunkSize, audioDataSize)
+                }
+
+                continuation.finish()
+            }
+        }
+
+        // Start the transcription running.
+
+        let output = try await client.startStreamTranscription(
+            input: StartStreamTranscriptionInput(
+                audioStream: audioStream,
+                languageCode: TranscribeStreamingClientTypes.LanguageCode(rawValue: lang),
+                mediaEncoding: mediaEncoding,
+                mediaSampleRateHertz: sampleRate
+            )
+        )
+
+        // A variable to receive the complete text.
+
+        var text = ""
+
+        // Iterate over the events in the transcript result stream. Each
+        // `transcriptevent` contains a list of result fragments which need
+        // to be concatenated together to build the final transcript.
+        for try await event in output.transcriptResultStream! {
+            switch event {
+            case .transcriptevent(let event):
+            for result in event.transcript?.results ?? [] {
+                guard let transcript = result.alternatives?.first?.transcript else {
+                    continue
+                }
+
+                if !result.isPartial {
+                    print(transcript)
+                    text.append(transcript + "\n")
+                }
+            }
+            default:
+                print("Error: Unexpected message from Amazon Transcribe:")
+            }
+        }
+
+        print("Transcription complete.")
+        print("-----------------------")
+        print(text)
+        print("-----------------------")
+    }
+}
+
+// -MARK: - Entry point
+
+/// The program's asynchronous entry point.
+@main
+struct Main {
+    static func main() async {
+        let args = Array(CommandLine.arguments.dropFirst())
+
+        do {
+            let command = try ExampleCommand.parse(args)
+            try await command.transcribe()
+        } catch let error as TranscribeError {
+            print("ERROR: \(error.errorDescription ?? "Unknown error")")
+        } catch {
+            ExampleCommand.exit(withError: error)
+        }
+    }    
+}


### PR DESCRIPTION
This PR adds a Swift SDK example showing how to use Transcribe streaming, and how to use event streaming, in one fairly simple example program. Requires a spoken audio file in PCM, FLAC, or Ogg format (though I've had poor luck with Ogg in Transcribe, personally).

Not quite ready for merging yet.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
