### PR TITLE
JavaScript (v3): Textract - Fix non-unique domain prefix in textract-react CFN template and some broke unit tests.

### DIFF
--- a/.github/workflows/lint-javascript.yml
+++ b/.github/workflows/lint-javascript.yml
@@ -26,7 +26,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-node@v3
         with:
-          node-version: "20.x"
+          node-version: "22.x"
       - name: Install dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
         run: npm i --prefix javascriptv3

--- a/javascriptv3/example_code/cross-services/textract-react/README.md
+++ b/javascriptv3/example_code/cross-services/textract-react/README.md
@@ -66,6 +66,8 @@ documents like medical records, financial reports, and tax forms.
 
         The stack is deployed when it reports a StackStatus of CREATE_COMPLETE.
 
+1.  Replace `<DOMAIN>` in in the `LoginUrl` value of `./src/Config.js` with the domain created for the Cognito user pool.
+
 1.  Add additional assets needed for the example by running the `AddRemoveAssets.js`
     script with the `add` option and pass the stack name you used in the previous step.
 

--- a/javascriptv3/example_code/cross-services/textract-react/README.md
+++ b/javascriptv3/example_code/cross-services/textract-react/README.md
@@ -66,8 +66,6 @@ documents like medical records, financial reports, and tax forms.
 
         The stack is deployed when it reports a StackStatus of CREATE_COMPLETE.
 
-1.  Replace `<DOMAIN>` in in the `LoginUrl` value of `./src/Config.js` with the domain created for the Cognito user pool.
-
 1.  Add additional assets needed for the example by running the `AddRemoveAssets.js`
     script with the `add` option and pass the stack name you used in the previous step.
 

--- a/javascriptv3/example_code/cross-services/textract-react/package.json
+++ b/javascriptv3/example_code/cross-services/textract-react/package.json
@@ -13,7 +13,7 @@
     "bootstrap": "^5.0.0-beta3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3",
+    "react-scripts": "5.0.0",
     "web-vitals": "^1.1.1"
   },
   "scripts": {
@@ -31,10 +31,13 @@
     ]
   },
   "devDependencies": {
-    "canvas": "^2.7.0",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
-    "@testing-library/user-event": "^12.8.3"
+    "@testing-library/user-event": "^12.8.3",
+    "canvas": "^3.0.1"
   },
-  "type": "module"
+  "type": "module",
+  "engines": {
+    "node": ">=22 <23"
+  }
 }

--- a/javascriptv3/example_code/cross-services/textract-react/setup.yaml
+++ b/javascriptv3/example_code/cross-services/textract-react/setup.yaml
@@ -201,7 +201,19 @@ Resources:
   textractcognitodemoidtextractcognitodemodomainEBB6899F:
     Type: AWS::Cognito::UserPoolDomain
     Properties:
-      Domain: textract-demo
+      Domain:
+        Fn::Join:
+          - '-'
+          - - textract-react
+            - Fn::Select:
+              - 4
+              - Fn::Split:
+                - '-'
+                - Fn::Select:
+                  - 2
+                  - Fn::Split:
+                    - /
+                    - Ref: AWS::StackId
       UserPoolId:
         Ref: textractcognitodemoidA350B90F
     Metadata:

--- a/javascriptv3/example_code/cross-services/textract-react/setup.yaml
+++ b/javascriptv3/example_code/cross-services/textract-react/setup.yaml
@@ -344,7 +344,9 @@ Outputs:
     Value:
       Fn::Join:
         - ""
-        - - https://textract-demo.auth.
+        - - https://
+          - Ref: textractcognitodemoidtextractcognitodemodomainEBB6899F
+          - .auth.
           - Ref: AWS::Region
           - .amazoncognito.com/login?client_id=
           - Ref: textractcognitodemoidtextractcognitodemoclientidB9ABA9D2

--- a/javascriptv3/example_code/cross-services/textract-react/src/App.js
+++ b/javascriptv3/example_code/cross-services/textract-react/src/App.js
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState, useEffect } from "react";
-import { ImageLoader } from "./ImageLoader";
-import { ImageDisplay } from "./ImageDisplay";
-import { ExtractButtons } from "./ExtractButtons";
-import { ExplorerCard } from "./ExplorerCard";
-import { LoginCard } from "./LoginCard";
+import { ImageLoader } from "./ImageLoader.js";
+import { ImageDisplay } from "./ImageDisplay.js";
+import { ExtractButtons } from "./ExtractButtons.js";
+import { ExplorerCard } from "./ExplorerCard.js";
+import { LoginCard } from "./LoginCard.js";
 
 /**
  * Main React application element. Includes panels for signing in, loading and

--- a/javascriptv3/example_code/cross-services/textract-react/src/Config.js
+++ b/javascriptv3/example_code/cross-services/textract-react/src/Config.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 export const Config = {
   ConfigError:
     "Demo resources not initialized. You must deploy AWS resources and demo elements before running this application. See the README for details.",

--- a/javascriptv3/example_code/cross-services/textract-react/src/Config.js
+++ b/javascriptv3/example_code/cross-services/textract-react/src/Config.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 export const Config = {
   StackName: "textract-react",
   DefaultImageName: "default_document_3.png",

--- a/javascriptv3/example_code/cross-services/textract-react/src/Config.js
+++ b/javascriptv3/example_code/cross-services/textract-react/src/Config.js
@@ -1,21 +1,4 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
 export const Config = {
-  StackName: "textract-react",
-  DefaultImageName: "default_document_3.png",
-  CognitoIdentityPoolId: "us-east-1:e831f5d1-3bb1-4c38-80a6-ac4a41094e16",
-  CognitoUserPoolId: "us-east-1_d0mAaaf9U",
-  DeployRegion: "us-east-1",
-  SNSTopicArn:
-    "arn:aws:sns:us-east-1:901487484989:textract-react-textractcognitodemotopicEEA53D4C-kScOieHI8JEs",
-  DefaultBucketName:
-    "textract-react-textractcognitodemobucket90cf6a3d-ido8j5smr8wg",
-  CognitoId: "cognito-idp.us-east-1.amazonaws.com/us-east-1_d0mAaaf9U",
-  LoginUrl:
-    "https://<DOMAIN>.auth.us-east-1.amazoncognito.com/login?client_id=4mnjju6vbc48jn4vtqgi7ug8d&response_type=token&scope=aws.cognito.signin.user.admin+email+openid+phone+profile&redirect_uri=http://localhost:3000",
-  RoleArn:
-    "arn:aws:iam::901487484989:role/textract-react-textractcognitodemotextractrole79875-Og6cWz9azWMs",
-  QueueUrl:
-    "https://sqs.us-east-1.amazonaws.com/901487484989/textract-react-textractcognitodemoqueue80660218-RrlFxsn3Hr4a",
+  ConfigError:
+    "Demo resources not initialized. You must deploy AWS resources and demo elements before running this application. See the README for details.",
 };

--- a/javascriptv3/example_code/cross-services/textract-react/src/Config.js
+++ b/javascriptv3/example_code/cross-services/textract-react/src/Config.js
@@ -1,6 +1,18 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 export const Config = {
-  ConfigError:
-    "Demo resources not initialized. You must deploy AWS resources and demo elements before running this application. See the README for details.",
+  StackName: "textract-react",
+  DefaultImageName: "default_document_3.png",
+  CognitoIdentityPoolId: "us-east-1:e831f5d1-3bb1-4c38-80a6-ac4a41094e16",
+  CognitoUserPoolId: "us-east-1_d0mAaaf9U",
+  DeployRegion: "us-east-1",
+  SNSTopicArn:
+    "arn:aws:sns:us-east-1:901487484989:textract-react-textractcognitodemotopicEEA53D4C-kScOieHI8JEs",
+  DefaultBucketName:
+    "textract-react-textractcognitodemobucket90cf6a3d-ido8j5smr8wg",
+  CognitoId: "cognito-idp.us-east-1.amazonaws.com/us-east-1_d0mAaaf9U",
+  LoginUrl:
+    "https://<DOMAIN>.auth.us-east-1.amazoncognito.com/login?client_id=4mnjju6vbc48jn4vtqgi7ug8d&response_type=token&scope=aws.cognito.signin.user.admin+email+openid+phone+profile&redirect_uri=http://localhost:3000",
+  RoleArn:
+    "arn:aws:iam::901487484989:role/textract-react-textractcognitodemotextractrole79875-Og6cWz9azWMs",
+  QueueUrl:
+    "https://sqs.us-east-1.amazonaws.com/901487484989/textract-react-textractcognitodemoqueue80660218-RrlFxsn3Hr4a",
 };

--- a/javascriptv3/example_code/cross-services/textract-react/src/ExplorerCard.js
+++ b/javascriptv3/example_code/cross-services/textract-react/src/ExplorerCard.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useRef } from "react";
-import { ExplorerTree } from "./ExplorerTree";
+import { ExplorerTree } from "./ExplorerTree.js";
 
 /**
  * Displays output from Amazon Textract as a hierarchical tree of checkboxes.

--- a/javascriptv3/example_code/cross-services/textract-react/src/ExplorerTree.js
+++ b/javascriptv3/example_code/cross-services/textract-react/src/ExplorerTree.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
-import { ColorMap, FilterMap } from "./Utils";
+import { ColorMap, FilterMap } from "./Utils.js";
 
 /**
  * An individual node that displays a block item from Amazon Textract as a checkbox.

--- a/javascriptv3/example_code/cross-services/textract-react/src/ImageDisplay.js
+++ b/javascriptv3/example_code/cross-services/textract-react/src/ImageDisplay.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useRef, useLayoutEffect } from "react";
-import { ColorMap } from "./Utils";
+import { ColorMap } from "./Utils.js";
 
 /**
  * Displays a PNG image formatted as a Base64 string and draws polygons on top of

--- a/javascriptv3/example_code/cross-services/textract-react/src/index.js
+++ b/javascriptv3/example_code/cross-services/textract-react/src/index.js
@@ -16,10 +16,10 @@
 import "bootstrap/dist/css/bootstrap.css";
 import React from "react";
 import ReactDOM from "react-dom";
-import { Config } from "./Config";
-import { awsFactory } from "./AwsFactory";
-import App from "./App";
-import TextractModel from "./TextractModel";
+import { Config } from "./Config.js";
+import { awsFactory } from "./AwsFactory.js";
+import App from "./App.js";
+import TextractModel from "./TextractModel.js";
 
 const params = new URLSearchParams(window.location.hash.slice(1));
 const idToken = params.get("id_token");

--- a/javascriptv3/example_code/s3/tests/copy-object.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/copy-object.unit.test.js
@@ -38,8 +38,8 @@ describe("copy-object", () => {
 
   it("should log a relevant error message if the object is in an archive tier", async () => {
     const error = new ObjectNotInActiveTierError();
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     send.mockRejectedValue(error);
 
     const spy = vi.spyOn(console, "error");

--- a/javascriptv3/example_code/s3/tests/copy-object.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/copy-object.unit.test.js
@@ -37,7 +37,10 @@ describe("copy-object", () => {
   });
 
   it("should log a relevant error message if the object is in an archive tier", async () => {
-    send.mockRejectedValue(new ObjectNotInActiveTierError());
+    const error = new ObjectNotInActiveTierError();
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    send.mockRejectedValue(error);
 
     const spy = vi.spyOn(console, "error");
 

--- a/javascriptv3/example_code/s3/tests/create-bucket.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/create-bucket.unit.test.js
@@ -34,8 +34,8 @@ describe("create-bucket", () => {
 
   it("should log a relevant error message if a bucket already exists globally", async () => {
     const error = new BucketAlreadyExists();
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     send.mockRejectedValue(error);
 
     const spy = vi.spyOn(console, "error");
@@ -49,8 +49,8 @@ describe("create-bucket", () => {
 
   it("should log a relevant error message if a bucket already exists in the users AWS account", async () => {
     const error = new BucketAlreadyOwnedByYou();
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     send.mockRejectedValue(error);
 
     const spy = vi.spyOn(console, "error");

--- a/javascriptv3/example_code/s3/tests/create-bucket.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/create-bucket.unit.test.js
@@ -34,6 +34,8 @@ describe("create-bucket", () => {
 
   it("should log a relevant error message if a bucket already exists globally", async () => {
     const error = new BucketAlreadyExists();
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     send.mockRejectedValue(error);
 
     const spy = vi.spyOn(console, "error");
@@ -47,6 +49,8 @@ describe("create-bucket", () => {
 
   it("should log a relevant error message if a bucket already exists in the users AWS account", async () => {
     const error = new BucketAlreadyOwnedByYou();
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     send.mockRejectedValue(error);
 
     const spy = vi.spyOn(console, "error");

--- a/javascriptv3/example_code/s3/tests/delete-bucket-policy.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/delete-bucket-policy.unit.test.js
@@ -33,8 +33,8 @@ describe("delete-bucket-policy", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -50,8 +50,8 @@ describe("delete-bucket-policy", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/delete-bucket-policy.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/delete-bucket-policy.unit.test.js
@@ -33,6 +33,8 @@ describe("delete-bucket-policy", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -48,6 +50,8 @@ describe("delete-bucket-policy", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/delete-bucket-website.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/delete-bucket-website.unit.test.js
@@ -21,8 +21,8 @@ const { main } = await import("../actions/delete-bucket-website.js");
 describe("delete-bucket-website", () => {
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -38,8 +38,8 @@ describe("delete-bucket-website", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/delete-bucket-website.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/delete-bucket-website.unit.test.js
@@ -21,6 +21,8 @@ const { main } = await import("../actions/delete-bucket-website.js");
 describe("delete-bucket-website", () => {
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -36,6 +38,8 @@ describe("delete-bucket-website", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/delete-bucket.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/delete-bucket.unit.test.js
@@ -31,6 +31,8 @@ describe("delete-bucket", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     send.mockRejectedValueOnce(error);
 
@@ -45,6 +47,8 @@ describe("delete-bucket", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     send.mockRejectedValueOnce(error);
 

--- a/javascriptv3/example_code/s3/tests/delete-bucket.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/delete-bucket.unit.test.js
@@ -31,8 +31,8 @@ describe("delete-bucket", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     send.mockRejectedValueOnce(error);
 
@@ -47,8 +47,8 @@ describe("delete-bucket", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     send.mockRejectedValueOnce(error);
 

--- a/javascriptv3/example_code/s3/tests/delete-object.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/delete-object.unit.test.js
@@ -34,8 +34,8 @@ describe("delete-object", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -51,8 +51,8 @@ describe("delete-object", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/delete-object.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/delete-object.unit.test.js
@@ -34,6 +34,8 @@ describe("delete-object", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -49,6 +51,8 @@ describe("delete-object", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/delete-objects.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/delete-objects.unit.test.js
@@ -36,6 +36,8 @@ describe("delete-objects", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -51,6 +53,8 @@ describe("delete-objects", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/delete-objects.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/delete-objects.unit.test.js
@@ -36,8 +36,8 @@ describe("delete-objects", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -53,8 +53,8 @@ describe("delete-objects", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/get-bucket-acl.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-bucket-acl.unit.test.js
@@ -36,6 +36,8 @@ describe("get-bucket-acl", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -51,6 +53,8 @@ describe("get-bucket-acl", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/get-bucket-acl.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-bucket-acl.unit.test.js
@@ -36,8 +36,8 @@ describe("get-bucket-acl", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -53,8 +53,8 @@ describe("get-bucket-acl", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/get-bucket-cors.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-bucket-cors.unit.test.js
@@ -49,8 +49,8 @@ describe("get-bucket-cors", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -66,8 +66,8 @@ describe("get-bucket-cors", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/get-bucket-cors.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-bucket-cors.unit.test.js
@@ -49,6 +49,8 @@ describe("get-bucket-cors", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -64,6 +66,8 @@ describe("get-bucket-cors", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/get-bucket-policy.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-bucket-policy.unit.test.js
@@ -33,8 +33,8 @@ describe("get-bucket-policy", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -50,8 +50,8 @@ describe("get-bucket-policy", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/get-bucket-policy.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-bucket-policy.unit.test.js
@@ -33,6 +33,8 @@ describe("get-bucket-policy", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -48,6 +50,8 @@ describe("get-bucket-policy", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/get-bucket-website.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-bucket-website.unit.test.js
@@ -38,6 +38,8 @@ describe("get-bucket-website", () => {
 
   it("should log a relevant error when the bucket isn't configured as a website.", async () => {
     const error = new S3ServiceException("Not such website configuration.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchWebsiteConfiguration";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -53,6 +55,8 @@ describe("get-bucket-website", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/get-bucket-website.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-bucket-website.unit.test.js
@@ -38,8 +38,8 @@ describe("get-bucket-website", () => {
 
   it("should log a relevant error when the bucket isn't configured as a website.", async () => {
     const error = new S3ServiceException("Not such website configuration.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchWebsiteConfiguration";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -55,8 +55,8 @@ describe("get-bucket-website", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/get-object-lock-configuration.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-object-lock-configuration.unit.test.js
@@ -33,8 +33,8 @@ describe("get-object-lock-configuration", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -50,8 +50,8 @@ describe("get-object-lock-configuration", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/get-object-lock-configuration.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-object-lock-configuration.unit.test.js
@@ -33,6 +33,8 @@ describe("get-object-lock-configuration", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -48,6 +50,8 @@ describe("get-object-lock-configuration", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/get-object.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-object.unit.test.js
@@ -39,8 +39,8 @@ describe("get-object", () => {
     const bucketName = "amzn-s3-demo-bucket";
     const key = "foo";
     const error = new NoSuchKey();
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     send.mockRejectedValueOnce(error);
 
     const spy = vi.spyOn(console, "error");
@@ -54,8 +54,8 @@ describe("get-object", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     const key = "foo";

--- a/javascriptv3/example_code/s3/tests/get-object.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/get-object.unit.test.js
@@ -38,7 +38,10 @@ describe("get-object", () => {
   it("should log a relevant error message when the object key doesn't exist in the bucket", async () => {
     const bucketName = "amzn-s3-demo-bucket";
     const key = "foo";
-    send.mockRejectedValueOnce(new NoSuchKey());
+    const error = new NoSuchKey();
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    send.mockRejectedValueOnce(error);
 
     const spy = vi.spyOn(console, "error");
 
@@ -51,6 +54,8 @@ describe("get-object", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     const key = "foo";

--- a/javascriptv3/example_code/s3/tests/list-buckets.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/list-buckets.unit.test.js
@@ -33,6 +33,8 @@ describe("list-buckets", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     paginateListBuckets.mockImplementationOnce(

--- a/javascriptv3/example_code/s3/tests/list-buckets.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/list-buckets.unit.test.js
@@ -33,8 +33,8 @@ describe("list-buckets", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     paginateListBuckets.mockImplementationOnce(

--- a/javascriptv3/example_code/s3/tests/list-objects.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/list-objects.unit.test.js
@@ -31,8 +31,8 @@ describe("list-objects", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -48,8 +48,8 @@ describe("list-objects", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/list-objects.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/list-objects.unit.test.js
@@ -31,6 +31,8 @@ describe("list-objects", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -46,6 +48,8 @@ describe("list-objects", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/put-bucket-acl.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/put-bucket-acl.unit.test.js
@@ -39,6 +39,8 @@ describe("put-bucket-acl", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     send.mockRejectedValueOnce(error);
 
@@ -59,6 +61,8 @@ describe("put-bucket-acl", () => {
     const error = new S3ServiceException({
       message: "Some S3 service exception",
     });
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     send.mockRejectedValueOnce(error);
 

--- a/javascriptv3/example_code/s3/tests/put-bucket-acl.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/put-bucket-acl.unit.test.js
@@ -39,8 +39,8 @@ describe("put-bucket-acl", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     send.mockRejectedValueOnce(error);
 
@@ -61,8 +61,8 @@ describe("put-bucket-acl", () => {
     const error = new S3ServiceException({
       message: "Some S3 service exception",
     });
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     send.mockRejectedValueOnce(error);
 

--- a/javascriptv3/example_code/s3/tests/put-bucket-cors.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/put-bucket-cors.unit.test.js
@@ -33,6 +33,8 @@ describe("put-bucket-cors", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -48,6 +50,8 @@ describe("put-bucket-cors", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/put-bucket-cors.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/put-bucket-cors.unit.test.js
@@ -33,8 +33,8 @@ describe("put-bucket-cors", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -50,8 +50,8 @@ describe("put-bucket-cors", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/put-bucket-policy.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/put-bucket-policy.unit.test.js
@@ -34,6 +34,8 @@ describe("put-bucket-policy", () => {
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
     error.name = "MalformedPolicy";
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
 
@@ -48,6 +50,8 @@ describe("put-bucket-policy", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/put-bucket-policy.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/put-bucket-policy.unit.test.js
@@ -34,8 +34,8 @@ describe("put-bucket-policy", () => {
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
     error.name = "MalformedPolicy";
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
 
@@ -50,8 +50,8 @@ describe("put-bucket-policy", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/put-bucket-website.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/put-bucket-website.unit.test.js
@@ -33,6 +33,8 @@ describe("put-bucket-website", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -48,6 +50,8 @@ describe("put-bucket-website", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/put-bucket-website.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/put-bucket-website.unit.test.js
@@ -33,8 +33,8 @@ describe("put-bucket-website", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "NoSuchBucket";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -50,8 +50,8 @@ describe("put-bucket-website", () => {
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
     const error = new S3ServiceException("Some S3 service exception.");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/put-object.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/put-object.unit.test.js
@@ -41,6 +41,8 @@ describe("put-object", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "EntityTooLarge";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -61,7 +63,11 @@ or the multipart upload API (5TB max).`,
   });
 
   it("should indicate a failure came from S3 when the error isn't generic", async () => {
-    const error = new S3ServiceException("Some S3 service exception.");
+    const error = new S3ServiceException({
+      message: "Some S3 service exception.",
+    });
+    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);

--- a/javascriptv3/example_code/s3/tests/put-object.unit.test.js
+++ b/javascriptv3/example_code/s3/tests/put-object.unit.test.js
@@ -41,8 +41,8 @@ describe("put-object", () => {
 
   it("should log a relevant error when the bucket doesn't exist", async () => {
     const error = new S3ServiceException("The specified bucket does not exist");
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "EntityTooLarge";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);
@@ -66,8 +66,8 @@ or the multipart upload API (5TB max).`,
     const error = new S3ServiceException({
       message: "Some S3 service exception.",
     });
-    error.$fault = "server"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
-    error.$metadata = "metadata"; // Workaround until PR is released. https://code.amazon.com/reviews/CR-171722725/revisions/1#/reviewers
+    error.$fault = "server"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
+    error.$metadata = "metadata"; // Workaround until PR is released. https://github.com/smithy-lang/smithy-typescript/pull/1503
     error.name = "ServiceException";
     const bucketName = "amzn-s3-demo-bucket";
     send.mockRejectedValueOnce(error);


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

Possible customer issue. Non-unique name was causing stack creation to fail.

Also uncovered some unit tests that were breaking only with fresh node modules. There's a bug in the SDK that's actively being patched, but the unit test changes are a workaround.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
