### PR TITLE
Dynamodb updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # AWS SDK Code Examples
 
-This repository contains code examples demonstrating how to use the [AWS SDKs](https://aws.amazon.com/developer/tools/) to interact with [AWS services](https://aws.amazon.com/products).
+This repository contains code examples that demonstrate how to use the [AWS SDKs](https://aws.amazon.com/developer/tools/) to interact with [AWS services](https://aws.amazon.com/products).
 
 Many examples are injected into the [AWS Documentation](https://docs.aws.amazon.com).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # AWS SDK Code Examples
 
-This repository contains code examples that demonstrate how to use the [AWS SDKs](https://aws.amazon.com/developer/tools/) to interact with [AWS services](https://aws.amazon.com/products).
+This repository contains code examples demonstrating how to use the [AWS SDKs](https://aws.amazon.com/developer/tools/) to interact with [AWS services](https://aws.amazon.com/products).
 
 Many examples are injected into the [AWS Documentation](https://docs.aws.amazon.com).
 

--- a/javascriptv3/example_code/dynamodb/actions/create-table.js
+++ b/javascriptv3/example_code/dynamodb/actions/create-table.js
@@ -26,10 +26,7 @@ export const main = async () => {
         KeyType: "HASH",
       },
     ],
-    ProvisionedThroughput: {
-      ReadCapacityUnits: 1,
-      WriteCapacityUnits: 1,
-    },
+    BillingMode: "PAY_PER_REQUEST",
   });
 
   const response = await client.send(command);

--- a/javascriptv3/example_code/dynamodb/tests/delete-table.integration.test.js
+++ b/javascriptv3/example_code/dynamodb/tests/delete-table.integration.test.js
@@ -28,10 +28,7 @@ describe("delete-table", () => {
           KeyType: "HASH",
         },
       ],
-      ProvisionedThroughput: {
-        ReadCapacityUnits: 1,
-        WriteCapacityUnits: 1,
-      },
+      BillingMode: "PAY_PER_REQUEST",
     });
 
     await client.send(createTableCommand);

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '3.1.2'
+ruby '3.3.7'
 
 gem 'aws-sdk'
 gem 'cli-ui'

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1520,6 +1520,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
@@ -1545,7 +1546,7 @@ DEPENDENCIES
   zip
 
 RUBY VERSION
-   ruby 3.1.2p20
+   ruby 3.3.7p123
 
 BUNDLED WITH
    2.3.7

--- a/ruby/example_code/dynamodb/README.md
+++ b/ruby/example_code/dynamodb/README.md
@@ -104,7 +104,7 @@ This example shows you how to do the following:
 Start the example by running the following at a command prompt:
 
 ```
-ruby ./basics/scenario_getting_started_dynamodb.rb
+ruby scaffold.rb
 ```
 
 <!--custom.basics.dynamodb_Scenario_GettingStartedMovies.start-->

--- a/ruby/example_code/dynamodb/README.md
+++ b/ruby/example_code/dynamodb/README.md
@@ -104,7 +104,7 @@ This example shows you how to do the following:
 Start the example by running the following at a command prompt:
 
 ```
-ruby scaffold.rb
+ruby ./basics/scenario_getting_started_dynamodb.rb
 ```
 
 <!--custom.basics.dynamodb_Scenario_GettingStartedMovies.start-->

--- a/ruby/example_code/dynamodb/scaffold.rb
+++ b/ruby/example_code/dynamodb/scaffold.rb
@@ -68,7 +68,7 @@ class Scaffold
         { attribute_name: 'year', attribute_type: 'N' },
         { attribute_name: 'title', attribute_type: 'S' }
       ],
-      billing_mode: "PAY_PER_REQUEST"
+      billing_mode: 'PAY_PER_REQUEST'
     )
     @dynamo_resource.client.wait_until(:table_exists, table_name: table_name)
     @table

--- a/ruby/example_code/dynamodb/scaffold.rb
+++ b/ruby/example_code/dynamodb/scaffold.rb
@@ -68,7 +68,7 @@ class Scaffold
         { attribute_name: 'year', attribute_type: 'N' },
         { attribute_name: 'title', attribute_type: 'S' }
       ],
-      provisioned_throughput: { read_capacity_units: 10, write_capacity_units: 10 }
+      billing_mode: "PAY_PER_REQUEST"
     )
     @dynamo_resource.client.wait_until(:table_exists, table_name: table_name)
     @table

--- a/rustv1/cross_service/photo_asset_management/integration/tests/update_label.rs
+++ b/rustv1/cross_service/photo_asset_management/integration/tests/update_label.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::collections::HashMap;
 
-use aws_sdk_dynamodb::types::{AttributeDefinition, KeySchemaElement, ProvisionedThroughput};
+use aws_sdk_dynamodb::types::{AttributeDefinition, KeySchemaElement, BillingMode};
 use aws_sdk_rekognition::types::Label;
 use photo_asset_management::{
     common::{init_tracing_subscriber, Common},
@@ -27,13 +27,8 @@ async fn create_table(common: &Common) -> Result<(), impl std::error::Error> {
         .attribute_definitions(
             AttributeDefinition::builder()
                 .attribute_name("Label")
-                .attribute_type(aws_sdk_dynamodb::types::ScalarAttributeType::S)
-                .build(),
-        )
-        .provisioned_throughput(
-            ProvisionedThroughput::builder()
-                .write_capacity_units(1)
-                .read_capacity_units(1)
+                .attribute_type(aws_sdk_dynamodb::types::ScalarAttributeType::S),
+                .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest
                 .build(),
         )
         .send()

--- a/rustv1/cross_service/photo_asset_management/integration/tests/update_label.rs
+++ b/rustv1/cross_service/photo_asset_management/integration/tests/update_label.rs
@@ -28,7 +28,7 @@ async fn create_table(common: &Common) -> Result<(), impl std::error::Error> {
             AttributeDefinition::builder()
                 .attribute_name("Label")
                 .attribute_type(aws_sdk_dynamodb::types::ScalarAttributeType::S),
-                .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest
+                .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
                 .build(),
         )
         .send()

--- a/rustv1/examples/dynamodb/src/bin/crud.rs
+++ b/rustv1/examples/dynamodb/src/bin/crud.rs
@@ -8,7 +8,7 @@ use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::create_table::CreateTableError;
 use aws_sdk_dynamodb::operation::put_item::PutItemError;
 use aws_sdk_dynamodb::types::{
-    AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ProvisionedThroughput,
+    AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, BillingMode,
     ScalarAttributeType, Select, TableStatus,
 };
 use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};
@@ -63,18 +63,12 @@ async fn make_table(
         .build()
         .expect("creating KeySchemaElement");
 
-    let pt = ProvisionedThroughput::builder()
-        .read_capacity_units(10)
-        .write_capacity_units(5)
-        .build()
-        .expect("creating ProvisionedThroughput");
-
     match client
         .create_table()
         .table_name(table)
         .key_schema(ks)
         .attribute_definitions(ad)
-        .provisioned_throughput(pt)
+        .billing_mode(BillingMode::PayPerRequest)
         .send()
         .await
     {

--- a/rustv1/examples/dynamodb/src/bin/crud.rs
+++ b/rustv1/examples/dynamodb/src/bin/crud.rs
@@ -8,7 +8,7 @@ use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::create_table::CreateTableError;
 use aws_sdk_dynamodb::operation::put_item::PutItemError;
 use aws_sdk_dynamodb::types::{
-    AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, BillingMode,
+    AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
     ScalarAttributeType, Select, TableStatus,
 };
 use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rustv1/examples/dynamodb/src/bin/dynamodb-helloworld.rs
+++ b/rustv1/examples/dynamodb/src/bin/dynamodb-helloworld.rs
@@ -5,7 +5,7 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_dynamodb::types::{
-    AttributeDefinition, KeySchemaElement, KeyType, ProvisionedThroughput, ScalarAttributeType,
+    AttributeDefinition, KeySchemaElement, KeyType, BillingMode, ScalarAttributeType,
 };
 use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};
 use clap::Parser;
@@ -47,18 +47,12 @@ async fn create_table(client: &Client) -> Result<(), Error> {
         .build()
         .expect("creating AttributeDefinition");
 
-    let pt = ProvisionedThroughput::builder()
-        .write_capacity_units(10)
-        .read_capacity_units(10)
-        .build()
-        .expect("creating ProvisionedThroughput");
-
     let new_table = client
         .create_table()
         .table_name("test-table")
         .key_schema(ks)
         .attribute_definitions(ad)
-        .provisioned_throughput(pt)
+        .billing_mode(BillingMode::PayPerRequest)
         .send()
         .await?;
     println!(

--- a/rustv1/examples/dynamodb/src/bin/dynamodb-helloworld.rs
+++ b/rustv1/examples/dynamodb/src/bin/dynamodb-helloworld.rs
@@ -5,7 +5,7 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_dynamodb::types::{
-    AttributeDefinition, KeySchemaElement, KeyType, BillingMode, ScalarAttributeType,
+    AttributeDefinition, BillingMode, KeySchemaElement, KeyType, ScalarAttributeType,
 };
 use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};
 use clap::Parser;

--- a/rustv1/examples/dynamodb/src/bin/partiql.rs
+++ b/rustv1/examples/dynamodb/src/bin/partiql.rs
@@ -8,7 +8,7 @@ use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::create_table::CreateTableError;
 use aws_sdk_dynamodb::operation::execute_statement::ExecuteStatementError;
 use aws_sdk_dynamodb::types::{
-    AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, BillingMode,
+    AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
     ScalarAttributeType, TableStatus,
 };
 use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};

--- a/rustv1/examples/dynamodb/src/bin/partiql.rs
+++ b/rustv1/examples/dynamodb/src/bin/partiql.rs
@@ -8,7 +8,7 @@ use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::create_table::CreateTableError;
 use aws_sdk_dynamodb::operation::execute_statement::ExecuteStatementError;
 use aws_sdk_dynamodb::types::{
-    AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ProvisionedThroughput,
+    AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, BillingMode,
     ScalarAttributeType, TableStatus,
 };
 use aws_sdk_dynamodb::{config::Region, meta::PKG_VERSION, Client, Error};
@@ -44,7 +44,7 @@ fn random_string(n: usize) -> String {
         .collect()
 }
 
-/// Create a new table.
+/// Create a new on-demand table.
 // snippet-start:[dynamodb.rust.partiql-make_table]
 async fn make_table(
     client: &Client,
@@ -63,18 +63,12 @@ async fn make_table(
         .build()
         .expect("creating KeySchemaElement");
 
-    let pt = ProvisionedThroughput::builder()
-        .read_capacity_units(10)
-        .write_capacity_units(5)
-        .build()
-        .expect("creating ProvisionedThroughput");
-
     match client
         .create_table()
         .table_name(table)
         .key_schema(ks)
         .attribute_definitions(ad)
-        .provisioned_throughput(pt)
+        .billing_mode(BillingMode::PayPerRequest)
         .send()
         .await
     {

--- a/rustv1/examples/dynamodb/src/scenario/create.rs
+++ b/rustv1/examples/dynamodb/src/scenario/create.rs
@@ -30,7 +30,6 @@ pub async fn create_table(
         .build()
         .map_err(Error::BuildError)?;
 
-
     let create_table_response = client
         .create_table()
         .table_name(table_name)

--- a/rustv1/examples/dynamodb/src/scenario/create.rs
+++ b/rustv1/examples/dynamodb/src/scenario/create.rs
@@ -4,11 +4,11 @@
 use crate::scenario::error::Error;
 use aws_sdk_dynamodb::operation::create_table::CreateTableOutput;
 use aws_sdk_dynamodb::types::{
-    AttributeDefinition, KeySchemaElement, KeyType, ProvisionedThroughput, ScalarAttributeType,
+    AttributeDefinition, BillingMode, KeySchemaElement, KeyType, ScalarAttributeType,
 };
 use aws_sdk_dynamodb::Client;
 
-// Create a table.
+// Create an on-demand table.
 // snippet-start:[dynamodb.rust.create-table]
 pub async fn create_table(
     client: &Client,
@@ -30,18 +30,13 @@ pub async fn create_table(
         .build()
         .map_err(Error::BuildError)?;
 
-    let pt = ProvisionedThroughput::builder()
-        .read_capacity_units(10)
-        .write_capacity_units(5)
-        .build()
-        .map_err(Error::BuildError)?;
 
     let create_table_response = client
         .create_table()
         .table_name(table_name)
         .key_schema(ks)
         .attribute_definitions(ad)
-        .provisioned_throughput(pt)
+        .billing_mode(BillingMode::PayPerRequest)
         .send()
         .await;
 

--- a/rustv1/examples/dynamodb/src/scenario/movies/startup.rs
+++ b/rustv1/examples/dynamodb/src/scenario/movies/startup.rs
@@ -5,8 +5,8 @@ use crate::scenario::error::Error;
 use aws_sdk_dynamodb::{
     operation::create_table::builders::CreateTableFluentBuilder,
     types::{
-        AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
-        TableStatus, WriteRequest,
+        AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType, TableStatus,
+        WriteRequest,
     },
     Client,
 };


### PR DESCRIPTION
Change all DynamoDB examples that create provisioned tables to creating on-demand tables instead (JavaScriptv3, RubyV3, RustV1)

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
