### PR TITLE
Rust 1.83 in dockerfile

### DIFF
--- a/rustv1/Dockerfile
+++ b/rustv1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG MSRV=1.80.1
+ARG MSRV=1.83.0
 FROM rust:$MSRV
 
 # Update image


### PR DESCRIPTION
This pull request bumps the rustv1 Dockerfile to also use Rust 1.83

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
