### PR TITLE
Bash: Default to on-demand tables in DynamoDB examples.

### DIFF
--- a/aws-cli/.gitattributes
+++ b/aws-cli/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf

--- a/aws-cli/bash-linux/dynamodb/README.md
+++ b/aws-cli/bash-linux/dynamodb/README.md
@@ -40,18 +40,18 @@ Code examples that show you how to perform the essential operations within a ser
 
 Code excerpts that show you how to call individual service functions.
 
-- [BatchGetItem](dynamodb_operations.sh#L902)
-- [BatchWriteItem](dynamodb_operations.sh#L834)
+- [BatchGetItem](dynamodb_operations.sh#L892)
+- [BatchWriteItem](dynamodb_operations.sh#L824)
 - [CreateTable](dynamodb_operations.sh#L17)
-- [DeleteItem](dynamodb_operations.sh#L535)
-- [DeleteTable](dynamodb_operations.sh#L998)
-- [DescribeTable](dynamodb_operations.sh#L183)
-- [GetItem](dynamodb_operations.sh#L439)
-- [ListTables](dynamodb_operations.sh#L969)
-- [PutItem](dynamodb_operations.sh#L257)
-- [Query](dynamodb_operations.sh#L614)
-- [Scan](dynamodb_operations.sh#L724)
-- [UpdateItem](dynamodb_operations.sh#L338)
+- [DeleteItem](dynamodb_operations.sh#L525)
+- [DeleteTable](dynamodb_operations.sh#L988)
+- [DescribeTable](dynamodb_operations.sh#L173)
+- [GetItem](dynamodb_operations.sh#L429)
+- [ListTables](dynamodb_operations.sh#L959)
+- [PutItem](dynamodb_operations.sh#L247)
+- [Query](dynamodb_operations.sh#L604)
+- [Scan](dynamodb_operations.sh#L714)
+- [UpdateItem](dynamodb_operations.sh#L328)
 
 
 <!--custom.examples.start-->

--- a/aws-cli/bash-linux/dynamodb/dynamodb_operations.sh
+++ b/aws-cli/bash-linux/dynamodb/dynamodb_operations.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 
 
 ###############################################################################
 #
@@ -24,14 +24,13 @@ source ./awsdocs_general.sh
 #       -n table_name  -- The name of the table to create.
 #       -a attribute_definitions -- JSON file path of a list of attributes and their types.
 #       -k key_schema -- JSON file path of a list of attributes and their key types.
-#       -p provisioned_throughput -- Provisioned throughput settings for the table.
 #
 #  Returns:
 #       0 - If successful.
 #       1 - If it fails.
 ###############################################################################
 function dynamodb_create_table() {
-  local table_name attribute_definitions key_schema provisioned_throughput response
+  local table_name attribute_definitions key_schema response
   local option OPTARG # Required to use getopts command in a function.
 
   #######################################
@@ -39,21 +38,19 @@ function dynamodb_create_table() {
   #######################################
   function usage() {
     echo "function dynamodb_create_table"
-    echo "Creates an Amazon DynamoDB table."
+    echo "Creates an Amazon DynamoDB table with on-demand billing."
     echo " -n table_name  -- The name of the table to create."
     echo " -a attribute_definitions -- JSON file path of a list of attributes and their types."
     echo " -k key_schema -- JSON file path of a list of attributes and their key types."
-    echo " -p provisioned_throughput -- Provisioned throughput settings for the table."
     echo ""
   }
 
   # Retrieve the calling parameters.
-  while getopts "n:a:k:p:h" option; do
+  while getopts "n:a:k:h" option; do
     case "${option}" in
       n) table_name="${OPTARG}" ;;
       a) attribute_definitions="${OPTARG}" ;;
       k) key_schema="${OPTARG}" ;;
-      p) provisioned_throughput="${OPTARG}" ;;
       h)
         usage
         return 0
@@ -85,24 +82,17 @@ function dynamodb_create_table() {
     return 1
   fi
 
-  if [[ -z "$provisioned_throughput" ]]; then
-    errecho "ERROR: You must provide a provisioned throughput json file path the -p parameter."
-    usage
-    return 1
-  fi
-
   iecho "Parameters:\n"
   iecho "    table_name:   $table_name"
   iecho "    attribute_definitions:   $attribute_definitions"
   iecho "    key_schema:   $key_schema"
-  iecho "    provisioned_throughput:   $provisioned_throughput"
   iecho ""
 
   response=$(aws dynamodb create-table \
     --table-name "$table_name" \
     --attribute-definitions file://"$attribute_definitions" \
-    --key-schema file://"$key_schema" \
-    --provisioned-throughput "$provisioned_throughput")
+    --billing-mode PAY_PER_REQUEST \
+    --key-schema file://"$key_schema" )
 
   local error_code=${?}
 

--- a/aws-cli/bash-linux/dynamodb/scenario_getting_started_movies.sh
+++ b/aws-cli/bash-linux/dynamodb/scenario_getting_started_movies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-# bashsupport disable=BP2002
+# bashsupport disable=BP2002 
 
 ###############################################################################
 #
@@ -65,8 +65,6 @@ function dynamodb_getting_started_movies() {
   get_input
   table_name=$get_input_result
 
-  local provisioned_throughput="ReadCapacityUnits=5,WriteCapacityUnits=5"
-
   echo '[
   {"AttributeName": "year", "KeyType": "HASH"},
    {"AttributeName": "title", "KeyType": "RANGE"}
@@ -78,7 +76,7 @@ function dynamodb_getting_started_movies() {
   ]' >"$attribute_definitions_json_file"
 
   if dynamodb_create_table -n "$table_name" -a "$attribute_definitions_json_file" \
-    -k "$key_schema_json_file" -p "$provisioned_throughput" 1>/dev/null; then
+    -k "$key_schema_json_file" 1>/dev/null; then
     echo "Created a DynamoDB table named $table_name"
   else
     errecho "The table failed to create. This demo will exit."

--- a/aws-cli/bash-linux/dynamodb/tests/test_dynamodb_examples.sh
+++ b/aws-cli/bash-linux/dynamodb/tests/test_dynamodb_examples.sh
@@ -85,7 +85,6 @@ function main() {
   iecho "***************SETUP STEPS******************"
   local test_table_name
   test_table_name=$(generate_random_name testcli)
-  local test_provisioned_throughput="ReadCapacityUnits=5,WriteCapacityUnits=5"
   local test_key_schema_json_file="test_dynamodb_key_schema.json"
   local test_attr_definitions_json_file="test_dynamodb_attr_def.json"
   local test_key_json_file="test_dynamodb_key.json"
@@ -111,7 +110,7 @@ function main() {
   ]' >"$test_attr_definitions_json_file"
 
   run_test "Creating table" \
-    "dynamodb_create_table -n $test_table_name -a $test_attr_definitions_json_file -k $test_key_schema_json_file -p $test_provisioned_throughput " \
+    "dynamodb_create_table -n $test_table_name -a $test_attr_definitions_json_file -k $test_key_schema_json_file " \
     0
 
   export exit_on_failure=false


### PR DESCRIPTION
This pull request updates the DynamoDB examples to default to on-demand tables instead of provisioned.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
