### PR TITLE
Tools - Weathertop: Update plugin_stack.ts

### DIFF
--- a/.tools/test/stacks/plugin/typescript/plugin_stack.ts
+++ b/.tools/test/stacks/plugin/typescript/plugin_stack.ts
@@ -114,7 +114,7 @@ class PluginStack extends cdk.Stack {
           type: "FARGATE",
           subnets: vpc.selectSubnets().subnetIds,
           securityGroupIds: [sg.securityGroupId],
-          maxvCpus: 1,
+          maxvCpus: 256,
         },
       }
     );


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

Increases batch compute CPU max from 1 to 256 to enable parallel compilation across our modules (this came up with Kotlin). Since compute time is proportional to build duration, costs remain equivalent while builds complete 256x faster in theory. i.e. this only changes the concurrent CPU ceiling, not the total compute used per build.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
