### PR TITLE
Kotlin: replace `CrtAwsSigner` with `DefaultAwsSigner`

### DIFF
--- a/kotlin/services/s3/src/main/kotlin/com/kotlin/s3/MrapExample.kt
+++ b/kotlin/services/s3/src/main/kotlin/com/kotlin/s3/MrapExample.kt
@@ -27,7 +27,7 @@ import aws.sdk.kotlin.services.s3control.model.Region
 import aws.sdk.kotlin.services.sts.StsClient
 import aws.sdk.kotlin.services.sts.getCallerIdentity
 import aws.sdk.kotlin.services.sts.model.GetCallerIdentityRequest
-import aws.smithy.kotlin.runtime.auth.awssigning.crt.CrtAwsSigner
+import aws.smithy.kotlin.runtime.auth.awssigning.DefaultAwsSigner
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.content.decodeToString
 import aws.smithy.kotlin.runtime.http.auth.SigV4AsymmetricAuthScheme
@@ -204,10 +204,10 @@ class MrapExample {
     companion object {
         // snippet-start:[s3.kotlin.mrap.create-s3client]
         suspend fun createS3Client(): S3Client {
-            // Configure your S3Client to use the Asymmetric Sigv4 (Sigv4a) signing algorithm.
-            val sigV4AScheme = SigV4AsymmetricAuthScheme(CrtAwsSigner)
+            // Configure your S3Client to use the Asymmetric SigV4 (SigV4a) signing algorithm.
+            val sigV4aScheme = SigV4AsymmetricAuthScheme(DefaultAwsSigner)
             val s3 = S3Client.fromEnvironment {
-                authSchemes = listOf(sigV4AScheme)
+                authSchemes = listOf(sigV4aScheme)
             }
             return s3
         }


### PR DESCRIPTION
Replace references to `CrtAwsSigner` with `DefaultAwsSigner`. The [default signer now supports SigV4a](https://github.com/awslabs/aws-sdk-kotlin/pull/1536), so users don't need to take an additional dependency on CRT.

The [developer guide page](https://docs.aws.amazon.com/sdk-for-kotlin/latest/developer-guide/use-services-s3-mrap.html) is being updated in parallel to reflect these changes.

Also updates capitalization of Sigv4 -> SigV4 to better align with S3 and Identity's documentation. 

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
