### PR TITLE
Tools - Weathertop: Allow plugin access to admin private images

### DIFF
--- a/.tools/test/stacks/images/typescript/image_stack.ts
+++ b/.tools/test/stacks/images/typescript/image_stack.ts
@@ -1,11 +1,14 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
 import "source-map-support/register";
-import * as cdk from "aws-cdk-lib";
-import { Stack, StackProps, aws_ecr as ecr, RemovalPolicy } from "aws-cdk-lib";
+import * as cdk from 'aws-cdk-lib';
+import { 
+  Stack, 
+  StackProps, 
+  aws_ecr as ecr, 
+  aws_iam as iam,
+  RemovalPolicy 
+} from "aws-cdk-lib";
 import { type Construct } from "constructs";
-import { readAccountConfig } from "./../../config/types";
+import { readAccountConfig } from "../../config/targets";
 
 class ImageStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -15,11 +18,28 @@ class ImageStack extends Stack {
 
     for (const language of Object.keys(acctConfig)) {
       if (acctConfig[language].status === "enabled") {
-        new ecr.Repository(this, `${language}-examples`, {
+        const repository = new ecr.Repository(this, `${language}-examples`, {
           repositoryName: `${language}`,
           imageScanOnPush: true,
           removalPolicy: RemovalPolicy.RETAIN,
         });
+
+        // Add repository policy to allow access from the specified account
+        repository.addToResourcePolicy(new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          principals: [
+            new iam.AccountPrincipal(acctConfig[language].account_id)
+          ],
+          actions: [
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchGetImage",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:PutImage",
+            "ecr:InitiateLayerUpload",
+            "ecr:UploadLayerPart",
+            "ecr:CompleteLayerUpload"
+          ]
+        }));
       }
     }
   }
@@ -32,6 +52,7 @@ new ImageStack(app, "ImageStack", {
     account: process.env.CDK_DEFAULT_ACCOUNT!,
     region: process.env.CDK_DEFAULT_REGION!,
   },
+  terminationProtection: true
 });
 
 app.synth();

--- a/.tools/test/stacks/images/typescript/package-lock.json
+++ b/.tools/test/stacks/images/typescript/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tstest",
+  "name": "image_stack",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tstest",
+      "name": "image_stack",
       "version": "0.1.0",
       "dependencies": {
         "@aws-cdk/aws-batch-alpha": "2.95.1-alpha.0",
@@ -2091,12 +2091,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2307,7 +2309,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/constructs": {
       "version": "10.3.0",
@@ -3656,6 +3659,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3994,6 +3998,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request allows the images deployed by the Admin stack to be able to be accessed by the Plugin accounts.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
