### PR TITLE
Replace argparse with typer for WRITEME flags.

### DIFF
--- a/.tools/readmes/README.md
+++ b/.tools/readmes/README.md
@@ -16,10 +16,10 @@ cd .tools/readmes
 python -m venv .venv
 
 # Windows
-.venv\Scripts\activate 
+.venv\Scripts\activate
 
 # Linux or MacOS
-source .venv/bin/activate 
+source .venv/bin/activate
 ```
 
 Depending on how you have Python installed and on your operating system,
@@ -60,7 +60,7 @@ This creates a README.md file in the `python/example_code/s3` folder.
 - `--dry-run`, `--no-dry-run` In dry run, compare current vs generated and exit with failure if they do not match.
 - `--check` Verifies whether the existing README.md matches the proposed new README.md
   (but does not write a new README.md). This is the same check that is run by the GitHub action.
- 
+
 You can get inline usage info by using the `-h` flag:
 
 ```

--- a/.tools/readmes/requirements.txt
+++ b/.tools/readmes/requirements.txt
@@ -1,3 +1,4 @@
 jinja2>=3.0.3
 pyyaml>=5.3.1
+typer==0.15.1
 aws-doc-sdk-examples-tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools

--- a/.tools/readmes/requirements_freeze.txt
+++ b/.tools/readmes/requirements_freeze.txt
@@ -1,0 +1,33 @@
+# -e git+ssh://git@github.com/DavidSouther/aws-doc-sdk-examples.git@278cfef0e1ab63fd1d6c696a52a0c5c1cf3d29bd#egg=aws_doc_sdk_examples_readmes&subdirectory=.tools/readmes
+aws_doc_sdk_examples_tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools@593603bf76d9a536dcc3f285720ba08c30007fce
+black==24.3.0
+certifi==2025.1.31
+charset-normalizer==3.4.1
+click==8.1.8
+flake8==6.1.0
+idna==3.10
+iniconfig==2.0.0
+Jinja2==3.1.4
+markdown-it-py==3.0.0
+MarkupSafe==3.0.2
+mccabe==0.7.0
+mdurl==0.1.2
+mypy==1.8.0
+mypy-extensions==1.0.0
+packaging==24.2
+pathspec==0.11.2
+platformdirs==4.3.6
+pluggy==1.5.0
+pycodestyle==2.11.1
+pyflakes==3.1.0
+Pygments==2.19.1
+pytest==8.0.0
+PyYAML==6.0.1
+requests==2.32.0
+rich==13.9.4
+shellingham==1.5.4
+typer==0.15.1
+types-PyYAML==6.0.12.12
+typing_extensions==4.12.2
+urllib3==2.3.0
+yamale==4.0.4

--- a/.tools/readmes/requirements_freeze.txt
+++ b/.tools/readmes/requirements_freeze.txt
@@ -1,5 +1,4 @@
-# -e git+ssh://git@github.com/DavidSouther/aws-doc-sdk-examples.git@278cfef0e1ab63fd1d6c696a52a0c5c1cf3d29bd#egg=aws_doc_sdk_examples_readmes&subdirectory=.tools/readmes
-aws_doc_sdk_examples_tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools@593603bf76d9a536dcc3f285720ba08c30007fce
+aws_doc_sdk_examples_tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools@2025.07.0
 black==24.3.0
 certifi==2025.1.31
 charset-normalizer==3.4.1

--- a/.tools/readmes/runner.py
+++ b/.tools/readmes/runner.py
@@ -60,20 +60,18 @@ def writeme(
     languages: Annotated[
         list[Language],  # type: ignore
         typer.Option(
-            "--language",
             help="The languages of the SDK.",
         ),
     ] = [
-        Language.all  # type: ignore
+        Language.all.value  # type: ignore
     ],  # type: ignore
     services: Annotated[
         list[Service],  # type: ignore
         typer.Option(
-            "--service",
             help="The targeted service.",
         ),
     ] = [
-        Service.all  # type: ignore
+        Service.all.value  # type: ignore
     ],  # type: ignore
     safe: Annotated[
         bool,
@@ -95,11 +93,13 @@ def writeme(
         bool, typer.Option(help="Show a diff of READMEs that have changed.")
     ] = False,
 ):
-    if "all" in languages:
+    if Language.all in languages:  # type: ignore
         languages = list(Language)  # type: ignore
+        languages.remove(Language.all)  # type: ignore
 
-    if "all" in services:
+    if Service.all in services:  # type: ignore
         services = list(Service)  # type: ignore
+        services.remove(Service.all)  # type: ignore
 
     if verbose:
         logging.basicConfig(level=logging.DEBUG)
@@ -123,7 +123,11 @@ def writeme(
 
     renderer = Renderer(scanner)
     for service in services:
+        if service == Service.all:  # type: ignore
+            continue
         for language_and_version in languages:
+            if language_and_version == Language.all:  # type: ignore
+                continue
             (language, version) = language_and_version.value.split(":")
             id = f"{language}:{version}:{service}"
             try:

--- a/.tools/readmes/writeme.py
+++ b/.tools/readmes/writeme.py
@@ -2,25 +2,30 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-
-from update import update
-
 # For debugging, engineers can skip update with the --no-update flag. Yes, it's
 # a double negative, but it's quick and early in the startup because of the
 # reliance on the side-effect imports from `update` and needing them to happen
 # before importing runner, which means before importing the runner argparser.
 NO_UPDATE_FLAG = "--no-update"
 
-
 if __name__ == "__main__":
+    import sys
+
     if NO_UPDATE_FLAG not in sys.argv:
+        from update import update
+
         update()
     else:
         sys.argv.remove(NO_UPDATE_FLAG)
 
     # This import must remain in the main, after the update, as it depends on
     # importing the things that got changed during update.
-    from runner import main
+    from typer import run
 
-    sys.exit(main())
+    from runner import writeme
+
+    run(writeme)
+else:
+    from .runner import writeme
+
+    main = writeme

--- a/.tools/readmes/writeme.py
+++ b/.tools/readmes/writeme.py
@@ -18,11 +18,11 @@ if __name__ == "__main__":
     else:
         sys.argv.remove(NO_UPDATE_FLAG)
 
-    # This import must remain in the main, after the update, as it depends on
-    # importing the things that got changed during update.
-    from typer import run
-
+    # This import from runner must remain in __main__, after calling update(),
+    # as it depends on things that got changed during update().
     from runner import writeme
+
+    from typer import run
 
     run(writeme)
 else:


### PR DESCRIPTION
This has the immediate benefit of allowing multiple '--language' and '--service' options.

<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request...

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
