### PR TITLE
Fix links to JavaScript examples for Amazon Nova

### DIFF
--- a/.doc_gen/metadata/bedrock-runtime_metadata.yaml
+++ b/.doc_gen/metadata/bedrock-runtime_metadata.yaml
@@ -107,7 +107,7 @@ bedrock-runtime_Converse_AmazonNovaText:
           excerpts:
             - description: Send a text message to Amazon Nova, using Bedrock's Converse API.
               snippet_tags:
-                - javascript.v3.bedrock-runtime.Converse_AmazonTitanText
+                - javascript.v3.bedrock-runtime.Converse_AmazonNovaText
     .NET:
       versions:
         - sdk_version: 3
@@ -438,7 +438,7 @@ bedrock-runtime_ConverseStream_AmazonNovaText:
           excerpts:
             - description: Send a text message to Amazon Nova using Bedrock's Converse API and process the response stream in real-time.
               snippet_tags:
-                - javascript.v3.bedrock-runtime.Converse_Mistral
+                - javascript.v3.bedrock-runtime.ConverseStream_AmazonNovaText
     .NET:
       versions:
         - sdk_version: 3

--- a/javascriptv3/example_code/bedrock-runtime/README.md
+++ b/javascriptv3/example_code/bedrock-runtime/README.md
@@ -52,8 +52,8 @@ functions within the same service.
 
 ### Amazon Nova
 
-- [Converse](models/amazonTitanText/converse.js#L4)
-- [ConverseStream](models/mistral/converse.js#L4)
+- [Converse](models/amazonNovaText/converse.js#L4)
+- [ConverseStream](models/amazonNovaText/converseStream.js#L4)
 
 ### Amazon Nova Canvas
 


### PR DESCRIPTION
This pull request fixes the links to the Nova Converse and Nova ConverseStream JavaScript (v3) examples. Fixing it in the metadata and in the corresponding README.

I just noticed that the wrong examples are shown here: https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/javascript_bedrock-runtime_code_examples.html#amazon_nova
So hope this PR helps!

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
