### PR TITLE
Fix typo for echoing invalid parameter

### DIFF
--- a/aws-cli/bash-linux/iam/iam_create_user_assume_role_scenario.sh
+++ b/aws-cli/bash-linux/iam/iam_create_user_assume_role_scenario.sh
@@ -504,7 +504,7 @@ function sts_assume_role() {
         return 0
         ;;
       \?)
-        ech o"Invalid parameter"
+        echo "Invalid parameter"
         usage
         return 1
         ;;


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request fixes the typo in the iam_create_user_assume_role_scenario.sh script under the aws-cli folder.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
