### PR TITLE
Add dependencies label to label-checker

### DIFF
--- a/.github/allowed-labels.yml
+++ b/.github/allowed-labels.yml
@@ -27,6 +27,9 @@
 - name: Bug
   color: f5f7f9
   description: "An update to fix incorrect code or typos."
+- name: dependencies
+  color: f5f7f9
+  description: "Pull request that updates a dependency file."
 
 # Labels for general which aren't tracked
 - name: Scout

--- a/.github/workflows/label-checker.yml
+++ b/.github/workflows/label-checker.yml
@@ -26,5 +26,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: Application,MVP,Feature Scenario,Task,Bug,Basics
+          one_of: Application,MVP,Feature Scenario,Task,Bug,Basics,dependencies
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request ensures dependabot PRs don't trigger the the label-checker github action warning.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
