### PR TITLE
Cpp: Remove broken assert

### DIFF
--- a/cpp/example_code/transfer-manager/transferOnStream.cpp
+++ b/cpp/example_code/transfer-manager/transferOnStream.cpp
@@ -98,9 +98,6 @@ int main(int argc, char** argv)
         {
             std::cout << "File upload finished." << std::endl;
 
-            // Verify that the upload retrieved the expected amount of data.
-            assert(uploadHandle->GetBytesTotalSize() == uploadHandle->GetBytesTransferred());
-
             auto downloadHandle = transfer_manager->DownloadFile(BUCKET,
                 KEY,
                 [&]() { //Define a lambda expression for the callback method parameter to stream back the data.
@@ -119,9 +116,6 @@ int main(int argc, char** argv)
             
             // Verify the download retrieved the expected length of data.
             assert(downloadHandle->GetBytesTotalSize() == downloadHandle->GetBytesTransferred());
-
-            // Verify that the length of the upload equals the download. 
-            assert(uploadHandle->GetBytesTotalSize() == downloadHandle->GetBytesTotalSize());
 
             // Write the buffered data to local file copy.
             Aws::OFStream storeFile(LOCAL_FILE_COPY.c_str(), Aws::OFStream::out | Aws::OFStream::trunc);


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request removes a incorrect assert as pointed out in https://github.com/aws/aws-sdk-cpp/discussions/3329. This asserts that number of bytes transferred is equal to the object size. Bytes transferred effectively equals the amount of bytes sent by the HTTP Client. Since we are now chunk encoding the stream of the objects the client is unaware if the bytes written are bytes from the stream or added by us for the aws-chunked stream. 

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
