### PR TITLE
JavaScript: Fixed syntax for Lambda trigger event handler : Amazon Cognito

### DIFF
--- a/javascript/example_code/cognito/lambda-trigger-pre-sign-up-auto-confirm.js
+++ b/javascript/example_code/cognito/lambda-trigger-pre-sign-up-auto-confirm.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // snippet-start:[cognito.javascript.lambda-trigger.pre-sign-up-auto-confirm]
-exports.handler = (event, context, callback) => {
+export const handler = async (event, context, callback) => {
   // Set the user pool autoConfirmUser flag after validating the email domain
   event.response.autoConfirmUser = false;
 


### PR DESCRIPTION
This pull request updates the Lambda trigger example at https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-sign-up.html#aws-lambda-triggers-pre-registration-example to use ES syntax that works out of the box with a new Node 22 function.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
