### PR TITLE
JavaV2: Update CloudFront signing for custom policy with new resourceUrlPattern property

### DIFF
--- a/javav2/example_code/cloudfront/pom.xml
+++ b/javav2/example_code/cloudfront/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.29.45</version>
+                <version>2.30.31</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/javav2/example_code/cloudfront/src/main/java/com/example/cloudfront/CreateCustomPolicyRequest.java
+++ b/javav2/example_code/cloudfront/src/main/java/com/example/cloudfront/CreateCustomPolicyRequest.java
@@ -30,6 +30,7 @@ public class CreateCustomPolicyRequest {
 
         return CustomSignerRequest.builder()
                 .resourceUrl(cloudFrontUrl)
+                // .resourceUrlPattern("https://*.example.com/*")  // Optional.
                 .privateKey(path)
                 .keyPairId(publicKeyId)
                 .expirationDate(expireDate)


### PR DESCRIPTION
This pull request updates the version of Java v2 SDK that provides a new API feature (`resourceUrlPattern` property) that is shown in the updated code example.

This fulfills ticket https://issues.amazon.com/issues/P201194040

CDD build: Look at `Sign URLs and cookies` under [Scenarios](http://tkhill2-clouddesk.aka.corp.amazon.com/sos-metadata-cloudsign/build/AWSCodeExampleUsageDocs/AWSCodeExampleUsageDocs-3.0/AL2_x86_64/DEV.STD.PTHREAD/build/server-root/code-library/latest/ug/java_2_cloudfront_code_examples.html#scenarios) -> Sign URLs and Cookies -> scroll to the second example (`CreateCustomPolicyRequest`).

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
