### PR TITLE
Python: Default to on-demand tables in Python DynamoDB examples.

### DIFF
--- a/python/example_code/dynamodb/GettingStarted/scenario_getting_started_movies.py
+++ b/python/example_code/dynamodb/GettingStarted/scenario_getting_started_movies.py
@@ -118,10 +118,7 @@ class Movies:
                     {"AttributeName": "year", "AttributeType": "N"},
                     {"AttributeName": "title", "AttributeType": "S"},
                 ],
-                ProvisionedThroughput={
-                    "ReadCapacityUnits": 10,
-                    "WriteCapacityUnits": 10,
-                },
+                BillingMode='PAY_PER_REQUEST',
             )
             self.table.wait_until_exists()
         except ClientError as err:

--- a/python/example_code/dynamodb/README.md
+++ b/python/example_code/dynamodb/README.md
@@ -52,18 +52,18 @@ Code excerpts that show you how to call individual service functions.
 
 - [BatchExecuteStatement](partiql/scenario_partiql_batch.py#L44)
 - [BatchGetItem](batching/dynamo_batching.py#L64)
-- [BatchWriteItem](GettingStarted/scenario_getting_started_movies.py#L164)
+- [BatchWriteItem](GettingStarted/scenario_getting_started_movies.py#L161)
 - [CreateTable](GettingStarted/scenario_getting_started_movies.py#L100)
-- [DeleteItem](GettingStarted/scenario_getting_started_movies.py#L342)
-- [DeleteTable](GettingStarted/scenario_getting_started_movies.py#L363)
+- [DeleteItem](GettingStarted/scenario_getting_started_movies.py#L339)
+- [DeleteTable](GettingStarted/scenario_getting_started_movies.py#L360)
 - [DescribeTable](GettingStarted/scenario_getting_started_movies.py#L70)
 - [ExecuteStatement](partiql/scenario_partiql_single.py#L43)
-- [GetItem](GettingStarted/scenario_getting_started_movies.py#L223)
-- [ListTables](GettingStarted/scenario_getting_started_movies.py#L140)
-- [PutItem](GettingStarted/scenario_getting_started_movies.py#L193)
-- [Query](GettingStarted/scenario_getting_started_movies.py#L280)
-- [Scan](GettingStarted/scenario_getting_started_movies.py#L303)
-- [UpdateItem](GettingStarted/scenario_getting_started_movies.py#L248)
+- [GetItem](GettingStarted/scenario_getting_started_movies.py#L220)
+- [ListTables](GettingStarted/scenario_getting_started_movies.py#L137)
+- [PutItem](GettingStarted/scenario_getting_started_movies.py#L190)
+- [Query](GettingStarted/scenario_getting_started_movies.py#L277)
+- [Scan](GettingStarted/scenario_getting_started_movies.py#L300)
+- [UpdateItem](GettingStarted/scenario_getting_started_movies.py#L245)
 
 ### Scenarios
 

--- a/python/example_code/dynamodb/TryDax/01-create-table.py
+++ b/python/example_code/dynamodb/TryDax/01-create-table.py
@@ -33,7 +33,7 @@ def create_dax_table(dyn_resource=None):
             {"AttributeName": "partition_key", "AttributeType": "N"},
             {"AttributeName": "sort_key", "AttributeType": "N"},
         ],
-        "ProvisionedThroughput": {"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
+        "BillingMode": "PAY_PER_REQUEST",
     }
     table = dyn_resource.create_table(**params)
     print(f"Creating {table_name}...")

--- a/python/example_code/dynamodb/batching/dynamo_batching.py
+++ b/python/example_code/dynamodb/batching/dynamo_batching.py
@@ -50,7 +50,7 @@ def create_table(table_name, schema):
                 {"AttributeName": item["name"], "AttributeType": item["type"]}
                 for item in schema
             ],
-            ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
+            BillingMode='PAY_PER_REQUEST',
         )
         table.wait_until_exists()
         logger.info("Created table %s.", table.name)
@@ -194,14 +194,7 @@ def archive_movies(movie_table, movie_data):
             TableName=f"{movie_table.name}-archive",
             KeySchema=movie_table.key_schema,
             AttributeDefinitions=movie_table.attribute_definitions,
-            ProvisionedThroughput={
-                "ReadCapacityUnits": movie_table.provisioned_throughput[
-                    "ReadCapacityUnits"
-                ],
-                "WriteCapacityUnits": movie_table.provisioned_throughput[
-                    "WriteCapacityUnits"
-                ],
-            },
+            BillingMode='PAY_PER_REQUEST',
         )
         logger.info("Table %s created, wait until exists.", archive_table.name)
         archive_table.wait_until_exists()

--- a/python/example_code/dynamodb/batching/test/test_dynamo_batching.py
+++ b/python/example_code/dynamodb/batching/test/test_dynamo_batching.py
@@ -27,7 +27,7 @@ def test_create_table(
 
     with stub_runner(error_code, stop_on_method) as runner:
         runner.add(
-            dyn_stubber.stub_create_table, table_name, schema, {"read": 10, "write": 10}
+            dyn_stubber.stub_create_table, table_name, schema
         )
         runner.add(dyn_stubber.stub_describe_table, table_name)
 

--- a/python/example_code/dynamodb/partiql/scaffold.py
+++ b/python/example_code/dynamodb/partiql/scaffold.py
@@ -46,10 +46,7 @@ class Scaffold:
                     {"AttributeName": "year", "AttributeType": "N"},
                     {"AttributeName": "title", "AttributeType": "S"},
                 ],
-                ProvisionedThroughput={
-                    "ReadCapacityUnits": 10,
-                    "WriteCapacityUnits": 10,
-                },
+                BillingMode='PAY_PER_REQUEST',
             )
             self.table.wait_until_exists()
         except ClientError as err:

--- a/python/test_tools/dynamodb_stubber.py
+++ b/python/test_tools/dynamodb_stubber.py
@@ -77,12 +77,9 @@ class DynamoStubber(ExampleStubber):
                 out_item[key] = {value_type: out_val}
         return out_item
 
-    def stub_create_table(self, table_name, schema, throughput, error_code=None):
+    def stub_create_table(self, table_name, schema, error_code=None):
         table_input = {
-            "ProvisionedThroughput": {
-                "ReadCapacityUnits": throughput["read"],
-                "WriteCapacityUnits": throughput["write"],
-            }
+            "BillingMode": "PAY_PER_REQUEST",
         }
         self._add_table_schema(table_input, table_name, schema)
 


### PR DESCRIPTION
This pull request updates the DynamoDB examples to default to on-demand tables instead of provisioned.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
