### PR TITLE
Bump to rust 1.83.0

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
-          toolchain: "1.81.0"
+          toolchain: "1.83.0"
           components: clippy, rustfmt
       - name: Set Environment
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/rustv1/cross_service/photo_asset_management/src/chunked_uploader.rs
+++ b/rustv1/cross_service/photo_asset_management/src/chunked_uploader.rs
@@ -1,13 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::io::Read;
-
 use anyhow::anyhow;
 use aws_sdk_dynamodb::primitives::DateTime;
 use aws_sdk_s3::{operation::get_object::GetObjectOutput, types::CompletedPart};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use chrono::NaiveDateTime;
 use pipe::{pipe, PipeReader, PipeWriter};
+use std::io::Read;
 use streaming_zip::{Archive, CompressionMode};
 use uuid::Uuid;
 
@@ -37,7 +36,7 @@ pub struct ZipUpload<'a> {
     s3_client: &'a aws_sdk_s3::Client,
 }
 
-impl<'a> std::fmt::Debug for ZipUpload<'a> {
+impl std::fmt::Debug for ZipUpload<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ZipUpload")
             .field("key", &self.key)
@@ -117,9 +116,9 @@ impl<'a> ZipUploadBuilder<'a> {
     }
 }
 
-impl<'a> ZipUpload<'a> {
+impl ZipUpload<'_> {
     // Start a builder for the ZipUpload.
-    pub fn builder(common: &'a Common) -> ZipUploadBuilder {
+    pub fn builder(common: &Common) -> ZipUploadBuilder {
         ZipUploadBuilder {
             key: None,
             bucket: None,

--- a/rustv1/cross_service/rest_ses/src/client.rs
+++ b/rustv1/cross_service/rest_ses/src/client.rs
@@ -96,7 +96,7 @@ impl AsRef<str> for Email {
     }
 }
 
-impl<'a> From<Email> for Address<'a> {
+impl From<Email> for Address<'_> {
     fn from(email: Email) -> Self {
         email.0.into()
     }

--- a/rustv1/cross_service/rest_ses/src/work_item/work_item_archived.rs
+++ b/rustv1/cross_service/rest_ses/src/work_item/work_item_archived.rs
@@ -104,7 +104,7 @@ impl<'de> Deserialize<'de> for WorkItemArchived {
         /// The RDS table encodes status as 1 and 0.
         /// This serde visit handles those disparate cases, using the try_from impls.
         struct Visitor;
-        impl<'de> de::Visitor<'de> for Visitor {
+        impl de::Visitor<'_> for Visitor {
             type Value = WorkItemArchived;
 
             fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>

--- a/rustv1/cross_service/rust-toolchain.toml
+++ b/rustv1/cross_service/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # This should be kept in sync with https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv
 [toolchain]
-channel = "1.81.0"
+channel = "1.83.0"

--- a/rustv1/examples/bedrock-runtime/src/bin/tool-use.rs
+++ b/rustv1/examples/bedrock-runtime/src/bin/tool-use.rs
@@ -1,6 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! This demo illustrates a tool use scenario using Amazon Bedrock's Converse API and a weather tool.
+//! The script interacts with a foundation model on Amazon Bedrock to provide weather information based on user
+//! input. It uses the Open-Meteo API (https://open-meteo.com) to retrieve current weather data for a given location.
+
 // snippet-start:[rust.bedrock-runtime.Converse_AnthropicClaude.tool-use.supporting]
 use std::{collections::HashMap, io::stdin};
 
@@ -18,10 +22,6 @@ use aws_sdk_bedrockruntime::{
 use aws_smithy_runtime_api::http::Response;
 use aws_smithy_types::Document;
 use tracing::debug;
-
-/// This demo illustrates a tool use scenario using Amazon Bedrock's Converse API and a weather tool.
-/// The script interacts with a foundation model on Amazon Bedrock to provide weather information based on user
-/// input. It uses the Open-Meteo API (https://open-meteo.com) to retrieve current weather data for a given location.
 
 // Set the model ID, e.g., Claude 3 Haiku.
 const MODEL_ID: &str = "anthropic.claude-3-haiku-20240307-v1:0";

--- a/rustv1/examples/rust-toolchain.toml
+++ b/rustv1/examples/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # This should be kept in sync with https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv
 [toolchain]
-channel = "1.81.0"
+channel = "1.83.0"

--- a/rustv1/examples/s3/src/bin/select-object-content.rs
+++ b/rustv1/examples/s3/src/bin/select-object-content.rs
@@ -25,7 +25,7 @@ struct Opt {
     bucket: String,
 
     /// The object key to scan. This example expects the object to be an uncompressed CSV file with:
-
+    ///
     /// Name,PhoneNumber,City,Occupation
     /// Person1,(nnn) nnn-nnnn,City1,Occupation1,Comment
     /// ...


### PR DESCRIPTION
This pull request bumps the Rust toolchain to 1.83.0 and fixes clippy issues.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
