### PR TITLE
SAP ABAP: add bedrock agents runtime example, abaplint formatting, improved test cases

### DIFF
--- a/.abapgit.xml
+++ b/.abapgit.xml
@@ -8,6 +8,7 @@
    <IGNORE>
     <item>/sap-abap/README.md</item>
     <item>/sap-abap/services/bdr/README.md</item>
+    <item>/sap-abap/services/bdz/README.md</item>
     <item>/sap-abap/services/cloudwatch/README.md</item>
     <item>/sap-abap/services/dyn/README.md</item>
     <item>/sap-abap/services/ec2/README.md</item>

--- a/.doc_gen/metadata/bedrock-agent-runtime_metadata.yaml
+++ b/.doc_gen/metadata/bedrock-agent-runtime_metadata.yaml
@@ -17,6 +17,14 @@ bedrock-agent-runtime_InvokeAgent:
             - description:
               snippet_files:
                 - javascriptv3/example_code/bedrock-agent-runtime/actions/invoke-agent.js
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/bdz
+          excerpts:
+            - description:
+              snippet_tags:
+                - bdz.abapv1.invokeagent
   services:
     bedrock-agent-runtime: {InvokeAgent}
 

--- a/.tools/readmes/config.py
+++ b/.tools/readmes/config.py
@@ -191,6 +191,7 @@ language = {
             "sdk_api_ref": 'https://docs.aws.amazon.com/sdk-for-sap-abap/v1/api/latest/{{service["name"]}}/index.html',
             "service_folder_overrides": {
                 "bedrock-runtime": "sap-abap/services/bdr",
+                "bedrock-agent-runtime": "sap-abap/services/bdz",
                 "dynamodb": "sap-abap/services/dyn",
             },
         }

--- a/abaplint.json
+++ b/abaplint.json
@@ -1,0 +1,945 @@
+{
+  "global": {
+    "files": "/sap-abap/**/*.*",
+    "exclude": [],
+    "noIssues": [],
+    "skipGeneratedBOPFInterfaces": false,
+    "skipGeneratedFunctionGroups": false,
+    "skipGeneratedGatewayClasses": false,
+    "skipGeneratedPersistentClasses": false,
+    "skipGeneratedProxyClasses": false,
+    "skipGeneratedProxyInterfaces": false,
+    "useApackDependencies": false,
+    "skipIncludesWithoutMain": false
+  },
+  "syntax": {
+    "version": "v740sp05",
+    "errorNamespace": "^(Z|Y|LCL_|TY_|LIF_)",
+    "globalConstants": [],
+    "globalMacros": []
+  },
+  "rules": {
+    "7bit_ascii": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "abapdoc": {
+      "exclude": [".*"],
+      "severity": "Error",
+      "checkLocal": false,
+      "classDefinition": false,
+      "interfaceDefinition": false
+    },
+    "align_parameters": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "allowed_object_naming": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "allowed_object_types": {
+      "exclude": [],
+      "severity": "Error",
+      "allowed": []
+    },
+    "ambiguous_statement": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "avoid_use": {
+      "exclude": [],
+      "severity": "Error",
+      "skipQuickFix": false,
+      "define": true,
+      "statics": true,
+      "defaultKey": false,
+      "break": true,
+      "testSeams": true,
+      "describeLines": true
+    },
+    "begin_end_names": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "begin_single_include": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "call_transaction_authority_check": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "cds_comment_style": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "cds_legacy_view": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "cds_parser_error": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "chain_mainly_declarations": {
+      "exclude": [],
+      "severity": "Error",
+      "definitions": true,
+      "write": true,
+      "move": true,
+      "refresh": true,
+      "unassign": true,
+      "clear": true,
+      "hide": true,
+      "free": true,
+      "include": true,
+      "check": true,
+      "sort": true
+    },
+    "change_if_to_case": {
+      "exclude": [],
+      "severity": "Error",
+      "skipNames": []
+    },
+    "check_abstract": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "check_comments": {
+      "exclude": [],
+      "severity": "Error",
+      "allowEndOfLine": true
+    },
+    "check_ddic": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "check_include": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "check_subrc": {
+      "exclude": [],
+      "severity": "Error",
+      "openDataset": true,
+      "authorityCheck": true,
+      "selectSingle": true,
+      "selectTable": true,
+      "updateDatabase": true,
+      "insertDatabase": true,
+      "modifyDatabase": true,
+      "readTable": true,
+      "assign": true,
+      "find": true
+    },
+    "check_syntax": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "check_text_elements": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "check_transformation_exists": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "class_attribute_names": {
+      "exclude": [],
+      "severity": "Error",
+      "patternKind": "required",
+      "ignoreNames": [],
+      "ignorePatterns": [],
+      "ignoreExceptions": true,
+      "ignoreLocal": true,
+      "ignoreInterfaces": false,
+      "statics": "^[GC]._.+$",
+      "instance": "^A._.+$",
+      "constants": "^C._.+$"
+    },
+    "classic_exceptions_overlap": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "cloud_types": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "colon_missing_space": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "commented_code": {
+      "exclude": [".*"],
+      "severity": "Warning",
+      "allowIncludeInFugr": true
+    },
+    "constant_classes": {
+      "exclude": [],
+      "severity": "Error",
+      "mapping": []
+    },
+    "constructor_visibility_public": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "contains_tab": {
+      "exclude": [],
+      "severity": "Error",
+      "spaces": 1
+    },
+    "cyclic_oo": {
+      "exclude": [".*"],
+      "severity": "Error",
+      "skip": [],
+      "skipSharedMemory": true,
+      "skipTestclasses": true
+    },
+    "cyclomatic_complexity": {
+      "exclude": [".*"],
+      "severity": "Error",
+      "max": 20
+    },
+    "dangerous_statement": {
+      "exclude": [],
+      "severity": "Error",
+      "execSQL": true,
+      "kernelCall": true,
+      "systemCall": true,
+      "insertReport": true,
+      "generateDynpro": true,
+      "generateReport": true,
+      "generateSubroutine": true,
+      "deleteReport": true,
+      "deleteTextpool": true,
+      "deleteDynpro": true,
+      "exportDynpro": true,
+      "dynamicSQL": true
+    },
+    "db_operation_in_loop": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "definitions_top": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "description_empty": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "double_space": {
+      "exclude": [],
+      "severity": "Error",
+      "keywords": true,
+      "startParen": true,
+      "endParen": true,
+      "afterColon": true
+    },
+    "downport": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "empty_line_in_statement": {
+      "exclude": [],
+      "severity": "Error",
+      "allowChained": false
+    },
+    "empty_statement": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "empty_structure": {
+      "exclude": [],
+      "severity": "Error",
+      "loop": true,
+      "if": true,
+      "while": true,
+      "case": true,
+      "select": true,
+      "do": true,
+      "at": true,
+      "try": true,
+      "when":false 
+    },
+    "exit_or_check": {
+      "exclude": [],
+      "severity": "Error",
+      "allowExit": false,
+      "allowCheck": false
+    },
+    "expand_macros": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "exporting": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "forbidden_identifier": {
+      "exclude": [],
+      "severity": "Error",
+      "check": []
+    },
+    "forbidden_pseudo_and_pragma": {
+      "exclude": [],
+      "severity": "Error",
+      "pseudo": [],
+      "pragmas": [],
+      "ignoreGlobalClassDefinition": false,
+      "ignoreGlobalInterface": false
+    },
+    "forbidden_void_type": {
+      "exclude": [],
+      "severity": "Error",
+      "check": []
+    },
+    "form_tables_obsolete": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "fully_type_constants": {
+      "exclude": [],
+      "severity": "Error",
+      "checkData": true
+    },
+    "function_module_recommendations": {
+      "exclude": [],
+      "severity": "Error",
+      "recommendations": [
+        {
+          "name": "CALCULATE_HASH_FOR_RAW",
+          "replace": "use CL_ABAP_HMAC"
+        },
+        {
+          "name": "ECATT_CONV_XSTRING_TO_STRING",
+          "replace": "use CL_BINARY_CONVERT"
+        },
+        {
+          "name": "F4_FILENAME",
+          "replace": "use CL_GUI_FRONTEND_SERVICES"
+        },
+        {
+          "name": "FUNCTION_EXISTS",
+          "replace": "surround with try-catch CX_SY_DYN_CALL_ILLEGAL_METHOD instead"
+        },
+        {
+          "name": "GUI_DOWNLOAD",
+          "replace": "use CL_GUI_FRONTEND_SERVICES"
+        },
+        {
+          "name": "GUI_UPLOAD",
+          "replace": "use CL_GUI_FRONTEND_SERVICES"
+        },
+        {
+          "name": "GUID_CREATE",
+          "replace": "use CL_SYSTEM_UUID"
+        },
+        {
+          "name": "IGN_TIMESTAMP_DIFFERENCE",
+          "replace": "use CL_ABAP_TSTMP"
+        },
+        {
+          "name": "IGN_TIMESTAMP_PLUSMINUS",
+          "replace": "use CL_ABAP_TSTMP"
+        },
+        {
+          "name": "JOB_CREATE",
+          "replace": "use CL_BP_ABAP_JOB"
+        },
+        {
+          "name": "JOB_SUBMIT",
+          "replace": "use CL_BP_ABAP_JOB"
+        },
+        {
+          "name": "POPUP_TO_DECIDE",
+          "replace": "use POPUP_TO_CONFIRM"
+        },
+        {
+          "name": "POPUP_TO_GET_VALUE",
+          "replace": "use POPUP_GET_VALUES"
+        },
+        {
+          "name": "REUSE_ALV_GRID_DISPLAY",
+          "replace": "use CL_SALV_TABLE=>FACTORY or CL_GUI_ALV_GRID"
+        },
+        {
+          "name": "ROUND",
+          "replace": "use built in function: round()"
+        },
+        {
+          "name": "SAPGUI_PROGRESS_INDICATOR",
+          "replace": "use CL_PROGRESS_INDICATOR"
+        },
+        {
+          "name": "SCMS_BASE64_DECODE_STR",
+          "replace": "use class CL_HTTP_UTILITY methods"
+        },
+        {
+          "name": "SCMS_STRING_TO_XSTRING",
+          "replace": "use CL_BINARY_CONVERT"
+        },
+        {
+          "name": "SO_NEW_DOCUMENT_ATT_SEND_API1",
+          "replace": "use CL_BCS"
+        },
+        {
+          "name": "SSFC_BASE64_DECODE",
+          "replace": "use class CL_HTTP_UTILITY methods"
+        },
+        {
+          "name": "SSFC_BASE64_ENCODE",
+          "replace": "use class CL_HTTP_UTILITY methods"
+        },
+        {
+          "name": "SUBST_GET_FILE_LIST",
+          "replace": "see note 1686357"
+        },
+        {
+          "name": "WS_FILENAME_GET",
+          "replace": "use CL_GUI_FRONTEND_SERVICES"
+        }
+      ]
+    },
+    "functional_writing": {
+      "exclude": [],
+      "severity": "Error",
+      "ignoreExceptions": true
+    },
+    "global_class": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "identical_conditions": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "identical_contents": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "identical_descriptions": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "identical_form_names": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "if_in_if": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "implement_methods": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "in_statement_indentation": {
+      "exclude": [],
+      "severity": "Error",
+      "blockStatements": 2,
+      "ignoreExceptions": true
+    },
+    "indentation": {
+      "exclude": [],
+      "severity": "Error",
+      "ignoreExceptions": true,
+      "alignTryCatch": false,
+      "selectionScreenBlockIndentation": false,
+      "globalClassSkipFirst": false,
+      "ignoreGlobalClassDefinition": false,
+      "ignoreGlobalInterface": false
+    },
+    "inline_data_old_versions": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "intf_referencing_clas": {
+      "exclude": [".*"],
+      "severity": "Error",
+      "allow": []
+    },
+    "keep_single_parameter_on_one_line": {
+      "exclude": [],
+      "severity": "Error",
+      "length": 120
+    },
+    "keyword_case": {
+      "exclude": [],
+      "severity": "Error",
+      "style": "upper",
+      "ignoreExceptions": true,
+      "ignoreLowerClassImplmentationStatement": true,
+      "ignoreGlobalClassDefinition": false,
+      "ignoreGlobalInterface": false,
+      "ignoreFunctionModuleName": false,
+      "ignoreGlobalClassBoundaries": false,
+      "ignoreKeywords": []
+    },
+    "line_break_multiple_parameters": {
+      "exclude": [],
+      "severity": "Error",
+      "count": 1
+    },
+    "line_break_style": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "line_length": {
+      "exclude": [],
+      "severity": "Error",
+      "length": 120
+    },
+    "line_only_punc": {
+      "exclude": [],
+      "severity": "Error",
+      "ignoreExceptions": true
+    },
+    "local_class_naming": {
+      "exclude": [],
+      "severity": "Error",
+      "patternKind": "required",
+      "ignoreNames": [],
+      "ignorePatterns": [],
+      "local": "^LCL_.+$",
+      "exception": "^LCX_.+$",
+      "test": "^LTC_.+$"
+    },
+    "local_testclass_consistency": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "local_variable_names": {
+      "exclude": [],
+      "severity": "Error",
+      "patternKind": "required",
+      "ignoreNames": [],
+      "ignorePatterns": [],
+      "expectedData": "^(L[VSTOR]|WA)_.+$",
+      "expectedConstant": "^(LC)|(CV)_.+$",
+      "expectedFS": "^(<L._.+>)|(.+)$"
+    },
+    "main_file_contents": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "many_parentheses": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "max_one_method_parameter_per_line": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "max_one_statement": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "message_exists": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "method_implemented_twice": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "method_length": {
+      "exclude": [".*"],
+      "severity": "Error",
+      "statements": 100,
+      "errorWhenEmpty": true,
+      "ignoreTestClasses": false,
+      "checkForms": true
+    },
+    "method_overwrites_builtin": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "method_parameter_names": {
+      "exclude": [],
+      "severity": "Error",
+      "patternKind": "required",
+      "ignoreNames": [],
+      "ignorePatterns": [],
+      "ignoreExceptions": true,
+      "importing": "^I._.+$",
+      "returning": "^O._.+$",
+      "changing": "^C._.+$",
+      "exporting": "^E._.+$"
+    },
+    "mix_returning": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "modify_only_own_db_tables": {
+      "exclude": [],
+      "severity": "Error",
+      "reportDynamic": true,
+      "ownTables": "^([yz]|/aws1/)"
+    },
+    "msag_consistency": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "names_no_dash": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "nesting": {
+      "exclude": [],
+      "severity": "Error",
+      "depth": 5
+    },
+    "newline_between_methods": {
+      "exclude": [],
+      "severity": "Error",
+      "count": 3,
+      "logic": "less"
+    },
+    "no_aliases": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "no_chained_assignment": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "no_external_form_calls": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "no_inline_in_optional_branches": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "no_public_attributes": {
+      "exclude": [],
+      "severity": "Error",
+      "allowReadOnly": false,
+      "ignoreTestClasses": false
+    },
+    "no_yoda_conditions": {
+      "exclude": [],
+      "severity": "Error",
+      "onlyConstants": false
+    },
+    "nrob_consistency": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "obsolete_statement": {
+      "exclude": [],
+      "severity": "Error",
+      "refresh": true,
+      "compute": true,
+      "add": true,
+      "subtract": true,
+      "multiply": true,
+      "divide": true,
+      "move": true,
+      "requested": true,
+      "occurs": true,
+      "setExtended": true,
+      "withHeaderLine": true,
+      "fieldSymbolStructure": true,
+      "typePools": true,
+      "load": true,
+      "parameter": true,
+      "ranges": true,
+      "communication": true,
+      "pack": true,
+      "selectWithoutInto": true,
+      "freeMemory": true,
+      "exitFromSQL": true,
+      "sortByFS": true,
+      "callTransformation": true,
+      "regex": true,
+      "occurences": true,
+      "clientSpecified": true,
+      "formDefinition": true,
+      "formImplementation": true
+    },
+    "omit_parameter_name": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "omit_preceding_zeros": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "omit_receiving": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "parser_702_chaining": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "parser_error": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "parser_missing_space": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "pragma_style": {
+      "exclude": [],
+      "severity": "Error",
+      "style": "upper"
+    },
+    "prefer_corresponding": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "prefer_inline": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "prefer_is_not": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "prefer_raise_exception_new": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "prefer_returning_to_exporting": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "prefer_xsdbool": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "preferred_compare_operator": {
+      "exclude": [],
+      "severity": "Error",
+      "badOperators": [
+        "EQ",
+        "><",
+        "NE",
+        "GE",
+        "GT",
+        "LT",
+        "LE"
+      ]
+    },
+    "prefix_is_current_class": {
+      "exclude": [],
+      "severity": "Error",
+      "omitMeInstanceCalls": true
+    },
+    "reduce_string_templates": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "release_idoc": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "remove_descriptions": {
+      "exclude": [".*"],
+      "severity": "Error",
+      "ignoreExceptions": false,
+      "ignoreWorkflow": true
+    },
+    "rfc_error_handling": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "select_add_order_by": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "select_performance": {
+      "exclude": [],
+      "severity": "Error",
+      "endSelect": true,
+      "selectStar": true,
+      "starOkayIfFewColumns": 10
+    },
+    "selection_screen_naming": {
+      "exclude": [],
+      "severity": "Error",
+      "patternKind": "required",
+      "ignoreNames": [],
+      "ignorePatterns": [],
+      "parameter": "^P_.+$",
+      "selectOption": "^S_.+$",
+      "screenElement": "^SC_.+$"
+    },
+    "sequential_blank": {
+      "exclude": [],
+      "severity": "Error",
+      "lines": 4
+    },
+    "short_case": {
+      "exclude": [],
+      "severity": "Error",
+      "length": 1,
+      "allow": []
+    },
+    "sicf_consistency": {
+      "exclude": [],
+      "severity": "Error",
+      "skipNames": []
+    },
+    "slow_parameter_passing": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "space_before_colon": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "space_before_dot": {
+      "exclude": [],
+      "severity": "Error",
+      "ignoreGlobalDefinition": true,
+      "ignoreExceptions": true
+    },
+    "sql_escape_host_variables": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "start_at_tab": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "static_call_via_instance": {
+      "exclude": [],
+      "severity": "Error",
+      "allowInTestclassIncludes": false
+    },
+    "superclass_final": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "superfluous_value": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "sy_modification": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "tabl_enhancement_category": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "try_without_catch": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "type_form_parameters": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "types_naming": {
+      "exclude": [],
+      "severity": "Error",
+      "pattern": "^(TS_.+)|(TT_.+)|(TY_.+)|(.+_TT)|(.+_TS)|(.+_TY)|(.+_ROW)$"
+    },
+    "uncaught_exception": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "unknown_types": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "unnecessary_chaining": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "unnecessary_pragma": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "unnecessary_return": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "unreachable_code": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "unsecure_fae": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "unused_ddic": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "unused_methods": {
+      "exclude": [".*"],
+      "severity": "Error"
+    },
+    "unused_types": {
+      "exclude": [".*"],
+      "severity": "Error",
+      "skipNames": []
+    },
+    "unused_variables": {
+      "exclude": [".*"],
+      "severity": "Error",
+      "skipNames": []
+    },
+    "use_bool_expression": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "use_class_based_exceptions": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "use_line_exists": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "use_new": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "when_others_last": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "whitespace_end": {
+      "exclude": [],
+      "severity": "Error"
+    },
+    "xml_consistency": {
+      "exclude": [],
+      "severity": "Error"
+    }
+  },
+  "object_naming": {
+    "exclude": [],
+    "severity": "Error",
+    "patternKind": "required",
+    "ignoreNames": [],
+    "ignorePatterns": [],
+    "clas": "^ZC(L|X)",
+    "intf": "^ZIF",
+    "prog": "^Z",
+    "fugr": "^Z",
+    "tabl": "^Z",
+    "ttyp": "^Z",
+    "dtel": "^Z",
+    "doma": "^Z",
+    "msag": "^Z",
+    "tran": "^Z",
+    "enqu": "^EZ",
+    "auth": "^Z",
+    "pinf": "^Z",
+    "idoc": "^Z",
+    "xslt": "^Z",
+    "ssfo": "^Z",
+    "ssst": "^Z",
+    "shlp": "^Z"
+  }
+}

--- a/sap-abap/README.md
+++ b/sap-abap/README.md
@@ -9,6 +9,7 @@ These examples demonstrate how to perform several operations using the AWS SDK f
 - We recommend that you grant this code least privilege, or at most the minimum permissions required to perform the task. For more information, see [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege) in the AWS Identity and Access Management User Guide.
 - This code has not been tested in all AWS Regions. Some AWS services are available only in specific [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 - Running this code might result in charges to your AWS account.
+- The included unit tests have been marked as `DANGEROUS` and will create and delete AWS assets. Only run these in a suitable test AWS account.
 
 ## Examples Layout
 
@@ -18,7 +19,7 @@ Examples show how to use the AWS SDK for SAP-ABAP using single actions and servi
 
 ## Running the code examples
 
-Each example has one or more examples that can be executed with `SE38`.
+Each example has one or more examples that can be executed with `SE24`.
 See the individual readme files in each service directory for information about specific code examples for that service.
 
 ### Prerequisites

--- a/sap-abap/services/bdr/zcl_aws1_bdr_actions.clas.abap
+++ b/sap-abap/services/bdr/zcl_aws1_bdr_actions.clas.abap
@@ -109,7 +109,8 @@ CLASS ZCL_AWS1_BDR_ACTIONS IMPLEMENTATION.
           io_bdr = lo_bdr
           iv_model_id = 'anthropic.claude-3-sonnet-20240229-v1:0' ).  " choosing Claude v3 Sonnet
         " iv_prompt can contain a prompt like 'tell me a joke about Java programmers'.
-        DATA(lv_answer) = lo_bdr_l2_claude->prompt_for_text( iv_prompt = iv_prompt iv_max_tokens = 100 ).
+        DATA(lv_answer) = lo_bdr_l2_claude->prompt_for_text( iv_prompt = iv_prompt
+                                                             iv_max_tokens = 100 ).
       CATCH /aws1/cx_bdraccessdeniedex INTO DATA(lo_ex).
         WRITE / lo_ex->get_text( ).
         WRITE / |Don't forget to enable model access at https://console.aws.amazon.com/bedrock/home?#/modelaccess|.

--- a/sap-abap/services/bdr/zcl_aws1_bdr_actions.clas.testclasses.abap
+++ b/sap-abap/services/bdr/zcl_aws1_bdr_actions.clas.testclasses.abap
@@ -4,7 +4,7 @@
 CLASS ltc_zcl_aws1_bdr_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_bdr_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_bdr_actions.
 
-CLASS ltc_zcl_aws1_bdr_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_bdr_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
     CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.

--- a/sap-abap/services/bdz/README.md
+++ b/sap-abap/services/bdz/README.md
@@ -1,0 +1,78 @@
+# Amazon Bedrock Agents Runtime code examples for the SDK for SAP ABAP
+
+## Overview
+
+Shows how to use the AWS SDK for SAP ABAP to work with Amazon Bedrock Agents Runtime.
+
+<!--custom.overview.start-->
+<!--custom.overview.end-->
+
+_Amazon Bedrock Agents Runtime offers you the ability to run autonomous agents in your application._
+
+## ⚠ Important
+
+* Running this code might result in charges to your AWS account. For more details, see [AWS Pricing](https://aws.amazon.com/pricing/) and [Free Tier](https://aws.amazon.com/free/).
+* Running the tests might result in charges to your AWS account.
+* We recommend that you grant your code least privilege. At most, grant only the minimum permissions required to perform the task. For more information, see [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege).
+* This code is not tested in every AWS Region. For more information, see [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+
+<!--custom.important.start-->
+<!--custom.important.end-->
+
+## Code examples
+
+### Prerequisites
+
+For prerequisites, see the [README](../../README.md#Prerequisites) in the `sap-abap` folder.
+
+
+<!--custom.prerequisites.start-->
+<!--custom.prerequisites.end-->
+
+### Single actions
+
+Code excerpts that show you how to call individual service functions.
+
+- [InvokeAgent](zcl_aws1_bdz_actions.clas.abap#L37)
+
+
+<!--custom.examples.start-->
+<!--custom.examples.end-->
+
+## Run the examples
+
+### Instructions
+
+
+<!--custom.instructions.start-->
+<!--custom.instructions.end-->
+
+
+
+### Tests
+
+⚠ Running tests might result in charges to your AWS account.
+
+
+To find instructions for running these tests, see the [README](../../README.md#Tests)
+in the `sap-abap` folder.
+
+
+
+<!--custom.tests.start-->
+<!--custom.tests.end-->
+
+## Additional resources
+
+- [Amazon Bedrock Agents Runtime User Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html)
+- [Amazon Bedrock Agents Runtime API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Agents_for_Amazon_Bedrock_Runtime.html)
+- [SDK for SAP ABAP Amazon Bedrock Agents Runtime reference](https://docs.aws.amazon.com/sdk-for-sap-abap/v1/api/latest/bedrock-agent-runtime/index.html)
+
+<!--custom.resources.start-->
+<!--custom.resources.end-->
+
+---
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0

--- a/sap-abap/services/bdz/package.devc.xml
+++ b/sap-abap/services/bdz/package.devc.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DEVC>
+    <CTEXT>Bedrock Agents Runtime</CTEXT>
+   </DEVC>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/sap-abap/services/bdz/zcl_aws1_bdz_actions.clas.abap
+++ b/sap-abap/services/bdz/zcl_aws1_bdz_actions.clas.abap
@@ -1,0 +1,82 @@
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
+CLASS zcl_aws1_bdz_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    METHODS invoke_bedrock_agent
+      IMPORTING
+        !io_session      TYPE REF TO /aws1/cl_rt_session_base
+        !iv_agentid      TYPE /aws1/bdaid
+        !iv_agentaliasid TYPE /aws1/bdaagentaliasid
+      RETURNING
+        VALUE(ov_answer) TYPE string
+      RAISING
+        /aws1/cx_bdzserverexc
+        /aws1/cx_bdzclientexc
+        /aws1/cx_rt_technical_generic
+        /aws1/cx_rt_service_generic
+        /aws1/cx_rt_no_auth_generic
+        cx_uuid_error .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+ENDCLASS.
+
+
+
+CLASS ZCL_AWS1_BDZ_ACTIONS IMPLEMENTATION.
+
+
+  METHOD invoke_bedrock_agent.
+    DATA(lo_bdz) = /aws1/cl_bdz_factory=>create( io_session ).
+
+    "snippet-start:[bdz.abapv1.invokeagent]
+
+    DATA(lo_result) = lo_bdz->invokeagent(
+      iv_agentid      = iv_agentid
+        iv_agentaliasid = iv_agentaliasid
+        iv_enabletrace  = abap_true
+        iv_sessionid    = CONV #( cl_system_uuid=>create_uuid_c26_static( ) )
+        iv_inputtext    = |Let's play "rock, paper, scissors".  I choose rock.| ).
+    DATA(lo_stream) = lo_result->get_completion( ).
+    TRY.
+        " loop while there are still events in the stream
+        WHILE lo_stream->/aws1/if_rt_stream_reader~data_available( ) = abap_true.
+          DATA(lo_evt) = lo_stream->read( ).
+          " each /AWS1/CL_BDZRESPONSESTREAM_EV event contains exactly one member
+          " all others are INITIAL.  For each event, process the non-initial
+          " member if desired
+          IF lo_evt->get_chunk( ) IS NOT INITIAL.
+            " Process a Chunk event
+            DATA(lv_xstr) = lo_evt->get_chunk( )->get_bytes( ).
+            DATA(lv_answer) = /aws1/cl_rt_util=>xstring_to_string( lv_xstr ).
+            " the answer says something like "I chose paper, so you lost"
+          ELSEIF lo_evt->get_files( ) IS NOT INITIAL.
+            " process a Files event if desired
+          ELSEIF lo_evt->get_returncontrol( ) IS NOT INITIAL.
+            " process a ReturnControl event if desired
+          ELSEIF lo_evt->get_trace( ) IS NOT INITIAL.
+            " process a Trace event if desired
+          ENDIF.
+        ENDWHILE.
+        " the stream of events can possibly contain an exception
+        " which will be raised to break the loop
+        " catch /AWS1/CX_BDZACCESSDENIEDEX.
+        " catch /AWS1/CX_BDZINTERNALSERVEREX.
+        " catch /AWS1/CX_BDZMODELNOTREADYEX.
+        " catch /AWS1/CX_BDZVALIDATIONEX.
+        " catch /AWS1/CX_BDZTHROTTLINGEX.
+        " catch /AWS1/CX_BDZDEPENDENCYFAILEDEX.
+        " catch /AWS1/CX_BDZBADGATEWAYEX.
+        " catch /AWS1/CX_BDZRESOURCENOTFOUNDEX.
+        " catch /AWS1/CX_BDZSERVICEQUOTAEXCDEX.
+        " catch /AWS1/CX_BDZCONFLICTEXCEPTION.
+    ENDTRY.
+    "snippet-end:[bdz.abapv1.invokeagent].
+    ov_answer = lv_answer.
+  ENDMETHOD.
+ENDCLASS.

--- a/sap-abap/services/bdz/zcl_aws1_bdz_actions.clas.testclasses.abap
+++ b/sap-abap/services/bdz/zcl_aws1_bdz_actions.clas.testclasses.abap
@@ -1,3 +1,5 @@
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 CLASS ltc_zcl_aws1_bdz_actions DEFINITION FOR TESTING
     DURATION SHORT
     RISK LEVEL DANGEROUS.

--- a/sap-abap/services/bdz/zcl_aws1_bdz_actions.clas.testclasses.abap
+++ b/sap-abap/services/bdz/zcl_aws1_bdz_actions.clas.testclasses.abap
@@ -1,0 +1,152 @@
+CLASS ltc_zcl_aws1_bdz_actions DEFINITION FOR TESTING
+    DURATION SHORT
+    RISK LEVEL DANGEROUS.
+  PROTECTED SECTION.
+    METHODS test_invoke_agent FOR TESTING RAISING /aws1/cx_rt_generic cx_uuid_error.
+
+  PRIVATE SECTION.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_bdz_lrole TYPE string VALUE 'YMIT1_BDZ_ROLEARN'.
+    CONSTANTS cv_foundationmodel TYPE string VALUE 'us.amazon.nova-micro-v1:0'.
+    CONSTANTS cv_alias TYPE string VALUE 'live'.
+    CONSTANTS cv_action_group_name TYPE string VALUE 'action_group'.
+
+    DATA av_func_name_fail TYPE /aws1/lmdfunctionname.
+    DATA ao_alias TYPE REF TO /aws1/cl_bdaagentalias.
+    DATA ao_bda TYPE REF TO /aws1/if_bda.
+    DATA ao_session TYPE REF TO /aws1/cl_rt_session_base.
+    DATA av_bdz_rolearn TYPE /aws1/bdaagentrolearn.
+
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
+    METHODS teardown RAISING /aws1/cx_rt_service_generic /aws1/cx_rt_technical_generic /aws1/cx_rt_generic zcx_aws1_ex_generic.
+
+    METHODS wait_for_agent_status
+      IMPORTING iv_agentid      TYPE string
+                iv_status       TYPE string
+      RETURNING VALUE(oo_agent) TYPE REF TO /aws1/cl_bdaagent
+      RAISING   /aws1/cx_rt_generic
+                zcx_aws1_ex_generic.
+
+    METHODS    wait_for_agent_alias_status
+      IMPORTING iv_agentid      TYPE string
+                iv_aliasid      TYPE string
+                iv_status       TYPE string
+      RETURNING VALUE(oo_alias) TYPE REF TO /aws1/cl_bdaagentalias
+      RAISING   /aws1/cx_rt_generic
+                zcx_aws1_ex_generic.
+
+    METHODS prepare
+      IMPORTING iv_agentid      TYPE string
+      RETURNING VALUE(oo_agent) TYPE REF TO /aws1/cl_bdaagent
+      RAISING   /aws1/cx_rt_generic zcx_aws1_ex_generic.
+
+ENDCLASS.
+
+
+
+CLASS ltc_ZCL_AWS1_BDZ_ACTIONS IMPLEMENTATION.
+
+  METHOD setup.
+    ao_session = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    ao_bda = /aws1/cl_bda_factory=>create( ao_session ).
+    av_bdz_rolearn = ao_session->resolve_lresource( cv_bdz_lrole ).
+
+    DATA(lv_random_string) = zcl_aws1_ex_utils=>get_random_string( ).
+
+    DATA(lv_instruction) = |You are an agent that plays "rock, paper, scissors". Choose rock, | &&
+                           |paper, or scissors.. When the human prompts you with | &&
+                           |their choice, reveal your choice and declare the winner. |.
+
+    DATA(lo_agent) = ao_bda->createagent(
+      iv_agentname = |{ zcl_aws1_ex_utils=>cv_asset_prefix }-bdragt-{ lv_random_string }|
+      iv_foundationmodel = cv_foundationmodel
+      iv_agentresourcerolearn = av_bdz_rolearn
+      iv_instruction = lv_instruction )->get_agent( ).
+    DATA(lv_agentid) = lo_agent->get_agentid( ).
+
+    wait_for_agent_status( iv_agentid = lv_agentid
+                           iv_status = |NOT_PREPARED| ).
+
+    " get draft version
+    prepare( lv_agentid ).
+
+    ao_alias = ao_bda->createagentalias( iv_agentid = lv_agentid
+                                         iv_agentaliasname = cv_alias )->get_agentalias( ).
+    wait_for_agent_alias_status( iv_agentid = lv_agentid
+                                 iv_aliasid = ao_alias->get_agentaliasid( )
+                                 iv_status = |PREPARED| ).
+
+  ENDMETHOD.
+
+  METHOD prepare.
+    ao_bda->prepareagent( iv_agentid = iv_agentid ).
+    oo_agent = wait_for_agent_status( iv_agentid = iv_agentid
+                                      iv_status = |PREPARED| ).
+  ENDMETHOD.
+
+  METHOD wait_for_agent_status.
+    oo_agent = ao_bda->getagent( iv_agentid )->get_agent( ).
+    WHILE oo_agent->get_agentstatus( ) <> iv_status.
+      WAIT UP TO 2 SECONDS.
+      IF sy-index > 20.
+        RAISE EXCEPTION TYPE zcx_aws1_ex_generic
+          EXPORTING
+            av_msg = |Bedrock agent { iv_agentid } never reached status { iv_status }|.
+      ENDIF.
+      oo_agent = ao_bda->getagent( iv_agentid )->get_agent( ).
+    ENDWHILE.
+  ENDMETHOD.
+
+  METHOD wait_for_agent_alias_status.
+    oo_alias = ao_bda->getagentalias( iv_agentid = iv_agentid
+                                      iv_agentaliasid = iv_aliasid )->get_agentalias( ).
+    WHILE oo_alias->get_agentaliasstatus( ) <> iv_status.
+      WAIT UP TO 2 SECONDS.
+      IF sy-index > 20.
+        RAISE EXCEPTION TYPE zcx_aws1_ex_generic
+          EXPORTING
+            av_msg = |Bedrock agent alias { iv_aliasid } never reached status { iv_status }|.
+      ENDIF.
+      oo_alias = ao_bda->getagentalias( iv_agentid = iv_agentid
+                                        iv_agentaliasid = iv_aliasid )->get_agentalias( ).
+    ENDWHILE.
+  ENDMETHOD.
+
+
+  METHOD teardown.
+    IF ao_alias IS NOT INITIAL.
+      DATA(lv_agentid) = ao_alias->get_agentid( ).
+      TRY.
+          " first delete aliases
+          DATA(lt_agent_aliases) = ao_bda->listagentaliases( iv_agentid = lv_agentid )->get_agentaliassummaries( ).
+          LOOP AT lt_agent_aliases INTO DATA(lo_alias).
+            ao_bda->deleteagentalias( iv_agentid = lv_agentid
+                                      iv_agentaliasid = ao_alias->get_agentaliasid( ) ).
+          ENDLOOP.
+          DATA(lv_status) = ao_bda->deleteagent( iv_agentid = lv_agentid )->get_agentstatus( ).
+          WHILE lv_status <> 'DELETED'.
+            lv_status = ao_bda->getagent( lv_agentid )->get_agent( )->get_agentstatus( ).
+          ENDWHILE.
+        CATCH /aws1/cx_bdaresourcenotfoundex.
+          " it's gone
+      ENDTRY.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD test_invoke_agent.
+    DATA lv_agentid TYPE string.
+    DATA lv_agentaliasid TYPE string.
+    DATA(lo_example) = NEW zcl_aws1_bdz_actions( ).
+    DATA(lv_result) = lo_example->invoke_bedrock_agent(
+      io_session      = ao_session
+      iv_agentid      = ao_alias->get_agentid( )
+      iv_agentaliasid = ao_alias->get_agentaliasid( ) ).
+    cl_abap_unit_assert=>assert_text_matches(
+      text = lv_result
+      pattern = '.*((rock)|(paper)|(scissors)).*'
+      msg = |Expected "rock", "paper" or "scissors" in the response but got { lv_result }| ).
+  ENDMETHOD.
+
+ENDCLASS.

--- a/sap-abap/services/bdz/zcl_aws1_bdz_actions.clas.xml
+++ b/sap-abap/services/bdz/zcl_aws1_bdz_actions.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_AWS1_BDZ_ACTIONS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Bedrock Agents Runtime</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.abap
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.abap
@@ -1,48 +1,48 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_CWT_ACTIONS definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_cwt_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods DELETE_ALARMS
-    importing
-      !IT_ALARM_NAMES type /AWS1/CL_CWTALARMNAMES_W=>TT_ALARMNAMES .
-  methods DESCRIBE_ALARMS
-    importing
-      !IT_ALARM_NAMES type /AWS1/CL_CWTALARMNAMES_W=>TT_ALARMNAMES
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_CWTDESCRALARMSOUTPUT .
-  methods DISABLE_ALARM_ACTIONS
-    importing
-      !IT_ALARM_NAMES type /AWS1/CL_CWTALARMNAMES_W=>TT_ALARMNAMES .
-  methods ENABLE_ALARM_ACTIONS
-    importing
-      !IT_ALARM_NAMES type /AWS1/CL_CWTALARMNAMES_W=>TT_ALARMNAMES .
-  methods LIST_METRICS
-    importing
-      !IV_NAMESPACE type /AWS1/CWTNAMESPACE
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_CWTLISTMETRICSOUTPUT .
-  methods PUT_METRIC_ALARM
-    importing
-      !IV_ALARM_NAME type /AWS1/CWTALARMNAME
-      !IV_METRIC_NAME type /AWS1/CWTMETRICNAME
-      !IV_NAMESPACE type /AWS1/CWTNAMESPACE
-      !IV_COMPARISON_OPERATOR type /AWS1/CWTCOMPARISONOPERATOR
-      !IV_STATISTIC type /AWS1/CWTSTATISTIC
-      !IV_THRESHOLD type /AWS1/RT_DOUBLE_AS_STRING
-      !IV_ALARM_DESCRIPTION type /AWS1/CWTALARMDESCRIPTION
-      !IV_ACTIONS_ENABLED type /AWS1/CWTACTIONSENABLED
-      !IV_EVALUATION_PERIODS type /AWS1/CWTEVALUATIONPERIODS
-      !IT_DIMENSIONS type /AWS1/CL_CWTDIMENSION=>TT_DIMENSIONS
-      !IV_UNIT type /AWS1/CWTSTANDARDUNIT
-      !IV_PERIOD type /AWS1/CWTPERIOD .
-protected section.
-private section.
+    METHODS delete_alarms
+      IMPORTING
+      !it_alarm_names TYPE /aws1/cl_cwtalarmnames_w=>tt_alarmnames .
+    METHODS describe_alarms
+      IMPORTING
+      !it_alarm_names TYPE /aws1/cl_cwtalarmnames_w=>tt_alarmnames
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_cwtdescralarmsoutput .
+    METHODS disable_alarm_actions
+      IMPORTING
+      !it_alarm_names TYPE /aws1/cl_cwtalarmnames_w=>tt_alarmnames .
+    METHODS enable_alarm_actions
+      IMPORTING
+      !it_alarm_names TYPE /aws1/cl_cwtalarmnames_w=>tt_alarmnames .
+    METHODS list_metrics
+      IMPORTING
+      !iv_namespace TYPE /aws1/cwtnamespace
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_cwtlistmetricsoutput .
+    METHODS put_metric_alarm
+      IMPORTING
+      !iv_alarm_name TYPE /aws1/cwtalarmname
+      !iv_metric_name TYPE /aws1/cwtmetricname
+      !iv_namespace TYPE /aws1/cwtnamespace
+      !iv_comparison_operator TYPE /aws1/cwtcomparisonoperator
+      !iv_statistic TYPE /aws1/cwtstatistic
+      !iv_threshold TYPE /aws1/rt_double_as_string
+      !iv_alarm_description TYPE /aws1/cwtalarmdescription
+      !iv_actions_enabled TYPE /aws1/cwtactionsenabled
+      !iv_evaluation_periods TYPE /aws1/cwtevaluationperiods
+      !it_dimensions TYPE /aws1/cl_cwtdimension=>tt_dimensions
+      !iv_unit TYPE /aws1/cwtstandardunit
+      !iv_period TYPE /aws1/cwtperiod .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -52,7 +52,7 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
 
   METHOD delete_alarms.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_cwt) = /aws1/cl_cwt_factory=>create( lo_session ).
@@ -60,10 +60,9 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
     "snippet-start:[cwt.abapv1.delete_alarms]
     TRY.
         lo_cwt->deletealarms(
-          it_alarmnames = it_alarm_names
-        ).
+          it_alarmnames = it_alarm_names ).
         MESSAGE 'Alarms deleted.' TYPE 'I'.
-      CATCH /aws1/cx_cwtresourcenotfound .
+      CATCH /aws1/cx_cwtresourcenotfound.
         MESSAGE 'Resource being accessed is not found.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[cwt.abapv1.delete_alarms]
@@ -73,7 +72,7 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
 
   METHOD describe_alarms.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_cwt) = /aws1/cl_cwt_factory=>create( lo_session ).
@@ -81,8 +80,7 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
     "snippet-start:[cwt.abapv1.describe_alarms]
     TRY.
         oo_result = lo_cwt->describealarms(                 " oo_result is returned for testing purposes. "
-          it_alarmnames = it_alarm_names
-        ).
+          it_alarmnames = it_alarm_names ).
         MESSAGE 'Alarms retrieved.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.
@@ -95,7 +93,7 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
 
   METHOD disable_alarm_actions.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_cwt) = /aws1/cl_cwt_factory=>create( lo_session ).
@@ -105,8 +103,7 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
     "Disables actions on the specified alarm. "
     TRY.
         lo_cwt->disablealarmactions(
-          it_alarmnames = it_alarm_names
-        ).
+          it_alarmnames = it_alarm_names ).
         MESSAGE 'Alarm actions disabled.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.
@@ -119,7 +116,7 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
 
   METHOD enable_alarm_actions.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_cwt) = /aws1/cl_cwt_factory=>create( lo_session ).
@@ -129,8 +126,7 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
     "Enable actions on the specified alarm."
     TRY.
         lo_cwt->enablealarmactions(
-          it_alarmnames = it_alarm_names
-        ).
+          it_alarmnames = it_alarm_names ).
         MESSAGE 'Alarm actions enabled.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.
@@ -143,7 +139,7 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
 
   METHOD list_metrics.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_cwt) = /aws1/cl_cwt_factory=>create( lo_session ).
@@ -152,11 +148,10 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
     "The following list-metrics example displays the metrics for Amazon CloudWatch."
     TRY.
         oo_result = lo_cwt->listmetrics(            " oo_result is returned for testing purposes. "
-          iv_namespace = iv_namespace
-        ).
+          iv_namespace = iv_namespace ).
         DATA(lt_metrics) = oo_result->get_metrics( ).
         MESSAGE 'Metrics retrieved.' TYPE 'I'.
-      CATCH /aws1/cx_cwtinvparamvalueex .
+      CATCH /aws1/cx_cwtinvparamvalueex.
         MESSAGE 'The specified argument was not valid.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[cwt.abapv1.list_metrics]
@@ -166,7 +161,7 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
 
   METHOD put_metric_alarm.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_cwt) = /aws1/cl_cwt_factory=>create( lo_session ).
@@ -185,8 +180,7 @@ CLASS ZCL_AWS1_CWT_ACTIONS IMPLEMENTATION.
           iv_alarmdescription          = iv_alarm_description
           iv_unit                      = iv_unit
           iv_period                    = iv_period
-          it_dimensions                = it_dimensions
-        ).
+          it_dimensions                = it_dimensions ).
         MESSAGE 'Alarm created.' TYPE 'I'.
       CATCH /aws1/cx_cwtlimitexceededfault.
         MESSAGE 'The request processing has exceeded the limit' TYPE 'E'.

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.testclasses.abap
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_actions.clas.testclasses.abap
@@ -1,7 +1,7 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-CLASS ltc_zcl_aws1_cwt_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_cwt_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
     CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
@@ -19,7 +19,7 @@ CLASS ltc_zcl_aws1_cwt_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL H
     METHODS enable_alarm_actions FOR TESTING.
     METHODS disable_alarm_actions FOR TESTING.
     METHODS list_metrics FOR TESTING.
-    METHODS setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
 
 ENDCLASS.       "ltc_Zcl_Aws1_Cwt_Actions
 
@@ -35,7 +35,7 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
 
   METHOD put_metric_alarm.
 
-    DATA lv_alarm_name  TYPE  /aws1/cwtalarmname.
+    DATA lv_alarm_name  TYPE /aws1/cwtalarmname.
     DATA lt_alarmnames TYPE /aws1/cl_cwtalarmnames_w=>tt_alarmnames.
     DATA lo_alarmname TYPE REF TO /aws1/cl_cwtalarmnames_w.
     DATA lt_dimensions TYPE /aws1/cl_cwtdimension=>tt_dimensions.
@@ -44,14 +44,14 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     DATA lv_bucket_name TYPE /aws1/s3_bucketname.
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
-    CONSTANTS cv_metric_name  TYPE  /aws1/cwtmetricname VALUE 'NumberOfObjects'.
-    CONSTANTS cv_namespace  TYPE  /aws1/cwtnamespace VALUE 'AWS/S3'.
-    CONSTANTS cv_comparison_operator  TYPE  /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
-    CONSTANTS cv_statistic  TYPE  /aws1/cwtstatistic VALUE 'Average'.
-    CONSTANTS cv_threshold  TYPE  /aws1/rt_double_as_string VALUE 10.
-    CONSTANTS cv_alarm_description  TYPE  /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
-    CONSTANTS cv_actions_enabled  TYPE  /aws1/cwtactionsenabled VALUE ' '.
-    CONSTANTS cv_evaluation_periods TYPE  /aws1/cwtevaluationperiods VALUE 1.
+    CONSTANTS cv_metric_name  TYPE /aws1/cwtmetricname VALUE 'NumberOfObjects'.
+    CONSTANTS cv_namespace  TYPE /aws1/cwtnamespace VALUE 'AWS/S3'.
+    CONSTANTS cv_comparison_operator  TYPE /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
+    CONSTANTS cv_statistic  TYPE /aws1/cwtstatistic VALUE 'Average'.
+    CONSTANTS cv_threshold  TYPE /aws1/rt_double_as_string VALUE 10.
+    CONSTANTS cv_alarm_description  TYPE /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
+    CONSTANTS cv_actions_enabled  TYPE /aws1/cwtactionsenabled VALUE ' '.
+    CONSTANTS cv_evaluation_periods TYPE /aws1/cwtevaluationperiods VALUE 1.
     CONSTANTS cv_unit TYPE /aws1/cwtstandardunit VALUE 'Percent'.
     CONSTANTS cv_period TYPE /aws1/cwtperiod VALUE 86400.
     CONSTANTS cv_bucket_name TYPE /aws1/s3_bucketname VALUE 'code-example-cwt-'.
@@ -60,28 +60,25 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     lv_uuid_16 = cl_system_uuid=>create_uuid_x16_static( ).
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
-
+    DATA(lo_s3_actions) = NEW zcl_aws1_s3_actions( ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
     "Define alarm name.
     lv_alarm_name = 'code-example-cwt-s3-alarm-' && lv_uuid_16.
     TRANSLATE lv_alarm_name TO LOWER CASE.
 
     "Create Amazon S3 dimensions.
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'StorageType'
-        iv_value = 'AllStorageTypes'.
+    lo_dimensions = NEW #( iv_name = 'StorageType'
+                           iv_value = 'AllStorageTypes' ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'BucketName'
-        iv_value = lv_bucket_name.
+    lo_dimensions = NEW #( iv_name = 'BucketName'
+                           iv_value = lv_bucket_name ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
     ao_cwt_actions->put_metric_alarm(
-      EXPORTING
-        iv_alarm_name          = lv_alarm_name
+      iv_alarm_name          = lv_alarm_name
         iv_metric_name         = cv_metric_name
         iv_namespace           = cv_namespace
         iv_comparison_operator = cv_comparison_operator
@@ -92,8 +89,7 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
         iv_evaluation_periods  = cv_evaluation_periods
         it_dimensions          = lt_dimensions
         iv_unit                = cv_unit
-        iv_period              = cv_period
-        ).
+        iv_period              = cv_period ).
 
     "Describe alarm.
     lo_alarm_list_result = ao_cwt->describealarms( it_alarmnames = lt_alarmnames ).
@@ -108,25 +104,22 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Alarm not found|
-    ).
+      msg = |Alarm not found| ).
 
     "Clean up.
-    CREATE OBJECT lo_alarmname EXPORTING iv_value = lv_alarm_name.
+    lo_alarmname = NEW #( iv_value = lv_alarm_name ).
     INSERT lo_alarmname INTO TABLE lt_alarmnames.
 
-    ao_cwt->deletealarms( it_alarmnames = lt_alarmnames
-    ).
+    ao_cwt->deletealarms( it_alarmnames = lt_alarmnames ).
 
     ao_s3->deletebucket(
-      iv_bucket = lv_bucket_name
-    ).
+      iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
   METHOD delete_alarms.
 
-    DATA lv_alarm_name  TYPE  /aws1/cwtalarmname.
+    DATA lv_alarm_name  TYPE /aws1/cwtalarmname.
     DATA lt_alarmnames TYPE /aws1/cl_cwtalarmnames_w=>tt_alarmnames.
     DATA lo_alarmname TYPE REF TO /aws1/cl_cwtalarmnames_w.
     DATA lt_dimensions TYPE /aws1/cl_cwtdimension=>tt_dimensions.
@@ -135,14 +128,14 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     DATA lv_bucket_name TYPE /aws1/s3_bucketname.
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
-    CONSTANTS cv_metric_name  TYPE  /aws1/cwtmetricname VALUE 'NumberOfObjects'.
-    CONSTANTS cv_namespace  TYPE  /aws1/cwtnamespace VALUE 'AWS/S3'.
-    CONSTANTS cv_comparison_operator  TYPE  /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
-    CONSTANTS cv_statistic  TYPE  /aws1/cwtstatistic VALUE 'Average'.
-    CONSTANTS cv_threshold  TYPE  /aws1/rt_double_as_string VALUE 10.
-    CONSTANTS cv_alarm_description  TYPE  /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
-    CONSTANTS cv_actions_enabled  TYPE  /aws1/cwtactionsenabled VALUE ' '.
-    CONSTANTS cv_evaluation_periods TYPE  /aws1/cwtevaluationperiods VALUE 1.
+    CONSTANTS cv_metric_name  TYPE /aws1/cwtmetricname VALUE 'NumberOfObjects'.
+    CONSTANTS cv_namespace  TYPE /aws1/cwtnamespace VALUE 'AWS/S3'.
+    CONSTANTS cv_comparison_operator  TYPE /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
+    CONSTANTS cv_statistic  TYPE /aws1/cwtstatistic VALUE 'Average'.
+    CONSTANTS cv_threshold  TYPE /aws1/rt_double_as_string VALUE 10.
+    CONSTANTS cv_alarm_description  TYPE /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
+    CONSTANTS cv_actions_enabled  TYPE /aws1/cwtactionsenabled VALUE ' '.
+    CONSTANTS cv_evaluation_periods TYPE /aws1/cwtevaluationperiods VALUE 1.
     CONSTANTS cv_unit TYPE /aws1/cwtstandardunit VALUE 'Percent'.
     CONSTANTS cv_period TYPE /aws1/cwtperiod VALUE 86400.
     CONSTANTS cv_bucket_name TYPE /aws1/s3_bucketname VALUE 'code-example-cwt-'.
@@ -151,28 +144,26 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     lv_uuid_16 = cl_system_uuid=>create_uuid_x16_static( ).
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+    DATA(lo_s3_actions) = NEW zcl_aws1_s3_actions( ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
 
     "Define alarm name.
     lv_alarm_name = 'code-example-cwt-s3-alarm-' && lv_uuid_16.
     TRANSLATE lv_alarm_name TO LOWER CASE.
 
     "Create Amazon S3 dimensions.
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'StorageType'
-        iv_value = 'AllStorageTypes'.
+    lo_dimensions = NEW #( iv_name = 'StorageType'
+                           iv_value = 'AllStorageTypes' ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'BucketName'
-        iv_value = lv_bucket_name.
+    lo_dimensions = NEW #( iv_name = 'BucketName'
+                           iv_value = lv_bucket_name ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
     ao_cwt->putmetricalarm(
-      EXPORTING
-        iv_alarmname          = lv_alarm_name
+      iv_alarmname          = lv_alarm_name
         iv_metricname         = cv_metric_name
         iv_namespace           = cv_namespace
         iv_comparisonoperator = cv_comparison_operator
@@ -183,14 +174,13 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
         iv_evaluationperiods  = cv_evaluation_periods
         iv_unit                = cv_unit
         iv_period              = cv_period
-        it_dimensions          = lt_dimensions
-        ).
+        it_dimensions          = lt_dimensions ).
 
     "Test delete_alarm.
-    CREATE OBJECT lo_alarmname EXPORTING iv_value = lv_alarm_name.
+    lo_alarmname = NEW #( iv_value = lv_alarm_name ).
     INSERT lo_alarmname INTO TABLE lt_alarmnames.
 
-    ao_cwt_actions->delete_alarms( it_alarm_names = lt_alarmnames ).
+    ao_cwt_actions->delete_alarms( lt_alarmnames ).
 
     "Describe alarm.
     lo_alarm_list_result = ao_cwt->describealarms( it_alarmnames = lt_alarmnames ).
@@ -205,19 +195,17 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_false(
       act = lv_found
-      msg = |Alarm not deleted|
-    ).
+      msg = |Alarm not deleted| ).
 
     "Clean up.
     ao_s3->deletebucket(
-      iv_bucket = lv_bucket_name
-    ).
+      iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
   METHOD describe_alarms.
 
-    DATA lv_alarm_name  TYPE  /aws1/cwtalarmname.
+    DATA lv_alarm_name  TYPE /aws1/cwtalarmname.
     DATA lt_alarmnames TYPE /aws1/cl_cwtalarmnames_w=>tt_alarmnames.
     DATA lo_alarmname TYPE REF TO /aws1/cl_cwtalarmnames_w.
     DATA lt_dimensions TYPE /aws1/cl_cwtdimension=>tt_dimensions.
@@ -226,14 +214,14 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     DATA lv_bucket_name TYPE /aws1/s3_bucketname.
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
-    CONSTANTS cv_metric_name  TYPE  /aws1/cwtmetricname VALUE 'NumberOfObjects'.
-    CONSTANTS cv_namespace  TYPE  /aws1/cwtnamespace VALUE 'AWS/S3'.
-    CONSTANTS cv_comparison_operator  TYPE  /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
-    CONSTANTS cv_statistic  TYPE  /aws1/cwtstatistic VALUE 'Average'.
-    CONSTANTS cv_threshold  TYPE  /aws1/rt_double_as_string VALUE 10.
-    CONSTANTS cv_alarm_description  TYPE  /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
-    CONSTANTS cv_actions_enabled  TYPE  /aws1/cwtactionsenabled VALUE ' '.
-    CONSTANTS cv_evaluation_periods TYPE  /aws1/cwtevaluationperiods VALUE 1.
+    CONSTANTS cv_metric_name  TYPE /aws1/cwtmetricname VALUE 'NumberOfObjects'.
+    CONSTANTS cv_namespace  TYPE /aws1/cwtnamespace VALUE 'AWS/S3'.
+    CONSTANTS cv_comparison_operator  TYPE /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
+    CONSTANTS cv_statistic  TYPE /aws1/cwtstatistic VALUE 'Average'.
+    CONSTANTS cv_threshold  TYPE /aws1/rt_double_as_string VALUE 10.
+    CONSTANTS cv_alarm_description  TYPE /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
+    CONSTANTS cv_actions_enabled  TYPE /aws1/cwtactionsenabled VALUE ' '.
+    CONSTANTS cv_evaluation_periods TYPE /aws1/cwtevaluationperiods VALUE 1.
     CONSTANTS cv_unit TYPE /aws1/cwtstandardunit VALUE 'Percent'.
     CONSTANTS cv_period TYPE /aws1/cwtperiod VALUE 86400.
     CONSTANTS cv_bucket_name TYPE /aws1/s3_bucketname VALUE 'code-example-cwt-'.
@@ -242,28 +230,27 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     lv_uuid_16 = cl_system_uuid=>create_uuid_x16_static( ).
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+
+    DATA(lo_s3_actions) = NEW zcl_aws1_s3_actions( ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
 
     "Define alarm name.
     lv_alarm_name = 'code-example-cwt-s3-alarm-' && lv_uuid_16.
     TRANSLATE lv_alarm_name TO LOWER CASE.
 
     "Create Amazon S3 dimensions.
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'StorageType'
-        iv_value = 'AllStorageTypes'.
+    lo_dimensions = NEW #( iv_name = 'StorageType'
+                           iv_value = 'AllStorageTypes' ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'BucketName'
-        iv_value = lv_bucket_name.
+    lo_dimensions = NEW #( iv_name = 'BucketName'
+                           iv_value = lv_bucket_name ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
     ao_cwt->putmetricalarm(
-      EXPORTING
-        iv_alarmname          = lv_alarm_name
+      iv_alarmname          = lv_alarm_name
         iv_metricname         = cv_metric_name
         iv_namespace           = cv_namespace
         iv_comparisonoperator = cv_comparison_operator
@@ -274,17 +261,15 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
         iv_evaluationperiods  = cv_evaluation_periods
         iv_unit                = cv_unit
         iv_period              = cv_period
-        it_dimensions          = lt_dimensions
-        ).
+        it_dimensions          = lt_dimensions ).
 
     "Test describe_alarms.
-    CREATE OBJECT lo_alarmname EXPORTING iv_value = lv_alarm_name.
+    lo_alarmname = NEW #( iv_value = lv_alarm_name ).
     INSERT lo_alarmname INTO TABLE lt_alarmnames.
 
     ao_cwt_actions->describe_alarms(
       EXPORTING it_alarm_names = lt_alarmnames
-      IMPORTING oo_result = lo_alarm_list_result
-    ).
+      IMPORTING oo_result = lo_alarm_list_result ).
 
     "Validation.
     lv_found = abap_false.
@@ -297,22 +282,19 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Alarm not found|
-    ).
+      msg = |Alarm not found| ).
 
     "Clean up.
-    ao_cwt->deletealarms( it_alarmnames = lt_alarmnames
-    ).
+    ao_cwt->deletealarms( it_alarmnames = lt_alarmnames ).
 
     ao_s3->deletebucket(
-      iv_bucket = lv_bucket_name
-    ).
+      iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
   METHOD enable_alarm_actions.
 
-    DATA lv_alarm_name  TYPE  /aws1/cwtalarmname.
+    DATA lv_alarm_name  TYPE /aws1/cwtalarmname.
     DATA lt_alarmnames TYPE /aws1/cl_cwtalarmnames_w=>tt_alarmnames.
     DATA lo_alarmname TYPE REF TO /aws1/cl_cwtalarmnames_w.
     DATA lt_dimensions TYPE /aws1/cl_cwtdimension=>tt_dimensions.
@@ -321,14 +303,14 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     DATA lv_bucket_name TYPE /aws1/s3_bucketname.
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
-    CONSTANTS cv_metric_name  TYPE  /aws1/cwtmetricname VALUE 'NumberOfObjects'.
-    CONSTANTS cv_namespace  TYPE  /aws1/cwtnamespace VALUE 'AWS/S3'.
-    CONSTANTS cv_comparison_operator  TYPE  /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
-    CONSTANTS cv_statistic  TYPE  /aws1/cwtstatistic VALUE 'Average'.
-    CONSTANTS cv_threshold  TYPE  /aws1/rt_double_as_string VALUE 10.
-    CONSTANTS cv_alarm_description  TYPE  /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
-    CONSTANTS cv_actions_enabled  TYPE  /aws1/cwtactionsenabled VALUE ' '.
-    CONSTANTS cv_evaluation_periods TYPE  /aws1/cwtevaluationperiods VALUE 1.
+    CONSTANTS cv_metric_name  TYPE /aws1/cwtmetricname VALUE 'NumberOfObjects'.
+    CONSTANTS cv_namespace  TYPE /aws1/cwtnamespace VALUE 'AWS/S3'.
+    CONSTANTS cv_comparison_operator  TYPE /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
+    CONSTANTS cv_statistic  TYPE /aws1/cwtstatistic VALUE 'Average'.
+    CONSTANTS cv_threshold  TYPE /aws1/rt_double_as_string VALUE 10.
+    CONSTANTS cv_alarm_description  TYPE /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
+    CONSTANTS cv_actions_enabled  TYPE /aws1/cwtactionsenabled VALUE ' '.
+    CONSTANTS cv_evaluation_periods TYPE /aws1/cwtevaluationperiods VALUE 1.
     CONSTANTS cv_unit TYPE /aws1/cwtstandardunit VALUE 'Percent'.
     CONSTANTS cv_period TYPE /aws1/cwtperiod VALUE 86400.
     CONSTANTS cv_bucket_name TYPE /aws1/s3_bucketname VALUE 'code-example-cwt-'.
@@ -337,28 +319,27 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     lv_uuid_16 = cl_system_uuid=>create_uuid_x16_static( ).
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+
+    DATA(lo_s3_actions) = NEW zcl_aws1_s3_actions( ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
 
     "Define alarm name.
     lv_alarm_name = 'code-example-cwt-s3-alarm-' && lv_uuid_16.
     TRANSLATE lv_alarm_name TO LOWER CASE.
 
     "Create Amazon S3 dimensions.
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'StorageType'
-        iv_value = 'AllStorageTypes'.
+    lo_dimensions = NEW #( iv_name = 'StorageType'
+                           iv_value = 'AllStorageTypes' ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'BucketName'
-        iv_value = lv_bucket_name.
+    lo_dimensions = NEW #( iv_name = 'BucketName'
+                           iv_value = lv_bucket_name ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
     ao_cwt->putmetricalarm(
-      EXPORTING
-        iv_alarmname          = lv_alarm_name
+      iv_alarmname          = lv_alarm_name
         iv_metricname         = cv_metric_name
         iv_namespace           = cv_namespace
         iv_comparisonoperator = cv_comparison_operator
@@ -369,19 +350,17 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
         iv_evaluationperiods  = cv_evaluation_periods
         iv_unit                = cv_unit
         iv_period              = cv_period
-        it_dimensions          = lt_dimensions
-        ).
+        it_dimensions          = lt_dimensions ).
 
     "Testing enable_alarm_actions.
-    CREATE OBJECT lo_alarmname EXPORTING iv_value = lv_alarm_name.
+    lo_alarmname = NEW #( iv_value = lv_alarm_name ).
     INSERT lo_alarmname INTO TABLE lt_alarmnames.
 
-    ao_cwt_actions->enable_alarm_actions( it_alarm_names = lt_alarmnames ).
+    ao_cwt_actions->enable_alarm_actions( lt_alarmnames ).
 
     "Validation.
     lo_alarm_list_result = ao_cwt->describealarms(
-      EXPORTING it_alarmnames = lt_alarmnames
-    ).
+      it_alarmnames = lt_alarmnames ).
 
     lv_found = abap_false.
 
@@ -393,25 +372,22 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Alarm actions not enabled|
-    ).
+      msg = |Alarm actions not enabled| ).
 
     "Clean up.
-    CREATE OBJECT lo_alarmname EXPORTING iv_value = lv_alarm_name.
+    lo_alarmname = NEW #( iv_value = lv_alarm_name ).
     INSERT lo_alarmname INTO TABLE lt_alarmnames.
 
-    ao_cwt->deletealarms( it_alarmnames = lt_alarmnames
-    ).
+    ao_cwt->deletealarms( it_alarmnames = lt_alarmnames ).
 
     ao_s3->deletebucket(
-      iv_bucket = lv_bucket_name
-    ).
+      iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
   METHOD disable_alarm_actions.
 
-    DATA lv_alarm_name  TYPE  /aws1/cwtalarmname.
+    DATA lv_alarm_name  TYPE /aws1/cwtalarmname.
     DATA lt_alarmnames TYPE /aws1/cl_cwtalarmnames_w=>tt_alarmnames.
     DATA lo_alarmname TYPE REF TO /aws1/cl_cwtalarmnames_w.
     DATA lt_dimensions TYPE /aws1/cl_cwtdimension=>tt_dimensions.
@@ -420,14 +396,14 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     DATA lv_bucket_name TYPE /aws1/s3_bucketname.
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
-    CONSTANTS cv_metric_name  TYPE  /aws1/cwtmetricname VALUE 'NumberOfObjects'.
-    CONSTANTS cv_namespace  TYPE  /aws1/cwtnamespace VALUE 'AWS/S3'.
-    CONSTANTS cv_comparison_operator  TYPE  /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
-    CONSTANTS cv_statistic  TYPE  /aws1/cwtstatistic VALUE 'Average'.
-    CONSTANTS cv_threshold  TYPE  /aws1/rt_double_as_string VALUE 10.
-    CONSTANTS cv_alarm_description  TYPE  /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
-    CONSTANTS cv_actions_enabled  TYPE  /aws1/cwtactionsenabled VALUE 'X'.
-    CONSTANTS cv_evaluation_periods TYPE  /aws1/cwtevaluationperiods VALUE 1.
+    CONSTANTS cv_metric_name  TYPE /aws1/cwtmetricname VALUE 'NumberOfObjects'.
+    CONSTANTS cv_namespace  TYPE /aws1/cwtnamespace VALUE 'AWS/S3'.
+    CONSTANTS cv_comparison_operator  TYPE /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
+    CONSTANTS cv_statistic  TYPE /aws1/cwtstatistic VALUE 'Average'.
+    CONSTANTS cv_threshold  TYPE /aws1/rt_double_as_string VALUE 10.
+    CONSTANTS cv_alarm_description  TYPE /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
+    CONSTANTS cv_actions_enabled  TYPE /aws1/cwtactionsenabled VALUE 'X'.
+    CONSTANTS cv_evaluation_periods TYPE /aws1/cwtevaluationperiods VALUE 1.
     CONSTANTS cv_unit TYPE /aws1/cwtstandardunit VALUE 'Percent'.
     CONSTANTS cv_period TYPE /aws1/cwtperiod VALUE 86400.
     CONSTANTS cv_bucket_name TYPE /aws1/s3_bucketname VALUE 'code-example-cwt-'.
@@ -436,28 +412,27 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     lv_uuid_16 = cl_system_uuid=>create_uuid_x16_static( ).
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+
+    DATA(lo_s3_actions) = NEW zcl_aws1_s3_actions( ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
 
     "Define alarm name.
     lv_alarm_name = 'code-example-cwt-s3-alarm-' && lv_uuid_16.
     TRANSLATE lv_alarm_name TO LOWER CASE.
 
     "Create Amazon S3 dimensions.
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'StorageType'
-        iv_value = 'AllStorageTypes'.
+    lo_dimensions = NEW #( iv_name = 'StorageType'
+                           iv_value = 'AllStorageTypes' ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'BucketName'
-        iv_value = lv_bucket_name.
+    lo_dimensions = NEW #( iv_name = 'BucketName'
+                           iv_value = lv_bucket_name ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
     ao_cwt->putmetricalarm(
-      EXPORTING
-        iv_alarmname          = lv_alarm_name
+      iv_alarmname          = lv_alarm_name
         iv_metricname         = cv_metric_name
         iv_namespace           = cv_namespace
         iv_comparisonoperator = cv_comparison_operator
@@ -468,19 +443,17 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
         iv_evaluationperiods  = cv_evaluation_periods
         iv_unit                = cv_unit
         iv_period              = cv_period
-        it_dimensions          = lt_dimensions
-        ).
+        it_dimensions          = lt_dimensions ).
 
     "Testing disable_alarm_actions.
-    CREATE OBJECT lo_alarmname EXPORTING iv_value = lv_alarm_name.
+    lo_alarmname = NEW #( iv_value = lv_alarm_name ).
     INSERT lo_alarmname INTO TABLE lt_alarmnames.
 
-    ao_cwt_actions->disable_alarm_actions( it_alarm_names = lt_alarmnames ).
+    ao_cwt_actions->disable_alarm_actions( lt_alarmnames ).
 
     "Validation.
     lo_alarm_list_result = ao_cwt->describealarms(
-      EXPORTING it_alarmnames = lt_alarmnames
-    ).
+      it_alarmnames = lt_alarmnames ).
 
     lv_found = abap_false.
 
@@ -492,25 +465,22 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Alarm actions not disabled|
-    ).
+      msg = |Alarm actions not disabled| ).
 
     "Clean up.
-    CREATE OBJECT lo_alarmname EXPORTING iv_value = lv_alarm_name.
+    lo_alarmname = NEW #( iv_value = lv_alarm_name ).
     INSERT lo_alarmname INTO TABLE lt_alarmnames.
 
-    ao_cwt->deletealarms( it_alarmnames = lt_alarmnames
-    ).
+    ao_cwt->deletealarms( it_alarmnames = lt_alarmnames ).
 
     ao_s3->deletebucket(
-      iv_bucket = lv_bucket_name
-    ).
+      iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
   METHOD list_metrics.
 
-    DATA lv_alarm_name  TYPE  /aws1/cwtalarmname.
+    DATA lv_alarm_name  TYPE /aws1/cwtalarmname.
     DATA lt_alarmnames TYPE /aws1/cl_cwtalarmnames_w=>tt_alarmnames.
     DATA lo_alarmname TYPE REF TO /aws1/cl_cwtalarmnames_w.
     DATA lt_dimensions TYPE /aws1/cl_cwtdimension=>tt_dimensions.
@@ -523,14 +493,14 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     DATA lt_metrics TYPE /aws1/cl_cwtmetric=>tt_metrics.
     DATA lo_metrics TYPE REF TO /aws1/cl_cwtmetric.
 
-    CONSTANTS cv_metric_name  TYPE  /aws1/cwtmetricname VALUE 'NumberOfObjects'.
-    CONSTANTS cv_namespace  TYPE  /aws1/cwtnamespace VALUE 'AWS/S3'.
-    CONSTANTS cv_comparison_operator  TYPE  /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
-    CONSTANTS cv_statistic  TYPE  /aws1/cwtstatistic VALUE 'Average'.
-    CONSTANTS cv_threshold  TYPE  /aws1/rt_double_as_string VALUE 10.
-    CONSTANTS cv_alarm_description  TYPE  /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
-    CONSTANTS cv_actions_enabled  TYPE  /aws1/cwtactionsenabled VALUE 'X'.
-    CONSTANTS cv_evaluation_periods TYPE  /aws1/cwtevaluationperiods VALUE 1.
+    CONSTANTS cv_metric_name  TYPE /aws1/cwtmetricname VALUE 'NumberOfObjects'.
+    CONSTANTS cv_namespace  TYPE /aws1/cwtnamespace VALUE 'AWS/S3'.
+    CONSTANTS cv_comparison_operator  TYPE /aws1/cwtcomparisonoperator VALUE 'GreaterThanThreshold'.
+    CONSTANTS cv_statistic  TYPE /aws1/cwtstatistic VALUE 'Average'.
+    CONSTANTS cv_threshold  TYPE /aws1/rt_double_as_string VALUE 10.
+    CONSTANTS cv_alarm_description  TYPE /aws1/cwtalarmdescription VALUE 'Alarm when number of objects exceeds 10'.
+    CONSTANTS cv_actions_enabled  TYPE /aws1/cwtactionsenabled VALUE 'X'.
+    CONSTANTS cv_evaluation_periods TYPE /aws1/cwtevaluationperiods VALUE 1.
     CONSTANTS cv_unit TYPE /aws1/cwtstandardunit VALUE 'Percent'.
     CONSTANTS cv_period TYPE /aws1/cwtperiod VALUE 86400.
     CONSTANTS cv_bucket_name TYPE /aws1/s3_bucketname VALUE 'code-example-cwt-'.
@@ -539,28 +509,27 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
     lv_uuid_16 = cl_system_uuid=>create_uuid_x16_static( ).
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+
+    DATA(lo_s3_actions) = NEW zcl_aws1_s3_actions( ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
 
     "Define alarm name.
     lv_alarm_name = 'code-example-cwt-s3-alarm-' && lv_uuid_16.
     TRANSLATE lv_alarm_name TO LOWER CASE.
 
     "Create Amazon S3 dimensions.
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'StorageType'
-        iv_value = 'AllStorageTypes'.
+    lo_dimensions = NEW #( iv_name = 'StorageType'
+                           iv_value = 'AllStorageTypes' ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
-    CREATE OBJECT lo_dimensions
-      EXPORTING
-        iv_name  = 'BucketName'
-        iv_value = lv_bucket_name.
+    lo_dimensions = NEW #( iv_name = 'BucketName'
+                           iv_value = lv_bucket_name ).
     INSERT lo_dimensions INTO TABLE lt_dimensions.
 
     ao_cwt->putmetricalarm(
-      EXPORTING
-        iv_alarmname           = lv_alarm_name
+      iv_alarmname           = lv_alarm_name
         iv_metricname          = cv_metric_name
         iv_namespace           = cv_namespace
         iv_comparisonoperator  = cv_comparison_operator
@@ -571,8 +540,7 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
         iv_evaluationperiods   = cv_evaluation_periods
         iv_unit                = cv_unit
         iv_period              = cv_period
-        it_dimensions          = lt_dimensions
-        ).
+        it_dimensions          = lt_dimensions ).
 
     "Testing list_metrics.
     ao_cwt_actions->list_metrics( EXPORTING iv_namespace = 'AWS/S3' IMPORTING oo_result = lo_list_metrics_result ).
@@ -589,19 +557,16 @@ CLASS ltc_zcl_aws1_cwt_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |No metric found|
-    ).
+      msg = |No metric found| ).
 
     "Clean up.
-    CREATE OBJECT lo_alarmname EXPORTING iv_value = lv_alarm_name.
+    lo_alarmname = NEW #( iv_value = lv_alarm_name ).
     INSERT lo_alarmname INTO TABLE lt_alarmnames.
 
-    ao_cwt->deletealarms( it_alarmnames = lt_alarmnames
-    ).
+    ao_cwt->deletealarms( it_alarmnames = lt_alarmnames ).
 
     ao_s3->deletebucket(
-      iv_bucket = lv_bucket_name
-    ).
+      iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 

--- a/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.abap
+++ b/sap-abap/services/cloudwatch/zcl_aws1_cwt_scenario.clas.abap
@@ -1,31 +1,31 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_CWT_SCENARIO definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_cwt_scenario DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods GETTING_STARTED_WITH_CWT
-    importing
-      !IV_ALARM_NAME type /AWS1/CWTALARMNAME
-      !IV_METRIC_NAME type /AWS1/CWTMETRICNAME
-      !IV_NAMESPACE type /AWS1/CWTNAMESPACE
-      !IV_COMPARISON_OPERATOR type /AWS1/CWTCOMPARISONOPERATOR
-      !IV_STATISTIC type /AWS1/CWTSTATISTIC
-      !IV_THRESHOLD type /AWS1/RT_DOUBLE_AS_STRING
-      !IV_ALARM_DESCRIPTION type /AWS1/CWTALARMDESCRIPTION
-      !IV_ACTIONS_ENABLED type /AWS1/CWTACTIONSENABLED
-      !IV_EVALUATION_PERIODS type /AWS1/CWTEVALUATIONPERIODS
-      !IT_DIMENSIONS type /AWS1/CL_CWTDIMENSION=>TT_DIMENSIONS
-      !IV_UNIT type /AWS1/CWTSTANDARDUNIT
-      !IV_PERIOD type /AWS1/CWTPERIOD
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_CWTDESCRALARMSOUTPUT .
-protected section.
-private section.
+    METHODS getting_started_with_cwt
+      IMPORTING
+      !iv_alarm_name TYPE /aws1/cwtalarmname
+      !iv_metric_name TYPE /aws1/cwtmetricname
+      !iv_namespace TYPE /aws1/cwtnamespace
+      !iv_comparison_operator TYPE /aws1/cwtcomparisonoperator
+      !iv_statistic TYPE /aws1/cwtstatistic
+      !iv_threshold TYPE /aws1/rt_double_as_string
+      !iv_alarm_description TYPE /aws1/cwtalarmdescription
+      !iv_actions_enabled TYPE /aws1/cwtactionsenabled
+      !iv_evaluation_periods TYPE /aws1/cwtevaluationperiods
+      !it_dimensions TYPE /aws1/cl_cwtdimension=>tt_dimensions
+      !iv_unit TYPE /aws1/cwtstandardunit
+      !iv_period TYPE /aws1/cwtperiod
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_cwtdescralarmsoutput .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -36,7 +36,7 @@ CLASS ZCL_AWS1_CWT_SCENARIO IMPLEMENTATION.
   METHOD getting_started_with_cwt.
 
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_cwt) = /aws1/cl_cwt_factory=>create( lo_session ).
@@ -66,22 +66,20 @@ CLASS ZCL_AWS1_CWT_SCENARIO IMPLEMENTATION.
           iv_alarmdescription          = iv_alarm_description
           iv_unit                      = iv_unit
           iv_period                    = iv_period
-          it_dimensions                = it_dimensions
-        ).
+          it_dimensions                = it_dimensions ).
         MESSAGE 'Alarm created' TYPE 'I'.
       CATCH /aws1/cx_cwtlimitexceededfault.
         MESSAGE 'The request processing has exceeded the limit' TYPE 'E'.
     ENDTRY.
 
     "Create an ABAP internal table for the created alarm."
-    CREATE OBJECT lo_alarmname EXPORTING iv_value = iv_alarm_name.
+    lo_alarmname = NEW #( iv_value = iv_alarm_name ).
     INSERT lo_alarmname INTO TABLE lt_alarmnames.
 
     "Disable alarm actions."
     TRY.
         lo_cwt->disablealarmactions(
-          it_alarmnames                = lt_alarmnames
-        ).
+          it_alarmnames                = lt_alarmnames ).
         MESSAGE 'Alarm actions disabled' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_disablealarm_exception).
         DATA(lv_disablealarm_error) = |"{ lo_disablealarm_exception->av_err_code }" - { lo_disablealarm_exception->av_err_msg }|.
@@ -91,8 +89,7 @@ CLASS ZCL_AWS1_CWT_SCENARIO IMPLEMENTATION.
     "Describe alarm using the same ABAP internal table."
     TRY.
         oo_result = lo_cwt->describealarms(                       " oo_result is returned for testing purpose "
-          it_alarmnames                = lt_alarmnames
-        ).
+          it_alarmnames                = lt_alarmnames ).
         MESSAGE 'Alarms retrieved' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_describealarms_exception).
         DATA(lv_describealarms_error) = |"{ lo_describealarms_exception->av_err_code }" - { lo_describealarms_exception->av_err_msg }|.
@@ -102,10 +99,9 @@ CLASS ZCL_AWS1_CWT_SCENARIO IMPLEMENTATION.
     "Delete alarm."
     TRY.
         lo_cwt->deletealarms(
-          it_alarmnames = lt_alarmnames
-        ).
+          it_alarmnames = lt_alarmnames ).
         MESSAGE 'Alarms deleted' TYPE 'I'.
-      CATCH /aws1/cx_cwtresourcenotfound .
+      CATCH /aws1/cx_cwtresourcenotfound.
         MESSAGE 'Resource being access is not found.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[cwt.abapv1.getting_started_with_cwt]

--- a/sap-abap/services/dyn/zcl_aws1_dyn_actions.clas.testclasses.abap
+++ b/sap-abap/services/dyn/zcl_aws1_dyn_actions.clas.testclasses.abap
@@ -6,7 +6,7 @@ CLASS zcl_aws1_dyn_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_dyn_actions.
 
 CLASS ltc_zcl_aws1_dyn_actions DEFINITION FOR TESTING
   DURATION LONG
-  RISK LEVEL HARMLESS.
+  RISK LEVEL DANGEROUS.
 
   PROTECTED SECTION.
     METHODS: create_table FOR TESTING RAISING /aws1/cx_rt_generic,

--- a/sap-abap/services/dyn/zcl_aws1_dyn_scenario.clas.testclasses.abap
+++ b/sap-abap/services/dyn/zcl_aws1_dyn_scenario.clas.testclasses.abap
@@ -6,7 +6,7 @@ CLASS zcl_aws1_dyn_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_dyn_scenario.
 
 CLASS ltc_zcl_aws1_dyn_scenario DEFINITION FOR TESTING
   DURATION LONG
-  RISK LEVEL HARMLESS.
+  RISK LEVEL DANGEROUS.
 
   PROTECTED SECTION.
     METHODS test_dyn FOR TESTING RAISING /aws1/cx_rt_generic.
@@ -38,7 +38,7 @@ CLASS ltc_zcl_aws1_dyn_scenario IMPLEMENTATION.
   METHOD test_dyn.
     DATA(av_table_name) = |code-example-getting-startted-with-tables|.
     ao_dyn_scenario->getting_started_with_tables( av_table_name ).
-    assert_table_not_exist( iv_table_name = av_table_name ).
+    assert_table_not_exist( av_table_name ).
   ENDMETHOD.
 
   METHOD assert_table_not_exist.

--- a/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.abap
+++ b/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.abap
@@ -1,87 +1,87 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_EC2_ACTIONS definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_ec2_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
-protected section.
-private section.
+  PUBLIC SECTION.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 
-  methods ALLOCATE_ADDRESS
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2ALLOCATEADDRESSRS .
-  methods CREATE_INSTANCE
-    importing
-      !IV_AMI_ID type /AWS1/EC2IMAGEID
-      !IV_TAG_VALUE type /AWS1/EC2STRING
-      !IV_SUBNET_ID type /AWS1/EC2SUBNETID
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2RESERVATION .
-  methods CREATE_KEY_PAIR
-    importing
-      !IV_KEY_NAME type /AWS1/EC2STRING
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2KEYPAIR .
-  methods CREATE_SECURITY_GROUP
-    importing
-      !IV_SECURITY_GROUP_NAME type /AWS1/EC2STRING
-      !IV_VPC_ID type /AWS1/EC2VPCID
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2CREATESECGROUPRSLT .
-  methods DELETE_SECURITY_GROUP
-    importing
-      !IV_SECURITY_GROUP_ID type /AWS1/EC2SECURITYGROUPID .
-  methods DELETE_KEY_PAIR
-    importing
-      !IV_KEY_NAME type /AWS1/EC2KEYPAIRNAME .
-  methods DESCRIBE_ADDRESSES
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2DESCRADDRESSESRSLT .
-  methods DESCRIBE_INSTANCES
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2DESCRINSTSRESULT .
-  methods DESCRIBE_KEY_PAIRS
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2DESCRKEYPAIRSRSLT .
-  methods DESCRIBE_REGIONS
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2DESCRREGIONSRESULT .
-  methods DESCRIBE_SECURITY_GROUPS
-    importing
-      !IV_GROUP_ID type /AWS1/EC2SECURITYGROUPID
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2DESCRSECGROUPSRSLT .
-  methods MONITOR_INSTANCE
-    importing
-      !IV_INSTANCE_ID type /AWS1/EC2INSTANCEID .
-  methods REBOOT_INSTANCE
-    importing
-      !IV_INSTANCE_ID type /AWS1/EC2INSTANCEID .
-  methods RELEASE_ADDRESS
-    importing
-      !IV_ALLOCATION_ID type /AWS1/EC2ALLOCATIONID .
-  methods START_INSTANCE
-    importing
-      !IV_INSTANCE_ID type /AWS1/EC2INSTANCEID
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2STARTINSTSRESULT .
-  methods STOP_INSTANCE
-    importing
-      !IV_INSTANCE_ID type /AWS1/EC2INSTANCEID
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2STOPINSTSRESULT .
-  methods ASSOCIATE_ADDRESS
-    importing
-      !IV_INSTANCE_ID type /AWS1/EC2INSTANCEID
-      !IV_ALLOCATION_ID type /AWS1/EC2ALLOCATIONID
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2ASSOCADDRESSRESULT .
-  methods DESCRIBE_AVAILABILITY_ZONES
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_EC2DESCRIBEAZSRESULT .
+    METHODS allocate_address
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2allocateaddressrs .
+    METHODS create_instance
+      IMPORTING
+      !iv_ami_id TYPE /aws1/ec2imageid
+      !iv_tag_value TYPE /aws1/ec2string
+      !iv_subnet_id TYPE /aws1/ec2subnetid
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2reservation .
+    METHODS create_key_pair
+      IMPORTING
+      !iv_key_name TYPE /aws1/ec2string
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2keypair .
+    METHODS create_security_group
+      IMPORTING
+      !iv_security_group_name TYPE /aws1/ec2string
+      !iv_vpc_id TYPE /aws1/ec2vpcid
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2createsecgrouprslt .
+    METHODS delete_security_group
+      IMPORTING
+      !iv_security_group_id TYPE /aws1/ec2securitygroupid .
+    METHODS delete_key_pair
+      IMPORTING
+      !iv_key_name TYPE /aws1/ec2keypairname .
+    METHODS describe_addresses
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2descraddressesrslt .
+    METHODS describe_instances
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2descrinstsresult .
+    METHODS describe_key_pairs
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2descrkeypairsrslt .
+    METHODS describe_regions
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2descrregionsresult .
+    METHODS describe_security_groups
+      IMPORTING
+      !iv_group_id TYPE /aws1/ec2securitygroupid
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2descrsecgroupsrslt .
+    METHODS monitor_instance
+      IMPORTING
+      !iv_instance_id TYPE /aws1/ec2instanceid .
+    METHODS reboot_instance
+      IMPORTING
+      !iv_instance_id TYPE /aws1/ec2instanceid .
+    METHODS release_address
+      IMPORTING
+      !iv_allocation_id TYPE /aws1/ec2allocationid .
+    METHODS start_instance
+      IMPORTING
+      !iv_instance_id TYPE /aws1/ec2instanceid
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2startinstsresult .
+    METHODS stop_instance
+      IMPORTING
+      !iv_instance_id TYPE /aws1/ec2instanceid
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2stopinstsresult .
+    METHODS associate_address
+      IMPORTING
+      !iv_instance_id TYPE /aws1/ec2instanceid
+      !iv_allocation_id TYPE /aws1/ec2allocationid
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2assocaddressresult .
+    METHODS describe_availability_zones
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_ec2describeazsresult .
 ENDCLASS.
 
 
@@ -90,7 +90,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD allocate_address.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -108,7 +108,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD associate_address.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -117,8 +117,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
     TRY.
         oo_result = lo_ec2->associateaddress(                         " oo_result is returned for testing purposes. "
             iv_allocationid = iv_allocation_id
-            iv_instanceid = iv_instance_id
-        ).
+            iv_instanceid = iv_instance_id ).
         MESSAGE 'Associated an Elastic IP address with an EC2 instance.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.
@@ -129,7 +128,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD create_instance.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -139,24 +138,22 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
     " Create tags for resource created during instance launch. "
     DATA lt_tagspecifications TYPE /aws1/cl_ec2tagspecification=>tt_tagspecificationlist.
     DATA ls_tagspecifications LIKE LINE OF lt_tagspecifications.
-    ls_tagspecifications =  NEW /aws1/cl_ec2tagspecification(
+    ls_tagspecifications = NEW /aws1/cl_ec2tagspecification(
       iv_resourcetype = 'instance'
       it_tags = VALUE /aws1/cl_ec2tag=>tt_taglist(
         ( NEW /aws1/cl_ec2tag( iv_key = 'Name' iv_value = iv_tag_value ) )
-      )
-    ).
+      ) ).
     APPEND ls_tagspecifications TO lt_tagspecifications.
 
     TRY.
         " Create/launch Amazon Elastic Compute Cloud (Amazon EC2) instance. "
         oo_result = lo_ec2->runinstances(                           " oo_result is returned for testing purposes. "
           iv_imageid = iv_ami_id
-          iv_instancetype = 't2.micro'
+          iv_instancetype = 't3.micro'
           iv_maxcount = 1
           iv_mincount = 1
           it_tagspecifications = lt_tagspecifications
-          iv_subnetid = iv_subnet_id
-        ).
+          iv_subnetid = iv_subnet_id ).
         MESSAGE 'EC2 instance created.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.
@@ -167,7 +164,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD create_key_pair.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -185,7 +182,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD create_security_group.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -195,8 +192,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
         oo_result = lo_ec2->createsecuritygroup(                 " oo_result is returned for testing purposes. "
           iv_description = 'Security group example'
           iv_groupname = iv_security_group_name
-          iv_vpcid = iv_vpc_id
-        ).
+          iv_vpcid = iv_vpc_id ).
         MESSAGE 'Security group created.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.
@@ -207,7 +203,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD delete_key_pair.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -225,7 +221,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD delete_security_group.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -243,14 +239,14 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD describe_addresses.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
 
     " snippet-start:[ec2.abapv1.describe_addresses]
     TRY.
-        oo_result = lo_ec2->describeaddresses( ) .                        " oo_result is returned for testing purposes. "
+        oo_result = lo_ec2->describeaddresses( ).                        " oo_result is returned for testing purposes. "
         DATA(lt_addresses) = oo_result->get_addresses( ).
         MESSAGE 'Retrieved information about Elastic IP addresses.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
@@ -262,14 +258,14 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD describe_availability_zones.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
 
     " snippet-start:[ec2.abapv1.describe_availability_zones]
     TRY.
-        oo_result = lo_ec2->describeavailabilityzones( ) .                        " oo_result is returned for testing purposes. "
+        oo_result = lo_ec2->describeavailabilityzones( ).                        " oo_result is returned for testing purposes. "
         DATA(lt_zones) = oo_result->get_availabilityzones( ).
         MESSAGE 'Retrieved information about Availability Zones.' TYPE 'I'.
 
@@ -283,14 +279,14 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD describe_instances.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
 
     " snippet-start:[ec2.abapv1.describe_instances]
     TRY.
-        oo_result = lo_ec2->describeinstances( ) .                        " oo_result is returned for testing purposes. "
+        oo_result = lo_ec2->describeinstances( ).                        " oo_result is returned for testing purposes. "
 
         " Retrieving details of EC2 instances. "
         DATA: lv_istance_id    TYPE /aws1/ec2string,
@@ -300,7 +296,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
         LOOP AT oo_result->get_reservations( ) INTO DATA(lo_reservation).
           LOOP AT lo_reservation->get_instances( ) INTO DATA(lo_instance).
             lv_istance_id = lo_instance->get_instanceid( ).
-            lv_status =  lo_instance->get_state( )->get_name( ).
+            lv_status = lo_instance->get_state( )->get_name( ).
             lv_instance_type = lo_instance->get_instancetype( ).
             lv_image_id = lo_instance->get_imageid( ).
           ENDLOOP.
@@ -315,14 +311,14 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD describe_key_pairs.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
 
     " snippet-start:[ec2.abapv1.describe_key_pairs]
     TRY.
-        oo_result = lo_ec2->describekeypairs( ) .                        " oo_result is returned for testing purposes. "
+        oo_result = lo_ec2->describekeypairs( ).                        " oo_result is returned for testing purposes. "
         DATA(lt_key_pairs) = oo_result->get_keypairs( ).
         MESSAGE 'Retrieved information about key pairs.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
@@ -334,14 +330,14 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD describe_regions.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
 
     " snippet-start:[ec2.abapv1.describe_regions]
     TRY.
-        oo_result = lo_ec2->describeregions( ) .                        " oo_result is returned for testing purposes. "
+        oo_result = lo_ec2->describeregions( ).                        " oo_result is returned for testing purposes. "
         DATA(lt_regions) = oo_result->get_regions( ).
         MESSAGE 'Retrieved information about Regions.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
@@ -354,7 +350,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD describe_security_groups.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -375,7 +371,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD monitor_instance.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -390,8 +386,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
         " DryRun is set to true. This checks for the required permissions to monitor the instance without actually making the request. "
         lo_ec2->monitorinstances(
           it_instanceids = lt_instance_ids
-          iv_dryrun = abap_true
-        ).
+          iv_dryrun = abap_true ).
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         " If the error code returned is `DryRunOperation`, then you have the required permissions to monitor this instance. "
         IF lo_exception->av_err_code = 'DryRunOperation'.
@@ -399,8 +394,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
           " DryRun is set to false to enable detailed monitoring. "
           lo_ec2->monitorinstances(
             it_instanceids = lt_instance_ids
-            iv_dryrun = abap_false
-          ).
+            iv_dryrun = abap_false ).
           MESSAGE 'Detailed monitoring enabled.' TYPE 'I'.
           " If the error code returned is `UnauthorizedOperation`, then you don't have the required permissions to monitor this instance. "
         ELSEIF lo_exception->av_err_code = 'UnauthorizedOperation'.
@@ -415,7 +409,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD reboot_instance.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -429,8 +423,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
         " DryRun is set to true. This checks for the required permissions to reboot the instance without actually making the request. "
         lo_ec2->rebootinstances(
           it_instanceids = lt_instance_ids
-          iv_dryrun = abap_true
-        ).
+          iv_dryrun = abap_true ).
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         " If the error code returned is `DryRunOperation`, then you have the required permissions to reboot this instance. "
         IF lo_exception->av_err_code = 'DryRunOperation'.
@@ -438,8 +431,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
           " DryRun is set to false to make a reboot request. "
           lo_ec2->rebootinstances(
              it_instanceids = lt_instance_ids
-             iv_dryrun = abap_false
-           ).
+             iv_dryrun = abap_false ).
           MESSAGE 'Instance rebooted.' TYPE 'I'.
           " If the error code returned is `UnauthorizedOperation`, then you don't have the required permissions to reboot this instance. "
         ELSEIF lo_exception->av_err_code = 'UnauthorizedOperation'.
@@ -454,7 +446,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD release_address.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -471,8 +463,8 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD START_INSTANCE.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+  METHOD start_instance.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -487,8 +479,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
         " DryRun is set to true. This checks for the required permissions to start the instance without actually making the request. "
         lo_ec2->startinstances(
           it_instanceids = lt_instance_ids
-          iv_dryrun = abap_true
-        ).
+          iv_dryrun = abap_true ).
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         " If the error code returned is `DryRunOperation`, then you have the required permissions to start this instance. "
         IF lo_exception->av_err_code = 'DryRunOperation'.
@@ -496,8 +487,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
           " DryRun is set to false to start instance. "
           oo_result = lo_ec2->startinstances(           " oo_result is returned for testing purposes. "
             it_instanceids = lt_instance_ids
-            iv_dryrun = abap_false
-          ).
+            iv_dryrun = abap_false ).
           MESSAGE 'Successfully started the EC2 instance.' TYPE 'I'.
           " If the error code returned is `UnauthorizedOperation`, then you don't have the required permissions to start this instance. "
         ELSEIF lo_exception->av_err_code = 'UnauthorizedOperation'.
@@ -512,7 +502,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
 
 
   METHOD stop_instance.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_ec2) = /aws1/cl_ec2_factory=>create( lo_session ).
@@ -527,8 +517,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
         " DryRun is set to true. This checks for the required permissions to stop the instance without actually making the request. "
         lo_ec2->stopinstances(
           it_instanceids = lt_instance_ids
-          iv_dryrun = abap_true
-        ).
+          iv_dryrun = abap_true ).
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         " If the error code returned is `DryRunOperation`, then you have the required permissions to stop this instance. "
         IF lo_exception->av_err_code = 'DryRunOperation'.
@@ -536,8 +525,7 @@ CLASS ZCL_AWS1_EC2_ACTIONS IMPLEMENTATION.
           " DryRun is set to false to stop instance. "
           oo_result = lo_ec2->stopinstances(           " oo_result is returned for testing purposes. "
             it_instanceids = lt_instance_ids
-            iv_dryrun = abap_false
-          ).
+            iv_dryrun = abap_false ).
           MESSAGE 'Successfully stopped the EC2 instance.' TYPE 'I'.
           " If the error code returned is `UnauthorizedOperation`, then you don't have the required permissions to stop this instance. "
         ELSEIF lo_exception->av_err_code = 'UnauthorizedOperation'.

--- a/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.testclasses.abap
+++ b/sap-abap/services/ec2/zcl_aws1_ec2_actions.clas.testclasses.abap
@@ -4,14 +4,18 @@
 CLASS ltc_zcl_aws1_ec2_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_ec2_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_ec2_actions.
 
-CLASS ltc_zcl_aws1_ec2_actions DEFINITION FOR TESTING  DURATION LONG RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_ec2_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
-    DATA ao_ec2 TYPE REF TO /aws1/if_ec2.
-    DATA ao_session TYPE REF TO /aws1/cl_rt_session_base.
-    DATA ao_ec2_actions TYPE REF TO zcl_aws1_ec2_actions.
+    CLASS-DATA ao_ec2 TYPE REF TO /aws1/if_ec2.
+    CLASS-DATA ao_session TYPE REF TO /aws1/cl_rt_session_base.
+    CLASS-DATA ao_ec2_actions TYPE REF TO zcl_aws1_ec2_actions.
+    CLASS-DATA av_vpc_id TYPE /aws1/ec2string.
+    CLASS-DATA av_subnet_id TYPE /aws1/ec2string.
+    CLASS-DATA at_instance_id TYPE TABLE OF /aws1/ec2string. " table of instance IDs to terminate
+    CLASS-DATA av_instance_id TYPE /aws1/ec2string. " main instance Id for tests
 
     METHODS: allocate_address FOR TESTING RAISING /aws1/cx_rt_generic,
       associate_address FOR TESTING RAISING /aws1/cx_rt_generic,
@@ -32,9 +36,11 @@ CLASS ltc_zcl_aws1_ec2_actions DEFINITION FOR TESTING  DURATION LONG RISK LEVEL 
       start_instances FOR TESTING RAISING /aws1/cx_rt_generic,
       stop_instances FOR TESTING RAISING /aws1/cx_rt_generic.
 
-    METHODS setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    CLASS-METHODS class_setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
+    CLASS-METHODS class_teardown RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
 
-    METHODS:
+
+    CLASS-METHODS:
       get_ami_id
         RETURNING VALUE(ov_ami_id) TYPE /aws1/ec2string
         RAISING   /aws1/cx_rt_generic,
@@ -55,401 +61,365 @@ ENDCLASS.
 
 CLASS ltc_zcl_aws1_ec2_actions IMPLEMENTATION.
 
-  METHOD setup.
+  METHOD class_setup.
     ao_session = /aws1/cl_rt_session_aws=>create( iv_profile_id = cv_pfl ).
     ao_ec2 = /aws1/cl_ec2_factory=>create( ao_session ).
     ao_ec2_actions = NEW zcl_aws1_ec2_actions( ).
+    av_vpc_id = ao_ec2->createvpc( iv_cidrblock  = '10.10.0.0/16' )->get_vpc( )->get_vpcid( ).
+    av_subnet_id = ao_ec2->createsubnet( iv_vpcid = av_vpc_id
+                                               iv_cidrblock = '10.10.0.0/24' )->get_subnet( )->get_subnetid( ).
+    av_instance_id = run_instance( av_subnet_id ).
 
   ENDMETHOD.
+
+  METHOD class_teardown.
+    LOOP AT at_instance_id ASSIGNING FIELD-SYMBOL(<instance_id>).
+      terminate_instance( <instance_id> ).
+    ENDLOOP.
+
+    DO 4 TIMES.
+      TRY.
+          ao_ec2->deletesubnet( iv_subnetid = av_subnet_id ).
+          EXIT.  " exit the loop
+        CATCH /aws1/cx_ec2clientexc INTO DATA(lo_ex).
+          IF lo_ex->get_text( ) CS 'dependencies'.
+            WAIT UP TO 15 SECONDS.
+          ELSE.
+            RAISE EXCEPTION lo_ex.
+          ENDIF.
+
+      ENDTRY.
+    ENDDO.
+    DO 4 TIMES.
+      TRY.
+          ao_ec2->deletevpc( iv_vpcid = av_vpc_id ).
+        CATCH /aws1/cx_ec2clientexc INTO lo_ex.
+          IF lo_ex->av_err_code = 'DependencyViolation'.
+            WAIT UP TO 15 SECONDS.
+          ELSEIF lo_ex->av_err_code = 'InvalidVpcID.NotFound'.
+            EXIT.
+          ELSE.
+            RAISE EXCEPTION lo_ex.
+          ENDIF.
+      ENDTRY.
+    ENDDO.
+  ENDMETHOD.
+
   METHOD allocate_address.
     DATA(lo_result) = ao_ec2_actions->allocate_address( ).
 
     cl_abap_unit_assert=>assert_not_initial(
           act = lo_result->get_allocationid( )
-          msg = |Failed to allocate an Elastic IP address|
-        ).
+          msg = |Failed to allocate an Elastic IP address| ).
 
     ao_ec2->releaseaddress( iv_allocationid = lo_result->get_allocationid( ) ).
 
   ENDMETHOD.
   METHOD associate_address.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.10.0.0/16' )->get_vpc( )->get_vpcid( ).
-    DATA(lv_subnet_id) = ao_ec2->createsubnet( iv_vpcid = lv_vpc_id iv_cidrblock = '10.10.0.0/24' )->get_subnet( )->get_subnetid( ).
     DATA(lv_internet_gateway_id) = ao_ec2->createinternetgateway( )->get_internetgateway( )->get_internetgatewayid( ).
-    ao_ec2->attachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id iv_vpcid = lv_vpc_id ).
-    DATA(lv_instance_id) = run_instance( iv_subnet_id = lv_subnet_id ).
-    wait_until_status_change( iv_instance_id = lv_instance_id iv_required_status = 'running' ).
+    ao_ec2->attachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id
+                                   iv_vpcid = av_vpc_id ).
+    wait_until_status_change( iv_instance_id = av_instance_id
+                              iv_required_status = 'running' ).
     DATA(lv_allocation_id) = ao_ec2->allocateaddress( iv_domain = 'vpc' )->get_allocationid( ).
 
     DATA(lo_result) = ao_ec2_actions->associate_address(
-        iv_instance_id = lv_instance_id
-        iv_allocation_id = lv_allocation_id
-    ).
+        iv_instance_id = av_instance_id
+        iv_allocation_id = lv_allocation_id ).
 
     cl_abap_unit_assert=>assert_not_initial(
           act = lo_result->get_associationid( )
-          msg = |Failed to associate Elastic IP address with EC2 instancce|
-        ).
+          msg = |Failed to associate Elastic IP address with EC2 instancce| ).
 
     ao_ec2->disassociateaddress( iv_associationid = lo_result->get_associationid( ) ).
     ao_ec2->releaseaddress( iv_allocationid = lv_allocation_id ).
-    terminate_instance( iv_instance_id = lv_instance_id ).
-    ao_ec2->detachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id iv_vpcid = lv_vpc_id ).
+    ao_ec2->detachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id
+                                   iv_vpcid = av_vpc_id ).
     ao_ec2->deleteinternetgateway( iv_internetgatewayid = lv_internet_gateway_id ).
-    ao_ec2->deletesubnet( iv_subnetid = lv_subnet_id ).
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
   ENDMETHOD.
   METHOD describe_addresses.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.11.0.0/16' )->get_vpc( )->get_vpcid( ).
-    DATA(lv_subnet_id) = ao_ec2->createsubnet( iv_vpcid = lv_vpc_id iv_cidrblock = '10.11.0.0/24' )->get_subnet( )->get_subnetid( ).
     DATA(lv_internet_gateway_id) = ao_ec2->createinternetgateway( )->get_internetgateway( )->get_internetgatewayid( ).
-    ao_ec2->attachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id iv_vpcid = lv_vpc_id ).
-    DATA(lv_instance_id) = run_instance( iv_subnet_id = lv_subnet_id ).
-    wait_until_status_change( iv_instance_id = lv_instance_id iv_required_status = 'running' ).
+    ao_ec2->attachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id
+                                   iv_vpcid = av_vpc_id ).
+    wait_until_status_change( iv_instance_id = av_instance_id
+                              iv_required_status = 'running' ).
 
     DATA(lo_allocate_result) = ao_ec2->allocateaddress( iv_domain = 'vpc' ).
-    DATA(lo_associate_result) = ao_ec2->associateaddress( iv_allocationid = lo_allocate_result->get_allocationid( ) iv_instanceid = lv_instance_id ).
+    DATA(lo_associate_result) = ao_ec2->associateaddress( iv_allocationid = lo_allocate_result->get_allocationid( )
+                                                          iv_instanceid = av_instance_id ).
 
     DATA(lo_describe_result) = ao_ec2_actions->describe_addresses( ).
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT lo_describe_result->get_addresses( ) INTO DATA(lo_address).
-      IF lo_address->get_instanceid( ) = lv_instance_id AND lo_address->get_publicip( ) = lo_allocate_result->get_publicip( ).
-        lv_found = abap_true.
+      IF lo_address->get_instanceid( ) = av_instance_id AND lo_address->get_publicip( ) = lo_allocate_result->get_publicip( ).
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Elastic IP address associated with EC2 instance should have been included in the address list|
-    ).
+      msg = |Elastic IP address associated with EC2 instance should have been included in the address list| ).
 
     ao_ec2->disassociateaddress( iv_associationid = lo_associate_result->get_associationid( ) ).
     ao_ec2->releaseaddress( iv_allocationid = lo_allocate_result->get_allocationid( ) ).
-    terminate_instance( iv_instance_id = lv_instance_id ).
-    ao_ec2->detachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id iv_vpcid = lv_vpc_id ).
+    ao_ec2->detachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id
+                                   iv_vpcid = av_vpc_id ).
     ao_ec2->deleteinternetgateway( iv_internetgatewayid = lv_internet_gateway_id ).
-    ao_ec2->deletesubnet( iv_subnetid = lv_subnet_id ).
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
   ENDMETHOD.
   METHOD release_address.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.12.0.0/16' )->get_vpc( )->get_vpcid( ).
-    DATA(lv_subnet_id) = ao_ec2->createsubnet( iv_vpcid = lv_vpc_id iv_cidrblock = '10.12.0.0/24' )->get_subnet( )->get_subnetid( ).
     DATA(lv_internet_gateway_id) = ao_ec2->createinternetgateway( )->get_internetgateway( )->get_internetgatewayid( ).
-    ao_ec2->attachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id iv_vpcid = lv_vpc_id ).
-    DATA(lv_instance_id) = run_instance( iv_subnet_id = lv_subnet_id ).
-    wait_until_status_change( iv_instance_id = lv_instance_id iv_required_status = 'running' ).
+    ao_ec2->attachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id
+                                   iv_vpcid = av_vpc_id ).
+    wait_until_status_change( iv_instance_id = av_instance_id
+                              iv_required_status = 'running' ).
 
     DATA(lo_allocate_result) = ao_ec2->allocateaddress( iv_domain = 'vpc' ).
-    DATA(lo_associate_result) = ao_ec2->associateaddress( iv_allocationid = lo_allocate_result->get_allocationid( ) iv_instanceid = lv_instance_id ).
+    DATA(lo_associate_result) = ao_ec2->associateaddress( iv_allocationid = lo_allocate_result->get_allocationid( )
+                                                          iv_instanceid = av_instance_id ).
 
     ao_ec2->disassociateaddress( iv_associationid = lo_associate_result->get_associationid( ) ).
-    ao_ec2_actions->release_address( iv_allocation_id = lo_allocate_result->get_allocationid( ) ).
+    ao_ec2_actions->release_address( lo_allocate_result->get_allocationid( ) ).
 
     DATA(lo_describe_result) = ao_ec2_actions->describe_addresses( ).
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT lo_describe_result->get_addresses( ) INTO DATA(lo_address).
       IF lo_address->get_publicip( ) = lo_allocate_result->get_publicip( ).
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_false(
       act = lv_found
-      msg = |Elastic IP address should have been released|
-    ).
+      msg = |Elastic IP address should have been released| ).
 
-    terminate_instance( iv_instance_id = lv_instance_id ).
-    ao_ec2->detachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id iv_vpcid = lv_vpc_id ).
+    ao_ec2->detachinternetgateway( iv_internetgatewayid = lv_internet_gateway_id
+                                   iv_vpcid = av_vpc_id ).
     ao_ec2->deleteinternetgateway( iv_internetgatewayid = lv_internet_gateway_id ).
-    ao_ec2->deletesubnet( iv_subnetid = lv_subnet_id ).
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
   ENDMETHOD.
   METHOD create_instance.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.4.0.0/16' )->get_vpc( )->get_vpcid( ).
-    DATA(lv_subnet_id) = ao_ec2->createsubnet( iv_vpcid = lv_vpc_id iv_cidrblock = '10.4.0.0/24' )->get_subnet( )->get_subnetid( ).
-
     DATA(lo_create_result) = ao_ec2_actions->create_instance(
         iv_ami_id = get_ami_id( )
         iv_tag_value = 'code-example-create-instance'
-        iv_subnet_id = lv_subnet_id
-    ).
+        iv_subnet_id = av_subnet_id ).
     READ TABLE lo_create_result->get_instances( ) INTO DATA(lo_instance) INDEX 1.
-    DATA(lv_current_status) =  wait_until_status_change( iv_instance_id = lo_instance->get_instanceid( ) iv_required_status = 'running' ).
+    DATA(lv_current_status) = wait_until_status_change( iv_instance_id = lo_instance->get_instanceid( )
+                                                        iv_required_status = 'running' ).
 
     cl_abap_unit_assert=>assert_equals(
       act = lv_current_status
       exp = 'running'
-      msg = |EC2 instance { lo_instance->get_instanceid( ) } should have been in 'running' state|
-    ).
-
-    terminate_instance( iv_instance_id = lo_instance->get_instanceid( ) ).
-    ao_ec2->deletesubnet( iv_subnetid = lv_subnet_id ).
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
+      msg = |EC2 instance { lo_instance->get_instanceid( ) } should have been in 'running' state| ).
+    APPEND lo_instance->get_instanceid( ) TO at_instance_id.
   ENDMETHOD.
   METHOD monitor_instance.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.6.0.0/16' )->get_vpc( )->get_vpcid( ).
-    DATA(lv_subnet_id) = ao_ec2->createsubnet( iv_vpcid = lv_vpc_id iv_cidrblock = '10.6.0.0/24' )->get_subnet( )->get_subnetid( ).
-    DATA(lv_instance_id) = run_instance( iv_subnet_id = lv_subnet_id ).
-    ao_ec2_actions->monitor_instance( iv_instance_id = lv_instance_id ).
+    ao_ec2_actions->monitor_instance( av_instance_id ).
     WAIT UP TO 5 SECONDS.
     DATA(lo_describe_result) = ao_ec2->describeinstances(
-     it_instanceids = VALUE /aws1/cl_ec2instidstringlist_w=>tt_instanceidstringlist(
-       ( NEW /aws1/cl_ec2instidstringlist_w( lv_instance_id ) )
-     )
-    ).
+      it_instanceids = VALUE /aws1/cl_ec2instidstringlist_w=>tt_instanceidstringlist(
+       ( NEW /aws1/cl_ec2instidstringlist_w( av_instance_id ) )
+      ) ).
     READ TABLE lo_describe_result->get_reservations( ) INTO DATA(lo_reservation) INDEX 1.
     READ TABLE lo_reservation->get_instances( ) INTO DATA(lo_describe_instance) INDEX 1.
     cl_abap_unit_assert=>assert_equals(
           exp = lo_describe_instance->get_monitoring( )->get_state( )
           act = 'enabled'
-          msg = |Detailed monitoring should have been enabled|
-        ).
-
-    terminate_instance( iv_instance_id = lv_instance_id ).
-    ao_ec2->deletesubnet( iv_subnetid = lv_subnet_id ).
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
+          msg = |Detailed monitoring should have been enabled| ).
   ENDMETHOD.
   METHOD reboot_instance.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.7.0.0/16' )->get_vpc( )->get_vpcid( ).
-    DATA(lv_subnet_id) = ao_ec2->createsubnet( iv_vpcid = lv_vpc_id iv_cidrblock = '10.7.0.0/24' )->get_subnet( )->get_subnetid( ).
-    DATA(lv_instance_id) = run_instance( iv_subnet_id = lv_subnet_id ).
-    wait_until_status_change( iv_instance_id = lv_instance_id iv_required_status = 'running' ).
-    ao_ec2_actions->reboot_instance( iv_instance_id =  lv_instance_id ).
-    DATA(lv_current_status) = wait_until_status_change( iv_instance_id = lv_instance_id iv_required_status = 'running' ).
+    wait_until_status_change( iv_instance_id = av_instance_id
+                              iv_required_status = 'running' ).
+    ao_ec2_actions->reboot_instance( av_instance_id ).
+    DATA(lv_current_status) = wait_until_status_change( iv_instance_id = av_instance_id
+                                                        iv_required_status = 'running' ).
 
     cl_abap_unit_assert=>assert_equals(
           exp = lv_current_status
           act = 'running'
-          msg = |Failed to reboot the specified instance|
-        ).
-
-    terminate_instance( iv_instance_id = lv_instance_id ).
-    ao_ec2->deletesubnet( iv_subnetid = lv_subnet_id ).
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
+          msg = |Failed to reboot the specified instance| ).
   ENDMETHOD.
   METHOD start_instances.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.8.0.0/16' )->get_vpc( )->get_vpcid( ).
-    DATA(lv_subnet_id) = ao_ec2->createsubnet( iv_vpcid = lv_vpc_id iv_cidrblock = '10.8.0.0/24' )->get_subnet( )->get_subnetid( ).
-    DATA(lv_instance_id) = run_instance( iv_subnet_id = lv_subnet_id ).
-    wait_until_status_change( iv_instance_id = lv_instance_id iv_required_status = 'running' ).
-
     ao_ec2->stopinstances(
       it_instanceids = VALUE /aws1/cl_ec2instidstringlist_w=>tt_instanceidstringlist(
-        ( NEW /aws1/cl_ec2instidstringlist_w( lv_instance_id ) )
-      )
-    ).
-    wait_until_status_change( iv_instance_id = lv_instance_id iv_required_status = 'stopped' ).
+        ( NEW /aws1/cl_ec2instidstringlist_w( av_instance_id ) )
+      ) ).
+    wait_until_status_change( iv_instance_id = av_instance_id
+                              iv_required_status = 'stopped' ).
 
-    DATA(lo_start_result) = ao_ec2_actions->start_instance( iv_instance_id = lv_instance_id ).
+    DATA(lo_start_result) = ao_ec2_actions->start_instance( av_instance_id ).
     READ TABLE lo_start_result->get_startinginstances( ) INTO DATA(lo_start_instance) INDEX 1.
     cl_abap_unit_assert=>assert_equals(
           exp = lo_start_instance->get_currentstate( )->get_name( )
           act = 'pending'
-          msg = |Instance should have been in 'pending' state when a request is made to start a stopped instance|
-        ).
+          msg = |Instance should have been in 'pending' state when a request is made to start a stopped instance| ).
 
-    DATA(lv_current_status) = wait_until_status_change( iv_instance_id = lv_instance_id iv_required_status = 'running' ).
+    DATA(lv_current_status) = wait_until_status_change( iv_instance_id = av_instance_id
+                                                        iv_required_status = 'running' ).
     cl_abap_unit_assert=>assert_equals(
           exp = lv_current_status
           act = 'running'
-          msg = |Failed to start a stopped instance|
-        ).
-
-    terminate_instance( iv_instance_id = lv_instance_id ).
-    ao_ec2->deletesubnet( iv_subnetid = lv_subnet_id ).
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
+          msg = |Failed to start a stopped instance| ).
   ENDMETHOD.
   METHOD stop_instances.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.5.0.0/16' )->get_vpc( )->get_vpcid( ).
-    DATA(lv_subnet_id) = ao_ec2->createsubnet( iv_vpcid = lv_vpc_id iv_cidrblock = '10.5.0.0/24' )->get_subnet( )->get_subnetid( ).
-    DATA(lv_instance_id) = run_instance( iv_subnet_id = lv_subnet_id ).
-    wait_until_status_change( iv_instance_id = lv_instance_id iv_required_status = 'running' ).
-    DATA(lo_stop_result) = ao_ec2_actions->stop_instance( iv_instance_id = lv_instance_id ).
+    DATA(lo_start_result) = ao_ec2_actions->start_instance( av_instance_id ).
+    wait_until_status_change( iv_instance_id = av_instance_id
+                              iv_required_status = 'running' ).
+    DATA(lo_stop_result) = ao_ec2_actions->stop_instance( av_instance_id ).
     READ TABLE lo_stop_result->get_stoppinginstances( ) INTO DATA(lo_stop_instance) INDEX 1.
     cl_abap_unit_assert=>assert_equals(
           exp = lo_stop_instance->get_currentstate( )->get_name( )
           act = 'stopping'
-          msg = |Instance should have been in 'stopping' state when a request is made to stop a running instance|
-        ).
+          msg = |Instance should have been in 'stopping' state when a request is made to stop a running instance| ).
 
-    DATA(lv_current_status) = wait_until_status_change( iv_instance_id = lv_instance_id iv_required_status = 'stopped' ).
+    DATA(lv_current_status) = wait_until_status_change( iv_instance_id = av_instance_id
+                                                        iv_required_status = 'stopped' ).
     cl_abap_unit_assert=>assert_equals(
           exp = lv_current_status
           act = 'stopped'
-          msg = |Failed to stop a running instance|
-        ).
+          msg = |Failed to stop a running instance| ).
 
-    terminate_instance( iv_instance_id = lv_instance_id ).
-    ao_ec2->deletesubnet( iv_subnetid = lv_subnet_id ).
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
   ENDMETHOD.
   METHOD describe_instances.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.9.0.0/16' )->get_vpc( )->get_vpcid( ).
-    DATA(lv_subnet_id) = ao_ec2->createsubnet( iv_vpcid = lv_vpc_id iv_cidrblock = '10.9.0.0/24' )->get_subnet( )->get_subnetid( ).
-    DATA(lv_instance_id) = run_instance( iv_subnet_id = lv_subnet_id ).
     DATA(lo_describe_result) = ao_ec2_actions->describe_instances( ).
     READ TABLE lo_describe_result->get_reservations( ) INTO DATA(lo_reservation) INDEX 1.
     cl_abap_unit_assert=>assert_not_initial(
           act = lo_reservation->get_instances( )
-          msg = |Instance List should not be empty|
-        ).
-    terminate_instance( iv_instance_id = lv_instance_id ).
-    ao_ec2->deletesubnet( iv_subnetid = lv_subnet_id ).
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
+          msg = |Instance List should not be empty| ).
   ENDMETHOD.
   METHOD create_key_pair.
     CONSTANTS cv_key_name TYPE /aws1/ec2string VALUE 'code-example-create-key-pair'.
-    DATA(lo_result) = ao_ec2_actions->create_key_pair( iv_key_name =  cv_key_name ).
+    DATA(lo_result) = ao_ec2_actions->create_key_pair( cv_key_name ).
     cl_abap_unit_assert=>assert_not_initial(
           act = lo_result->get_keypairid( )
-          msg = |Failed to create key pair { cv_key_name }|
-        ).
+          msg = |Failed to create key pair { cv_key_name }| ).
 
-    DATA lv_has_details TYPE abap_bool VALUE abap_false.
+
     IF lo_result->get_keyfingerprint( ) IS NOT INITIAL AND lo_result->get_keymaterial( ) IS NOT INITIAL AND lo_result->get_keyname( ) = cv_key_name.
-      lv_has_details = abap_true.
+      DATA(lv_has_details) = abap_true.
     ENDIF.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_has_details
-      msg = |The response object for key pair { cv_key_name } does not contain the required elements|
-    ).
+      msg = |The response object for key pair { cv_key_name } does not contain the required elements| ).
 
-    ao_ec2->deletekeypair( iv_keyname =  cv_key_name ).
+    ao_ec2->deletekeypair( iv_keyname = cv_key_name ).
   ENDMETHOD.
   METHOD delete_key_pair.
     CONSTANTS cv_key_name TYPE /aws1/ec2string VALUE 'code-example-delete-key-pair'.
-    ao_ec2->createkeypair( iv_keyname =  cv_key_name ).
-    ao_ec2_actions->delete_key_pair( iv_key_name =  cv_key_name ).
+    ao_ec2->createkeypair( iv_keyname = cv_key_name ).
+    ao_ec2_actions->delete_key_pair( cv_key_name ).
     DATA(lo_result) = ao_ec2->describekeypairs( ).
 
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT lo_result->get_keypairs( ) INTO DATA(lo_key_pair).
       IF lo_key_pair->get_keyname( ) = cv_key_name.
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_false(
       act = lv_found
-      msg = |Key Pair { cv_key_name } should have been deleted|
-    ).
+      msg = |Key Pair { cv_key_name } should have been deleted| ).
   ENDMETHOD.
   METHOD describe_key_pairs.
     CONSTANTS cv_key_name TYPE /aws1/ec2string VALUE 'code-example-describe-key-pairs'.
-    ao_ec2->createkeypair( iv_keyname =  cv_key_name ).
+    ao_ec2->createkeypair( iv_keyname = cv_key_name ).
     DATA(lo_result) = ao_ec2_actions->describe_key_pairs( ).
 
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT lo_result->get_keypairs( ) INTO DATA(lo_key_pair).
       IF lo_key_pair->get_keyname( ) = cv_key_name.
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Key Pair { cv_key_name } should have been included in key pair list|
-    ).
-    ao_ec2->deletekeypair( iv_keyname =  cv_key_name ).
+      msg = |Key Pair { cv_key_name } should have been included in key pair list| ).
+    ao_ec2->deletekeypair( iv_keyname = cv_key_name ).
   ENDMETHOD.
   METHOD describe_regions.
     DATA(lo_result) = ao_ec2_actions->describe_regions( ).
     cl_abap_unit_assert=>assert_not_initial(
           act = lo_result->get_regions( )
-          msg = |Failed to retrieve list of regions|
-        ).
+          msg = |Failed to retrieve list of regions| ).
   ENDMETHOD.
   METHOD describe_availability_zones.
     DATA(lo_result) = ao_ec2_actions->describe_availability_zones( ).
     cl_abap_unit_assert=>assert_not_initial(
           act = lo_result->get_availabilityzones( )
-          msg = |Failed to retrieve list of availability zones|
-        ).
+          msg = |Failed to retrieve list of availability zones| ).
   ENDMETHOD.
   METHOD create_security_group.
     CONSTANTS cv_security_group_name TYPE /aws1/ec2string VALUE 'code-example-create-security-group'.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.1.0.0/16' )->get_vpc( )->get_vpcid( ).
-    DATA(lo_create_result) = ao_ec2_actions->create_security_group( iv_security_group_name =  cv_security_group_name iv_vpc_id = lv_vpc_id ).
+    DATA(lo_create_result) = ao_ec2_actions->create_security_group( iv_security_group_name = cv_security_group_name
+                                                                    iv_vpc_id = av_vpc_id ).
     DATA(lo_describe_result) = ao_ec2->describesecuritygroups(
       it_groupids = VALUE /aws1/cl_ec2groupidstrlist_w=>tt_groupidstringlist(
                       ( NEW /aws1/cl_ec2groupidstrlist_w( lo_create_result->get_groupid( ) ) )
-                    )
-    ).
+                    ) ).
 
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT lo_describe_result->get_securitygroups( ) INTO DATA(lo_security_group).
       IF lo_security_group->get_groupname( ) = cv_security_group_name.
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Failed to create security group { cv_security_group_name }|
-    ).
+      msg = |Failed to create security group { cv_security_group_name }| ).
 
     ao_ec2->deletesecuritygroup( iv_groupid = lo_create_result->get_groupid( ) ).
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
   ENDMETHOD.
   METHOD delete_security_group.
     CONSTANTS cv_security_group_name TYPE /aws1/ec2string VALUE 'code-example-delete-security-group'.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.2.0.0/16' )->get_vpc( )->get_vpcid( ).
     DATA(lo_create_result) = ao_ec2->createsecuritygroup(
-        iv_groupname =  cv_security_group_name
+        iv_groupname = cv_security_group_name
         iv_description = |security group for delete_security_group test|
-        iv_vpcid = lv_vpc_id
-    ).
-    ao_ec2_actions->delete_security_group( iv_security_group_id = lo_create_result->get_groupid( ) ).
+        iv_vpcid = av_vpc_id ).
+    ao_ec2_actions->delete_security_group( lo_create_result->get_groupid( ) ).
     DATA(lo_describe_result) = ao_ec2->describesecuritygroups(
       it_filters = VALUE /aws1/cl_ec2filter=>tt_filterlist(
                       ( NEW /aws1/cl_ec2filter(
                         iv_name = 'vpc-id'
                         it_values = VALUE /aws1/cl_ec2valuestringlist_w=>tt_valuestringlist(
-                          ( NEW /aws1/cl_ec2valuestringlist_w( lv_vpc_id ) )
+                          ( NEW /aws1/cl_ec2valuestringlist_w( av_vpc_id ) )
                         )
                       ) )
-                    )
-    ).
+                    ) ).
 
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT lo_describe_result->get_securitygroups( ) INTO DATA(lo_security_group).
       IF lo_security_group->get_groupname( ) = cv_security_group_name.
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_false(
       act = lv_found
-      msg = |Security Group { cv_security_group_name } should have been deleted|
-    ).
+      msg = |Security Group { cv_security_group_name } should have been deleted| ).
 
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
   ENDMETHOD.
   METHOD describe_security_groups.
     CONSTANTS cv_security_group_name TYPE /aws1/ec2string VALUE 'code-example-describe-security-groups'.
-    DATA(lv_vpc_id) = ao_ec2->createvpc( iv_cidrblock  = '10.3.0.0/16' )->get_vpc( )->get_vpcid( ).
     DATA(lo_create_result) = ao_ec2->createsecuritygroup(
-        iv_groupname =  cv_security_group_name
+        iv_groupname = cv_security_group_name
         iv_description = |security group for describe_security_groups test|
-        iv_vpcid = lv_vpc_id
-    ).
+        iv_vpcid = av_vpc_id ).
 
-    DATA(lo_describe_result) = ao_ec2_actions->describe_security_groups( iv_group_id = lo_create_result->get_groupid( ) ).
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+    DATA(lo_describe_result) = ao_ec2_actions->describe_security_groups( lo_create_result->get_groupid( ) ).
+
     LOOP AT lo_describe_result->get_securitygroups( ) INTO DATA(lo_security_group).
       IF lo_security_group->get_groupname( ) = cv_security_group_name.
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Security Group { cv_security_group_name } should have been included in security group list|
-    ).
+      msg = |Security Group { cv_security_group_name } should have been included in security group list| ).
 
     ao_ec2->deletesecuritygroup( iv_groupid = lo_create_result->get_groupid( ) ).
-    ao_ec2->deletevpc( iv_vpcid = lv_vpc_id ).
   ENDMETHOD.
   METHOD get_ami_id.
     CONSTANTS: cv_ami_name     TYPE string VALUE 'amzn2-ami-kernel-5.10-hvm*',
@@ -463,12 +433,12 @@ CLASS ltc_zcl_aws1_ec2_actions IMPLEMENTATION.
            ( NEW /aws1/cl_ec2filter(
                iv_name = 'name'
                it_values = VALUE /aws1/cl_ec2valuestringlist_w=>tt_valuestringlist(
-                 ( NEW /aws1/cl_ec2valuestringlist_w( cv_ami_name )  )
+                 ( NEW /aws1/cl_ec2valuestringlist_w( cv_ami_name ) )
            ) ) )
            ( NEW /aws1/cl_ec2filter(
                iv_name = 'architecture'
                it_values = VALUE /aws1/cl_ec2valuestringlist_w=>tt_valuestringlist(
-                ( NEW /aws1/cl_ec2valuestringlist_w( cv_architecture )  )
+                ( NEW /aws1/cl_ec2valuestringlist_w( cv_architecture ) )
            ) ) )
          )
        )->get_images( ).
@@ -481,13 +451,12 @@ CLASS ltc_zcl_aws1_ec2_actions IMPLEMENTATION.
     ov_ami_id = lo_ami-image->get_imageid( ).
   ENDMETHOD.
   METHOD wait_until_status_change.
-    DO 10 TIMES.
+    DO 96 TIMES.
       WAIT UP TO 5 SECONDS.
       DATA(lo_describe_result) = ao_ec2->describeinstances(
           it_instanceids = VALUE /aws1/cl_ec2instidstringlist_w=>tt_instanceidstringlist(
             ( NEW /aws1/cl_ec2instidstringlist_w( iv_instance_id ) )
-          )
-      ).
+          ) ).
       READ TABLE lo_describe_result->get_reservations( ) INTO DATA(lo_reservation) INDEX 1.
       READ TABLE lo_reservation->get_instances( ) INTO DATA(lo_describe_instance) INDEX 1.
       IF lo_describe_instance->get_state( )->get_name( ) = iv_required_status.
@@ -499,20 +468,20 @@ CLASS ltc_zcl_aws1_ec2_actions IMPLEMENTATION.
   METHOD run_instance.
     DATA(lo_create_result) = ao_ec2->runinstances(
         iv_imageid = get_ami_id( )
-        iv_instancetype = 't2.micro'
+        iv_instancetype = 't3.micro'
         iv_maxcount = 1
         iv_mincount = 1
-        iv_subnetid = iv_subnet_id
-    ).
+        iv_subnetid = iv_subnet_id ).
     READ TABLE lo_create_result->get_instances( ) INTO DATA(lo_instance) INDEX 1.
     ov_instance_id = lo_instance->get_instanceid( ).
+    APPEND ov_instance_id TO at_instance_id.
   ENDMETHOD.
   METHOD terminate_instance.
     ao_ec2->terminateinstances00(
         it_instanceids = VALUE /aws1/cl_ec2instidstringlist_w=>tt_instanceidstringlist(
           ( NEW /aws1/cl_ec2instidstringlist_w( iv_instance_id ) )
-        )
-      ).
-    wait_until_status_change( iv_instance_id = iv_instance_id iv_required_status = 'terminated' ).
+        ) ).
+    wait_until_status_change( iv_instance_id = iv_instance_id
+                              iv_required_status = 'terminated' ).
   ENDMETHOD.
 ENDCLASS.

--- a/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.abap
@@ -1,50 +1,50 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_KNS_ACTIONS definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_kns_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods CREATE_STREAM
-    importing
-      !IV_STREAM_NAME type /AWS1/KNSSTREAMNAME
-      !IV_SHARD_COUNT type /AWS1/KNSPOSITIVEINTEGEROBJECT .
-  methods DELETE_STREAM
-    importing
-      !IV_STREAM_NAME type /AWS1/KNSSTREAMNAME .
-  methods DESCRIBE_STREAM
-    importing
-      !IV_STREAM_NAME type /AWS1/KNSSTREAMNAME
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_KNSDESCRSTREAMOUTPUT .
-  methods GET_RECORDS
-    importing
-      !IV_SHARD_ITERATOR type /AWS1/KNSSHARDITERATOR
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_KNSGETRECORDSOUTPUT .
-  methods LIST_STREAMS
-    importing
-      !IV_LIMIT type /AWS1/KNSLISTSTREAMSINPUTLIMIT
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_KNSLISTSTREAMSOUTPUT .
-  methods PUT_RECORD
-    importing
-      !IV_STREAM_NAME type /AWS1/KNSSTREAMNAME
-      !IV_DATA type /AWS1/KNSDATA
-      !IV_PARTITION_KEY type /AWS1/KNSPARTITIONKEY
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_KNSPUTRECORDOUTPUT .
-  methods REGISTER_STREAM_CONSUMER
-    importing
-      !IV_STREAM_ARN type /AWS1/KNSSTREAMARN
-      !IV_CONSUMER_NAME type /AWS1/KNSCONSUMERNAME
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_KNSREGSTREAMCONSOUT .
-protected section.
-private section.
+    METHODS create_stream
+      IMPORTING
+      !iv_stream_name TYPE /aws1/knsstreamname
+      !iv_shard_count TYPE /aws1/knspositiveintegerobject .
+    METHODS delete_stream
+      IMPORTING
+      !iv_stream_name TYPE /aws1/knsstreamname .
+    METHODS describe_stream
+      IMPORTING
+      !iv_stream_name TYPE /aws1/knsstreamname
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_knsdescrstreamoutput .
+    METHODS get_records
+      IMPORTING
+      !iv_shard_iterator TYPE /aws1/knssharditerator
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_knsgetrecordsoutput .
+    METHODS list_streams
+      IMPORTING
+      !iv_limit TYPE /aws1/knsliststreamsinputlimit
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_knsliststreamsoutput .
+    METHODS put_record
+      IMPORTING
+      !iv_stream_name TYPE /aws1/knsstreamname
+      !iv_data TYPE /aws1/knsdata
+      !iv_partition_key TYPE /aws1/knspartitionkey
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_knsputrecordoutput .
+    METHODS register_stream_consumer
+      IMPORTING
+      !iv_stream_arn TYPE /aws1/knsstreamarn
+      !iv_consumer_name TYPE /aws1/knsconsumername
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_knsregstreamconsout .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -54,7 +54,7 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
 
   METHOD create_stream.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_kns) = /aws1/cl_kns_factory=>create( lo_session ).
@@ -63,14 +63,13 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
     TRY.
         lo_kns->createstream(
             iv_streamname = iv_stream_name
-            iv_shardcount = iv_shard_count
-        ).
+            iv_shardcount = iv_shard_count ).
         MESSAGE 'Stream created.' TYPE 'I'.
       CATCH /aws1/cx_knsinvalidargumentex.
         MESSAGE 'The specified argument was not valid.' TYPE 'E'.
-      CATCH /aws1/cx_knslimitexceededex .
+      CATCH /aws1/cx_knslimitexceededex.
         MESSAGE 'The request processing has failed because of a limit exceed exception.' TYPE 'E'.
-      CATCH /aws1/cx_knsresourceinuseex .
+      CATCH /aws1/cx_knsresourceinuseex.
         MESSAGE 'The request processing has failed because the resource is in use.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[kns.abapv1.create_stream]
@@ -80,7 +79,7 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
 
   METHOD delete_stream.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_kns) = /aws1/cl_kns_factory=>create( lo_session ).
@@ -88,12 +87,11 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
     "snippet-start:[kns.abapv1.delete_stream]
     TRY.
         lo_kns->deletestream(
-            iv_streamname = iv_stream_name
-        ).
+            iv_streamname = iv_stream_name ).
         MESSAGE 'Stream deleted.' TYPE 'I'.
-      CATCH /aws1/cx_knslimitexceededex .
+      CATCH /aws1/cx_knslimitexceededex.
         MESSAGE 'The request processing has failed because of a limit exceed exception.' TYPE 'E'.
-      CATCH /aws1/cx_knsresourceinuseex .
+      CATCH /aws1/cx_knsresourceinuseex.
         MESSAGE 'The request processing has failed because the resource is in use.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[kns.abapv1.delete_stream]
@@ -103,7 +101,7 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
 
   METHOD describe_stream.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_kns) = /aws1/cl_kns_factory=>create( lo_session ).
@@ -111,13 +109,12 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
     "snippet-start:[kns.abapv1.describe_stream]
     TRY.
         oo_result = lo_kns->describestream(
-            iv_streamname = iv_stream_name
-        ).
+            iv_streamname = iv_stream_name ).
         DATA(lt_stream_description) = oo_result->get_streamdescription( ).
         MESSAGE 'Streams retrieved.' TYPE 'I'.
-      CATCH /aws1/cx_knslimitexceededex .
+      CATCH /aws1/cx_knslimitexceededex.
         MESSAGE 'The request processing has failed because of a limit exceed exception.' TYPE 'E'.
-      CATCH /aws1/cx_knsresourcenotfoundex .
+      CATCH /aws1/cx_knsresourcenotfoundex.
         MESSAGE 'Resource being accessed is not found.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[kns.abapv1.describe_stream]
@@ -129,7 +126,7 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
 
   METHOD get_records.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_kns) = /aws1/cl_kns_factory=>create( lo_session ).
@@ -137,29 +134,28 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
     "snippet-start:[kns.abapv1.get_records]
     TRY.
         oo_result = lo_kns->getrecords(             " oo_result is returned for testing purposes. "
-            iv_sharditerator = iv_shard_iterator
-        ).
+            iv_sharditerator = iv_shard_iterator ).
         DATA(lt_records) = oo_result->get_records( ).
         MESSAGE 'Record retrieved.' TYPE 'I'.
-      CATCH /aws1/cx_knsexpirediteratorex .
+      CATCH /aws1/cx_knsexpirediteratorex.
         MESSAGE 'Iterator expired.' TYPE 'E'.
-      CATCH /aws1/cx_knsinvalidargumentex .
+      CATCH /aws1/cx_knsinvalidargumentex.
         MESSAGE 'The specified argument was not valid.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsaccessdeniedex .
+      CATCH /aws1/cx_knskmsaccessdeniedex.
         MESSAGE 'You do not have permission to perform this AWS KMS action.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsdisabledex .
+      CATCH /aws1/cx_knskmsdisabledex.
         MESSAGE 'KMS key used is disabled.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsinvalidstateex .
+      CATCH /aws1/cx_knskmsinvalidstateex.
         MESSAGE 'KMS key used is in an invalid state. ' TYPE 'E'.
-      CATCH /aws1/cx_knskmsnotfoundex .
+      CATCH /aws1/cx_knskmsnotfoundex.
         MESSAGE 'KMS key used is not found.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsoptinrequired .
+      CATCH /aws1/cx_knskmsoptinrequired.
         MESSAGE 'KMS key option is required.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsthrottlingex .
+      CATCH /aws1/cx_knskmsthrottlingex.
         MESSAGE 'The rate of requests to AWS KMS is exceeding the request quotas.' TYPE 'E'.
-      CATCH /aws1/cx_knsprovthruputexcdex .
+      CATCH /aws1/cx_knsprovthruputexcdex.
         MESSAGE 'The request rate for the stream is too high, or the requested data is too large for the available throughput.' TYPE 'E'.
-      CATCH /aws1/cx_knsresourcenotfoundex .
+      CATCH /aws1/cx_knsresourcenotfoundex.
         MESSAGE 'Resource being accessed is not found.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[kns.abapv1.get_records]
@@ -169,7 +165,7 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
 
   METHOD list_streams.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_kns) = /aws1/cl_kns_factory=>create( lo_session ).
@@ -178,11 +174,10 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
     TRY.
         oo_result = lo_kns->liststreams(        " oo_result is returned for testing purposes. "
             "Set Limit to specify that a maximum of streams should be returned."
-            iv_limit = iv_limit
-        ).
+            iv_limit = iv_limit ).
         DATA(lt_streams) = oo_result->get_streamnames( ).
         MESSAGE 'Streams listed.' TYPE 'I'.
-      CATCH /aws1/cx_knslimitexceededex .
+      CATCH /aws1/cx_knslimitexceededex.
         MESSAGE 'The request processing has failed because of a limit exceed exception.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[kns.abapv1.list_streams]
@@ -192,7 +187,7 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
 
   METHOD put_record.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_kns) = /aws1/cl_kns_factory=>create( lo_session ).
@@ -202,26 +197,25 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
         oo_result = lo_kns->putrecord(            " oo_result is returned for testing purposes. "
             iv_streamname = iv_stream_name
             iv_data       = iv_data
-            iv_partitionkey = iv_partition_key
-        ).
+            iv_partitionkey = iv_partition_key ).
         MESSAGE 'Record created.' TYPE 'I'.
-      CATCH /aws1/cx_knsinvalidargumentex .
+      CATCH /aws1/cx_knsinvalidargumentex.
         MESSAGE 'The specified argument was not valid.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsaccessdeniedex .
+      CATCH /aws1/cx_knskmsaccessdeniedex.
         MESSAGE 'You do not have permission to perform this AWS KMS action.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsdisabledex .
+      CATCH /aws1/cx_knskmsdisabledex.
         MESSAGE 'KMS key used is disabled.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsinvalidstateex .
+      CATCH /aws1/cx_knskmsinvalidstateex.
         MESSAGE 'KMS key used is in an invalid state. ' TYPE 'E'.
-      CATCH /aws1/cx_knskmsnotfoundex .
+      CATCH /aws1/cx_knskmsnotfoundex.
         MESSAGE 'KMS key used is not found.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsoptinrequired .
+      CATCH /aws1/cx_knskmsoptinrequired.
         MESSAGE 'KMS key option is required.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsthrottlingex .
+      CATCH /aws1/cx_knskmsthrottlingex.
         MESSAGE 'The rate of requests to AWS KMS is exceeding the request quotas.' TYPE 'E'.
-      CATCH /aws1/cx_knsprovthruputexcdex .
+      CATCH /aws1/cx_knsprovthruputexcdex.
         MESSAGE 'The request rate for the stream is too high, or the requested data is too large for the available throughput.' TYPE 'E'.
-      CATCH /aws1/cx_knsresourcenotfoundex .
+      CATCH /aws1/cx_knsresourcenotfoundex.
         MESSAGE 'Resource being accessed is not found.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[kns.abapv1.put_record]
@@ -230,7 +224,7 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
 
   METHOD register_stream_consumer.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_kns) = /aws1/cl_kns_factory=>create( lo_session ).
@@ -239,10 +233,9 @@ CLASS ZCL_AWS1_KNS_ACTIONS IMPLEMENTATION.
     TRY.
         oo_result = lo_kns->registerstreamconsumer(       " oo_result is returned for testing purposes. "
             iv_streamarn = iv_stream_arn
-            iv_consumername = iv_consumer_name
-        ).
+            iv_consumername = iv_consumer_name ).
         MESSAGE 'Stream consumer registered.' TYPE 'I'.
-      CATCH /aws1/cx_knsinvalidargumentex .
+      CATCH /aws1/cx_knsinvalidargumentex.
         MESSAGE 'The specified argument was not valid.' TYPE 'E'.
       CATCH /aws1/cx_sgmresourcelimitexcd.
         MESSAGE 'You have reached the limit on the number of resources.' TYPE 'E'.

--- a/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.testclasses.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_actions.clas.testclasses.abap
@@ -1,7 +1,7 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-CLASS ltc_zcl_aws1_kns_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_kns_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
 
@@ -37,7 +37,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     DATA lo_stream_describe_result TYPE REF TO /aws1/cl_knsdescrstreamoutput.
     DATA lo_stream_description TYPE REF TO /aws1/cl_knsstreamdescription.
     DATA lv_stream_status TYPE /aws1/knsstreamstatus.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
     CONSTANTS cv_shard_count TYPE /aws1/knspositiveintegerobject VALUE 1.
@@ -50,8 +50,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     "Testing.
     ao_kns_actions->create_stream(
         iv_stream_name        = lv_stream_name
-        iv_shard_count        = cv_shard_count
-      ).
+        iv_shard_count        = cv_shard_count ).
 
     "Wait for stream to become active.
     lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
@@ -62,11 +61,11 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
       ENDIF.
       WAIT UP TO 10 SECONDS.
       lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
-      lo_stream_description =  lo_stream_describe_result->get_streamdescription( ).
+      lo_stream_description = lo_stream_describe_result->get_streamdescription( ).
     ENDWHILE.
 
     "Testing.
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
     IF lo_stream_description->get_streamstatus( ) = 'ACTIVE'.
       lv_found = abap_true.
     ENDIF.
@@ -74,8 +73,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     "Validation.
     cl_abap_unit_assert=>assert_true(
        act                    = lv_found
-       msg                    = |Stream cannot be found|
-    ).
+       msg                    = |Stream cannot be found| ).
 
     "Clean up.
     ao_kns->deletestream(
@@ -91,7 +89,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     DATA lo_stream_list_result TYPE REF TO /aws1/cl_knsliststreamsoutput.
     DATA lo_stream_description TYPE REF TO /aws1/cl_knsstreamdescription.
     DATA lv_stream_status TYPE /aws1/knsstreamstatus.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
     CONSTANTS cv_shard_count TYPE /aws1/knspositiveintegerobject VALUE 1.
@@ -103,10 +101,8 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
 
     "Create stream.
     ao_kns->createstream(
-      EXPORTING
-        iv_streamname        = lv_stream_name
-        iv_shardcount        = cv_shard_count
-      ).
+      iv_streamname        = lv_stream_name
+        iv_shardcount        = cv_shard_count ).
 
     "Wait for stream to become active.
     lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
@@ -122,22 +118,19 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
 
     "Testing.
     ao_kns_actions->delete_stream(
-      EXPORTING
-        iv_stream_name        = lv_stream_name
-    ).
+      lv_stream_name ).
 
     "Confirm deletion.
-    lv_found = abap_true.
+    DATA(lv_found) = abap_true.
     lo_stream_list_result = ao_kns->liststreams( iv_exclusivestartstreamname = lv_stream_name ).
 
-    IF  lo_stream_list_result->has_streamnames( ) = 'X'.
+    IF lo_stream_list_result->has_streamnames( ) = 'X'.
       lv_found = abap_false.
     ENDIF.
 
     cl_abap_unit_assert=>assert_false(
        act                    = lv_found
-       msg                    = |Stream not deleted|
-    ).
+       msg                    = |Stream not deleted| ).
 
     "Nothing to clean up.
 
@@ -150,7 +143,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     DATA lo_stream_description TYPE REF TO /aws1/cl_knsstreamdescription.
     DATA lo_stream_list_result TYPE REF TO /aws1/cl_knsliststreamsoutput.
     DATA lv_stream_status TYPE /aws1/knsstreamstatus.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
     CONSTANTS cv_shard_count TYPE /aws1/knspositiveintegerobject VALUE 1.
@@ -163,10 +156,8 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
 
     "Create stream.
     ao_kns->createstream(
-      EXPORTING
-        iv_streamname        = lv_stream_name
-        iv_shardcount        = cv_shard_count
-      ).
+      iv_streamname        = lv_stream_name
+        iv_shardcount        = cv_shard_count ).
 
     "Wait for stream to become active.
     lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
@@ -177,33 +168,26 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
       ENDIF.
       WAIT UP TO 10 SECONDS.
       lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
-      lo_stream_description =  lo_stream_describe_result->get_streamdescription( ).
+      lo_stream_description = lo_stream_describe_result->get_streamdescription( ).
     ENDWHILE.
 
     "Testing.
-    CALL METHOD ao_kns_actions->list_streams(
-      EXPORTING
-        iv_limit  = cv_limit
-      IMPORTING
-        oo_result = lo_stream_list_result
-                    ).
+    ao_kns_actions->list_streams( EXPORTING iv_limit = cv_limit IMPORTING oo_result = lo_stream_list_result ).
 
     "Validation.
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
-    IF  lo_stream_list_result->has_streamnames( ) = 'X'.
+    IF lo_stream_list_result->has_streamnames( ) = 'X'.
       lv_found = abap_true.
     ENDIF.
 
     cl_abap_unit_assert=>assert_true(
        act                    = lv_found
-       msg                    = |Stream not found|
-    ).
+       msg                    = |Stream not found| ).
 
     "Clean up.
     ao_kns->deletestream(
-        iv_streamname = lv_stream_name
-        ).
+        iv_streamname = lv_stream_name ).
 
   ENDMETHOD.
 
@@ -214,7 +198,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     DATA lo_stream_description TYPE REF TO /aws1/cl_knsstreamdescription.
     DATA lo_stream_list_result TYPE REF TO /aws1/cl_knsliststreamsoutput.
     DATA lv_stream_status TYPE /aws1/knsstreamstatus.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
     CONSTANTS cv_shard_count TYPE /aws1/knspositiveintegerobject VALUE 1.
@@ -226,10 +210,8 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
 
     "Create stream.
     ao_kns->createstream(
-      EXPORTING
-        iv_streamname        = lv_stream_name
-        iv_shardcount        = cv_shard_count
-      ).
+      iv_streamname        = lv_stream_name
+        iv_shardcount        = cv_shard_count ).
 
     "Wait for stream to become active.
     lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
@@ -240,35 +222,28 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
       ENDIF.
       WAIT UP TO 10 SECONDS.
       lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
-      lo_stream_description =  lo_stream_describe_result->get_streamdescription( ).
+      lo_stream_description = lo_stream_describe_result->get_streamdescription( ).
     ENDWHILE.
 
     "Testing.
-    CALL METHOD ao_kns_actions->describe_stream(
-      EXPORTING
-        iv_stream_name = lv_stream_name
-      IMPORTING
-        oo_result      = lo_stream_describe_result
-                         ).
+    ao_kns_actions->describe_stream( EXPORTING iv_stream_name = lv_stream_name IMPORTING oo_result = lo_stream_describe_result ).
 
     "Validation.
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
     lo_stream_description = lo_stream_describe_result->get_streamdescription( ).
-    IF  lo_stream_description->get_streamstatus( ) = 'ACTIVE'.
+    IF lo_stream_description->get_streamstatus( ) = 'ACTIVE'.
       lv_found = abap_true.
     ENDIF.
 
     cl_abap_unit_assert=>assert_true(
        act                    = lv_found
-       msg                    = |Stream not found|
-    ).
+       msg                    = |Stream not found| ).
 
     "Clean up.
     ao_kns->deletestream(
-        iv_streamname = lv_stream_name
-        ).
+        iv_streamname = lv_stream_name ).
 
   ENDMETHOD.
 
@@ -284,7 +259,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     DATA lv_record_data TYPE /aws1/knsdata.
     DATA lv_stream_name TYPE /aws1/knsstreamname.
     DATA lv_shardid TYPE /aws1/knsshardid.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lv_uuid_16 TYPE sysuuid_x16.
     DATA(lv_data) = /aws1/cl_rt_util=>string_to_xstring(
       `{`  &&
@@ -293,8 +268,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
         `"word": "a"` &&
         `"word": "code"` &&
         `"word": "example"` &&
-      `}`
-    ).
+      `}` ).
 
     CONSTANTS cv_shard_count TYPE /aws1/knspositiveintegerobject VALUE 1.
     CONSTANTS cv_partition_key TYPE /aws1/knspartitionkey VALUE '123'.
@@ -307,10 +281,8 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
 
     "Create stream.
     ao_kns->createstream(
-      EXPORTING
-        iv_streamname        = lv_stream_name
-        iv_shardcount        = cv_shard_count
-      ).
+      iv_streamname        = lv_stream_name
+        iv_shardcount        = cv_shard_count ).
 
     "Wait for stream to become active.
     lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
@@ -321,18 +293,13 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
       ENDIF.
       WAIT UP TO 10 SECONDS.
       lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
-      lo_stream_description =  lo_stream_describe_result->get_streamdescription( ).
+      lo_stream_description = lo_stream_describe_result->get_streamdescription( ).
     ENDWHILE.
 
     "Testing.
-    CALL METHOD ao_kns_actions->put_record(
-      EXPORTING
-        iv_stream_name   = lv_stream_name
-        iv_data          = lv_data
-        iv_partition_key = cv_partition_key
-      IMPORTING
-        oo_result        = lo_put_record_output
-                           ).
+    ao_kns_actions->put_record( EXPORTING iv_stream_name = lv_stream_name
+                                          iv_data = lv_data
+                                          iv_partition_key = cv_partition_key IMPORTING oo_result = lo_put_record_output ).
 
     "Get the shard ID.
     lv_shardid = lo_put_record_output->get_shardid( ).
@@ -341,13 +308,11 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     lo_sharditerator = ao_kns->getsharditerator(
         iv_shardid = lv_shardid
         iv_sharditeratortype = cv_sharditeratortype
-        iv_streamname = lv_stream_name
-    ).
+        iv_streamname = lv_stream_name ).
 
     "Get the record using the shard iterator.
     lo_get_record_output = ao_kns->getrecords(
-        iv_sharditerator   = lo_sharditerator->get_sharditerator( )
-    ).
+        iv_sharditerator   = lo_sharditerator->get_sharditerator( ) ).
 
     lt_record_list = lo_get_record_output->get_records( ).
     LOOP AT lt_record_list INTO DATA(lo_record).
@@ -355,7 +320,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     ENDLOOP.
 
     "Validation.
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     IF lv_record_data = lv_data.
       lv_found = abap_true.
@@ -363,13 +328,11 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
        act                    = lv_found
-       msg                    = |Record not found|
-    ).
+       msg                    = |Record not found| ).
 
     "Clean up.
     ao_kns->deletestream(
-        iv_streamname = lv_stream_name
-        ).
+        iv_streamname = lv_stream_name ).
 
   ENDMETHOD.
 
@@ -385,7 +348,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     DATA lv_record_data TYPE /aws1/knsdata.
     DATA lv_stream_name TYPE /aws1/knsstreamname.
     DATA lv_shardid TYPE /aws1/knsshardid.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lv_uuid_16 TYPE sysuuid_x16.
     DATA(lv_data) = /aws1/cl_rt_util=>string_to_xstring(
       `{`  &&
@@ -394,8 +357,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
         `"word": "a"` &&
         `"word": "code"` &&
         `"word": "example"` &&
-      `}`
-    ).
+      `}` ).
 
     CONSTANTS cv_shard_count TYPE /aws1/knspositiveintegerobject VALUE 1.
     CONSTANTS cv_partition_key TYPE /aws1/knspartitionkey VALUE '123'.
@@ -408,10 +370,8 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
 
     "Create stream.
     ao_kns->createstream(
-      EXPORTING
-        iv_streamname        = lv_stream_name
-        iv_shardcount        = cv_shard_count
-      ).
+      iv_streamname        = lv_stream_name
+        iv_shardcount        = cv_shard_count ).
 
     "Wait for stream to become active.
     lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
@@ -423,16 +383,14 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
       ENDIF.
       WAIT UP TO 10 SECONDS.
       lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
-      lo_stream_description =  lo_stream_describe_result->get_streamdescription( ).
+      lo_stream_description = lo_stream_describe_result->get_streamdescription( ).
     ENDWHILE.
 
     "Create a record.
     lo_put_record_output = ao_kns->putrecord(
-
-        iv_streamname   = lv_stream_name
+      iv_streamname   = lv_stream_name
         iv_data          = lv_data
-        iv_partitionkey = cv_partition_key
-    ).
+        iv_partitionkey = cv_partition_key ).
 
     "Get the shard ID.
     lv_shardid = lo_put_record_output->get_shardid( ).
@@ -441,16 +399,10 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     lo_sharditerator = ao_kns->getsharditerator(
         iv_shardid = lv_shardid
         iv_sharditeratortype = cv_sharditeratortype
-        iv_streamname = lv_stream_name
-    ).
+        iv_streamname = lv_stream_name ).
 
     "Testing.
-    CALL METHOD ao_kns_actions->get_records(
-      EXPORTING
-        iv_shard_iterator = lo_sharditerator->get_sharditerator( )
-      IMPORTING
-        oo_result         = lo_get_record_output
-                            ).
+    ao_kns_actions->get_records( EXPORTING iv_shard_iterator = lo_sharditerator->get_sharditerator( ) IMPORTING oo_result = lo_get_record_output ).
 
     "Get records.
     lt_record_list = lo_get_record_output->get_records( ).
@@ -460,20 +412,18 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     ENDLOOP.
 
     "Validation.
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
     IF lv_record_data = lv_data.
       lv_found = abap_true.
     ENDIF.
 
     cl_abap_unit_assert=>assert_true(
        act                    = lv_found
-       msg                    = |Record not found|
-    ).
+       msg                    = |Record not found| ).
 
     "Clean up.
     ao_kns->deletestream(
-        iv_streamname = lv_stream_name
-        ).
+        iv_streamname = lv_stream_name ).
 
   ENDMETHOD.
 
@@ -492,7 +442,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
     DATA lv_consumer_name TYPE /aws1/knsconsumername.
     DATA lv_shardid TYPE /aws1/knsshardid.
     DATA lv_stream_arn TYPE /aws1/knsstreamarn.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lo_knsliststreamconsout TYPE REF TO /aws1/cl_knsliststreamconsout.
     DATA lo_knsconsumer TYPE REF TO /aws1/cl_knsconsumer.
     DATA lv_uuid_16 TYPE sysuuid_x16.
@@ -508,8 +458,7 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
         `"word": "a"` &&
         `"word": "code"` &&
         `"word": "example"` &&
-      `}`
-    ).
+      `}` ).
 
     "Define name.
     lv_uuid_16 = cl_system_uuid=>create_uuid_x16_static( ).
@@ -520,10 +469,8 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
 
     "Create stream.
     ao_kns->createstream(
-      EXPORTING
-        iv_streamname        = lv_stream_name
-        iv_shardcount        = cv_shard_count
-      ).
+      iv_streamname        = lv_stream_name
+        iv_shardcount        = cv_shard_count ).
 
     "Wait for stream to become active.
     lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
@@ -534,27 +481,21 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
       ENDIF.
       WAIT UP TO 10 SECONDS.
       lo_stream_describe_result = ao_kns->describestream( iv_streamname = lv_stream_name ).
-      lo_stream_description =  lo_stream_describe_result->get_streamdescription( ).
+      lo_stream_description = lo_stream_describe_result->get_streamdescription( ).
     ENDWHILE.
 
     "Get stream Amazon Resource Name (ARN).
     lv_stream_arn = lo_stream_description->get_streamarn( ).
 
     "Testing.
-    CALL METHOD ao_kns_actions->register_stream_consumer(
-      EXPORTING
-        iv_consumer_name = lv_consumer_name
-        iv_stream_arn    = lv_stream_arn
-      IMPORTING
-        oo_result        = lo_knsregstreamconsout
-                           ).
+    ao_kns_actions->register_stream_consumer( EXPORTING iv_consumer_name = lv_consumer_name
+                                                        iv_stream_arn = lv_stream_arn IMPORTING oo_result = lo_knsregstreamconsout ).
 
     "Validation.
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     lo_knsliststreamconsout = ao_kns->liststreamconsumers(
-        iv_streamarn    = lv_stream_arn
-    ).
+        iv_streamarn    = lv_stream_arn ).
     lo_knsconsumer = lo_knsregstreamconsout->get_consumer( ).
 
     IF lo_knsconsumer->get_consumername( ) = lv_consumer_name.
@@ -563,18 +504,15 @@ CLASS ltc_zcl_aws1_kns_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
        act                    = lv_found
-       msg                    = |Record not found|
-    ).
+       msg                    = |Record not found| ).
 
     "Clean up.
     ao_kns->deregisterstreamconsumer(
         iv_streamarn    = lv_stream_arn
-        iv_consumername = lv_consumer_name
-        ).
+        iv_consumername = lv_consumer_name ).
 
     ao_kns->deletestream(
-        iv_streamname = lv_stream_name
-        ).
+        iv_streamname = lv_stream_name ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.abap
@@ -1,24 +1,24 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_KNS_SCENARIO definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_kns_scenario DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods GETTING_STARTED_WITH_KNS
-    importing
-      !IV_STREAM_NAME type /AWS1/KNSSTREAMNAME
-      !IV_PARTITION_KEY type /AWS1/KNSPARTITIONKEY
-      !IV_DATA type /AWS1/KNSDATA
-      !IV_SHARD_COUNT type /AWS1/KNSPOSITIVEINTEGEROBJECT
-      !IV_SHARDITERATORTYPE type /AWS1/KNSSHARDITERATORTYPE
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_KNSGETRECORDSOUTPUT .
-protected section.
-private section.
+    METHODS getting_started_with_kns
+      IMPORTING
+      !iv_stream_name TYPE /aws1/knsstreamname
+      !iv_partition_key TYPE /aws1/knspartitionkey
+      !iv_data TYPE /aws1/knsdata
+      !iv_shard_count TYPE /aws1/knspositiveintegerobject
+      !iv_sharditeratortype TYPE /aws1/knssharditeratortype
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_knsgetrecordsoutput .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -28,7 +28,7 @@ CLASS ZCL_AWS1_KNS_SCENARIO IMPLEMENTATION.
 
   METHOD getting_started_with_kns.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_kns) = /aws1/cl_kns_factory=>create( lo_session ).
@@ -51,14 +51,13 @@ CLASS ZCL_AWS1_KNS_SCENARIO IMPLEMENTATION.
     TRY.
         lo_kns->createstream(
             iv_streamname = iv_stream_name
-            iv_shardcount = iv_shard_count
-        ).
+            iv_shardcount = iv_shard_count ).
         MESSAGE 'Stream created.' TYPE 'I'.
       CATCH /aws1/cx_knsinvalidargumentex.
         MESSAGE 'The specified argument was not valid.' TYPE 'E'.
-      CATCH /aws1/cx_knslimitexceededex .
+      CATCH /aws1/cx_knslimitexceededex.
         MESSAGE 'The request processing has failed because of a limit exceeded exception.' TYPE 'E'.
-      CATCH /aws1/cx_knsresourceinuseex .
+      CATCH /aws1/cx_knsresourceinuseex.
         MESSAGE 'The request processing has failed because the resource is in use.' TYPE 'E'.
     ENDTRY.
 
@@ -71,7 +70,7 @@ CLASS ZCL_AWS1_KNS_SCENARIO IMPLEMENTATION.
       ENDIF.
       WAIT UP TO 10 SECONDS.
       lo_stream_describe_result = lo_kns->describestream( iv_streamname = iv_stream_name ).
-      lo_stream_description =  lo_stream_describe_result->get_streamdescription( ).
+      lo_stream_description = lo_stream_describe_result->get_streamdescription( ).
     ENDWHILE.
 
     "Create record."
@@ -79,26 +78,25 @@ CLASS ZCL_AWS1_KNS_SCENARIO IMPLEMENTATION.
         lo_record_result = lo_kns->putrecord(
             iv_streamname = iv_stream_name
             iv_data       = iv_data
-            iv_partitionkey = iv_partition_key
-        ).
+            iv_partitionkey = iv_partition_key ).
         MESSAGE 'Record created.' TYPE 'I'.
-      CATCH /aws1/cx_knsinvalidargumentex .
+      CATCH /aws1/cx_knsinvalidargumentex.
         MESSAGE 'The specified argument was not valid.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsaccessdeniedex .
+      CATCH /aws1/cx_knskmsaccessdeniedex.
         MESSAGE 'You do not have permission to perform this AWS KMS action.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsdisabledex .
+      CATCH /aws1/cx_knskmsdisabledex.
         MESSAGE 'KMS key used is disabled.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsinvalidstateex .
+      CATCH /aws1/cx_knskmsinvalidstateex.
         MESSAGE 'KMS key used is in an invalid state. ' TYPE 'E'.
-      CATCH /aws1/cx_knskmsnotfoundex .
+      CATCH /aws1/cx_knskmsnotfoundex.
         MESSAGE 'KMS key used is not found.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsoptinrequired .
+      CATCH /aws1/cx_knskmsoptinrequired.
         MESSAGE 'KMS key option is required.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsthrottlingex .
+      CATCH /aws1/cx_knskmsthrottlingex.
         MESSAGE 'The rate of requests to AWS KMS is exceeding the request quotas.' TYPE 'E'.
-      CATCH /aws1/cx_knsprovthruputexcdex .
+      CATCH /aws1/cx_knsprovthruputexcdex.
         MESSAGE 'The request rate for the stream is too high, or the requested data is too large for the available throughput.' TYPE 'E'.
-      CATCH /aws1/cx_knsresourcenotfoundex .
+      CATCH /aws1/cx_knsresourcenotfoundex.
         MESSAGE 'Resource being accessed is not found.' TYPE 'E'.
     ENDTRY.
 
@@ -107,12 +105,11 @@ CLASS ZCL_AWS1_KNS_SCENARIO IMPLEMENTATION.
         lo_sharditerator = lo_kns->getsharditerator(
           iv_shardid = lo_record_result->get_shardid( )
           iv_sharditeratortype = iv_sharditeratortype
-          iv_streamname = iv_stream_name
-      ).
+          iv_streamname = iv_stream_name ).
         MESSAGE 'Shard iterator created.' TYPE 'I'.
       CATCH /aws1/cx_knsinvalidargumentex.
         MESSAGE 'The specified argument was not valid.' TYPE 'E'.
-      CATCH /aws1/cx_knsprovthruputexcdex .
+      CATCH /aws1/cx_knsprovthruputexcdex.
         MESSAGE 'The request rate for the stream is too high, or the requested data is too large for the available throughput.' TYPE 'E'.
       CATCH /aws1/cx_sgmresourcenotfound.
         MESSAGE 'Resource being accessed is not found.' TYPE 'E'.
@@ -121,40 +118,38 @@ CLASS ZCL_AWS1_KNS_SCENARIO IMPLEMENTATION.
     "Read the record."
     TRY.
         oo_result = lo_kns->getrecords(                    " oo_result is returned for testing purposes. "
-            iv_sharditerator   = lo_sharditerator->get_sharditerator( )
-        ).
+            iv_sharditerator   = lo_sharditerator->get_sharditerator( ) ).
         MESSAGE 'Shard iterator created.' TYPE 'I'.
-      CATCH /aws1/cx_knsexpirediteratorex .
+      CATCH /aws1/cx_knsexpirediteratorex.
         MESSAGE 'Iterator expired.' TYPE 'E'.
-      CATCH /aws1/cx_knsinvalidargumentex .
+      CATCH /aws1/cx_knsinvalidargumentex.
         MESSAGE 'The specified argument was not valid.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsaccessdeniedex .
+      CATCH /aws1/cx_knskmsaccessdeniedex.
         MESSAGE 'You do not have permission to perform this AWS KMS action.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsdisabledex .
+      CATCH /aws1/cx_knskmsdisabledex.
         MESSAGE 'KMS key used is disabled.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsinvalidstateex .
+      CATCH /aws1/cx_knskmsinvalidstateex.
         MESSAGE 'KMS key used is in an invalid state. ' TYPE 'E'.
-      CATCH /aws1/cx_knskmsnotfoundex .
+      CATCH /aws1/cx_knskmsnotfoundex.
         MESSAGE 'KMS key used is not found.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsoptinrequired .
+      CATCH /aws1/cx_knskmsoptinrequired.
         MESSAGE 'KMS key option is required.' TYPE 'E'.
-      CATCH /aws1/cx_knskmsthrottlingex .
+      CATCH /aws1/cx_knskmsthrottlingex.
         MESSAGE 'The rate of requests to AWS KMS is exceeding the request quotas.' TYPE 'E'.
-      CATCH /aws1/cx_knsprovthruputexcdex .
+      CATCH /aws1/cx_knsprovthruputexcdex.
         MESSAGE 'The request rate for the stream is too high, or the requested data is too large for the available throughput.' TYPE 'E'.
-      CATCH /aws1/cx_knsresourcenotfoundex .
+      CATCH /aws1/cx_knsresourcenotfoundex.
         MESSAGE 'Resource being accessed is not found.' TYPE 'E'.
     ENDTRY.
 
     "Delete stream."
     TRY.
         lo_kns->deletestream(
-            iv_streamname = iv_stream_name
-        ).
+            iv_streamname = iv_stream_name ).
         MESSAGE 'Stream deleted.' TYPE 'I'.
-      CATCH /aws1/cx_knslimitexceededex .
+      CATCH /aws1/cx_knslimitexceededex.
         MESSAGE 'The request processing has failed because of a limit exceeded exception.' TYPE 'E'.
-      CATCH /aws1/cx_knsresourceinuseex .
+      CATCH /aws1/cx_knsresourceinuseex.
         MESSAGE 'The request processing has failed because the resource is in use.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[kns.abapv1.getting_started_with_kns]

--- a/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.testclasses.abap
+++ b/sap-abap/services/kinesis/zcl_aws1_kns_scenario.clas.testclasses.abap
@@ -1,19 +1,19 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0""
 
-CLASS ltc_zcl_aws1_kns_scenario DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_kns_scenario DEFINITION FOR TESTING DURATION SHORT RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA ao_kns TYPE REF TO /aws1/if_kns.
     DATA ao_session TYPE REF TO /aws1/cl_rt_session_base.
     DATA ao_kns_scenario TYPE REF TO zcl_aws1_kns_scenario.
     DATA lv_found TYPE abap_bool VALUE abap_false.
 
-    METHODS: getting_started_with_kns FOR TESTING.
-    METHODS: setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    METHODS getting_started_with_kns FOR TESTING.
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
 
 ENDCLASS.       "ltc_Zcl_Aws1_Kns_Scenario
 
@@ -33,7 +33,7 @@ CLASS ltc_zcl_aws1_kns_scenario IMPLEMENTATION.
     DATA lv_record_data TYPE /aws1/knsdata.
     DATA lv_stream_name TYPE /aws1/knsstreamname.
     DATA lv_shardid TYPE /aws1/knsshardid.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA(lv_data) = /aws1/cl_rt_util=>string_to_xstring(
       `{`  &&
         `"word": "This",`  &&
@@ -41,8 +41,7 @@ CLASS ltc_zcl_aws1_kns_scenario IMPLEMENTATION.
         `"word": "a"` &&
         `"word": "code"` &&
         `"word": "example"` &&
-      `}`
-    ).
+      `}` ).
 
     CONSTANTS cv_shard_count TYPE /aws1/knspositiveintegerobject VALUE 1.
     CONSTANTS cv_partition_key TYPE /aws1/knspartitionkey VALUE '123'.
@@ -61,8 +60,7 @@ CLASS ltc_zcl_aws1_kns_scenario IMPLEMENTATION.
         iv_sharditeratortype  = cv_sharditeratortype
         iv_data               = lv_data
       IMPORTING
-        oo_result = lo_get_record_output
-      ).
+        oo_result = lo_get_record_output ).
 
     lt_record_list = lo_get_record_output->get_records( ).
 
@@ -72,23 +70,21 @@ CLASS ltc_zcl_aws1_kns_scenario IMPLEMENTATION.
     ENDLOOP.
 
     IF lv_record_data = lv_data.
-      lv_found = abap_true.
+      DATA(lv_found) = abap_true.
     ENDIF.
 
     cl_abap_unit_assert=>assert_true(
        act                    = lv_found
-       msg                    = |Record not found|
-    ).
+       msg                    = |Record not found| ).
 
     lv_found = abap_true.
-    IF  ao_kns->liststreams( iv_exclusivestartstreamname = lv_stream_name )->has_streamnames( ) = 'X'.
+    IF ao_kns->liststreams( iv_exclusivestartstreamname = lv_stream_name )->has_streamnames( ) = 'X'.
       lv_found = abap_false.
     ENDIF.
 
     cl_abap_unit_assert=>assert_false(
        act                    = lv_found
-       msg                    = |Stream not deleted|
-    ).
+       msg                    = |Stream not deleted| ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.abap
+++ b/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.abap
@@ -1,50 +1,50 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_LMD_ACTIONS definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_lmd_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
-protected section.
-private section.
+  PUBLIC SECTION.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 
-  methods CREATE_FUNCTION
-    importing
-      !IV_FUNCTION_NAME type /AWS1/LMDFUNCTIONNAME
-      !IV_ROLE_ARN type /AWS1/LMDROLEARN
-      !IV_HANDLER type /AWS1/LMDHANDLER
-      !IO_ZIP_FILE type ref to /AWS1/CL_LMDFUNCTIONCODE .
-  methods GET_FUNCTION
-    importing
-      !IV_FUNCTION_NAME type /AWS1/LMDNAMESPACEDFUNCNAME
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_LMDGETFUNCRESPONSE .
-  methods LIST_FUNCTIONS
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_LMDLISTFUNCSRESPONSE .
-  methods INVOKE_FUNCTION
-    importing
-      !IV_FUNCTION_NAME type /AWS1/LMDNAMESPACEDFUNCNAME
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_LMDINVOCATIONRESPONSE .
-  methods UPDATE_FUNCTION_CODE
-    importing
-      !IV_FUNCTION_NAME type /AWS1/LMDFUNCTIONNAME
-      !IO_ZIP_FILE type /AWS1/LMDBLOB
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_LMDFUNCTIONCONF .
-  methods UPDATE_FUNCTION_CONFIGURATION
-    importing
-      !IV_FUNCTION_NAME type /AWS1/LMDRUNTIME
-      !IV_RUNTIME type /AWS1/LMDHANDLER
-      !IV_MEMORY_SIZE type /AWS1/LMDMEMORYSIZE
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_LMDFUNCTIONCONF .
-  methods DELETE_FUNCTION
-    importing
-      !IV_FUNCTION_NAME type /AWS1/LMDFUNCTIONNAME .
+    METHODS create_function
+      IMPORTING
+      !iv_function_name TYPE /aws1/lmdfunctionname
+      !iv_role_arn TYPE /aws1/lmdrolearn
+      !iv_handler TYPE /aws1/lmdhandler
+      !io_zip_file TYPE REF TO /aws1/cl_lmdfunctioncode .
+    METHODS get_function
+      IMPORTING
+      !iv_function_name TYPE /aws1/lmdnamespacedfuncname
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_lmdgetfuncresponse .
+    METHODS list_functions
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_lmdlistfuncsresponse .
+    METHODS invoke_function
+      IMPORTING
+      !iv_function_name TYPE /aws1/lmdnamespacedfuncname
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_lmdinvocationresponse .
+    METHODS update_function_code
+      IMPORTING
+      !iv_function_name TYPE /aws1/lmdfunctionname
+      !io_zip_file TYPE /aws1/lmdblob
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_lmdfunctionconf .
+    METHODS update_function_configuration
+      IMPORTING
+      !iv_function_name TYPE /aws1/lmdruntime
+      !iv_runtime TYPE /aws1/lmdhandler
+      !iv_memory_size TYPE /aws1/lmdmemorysize
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_lmdfunctionconf .
+    METHODS delete_function
+      IMPORTING
+      !iv_function_name TYPE /aws1/lmdfunctionname .
 ENDCLASS.
 
 
@@ -54,7 +54,7 @@ CLASS ZCL_AWS1_LMD_ACTIONS IMPLEMENTATION.
 
   METHOD create_function.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_lmd) = /aws1/cl_lmd_factory=>create( lo_session ).
@@ -67,8 +67,7 @@ CLASS ZCL_AWS1_LMD_ACTIONS IMPLEMENTATION.
             iv_role = iv_role_arn
             iv_handler = iv_handler
             io_code = io_zip_file
-            iv_description = 'AWS Lambda code example'
-        ).
+            iv_description = 'AWS Lambda code example' ).
         MESSAGE 'Lambda function created.' TYPE 'I'.
       CATCH /aws1/cx_lmdcodesigningcfgno00.
         MESSAGE 'Code signing configuration does not exist.' TYPE 'E'.
@@ -94,7 +93,7 @@ CLASS ZCL_AWS1_LMD_ACTIONS IMPLEMENTATION.
 
 
   METHOD delete_function.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_lmd) = /aws1/cl_lmd_factory=>create( lo_session ).
@@ -119,14 +118,14 @@ CLASS ZCL_AWS1_LMD_ACTIONS IMPLEMENTATION.
 
 
   METHOD get_function.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_lmd) = /aws1/cl_lmd_factory=>create( lo_session ).
 
     " snippet-start:[lmd.abapv1.get_function]
     TRY.
-        oo_result =  lo_lmd->getfunction( iv_functionname = iv_function_name ).       " oo_result is returned for testing purposes. "
+        oo_result = lo_lmd->getfunction( iv_functionname = iv_function_name ).       " oo_result is returned for testing purposes. "
         MESSAGE 'Lambda function information retrieved.' TYPE 'I'.
       CATCH /aws1/cx_lmdinvparamvalueex.
         MESSAGE 'The request contains a non-valid parameter.' TYPE 'E'.
@@ -140,7 +139,7 @@ CLASS ZCL_AWS1_LMD_ACTIONS IMPLEMENTATION.
 
 
   METHOD invoke_function.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_lmd) = /aws1/cl_lmd_factory=>create( lo_session ).
@@ -151,12 +150,10 @@ CLASS ZCL_AWS1_LMD_ACTIONS IMPLEMENTATION.
           `{`  &&
             `"action": "increment",`  &&
             `"number": 10` &&
-          `}`
-        ).
-        oo_result =  lo_lmd->invoke(                  " oo_result is returned for testing purposes. "
+          `}` ).
+        oo_result = lo_lmd->invoke(                  " oo_result is returned for testing purposes. "
                  iv_functionname = iv_function_name
-                 iv_payload = lv_json
-             ).
+                 iv_payload = lv_json ).
         MESSAGE 'Lambda function invoked.' TYPE 'I'.
       CATCH /aws1/cx_lmdinvparamvalueex.
         MESSAGE 'The request contains a non-valid parameter.' TYPE 'E'.
@@ -182,14 +179,14 @@ CLASS ZCL_AWS1_LMD_ACTIONS IMPLEMENTATION.
 
 
   METHOD list_functions.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_lmd) = /aws1/cl_lmd_factory=>create( lo_session ).
 
     " snippet-start:[lmd.abapv1.list_functions]
     TRY.
-        oo_result =  lo_lmd->listfunctions( ).       " oo_result is returned for testing purposes. "
+        oo_result = lo_lmd->listfunctions( ).       " oo_result is returned for testing purposes. "
         DATA(lt_functions) = oo_result->get_functions( ).
         MESSAGE 'Retrieved list of Lambda functions.' TYPE 'I'.
       CATCH /aws1/cx_lmdinvparamvalueex.
@@ -205,7 +202,7 @@ CLASS ZCL_AWS1_LMD_ACTIONS IMPLEMENTATION.
 
   METHOD update_function_code.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_lmd) = /aws1/cl_lmd_factory=>create( lo_session ).
@@ -214,8 +211,7 @@ CLASS ZCL_AWS1_LMD_ACTIONS IMPLEMENTATION.
     TRY.
         oo_result = lo_lmd->updatefunctioncode(     " oo_result is returned for testing purposes. "
               iv_functionname = iv_function_name
-              iv_zipfile = io_zip_file
-          ).
+              iv_zipfile = io_zip_file ).
 
         MESSAGE 'Lambda function code updated.' TYPE 'I'.
       CATCH /aws1/cx_lmdcodesigningcfgno00.
@@ -242,7 +238,7 @@ CLASS ZCL_AWS1_LMD_ACTIONS IMPLEMENTATION.
 
 
   METHOD update_function_configuration.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_lmd) = /aws1/cl_lmd_factory=>create( lo_session ).
@@ -253,8 +249,7 @@ CLASS ZCL_AWS1_LMD_ACTIONS IMPLEMENTATION.
               iv_functionname = iv_function_name
               iv_runtime = iv_runtime
               iv_description  = 'Updated Lambda function'
-              iv_memorysize  = iv_memory_size
-          ).
+              iv_memorysize  = iv_memory_size ).
 
         MESSAGE 'Lambda function configuration/settings updated.' TYPE 'I'.
       CATCH /aws1/cx_lmdcodesigningcfgno00.

--- a/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.testclasses.abap
+++ b/sap-abap/services/lambda/zcl_aws1_lmd_actions.clas.testclasses.abap
@@ -4,15 +4,18 @@
 CLASS ltc_zcl_aws1_lmd_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_lmd_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_lmd_actions.
 
-CLASS ltc_zcl_aws1_lmd_actions DEFINITION FOR TESTING  DURATION SHORT RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_lmd_actions DEFINITION FOR TESTING DURATION SHORT RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA ao_lmd TYPE REF TO /aws1/if_lmd.
     DATA ao_session TYPE REF TO /aws1/cl_rt_session_base.
     DATA ao_lmd_actions TYPE REF TO zcl_aws1_lmd_actions.
     DATA av_lrole TYPE /aws1/lmdrolearn.
+    CONSTANTS cv_create_function_name TYPE /aws1/lmdfunctionname VALUE 'code-example-create-function'.
+    CONSTANTS cv_misc_function_name TYPE /aws1/lmdfunctionname VALUE 'code-example-misce-function'.
+    CONSTANTS cv_del_function_name TYPE /aws1/lmdfunctionname VALUE 'code-example-delete-function'.
 
     METHODS: create_function FOR TESTING RAISING /aws1/cx_rt_generic,
       get_function FOR TESTING RAISING /aws1/cx_rt_generic,
@@ -22,8 +25,8 @@ CLASS ltc_zcl_aws1_lmd_actions DEFINITION FOR TESTING  DURATION SHORT RISK LEVEL
       update_function_configuration FOR TESTING RAISING /aws1/cx_rt_generic,
       delete_function FOR TESTING RAISING /aws1/cx_rt_generic.
 
-    METHODS setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
-
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
+    METHODS teardown RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
     METHODS:
       create_code
         RETURNING VALUE(oo_code) TYPE REF TO /aws1/cl_lmdfunctioncode
@@ -53,93 +56,96 @@ CLASS ltc_zcl_aws1_lmd_actions IMPLEMENTATION.
     ao_lmd_actions = NEW zcl_aws1_lmd_actions( ).
 
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role). " use the first role we find in the profile, as our lambda role
     av_lrole = lo_role-iam_role_arn.
 
+    create_lambda_function( cv_misc_function_name ).
+
   ENDMETHOD.
+  METHOD teardown.
+    TRY.
+        ao_lmd->deletefunction( iv_functionname = cv_misc_function_name ).
+      CATCH /aws1/cx_lmdresourcenotfoundex.
+    ENDTRY.
+    TRY.
+        ao_lmd->deletefunction( iv_functionname = cv_create_function_name ).
+      CATCH /aws1/cx_lmdresourcenotfoundex.
+    ENDTRY.
+    TRY.
+        ao_lmd->deletefunction( iv_functionname = cv_create_function_name ).
+      CATCH /aws1/cx_lmdresourcenotfoundex.
+    ENDTRY.
+  ENDMETHOD.
+
   METHOD create_function.
-    CONSTANTS: cv_function_name TYPE /aws1/lmdfunctionname VALUE 'code-example-create-function'.
     ao_lmd_actions->create_function(
-            iv_function_name = cv_function_name
+            iv_function_name = cv_create_function_name
             iv_role_arn      = av_lrole
             iv_handler       = |lambda_function.lambda_handler|
-            io_zip_file      = create_code( )
-        ).
-    DATA(lv_function_arn) =  ao_lmd->getfunctionconfiguration( iv_functionname = cv_function_name )->get_functionarn( ).
+            io_zip_file      = create_code( ) ).
+    DATA(lv_function_arn) = ao_lmd->getfunctionconfiguration( iv_functionname = cv_create_function_name )->get_functionarn( ).
     cl_abap_unit_assert=>assert_not_initial(
               act = lv_function_arn
-              msg = |Failed to create Lambda function { cv_function_name }|
-            ).
-    ao_lmd->deletefunction( iv_functionname = cv_function_name ).
+              msg = |Failed to create Lambda function { cv_create_function_name }| ).
   ENDMETHOD.
   METHOD create_code.
     DATA(lo_zip) = NEW cl_abap_zip( ).
     DATA(lv_code) =
-    |import logging\n| &&
-    |import json\n| &&
-    |\n| &&
-    |logger = logging.getLogger()\n| &&
-    |logger.setLevel(logging.INFO)\n| &&
-    |\n| &&
-    |def lambda_handler(event, context):\n| &&
-    | # TODO implement\n| &&
-    | action = event.get('action')\n| &&
-    | if action == 'increment':\n| &&
-    |  result = event.get('number', 0) + 1\n| &&
-    |  logger.info('Calculated result of %s', result)\n| &&
-    | else:\n| &&
-    |  logger.error("%s is not a valid action.", action)\n| &&
-    | return \{\n| &&
-    |  'statusCode': 200,\n| &&
-    |  'body': json.dumps(result)\n| &&
-    | \}\n|.
+      |import logging\n| &&
+      |import json\n| &&
+      |\n| &&
+      |logger = logging.getLogger()\n| &&
+      |logger.setLevel(logging.INFO)\n| &&
+      |\n| &&
+      |def lambda_handler(event, context):\n| &&
+      | # TODO implement\n| &&
+      | action = event.get('action')\n| &&
+      | if action == 'increment':\n| &&
+      |  result = event.get('number', 0) + 1\n| &&
+      |  logger.info('Calculated result of %s', result)\n| &&
+      | else:\n| &&
+      |  logger.error("%s is not a valid action.", action)\n| &&
+      | return \{\n| &&
+      |  'statusCode': 200,\n| &&
+      |  'body': json.dumps(result)\n| &&
+      | \}\n|.
 
     DATA(lv_xcode) = /aws1/cl_rt_util=>string_to_xstring( lv_code ).
-    lo_zip->add( name = 'lambda_function.py' content = lv_xcode ).
+    lo_zip->add( name = 'lambda_function.py'
+                 content = lv_xcode ).
     DATA(lv_xzip) = lo_zip->save( ).
     oo_code = NEW /aws1/cl_lmdfunctioncode( iv_zipfile = lv_xzip ).
   ENDMETHOD.
   METHOD get_function.
-    CONSTANTS: cv_function_name TYPE /aws1/lmdfunctionname VALUE 'code-example-get-function'.
-    create_lambda_function( iv_function_name = cv_function_name ).
-
-    DATA(lo_result) = ao_lmd_actions->get_function( iv_function_name = cv_function_name ).
+    DATA(lo_result) = ao_lmd_actions->get_function( cv_misc_function_name ).
 
     cl_abap_unit_assert=>assert_not_initial(
-    act = lo_result
-    msg = |Failed to retrieve information about Lambda function { cv_function_name }|
-    ).
+      act = lo_result
+      msg = |Failed to retrieve information about Lambda function { cv_misc_function_name }| ).
 
     cl_abap_unit_assert=>assert_equals(
-      exp = cv_function_name
+      exp = cv_misc_function_name
       act = lo_result->get_configuration( )->get_functionname( )
-      msg = |Lambda function name did not match expected value { cv_function_name }|
-    ).
+      msg = |Lambda function name did not match expected value { cv_misc_function_name }| ).
 
     cl_abap_unit_assert=>assert_equals(
       exp = `lambda_function.lambda_handler`
       act = lo_result->get_configuration( )->get_handler( )
-      msg = |Handler did not match expected value|
-    ).
+      msg = |Handler did not match expected value| ).
 
     cl_abap_unit_assert=>assert_equals(
       exp = av_lrole
       act = lo_result->get_configuration( )->get_role( )
-      msg = |Function's execution role did not match expected value { av_lrole }|
-    ).
+      msg = |Function's execution role did not match expected value { av_lrole }| ).
 
     cl_abap_unit_assert=>assert_equals(
       exp = `python3.9`
       act = lo_result->get_configuration( )->get_runtime( )
-      msg = |Function's runtime did not match expected value |
-    ).
+      msg = |Function's runtime did not match expected value | ).
 
     cl_abap_unit_assert=>assert_not_initial(
-    act = lo_result->get_code( )->get_location( )
-    msg = |Failed to retrieve value of Lambda location/URL|
-    ).
-
-    ao_lmd->deletefunction( iv_functionname = cv_function_name ).
+      act = lo_result->get_code( )->get_location( )
+      msg = |Failed to retrieve value of Lambda location/URL| ).
   ENDMETHOD.
   METHOD create_lambda_function.
     ao_lmd->createfunction(
@@ -147,43 +153,32 @@ CLASS ltc_zcl_aws1_lmd_actions IMPLEMENTATION.
         iv_runtime = `python3.9`
         iv_role      = av_lrole
         iv_handler       = `lambda_function.lambda_handler`
-        io_code      = create_code( )
-    ).
+        io_code      = create_code( ) ).
   ENDMETHOD.
   METHOD list_functions.
-    CONSTANTS: cv_function_name TYPE /aws1/lmdfunctionname VALUE 'code-example-list-functions'.
-    create_lambda_function( iv_function_name = cv_function_name ).
-
     DATA(lo_result) = ao_lmd_actions->list_functions( ).
-    DATA lv_found TYPE abap_bool VALUE abap_false.
-    LOOP AT lo_result->get_functions( ) INTO DATA(lo_function).
-      IF lo_function->get_functionname( ) = cv_function_name.
-        lv_found = abap_true.
-      ENDIF.
-    ENDLOOP.
 
-    cl_abap_unit_assert=>assert_true(
-      act = lv_found
-      msg =  |Function { cv_function_name } should have been included in function list|
-    ).
-    ao_lmd->deletefunction( iv_functionname = cv_function_name ).
+
+    cl_abap_unit_assert=>assert_number_between(
+      number = lines( lo_result->get_functions( ) )
+      lower = 1
+      upper = 1000000
+      msg = |At least one function should have been found by ListFunctions| ).
   ENDMETHOD.
   METHOD invoke_function.
-    CONSTANTS: cv_function_name TYPE /aws1/lmdfunctionname VALUE 'code-example-invoke-function'.
-    create_lambda_function( iv_function_name = cv_function_name ).
-    verify_lambda_state( iv_function_name = cv_function_name ).
+    CONSTANTS cv_function_name TYPE /aws1/lmdfunctionname VALUE 'code-example-invoke-function'.
+    create_lambda_function( cv_function_name ).
+    verify_lambda_state( cv_function_name ).
 
-    DATA(lo_result) = ao_lmd_actions->invoke_function( iv_function_name = cv_function_name ).
+    DATA(lo_result) = ao_lmd_actions->invoke_function( cv_function_name ).
 
     cl_abap_unit_assert=>assert_initial(
       act = lo_result->get_functionerror( )
-      msg = |Invoke function call failed with error { lo_result->get_functionerror( ) }|
-    ).
+      msg = |Invoke function call failed with error { lo_result->get_functionerror( ) }| ).
 
     assert_lambda_result(
       iv_payload = lo_result->ask_payload( )
-      iv_exp = 11
-    ).
+      iv_exp = 11 ).
 
     ao_lmd->deletefunction( iv_functionname = cv_function_name ).
 
@@ -199,17 +194,17 @@ CLASS ltc_zcl_aws1_lmd_actions IMPLEMENTATION.
   METHOD assert_lambda_result.
     DATA(lo_doc) = cl_ixml=>create( )->create_document( ).
     CALL TRANSFORMATION id
-    SOURCE XML iv_payload
-    RESULT XML lo_doc.
+      SOURCE XML iv_payload
+      RESULT XML lo_doc.
 
     DATA(lo_iter) = lo_doc->get_first_child( )->get_children( )->create_iterator( ).
     DATA(lo_node) = lo_iter->get_next( ).
-    DATA lv_value TYPE i.
+
 
     WHILE lo_node IS NOT INITIAL.
       DATA(lv_name) = lo_node->get_attributes( )->get_named_item_ns( name = 'name' )->get_value( ).
       IF lv_name = 'body'.
-        lv_value = lo_node->get_value( ).
+        DATA(lv_value) = lo_node->get_value( ).
       ENDIF.
       lo_node = lo_iter->get_next( ).
     ENDWHILE.
@@ -217,143 +212,121 @@ CLASS ltc_zcl_aws1_lmd_actions IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       exp = iv_exp
       act = lv_value
-      msg = |Invoke function response ({ lv_value }) was not as expected ({ iv_exp })|
-    ).
+      msg = |Invoke function response ({ lv_value }) was not as expected ({ iv_exp })| ).
   ENDMETHOD.
 
   METHOD update_function_code.
 
-    CONSTANTS: cv_function_name TYPE /aws1/lmdfunctionname VALUE 'code-example-update-function-code'.
-    create_lambda_function( iv_function_name = cv_function_name ).
-    verify_lambda_state( iv_function_name = cv_function_name ).
+    verify_lambda_state( cv_misc_function_name ).
 
-    DATA(lo_update_result) =  ao_lmd_actions->update_function_code(
-      iv_function_name = cv_function_name
-      io_zip_file = update_code( )
-    ).
+    DATA(lo_update_result) = ao_lmd_actions->update_function_code(
+      iv_function_name = cv_misc_function_name
+      io_zip_file = update_code( ) ).
     WAIT UP TO 10 SECONDS.
 
     cl_abap_unit_assert=>assert_not_initial(
-    act = lo_update_result
-    msg = |Failed to update Lambda function code|
-    ).
+      act = lo_update_result
+      msg = |Failed to update Lambda function code| ).
 
     DATA(lv_json) = /aws1/cl_rt_util=>string_to_xstring(
       `{`  &&
         `"action": "decrement",`  &&
         `"number": 10` &&
-      `}`
-    ).
+      `}` ).
 
     DATA(lo_invoke_result) = ao_lmd->invoke(
-         iv_functionname = cv_function_name
-         iv_payload = lv_json
-    ).
+         iv_functionname = cv_misc_function_name
+         iv_payload = lv_json ).
 
     cl_abap_unit_assert=>assert_initial(
        act = lo_invoke_result->get_functionerror( )
-       msg = |Invoke function call failed with error { lo_invoke_result->get_functionerror( ) }|
-     ).
+       msg = |Invoke function call failed with error { lo_invoke_result->get_functionerror( ) }| ).
 
     assert_lambda_result(
       iv_payload = lo_invoke_result->ask_payload( )
-      iv_exp = 9
-    ).
-
-    ao_lmd->deletefunction( iv_functionname = cv_function_name ).
+      iv_exp = 9 ).
   ENDMETHOD.
   METHOD update_code.
     DATA(lo_zip) = NEW cl_abap_zip( ).
     DATA(lv_code) =
-    |import logging\n| &&
-    |import json\n| &&
-    |\n| &&
-    |logger = logging.getLogger()\n| &&
-    |logger.setLevel(logging.INFO)\n| &&
-    |\n| &&
-    |def lambda_handler(event, context):\n| &&
-    | # TODO implement\n| &&
-    | action = event.get('action')\n| &&
-    | if action == 'increment':\n| &&
-    |  result = event.get('number', 0) + 1\n| &&
-    |  logger.info('Calculated result of %s', result)\n| &&
-    | elif action == 'decrement':\n| &&
-    |  result = event.get('number', 0) - 1\n| &&
-    |  logger.info('Calculated result of %s', result)\n| &&
-    | else:\n| &&
-    |  logger.error("%s is not a valid action.", action)\n| &&
-    | return \{\n| &&
-    |  'statusCode': 200,\n| &&
-    |  'body': json.dumps(result)\n| &&
-    | \}\n|.
+      |import logging\n| &&
+      |import json\n| &&
+      |\n| &&
+      |logger = logging.getLogger()\n| &&
+      |logger.setLevel(logging.INFO)\n| &&
+      |\n| &&
+      |def lambda_handler(event, context):\n| &&
+      | # TODO implement\n| &&
+      | action = event.get('action')\n| &&
+      | if action == 'increment':\n| &&
+      |  result = event.get('number', 0) + 1\n| &&
+      |  logger.info('Calculated result of %s', result)\n| &&
+      | elif action == 'decrement':\n| &&
+      |  result = event.get('number', 0) - 1\n| &&
+      |  logger.info('Calculated result of %s', result)\n| &&
+      | else:\n| &&
+      |  logger.error("%s is not a valid action.", action)\n| &&
+      | return \{\n| &&
+      |  'statusCode': 200,\n| &&
+      |  'body': json.dumps(result)\n| &&
+      | \}\n|.
 
 
     DATA(lv_xcode) = /aws1/cl_rt_util=>string_to_xstring( lv_code ).
-    lo_zip->add( name = 'lambda_function.py' content = lv_xcode ).
+    lo_zip->add( name = 'lambda_function.py'
+                 content = lv_xcode ).
     oo_code = lo_zip->save( ).
   ENDMETHOD.
   METHOD update_function_configuration.
-    CONSTANTS: cv_function_name TYPE /aws1/lmdfunctionname VALUE 'code-example-update-function-conf'.
-    create_lambda_function( iv_function_name = cv_function_name ).
-    verify_lambda_state( iv_function_name = cv_function_name ).
+    verify_lambda_state( cv_misc_function_name ).
 
     DATA(lo_result) = ao_lmd_actions->update_function_configuration(
-        iv_function_name = cv_function_name
+        iv_function_name = cv_misc_function_name
         iv_runtime = `python3.9`
-        iv_memory_size = 150
-     ).
+        iv_memory_size = 150 ).
 
     cl_abap_unit_assert=>assert_not_initial(
       act = lo_result
-      msg = |Failed to update Lambda function configuration|
-      ).
+      msg = |Failed to update Lambda function configuration| ).
 
     cl_abap_unit_assert=>assert_equals(
       exp = `lambda_function.lambda_handler`
       act = lo_result->get_handler( )
-      msg = |Handler did not match expected value|
-    ).
+      msg = |Handler did not match expected value| ).
 
     cl_abap_unit_assert=>assert_equals(
       exp = av_lrole
       act = lo_result->get_role( )
-      msg = |Function's execution role did not match expected value { av_lrole }|
-    ).
+      msg = |Function's execution role did not match expected value { av_lrole }| ).
 
     cl_abap_unit_assert=>assert_equals(
       exp = `python3.9`
       act = lo_result->get_runtime( )
-      msg = |Function's runtime did not match expected value |
-    ).
+      msg = |Function's runtime did not match expected value | ).
 
     cl_abap_unit_assert=>assert_equals(
-      exp = 'Updated Lambda Function'
-      act = lo_result->get_description( )
-      msg = |Function's description did not match expected value |
-    ).
+      exp = 'updated lambda function'
+      act = to_lower( lo_result->get_description( ) )
+      msg = |Function's description did not match expected value | ).
 
     cl_abap_unit_assert=>assert_equals(
       exp = 150
       act = lo_result->get_memorysize( )
-      msg = |Function memory did not match expected value|
-    ).
-
-    ao_lmd->deletefunction( iv_functionname = cv_function_name ).
+      msg = |Function memory did not match expected value| ).
   ENDMETHOD.
   METHOD delete_function.
-    CONSTANTS: cv_function_name TYPE /aws1/lmdfunctionname VALUE 'code-example-delete-function'.
-    create_lambda_function( iv_function_name = cv_function_name ).
-    ao_lmd_actions->delete_function( iv_function_name = cv_function_name ).
-    DATA lv_found TYPE abap_bool VALUE abap_false.
-    LOOP AT ao_lmd->listfunctions( )->get_functions( ) INTO DATA(lo_function).
-      IF lo_function->get_functionname( ) = cv_function_name.
-        lv_found = abap_true.
-      ENDIF.
-    ENDLOOP.
+    create_lambda_function( cv_del_function_name ).
+    ao_lmd_actions->delete_function( cv_del_function_name ).
 
-    cl_abap_unit_assert=>assert_false(
-      act = lv_found
-      msg =  |Function { cv_function_name } should have been deleted|
-    ).
+    TRY.
+        ao_lmd->getfunction( iv_functionname = cv_del_function_name ).
+        " should not reach here
+        cl_abap_unit_assert=>assert_true(
+          act = abap_false
+          msg = |Function { cv_del_function_name } should have been deleted| ).
+      CATCH /aws1/cx_lmdresourcenotfoundex.
+        " expected this exception
+    ENDTRY.
+
   ENDMETHOD.
 ENDCLASS.

--- a/sap-abap/services/lambda/zcl_aws1_lmd_scenario.clas.abap
+++ b/sap-abap/services/lambda/zcl_aws1_lmd_scenario.clas.abap
@@ -1,25 +1,25 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_LMD_SCENARIO definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_lmd_scenario DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
-protected section.
-private section.
+  PUBLIC SECTION.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 
-  methods GETTING_STARTED_WITH_FUNCTIONS
-    importing
-      !IV_ROLE_NAME type /AWS1/IAMROLENAMETYPE
-      !IV_FUNCTION_NAME type /AWS1/LMDFUNCTIONNAME
-      !IV_HANDLER type /AWS1/LMDHANDLER
-      !IO_INITIAL_ZIP_FILE type ref to /AWS1/CL_LMDFUNCTIONCODE
-      !IO_UPDATED_ZIP_FILE type /AWS1/LMDBLOB
-    exporting
-      !OV_UPDATED_INVOKE_PAYLOAD type /AWS1/LMDBLOB
-      !OV_INITIAL_INVOKE_PAYLOAD type /AWS1/LMDBLOB .
+    METHODS getting_started_with_functions
+      IMPORTING
+      !iv_role_name TYPE /aws1/iamrolenametype
+      !iv_function_name TYPE /aws1/lmdfunctionname
+      !iv_handler TYPE /aws1/lmdhandler
+      !io_initial_zip_file TYPE REF TO /aws1/cl_lmdfunctioncode
+      !io_updated_zip_file TYPE /aws1/lmdblob
+      EXPORTING
+      !ov_updated_invoke_payload TYPE /aws1/lmdblob
+      !ov_initial_invoke_payload TYPE /aws1/lmdblob .
 ENDCLASS.
 
 
@@ -29,7 +29,7 @@ CLASS ZCL_AWS1_LMD_SCENARIO IMPLEMENTATION.
 
   METHOD getting_started_with_functions.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_iam) = /aws1/cl_iam_factory=>create( lo_session ).
@@ -57,15 +57,16 @@ CLASS ZCL_AWS1_LMD_SCENARIO IMPLEMENTATION.
                   `]` &&
                 `}`.
         TRY.
-            DATA(lo_create_role_output) =  lo_iam->createrole(
+            DATA(lo_create_role_output) = lo_iam->createrole(
                     iv_rolename = iv_role_name
                     iv_assumerolepolicydocument = lv_policy_document
-                    iv_description = 'Grant lambda permission to write to logs'
-                ).
+                    iv_description = 'Grant lambda permission to write to logs' ).
+            DATA(lv_role_arn) = lo_create_role_output->get_role( )->get_arn( ).
             MESSAGE 'IAM role created.' TYPE 'I'.
             WAIT UP TO 10 SECONDS.            " Make sure that the IAM role is ready for use. "
           CATCH /aws1/cx_iamentityalrdyexex.
-            MESSAGE 'IAM role already exists.' TYPE 'E'.
+            DATA(lo_role) = lo_iam->getrole( iv_rolename = iv_role_name ).
+            lv_role_arn = lo_role->get_role( )->get_arn( ).
           CATCH /aws1/cx_iaminvalidinputex.
             MESSAGE 'The request contains a non-valid parameter.' TYPE 'E'.
           CATCH /aws1/cx_iammalformedplydocex.
@@ -75,8 +76,7 @@ CLASS ZCL_AWS1_LMD_SCENARIO IMPLEMENTATION.
         TRY.
             lo_iam->attachrolepolicy(
                 iv_rolename  = iv_role_name
-                iv_policyarn = 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
-            ).
+                iv_policyarn = 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole' ).
             MESSAGE 'Attached policy to the IAM role.' TYPE 'I'.
           CATCH /aws1/cx_iaminvalidinputex.
             MESSAGE 'The request contains a non-valid parameter.' TYPE 'E'.
@@ -94,11 +94,10 @@ CLASS ZCL_AWS1_LMD_SCENARIO IMPLEMENTATION.
             lo_lmd->createfunction(
                  iv_functionname = iv_function_name
                  iv_runtime = `python3.9`
-                 iv_role = lo_create_role_output->get_role( )->get_arn( )
+                 iv_role = lv_role_arn
                  iv_handler = iv_handler
                  io_code = io_initial_zip_file
-                 iv_description = 'AWS Lambda code example'
-             ).
+                 iv_description = 'AWS Lambda code example' ).
             MESSAGE 'Lambda function created.' TYPE 'I'.
           CATCH /aws1/cx_lmdcodestorageexcdex.
             MESSAGE 'Maximum total code size per account exceeded.' TYPE 'E'.
@@ -122,12 +121,10 @@ CLASS ZCL_AWS1_LMD_SCENARIO IMPLEMENTATION.
               `{`  &&
                 `"action": "increment",`  &&
                 `"number": 10` &&
-              `}`
-            ).
-            DATA(lo_initial_invoke_output) =  lo_lmd->invoke(
+              `}` ).
+            DATA(lo_initial_invoke_output) = lo_lmd->invoke(
                        iv_functionname = iv_function_name
-                       iv_payload = lv_json
-                   ).
+                       iv_payload = lv_json ).
             ov_initial_invoke_payload = lo_initial_invoke_output->get_payload( ).           " ov_initial_invoke_payload is returned for testing purposes. "
             DATA(lo_writer_json) = cl_sxml_string_writer=>create( type = if_sxml=>co_xt_json ).
             CALL TRANSFORMATION id SOURCE XML ov_initial_invoke_payload RESULT XML lo_writer_json.
@@ -148,8 +145,7 @@ CLASS ZCL_AWS1_LMD_SCENARIO IMPLEMENTATION.
         TRY.
             lo_lmd->updatefunctioncode(
                   iv_functionname = iv_function_name
-                  iv_zipfile = io_updated_zip_file
-              ).
+                  iv_zipfile = io_updated_zip_file ).
             WAIT UP TO 10 SECONDS.            " Make sure that the update is completed. "
             MESSAGE 'Lambda function code updated.' TYPE 'I'.
           CATCH /aws1/cx_lmdcodestorageexcdex.
@@ -169,8 +165,7 @@ CLASS ZCL_AWS1_LMD_SCENARIO IMPLEMENTATION.
 
             lo_lmd->updatefunctionconfiguration(
                   iv_functionname = iv_function_name
-                  io_environment = NEW /aws1/cl_lmdenvironment( it_variables = lt_variables )
-              ).
+                  io_environment = NEW /aws1/cl_lmdenvironment( it_variables = lt_variables ) ).
             WAIT UP TO 10 SECONDS.            " Make sure that the update is completed. "
             MESSAGE 'Lambda function configuration/settings updated.' TYPE 'I'.
           CATCH /aws1/cx_lmdinvparamvalueex.
@@ -187,12 +182,10 @@ CLASS ZCL_AWS1_LMD_SCENARIO IMPLEMENTATION.
               `{`  &&
                 `"action": "decrement",`  &&
                 `"number": 10` &&
-              `}`
-            ).
-            DATA(lo_updated_invoke_output) =  lo_lmd->invoke(
+              `}` ).
+            DATA(lo_updated_invoke_output) = lo_lmd->invoke(
                        iv_functionname = iv_function_name
-                       iv_payload = lv_json
-                   ).
+                       iv_payload = lv_json ).
             ov_updated_invoke_payload = lo_updated_invoke_output->get_payload( ).           " ov_updated_invoke_payload is returned for testing purposes. "
             lo_writer_json = cl_sxml_string_writer=>create( type = if_sxml=>co_xt_json ).
             CALL TRANSFORMATION id SOURCE XML ov_updated_invoke_payload RESULT XML lo_writer_json.
@@ -224,20 +217,19 @@ CLASS ZCL_AWS1_LMD_SCENARIO IMPLEMENTATION.
           CATCH /aws1/cx_lmdinvparamvalueex.
             MESSAGE 'The request contains a non-valid parameter.' TYPE 'E'.
           CATCH /aws1/cx_lmdresourcenotfoundex.
-            MESSAGE 'The requested resource does not exist.' TYPE 'E'.
+            MESSAGE 'The requested resource does not exist.' TYPE 'W'.
         ENDTRY.
 
         " Detach role policy. "
         TRY.
             lo_iam->detachrolepolicy(
                 iv_rolename  = iv_role_name
-                iv_policyarn = 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
-            ).
+                iv_policyarn = 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole' ).
             MESSAGE 'Detached policy from the IAM role.' TYPE 'I'.
           CATCH /aws1/cx_iaminvalidinputex.
             MESSAGE 'The request contains a non-valid parameter.' TYPE 'E'.
           CATCH /aws1/cx_iamnosuchentityex.
-            MESSAGE 'The requested resource entity does not exist.' TYPE 'E'.
+            MESSAGE 'The requested resource entity does not exist.' TYPE 'W'.
           CATCH /aws1/cx_iamplynotattachableex.
             MESSAGE 'Service role policies can only be attached to the service-linked role for their service.' TYPE 'E'.
           CATCH /aws1/cx_iamunmodableentityex.
@@ -249,7 +241,7 @@ CLASS ZCL_AWS1_LMD_SCENARIO IMPLEMENTATION.
             lo_iam->deleterole( iv_rolename = iv_role_name ).
             MESSAGE 'IAM role deleted.' TYPE 'I'.
           CATCH /aws1/cx_iamnosuchentityex.
-            MESSAGE 'The requested resource entity does not exist.' TYPE 'E'.
+            MESSAGE 'The requested resource entity does not exist.' TYPE 'W'.
           CATCH /aws1/cx_iamunmodableentityex.
             MESSAGE 'Service that depends on the service-linked role is not modifiable.' TYPE 'E'.
         ENDTRY.

--- a/sap-abap/services/s3/zcl_aws1_s3_actions.clas.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_actions.clas.abap
@@ -53,7 +53,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
 
 
   METHOD copy_object.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_s3) = /aws1/cl_s3_factory=>create( lo_session ).
@@ -63,8 +63,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
         lo_s3->copyobject(
           iv_bucket = iv_dest_bucket
           iv_key = iv_dest_object
-          iv_copysource = |{ iv_src_bucket }/{ iv_src_object }|
-        ).
+          iv_copysource = |{ iv_src_bucket }/{ iv_src_object }| ).
         MESSAGE 'Object copied to another bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.
@@ -77,16 +76,27 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
 
   METHOD create_bucket.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_s3) = /aws1/cl_s3_factory=>create( lo_session ).
 
     " snippet-start:[s3.abapv1.create_bucket]
     TRY.
+        " determine our region from our session
+        DATA(lv_region) = CONV /aws1/s3_bucketlocationcnstrnt( lo_session->get_region( ) ).
+        DATA lo_constraint TYPE REF TO /aws1/cl_s3_createbucketconf.
+        " When in the us-east-1 region, you must not specify a constraint
+        " In all other regions, specify the region as the constraint
+        IF lv_region = 'us-east-1'.
+          CLEAR lo_constraint.
+        ELSE.
+          lo_constraint = NEW /aws1/cl_s3_createbucketconf( lv_region ).
+        ENDIF.
+
         lo_s3->createbucket(
             iv_bucket = iv_bucket_name
-        ).
+            io_createbucketconfiguration  = lo_constraint ).
         MESSAGE 'S3 bucket created.' TYPE 'I'.
       CATCH /aws1/cx_s3_bucketalrdyexists.
         MESSAGE 'Bucket name already exists.' TYPE 'E'.
@@ -99,7 +109,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
 
   METHOD delete_bucket.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_s3) = /aws1/cl_s3_factory=>create( lo_session ).
@@ -108,8 +118,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
     TRY.
 
         lo_s3->deletebucket(
-            iv_bucket = iv_bucket_name
-        ).
+            iv_bucket = iv_bucket_name ).
         MESSAGE 'Deleted S3 bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.
@@ -120,7 +129,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
 
 
   METHOD delete_object.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_s3) = /aws1/cl_s3_factory=>create( lo_session ).
@@ -129,8 +138,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
     TRY.
         lo_s3->deleteobject(
             iv_bucket = iv_bucket_name
-            iv_key = iv_object_key
-        ).
+            iv_key = iv_object_key ).
         MESSAGE 'Object deleted from S3 bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.
@@ -140,7 +148,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
 
 
   METHOD get_object.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_s3) = /aws1/cl_s3_factory=>create( lo_session ).
@@ -149,8 +157,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
     TRY.
         oo_result = lo_s3->getobject(           " oo_result is returned for testing purposes. "
                   iv_bucket = iv_bucket_name
-                  iv_key = iv_object_key
-               ).
+                  iv_key = iv_object_key ).
         DATA(lv_object_data) = oo_result->get_body( ).
         MESSAGE 'Object retrieved from S3 bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
@@ -164,7 +171,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
 
 
   METHOD list_objects.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_s3) = /aws1/cl_s3_factory=>create( lo_session ).
@@ -172,8 +179,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
     "snippet-start:[s3.abapv1.list_objects]
     TRY.
         oo_result = lo_s3->listobjects(         " oo_result is returned for testing purposes. "
-          iv_bucket = iv_bucket_name
-        ).
+          iv_bucket = iv_bucket_name ).
         MESSAGE 'Retrieved list of objects in S3 bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.
@@ -183,7 +189,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
 
 
   METHOD list_objects_v2.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_s3) = /aws1/cl_s3_factory=>create( lo_session ).
@@ -191,8 +197,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
     "snippet-start:[s3.abapv1.list_objects_v2]
     TRY.
         oo_result = lo_s3->listobjectsv2(         " oo_result is returned for testing purposes. "
-          iv_bucket = iv_bucket_name
-        ).
+          iv_bucket = iv_bucket_name ).
         MESSAGE 'Retrieved list of objects in S3 bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.
@@ -203,7 +208,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
 
   METHOD put_object.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_s3) = /aws1/cl_s3_factory=>create( lo_session ).
@@ -221,8 +226,7 @@ CLASS ZCL_AWS1_S3_ACTIONS IMPLEMENTATION.
         lo_s3->putobject(
             iv_bucket = iv_bucket_name
             iv_key = iv_file_name
-            iv_body = lv_body
-        ).
+            iv_body = lv_body ).
         MESSAGE 'Object uploaded to S3 bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.

--- a/sap-abap/services/s3/zcl_aws1_s3_actions.clas.testclasses.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_actions.clas.testclasses.abap
@@ -4,14 +4,21 @@
 CLASS ltc_zcl_aws1_s3_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_s3_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_s3_actions.
 
-CLASS ltc_zcl_aws1_s3_actions DEFINITION FOR TESTING  DURATION SHORT RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_s3_actions DEFINITION FOR TESTING DURATION SHORT RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
-    DATA ao_s3 TYPE REF TO /aws1/if_s3.
-    DATA ao_session TYPE REF TO /aws1/cl_rt_session_base.
-    DATA ao_s3_actions TYPE REF TO zcl_aws1_s3_actions.
+
+    CLASS-DATA av_bucket         TYPE /aws1/s3_bucketname.
+    CLASS-DATA av_bucket_create      TYPE /aws1/s3_bucketname.
+    CLASS-DATA av_bucket_delete      TYPE /aws1/s3_bucketname.
+    CLASS-DATA av_src_bucket TYPE /aws1/s3_bucketname.
+    CLASS-DATA av_dest_bucket TYPE /aws1/s3_bucketname.
+
+    CLASS-DATA ao_s3 TYPE REF TO /aws1/if_s3.
+    CLASS-DATA ao_session TYPE REF TO /aws1/cl_rt_session_base.
+    CLASS-DATA ao_s3_actions TYPE REF TO zcl_aws1_s3_actions.
 
     METHODS: create_bucket FOR TESTING RAISING /aws1/cx_rt_generic,
       put_object FOR TESTING RAISING /aws1/cx_rt_generic,
@@ -22,7 +29,8 @@ CLASS ltc_zcl_aws1_s3_actions DEFINITION FOR TESTING  DURATION SHORT RISK LEVEL 
       delete_object FOR TESTING RAISING /aws1/cx_rt_generic,
       delete_bucket FOR TESTING RAISING /aws1/cx_rt_generic.
 
-    METHODS setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    CLASS-METHODS class_setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
+    CLASS-METHODS class_teardown RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
 
     METHODS assert_bucket_exists
       IMPORTING
@@ -41,51 +49,66 @@ CLASS ltc_zcl_aws1_s3_actions DEFINITION FOR TESTING  DURATION SHORT RISK LEVEL 
       IMPORTING
         iv_bucket TYPE /aws1/s3_bucketname
         iv_file   TYPE /aws1/s3_objectkey.
-
 ENDCLASS.
 
 CLASS ltc_zcl_aws1_s3_actions IMPLEMENTATION.
 
-  METHOD setup.
+  METHOD class_setup.
     ao_session = /aws1/cl_rt_session_aws=>create( iv_profile_id = cv_pfl ).
     ao_s3 = /aws1/cl_s3_factory=>create( ao_session ).
     ao_s3_actions = NEW zcl_aws1_s3_actions( ).
+
+    DATA(lv_acct) = ao_session->get_account_id( ).
+    av_bucket = |sap-abap-s3-demo-bucket-{ lv_acct }|.
+    av_src_bucket = |sap-abap-s3-demo-copy-object-src-bucket-{ lv_acct }|.
+    av_dest_bucket = |sap-abap-s3-demo-copy-object-dst-bucket-{ lv_acct }|.
+    av_bucket_delete = |sap-abap-s3-demo-bucket-delete-{ lv_acct }|.
+    av_bucket_create = |sap-abap-s3-demo-bucket-create-{ lv_acct }|.
+    ao_s3_actions->create_bucket( av_bucket ).
+    ao_s3_actions->create_bucket( av_src_bucket ).
+    ao_s3_actions->create_bucket( av_dest_bucket ).
+    ao_s3_actions->create_bucket( av_bucket_delete ).
+
+
   ENDMETHOD.
+  METHOD class_teardown.
+    zcl_aws1_ex_utils=>cleanup_bucket( io_s3 = ao_s3
+                                       iv_bucket = av_bucket ).
+    zcl_aws1_ex_utils=>cleanup_bucket( io_s3 = ao_s3
+                                       iv_bucket = av_bucket_create ).
+    zcl_aws1_ex_utils=>cleanup_bucket( io_s3 = ao_s3
+                                       iv_bucket = av_bucket_delete ).
+    zcl_aws1_ex_utils=>cleanup_bucket( io_s3 = ao_s3
+                                       iv_bucket = av_src_bucket ).
+    zcl_aws1_ex_utils=>cleanup_bucket( io_s3 = ao_s3
+                                       iv_bucket = av_dest_bucket ).
+  ENDMETHOD.
+
   METHOD create_bucket.
-    CONSTANTS cv_bucket TYPE /aws1/s3_bucketname VALUE 'amzn-s3-demo-bucket'.
-    ao_s3_actions->create_bucket( iv_bucket_name = cv_bucket ).
+    ao_s3_actions->create_bucket( av_bucket_create ).
 
     assert_bucket_exists(
-      iv_bucket = cv_bucket
+      iv_bucket = av_bucket
       iv_exp = abap_true
-      iv_msg = |Bucket { cv_bucket } was not created|
-    ).
-
-    ao_s3->deletebucket( iv_bucket = cv_bucket ).
+      iv_msg = |Bucket { av_bucket_create } was not created| ).
 
   ENDMETHOD.
   METHOD put_object.
-
-    CONSTANTS cv_bucket TYPE /aws1/s3_bucketname VALUE 'code-example-put-object'.
-    ao_s3->createbucket( iv_bucket = cv_bucket ).
-
     CONSTANTS cv_file TYPE /aws1/s3_objectkey VALUE 'put_object_ex_file'.
-    create_file( iv_file = cv_file ).
+    create_file( cv_file ).
 
     ao_s3_actions->put_object(
-        iv_bucket_name = cv_bucket
-        iv_file_name = cv_file
-     ).
+        iv_bucket_name = av_bucket
+        iv_file_name = cv_file ).
 
     cl_abap_unit_assert=>assert_equals(
         exp = get_file_data( iv_file = cv_file )
-        act = ao_s3->getobject( iv_bucket = cv_bucket iv_key = cv_file )->get_body( )
-        msg = |Object { cv_file } did not match expected value|
-    ).
+        act = ao_s3->getobject( iv_bucket = av_bucket iv_key = cv_file )->get_body( )
+        msg = |Object { cv_file } did not match expected value| ).
 
-    ao_s3->deleteobject( iv_bucket = cv_bucket iv_key = cv_file ).
-    ao_s3->deletebucket( iv_bucket = cv_bucket ).
-    delete_file( iv_file = cv_file ).
+    ao_s3->deleteobject( iv_bucket = av_bucket
+                         iv_key = cv_file ).
+    delete_file( cv_file ).
 
   ENDMETHOD.
   METHOD create_file.
@@ -98,7 +121,8 @@ CLASS ltc_zcl_aws1_s3_actions IMPLEMENTATION.
         operatingsystem       = 'ANYOS'
       EXCEPTIONS
         OTHERS                = 15.
-    /aws1/cl_rt_assert_abap=>assert_subrc( iv_exp = 0 iv_msg = |Could not create { iv_file }| ).
+    /aws1/cl_rt_assert_abap=>assert_subrc( iv_exp = 0
+                                           iv_msg = |Could not create { iv_file }| ).
   ENDMETHOD.
   METHOD get_file_data.
     "Get file content.
@@ -111,201 +135,185 @@ CLASS ltc_zcl_aws1_s3_actions IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       exp = sy-subrc
       act = 0
-      msg = |Could not delete { iv_file }|
-     ).
+      msg = |Could not delete { iv_file }| ).
   ENDMETHOD.
   METHOD get_object.
-
-    CONSTANTS cv_bucket TYPE /aws1/s3_bucketname VALUE 'code-example-get-object'.
-    ao_s3->createbucket( iv_bucket = cv_bucket ).
-
     CONSTANTS cv_file TYPE /aws1/s3_objectkey VALUE 'get_object_ex_file'.
-    create_file( iv_file = cv_file ).
-
-    put_file_in_bucket( iv_bucket = cv_bucket iv_file = cv_file ).
-
     DATA lo_result TYPE REF TO /aws1/cl_s3_getobjectoutput.
+    create_file( cv_file ).
+
+    put_file_in_bucket( iv_bucket = av_bucket
+                        iv_file = cv_file ).
+
+
     ao_s3_actions->get_object(
       EXPORTING
-        iv_bucket_name = cv_bucket
+        iv_bucket_name = av_bucket
         iv_object_key = cv_file
       IMPORTING
-        oo_result = lo_result
-    ).
+        oo_result = lo_result ).
 
     cl_abap_unit_assert=>assert_equals(
       exp = get_file_data( iv_file = cv_file )
       act = lo_result->get_body( )
-      msg = |Object { cv_file } did not match expected value|
-    ).
+      msg = |Object { cv_file } did not match expected value| ).
 
-    ao_s3->deleteobject( iv_bucket = cv_bucket iv_key = cv_file ).
-    ao_s3->deletebucket( iv_bucket = cv_bucket ).
-    delete_file( iv_file = cv_file ).
+    ao_s3->deleteobject( iv_bucket = av_bucket
+                         iv_key = cv_file ).
+    delete_file( cv_file ).
 
   ENDMETHOD.
   METHOD put_file_in_bucket.
     ao_s3->putobject(
           iv_bucket = iv_bucket
           iv_key = iv_file
-          iv_body = get_file_data( iv_file = iv_file )
-        ).
+          iv_body = get_file_data( iv_file = iv_file ) ).
   ENDMETHOD.
   METHOD copy_object.
-    CONSTANTS cv_src_bucket TYPE /aws1/s3_bucketname VALUE 'amzn-s3-demo-copy-object-src-bucket'.
-    ao_s3->createbucket( iv_bucket = cv_src_bucket ).
-    CONSTANTS cv_dest_bucket TYPE /aws1/s3_bucketname VALUE 'amzn-s3-demo-copy-object-dest-bucket'.
-    ao_s3->createbucket( iv_bucket = cv_dest_bucket ).
-
     CONSTANTS cv_src_file TYPE /aws1/s3_objectkey VALUE 'copy_object_ex_file'.
     CONSTANTS cv_dest_file TYPE /aws1/s3_objectkey VALUE 'copied_object_ex_file'.
-    create_file( iv_file = cv_src_file ).
-    put_file_in_bucket( iv_bucket = cv_src_bucket iv_file = cv_src_file ).
+
+
+    create_file( cv_src_file ).
+    put_file_in_bucket( iv_bucket = av_src_bucket
+                        iv_file = cv_src_file ).
 
     ao_s3_actions->copy_object(
-      EXPORTING
-        iv_dest_bucket = cv_dest_bucket
+      iv_dest_bucket = av_dest_bucket
         iv_dest_object = cv_dest_file
-        iv_src_bucket  = cv_src_bucket
-        iv_src_object  = cv_src_file
-    ).
+        iv_src_bucket  = av_src_bucket
+        iv_src_object  = cv_src_file ).
 
     cl_abap_unit_assert=>assert_equals(
       exp = get_file_data( iv_file = cv_src_file )
-      act = ao_s3->getobject( iv_bucket = cv_dest_bucket iv_key = cv_dest_file )->get_body( )
-      msg = |Object { cv_dest_file } did not match expected value|
-    ).
+      act = ao_s3->getobject( iv_bucket = av_dest_bucket iv_key = cv_dest_file )->get_body( )
+      msg = |Object { cv_dest_file } did not match expected value| ).
 
-    ao_s3->deleteobject( iv_bucket = cv_src_bucket iv_key = cv_src_file ).
-    ao_s3->deletebucket( iv_bucket = cv_src_bucket ).
-    delete_file( iv_file = cv_src_file ).
+    ao_s3->deleteobject( iv_bucket = av_src_bucket
+                         iv_key = cv_src_file ).
+    ao_s3->deletebucket( iv_bucket = av_src_bucket ).
+    delete_file( cv_src_file ).
 
-    ao_s3->deleteobject( iv_bucket = cv_dest_bucket iv_key = cv_dest_file ).
-    ao_s3->deletebucket( iv_bucket = cv_dest_bucket ).
-    delete_file( iv_file = cv_dest_file ).
+    ao_s3->deleteobject( iv_bucket = av_dest_bucket
+                         iv_key = cv_dest_file ).
+    ao_s3->deletebucket( iv_bucket = av_dest_bucket ).
+    delete_file( cv_dest_file ).
 
   ENDMETHOD.
   METHOD list_objects.
-
-    CONSTANTS cv_bucket TYPE /aws1/s3_bucketname VALUE 'code-example-list-objects'.
-    ao_s3->createbucket( iv_bucket = cv_bucket ).
-
     CONSTANTS cv_file TYPE /aws1/s3_objectkey VALUE 'list_objects_ex_file1'.
-    create_file( iv_file = cv_file ).
+    create_file( cv_file ).
 
-    put_file_in_bucket( iv_bucket = cv_bucket iv_file = cv_file ).
+    put_file_in_bucket( iv_bucket = av_bucket
+                        iv_file = cv_file ).
 
     DATA lo_list TYPE REF TO /aws1/cl_s3_listobjectsoutput.
     ao_s3_actions->list_objects(
       EXPORTING
-        iv_bucket_name = cv_bucket
+        iv_bucket_name = av_bucket
       IMPORTING
-        oo_result = lo_list
-    ).
+        oo_result = lo_list ).
 
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT lo_list->get_contents( ) INTO DATA(lo_object).
       IF lo_object->get_key( ) = cv_file.
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Could not find object { cv_file } in the list|
-    ).
+      msg = |Could not find object { cv_file } in the list| ).
 
-    ao_s3->deleteobject( iv_bucket = cv_bucket iv_key = cv_file ).
-    ao_s3->deletebucket( iv_bucket = cv_bucket ).
-    delete_file( iv_file = cv_file ).
+    ao_s3->deleteobject( iv_bucket = av_bucket
+                         iv_key = cv_file ).
+    delete_file( cv_file ).
 
   ENDMETHOD.
 
   METHOD list_objects_v2.
-    CONSTANTS cv_bucket TYPE /aws1/s3_bucketname VALUE 'code-example-list-objects'.
-    ao_s3->createbucket( iv_bucket = cv_bucket ).
-
     CONSTANTS cv_file TYPE /aws1/s3_objectkey VALUE 'list_objects_ex_file1'.
-    create_file( iv_file = cv_file ).
+    create_file( cv_file ).
 
-    put_file_in_bucket( iv_bucket = cv_bucket iv_file = cv_file ).
+    put_file_in_bucket( iv_bucket = av_bucket
+                        iv_file = cv_file ).
 
-    DATA lo_list TYPE REF TO /AWS1/CL_S3_LISTOBJSV2OUTPUT.
+    DATA lo_list TYPE REF TO /aws1/cl_s3_listobjsv2output.
     ao_s3_actions->list_objects_v2(
       EXPORTING
-        iv_bucket_name = cv_bucket
+        iv_bucket_name = av_bucket
       IMPORTING
-        oo_result = lo_list
-    ).
+        oo_result = lo_list ).
 
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT lo_list->get_contents( ) INTO DATA(lo_object).
       IF lo_object->get_key( ) = cv_file.
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Could not find object { cv_file } in the list|
-    ).
+      msg = |Could not find object { cv_file } in the list| ).
 
-    ao_s3->deleteobject( iv_bucket = cv_bucket iv_key = cv_file ).
-    ao_s3->deletebucket( iv_bucket = cv_bucket ).
-    delete_file( iv_file = cv_file ).
+    ao_s3->deleteobject( iv_bucket = av_bucket
+                         iv_key = cv_file ).
+    delete_file( cv_file ).
 
   ENDMETHOD.
   METHOD delete_object.
-    CONSTANTS cv_bucket TYPE /aws1/s3_bucketname VALUE 'code-example-delete-object'.
-    ao_s3->createbucket( iv_bucket = cv_bucket ).
-
     CONSTANTS cv_file1 TYPE /aws1/s3_objectkey VALUE 'delete_object_ex_file1'.
     CONSTANTS cv_file2 TYPE /aws1/s3_objectkey VALUE 'delete_object_ex_file2'.
-    create_file( iv_file = cv_file1 ).
-    create_file( iv_file = cv_file2 ).
+    create_file( cv_file1 ).
+    create_file( cv_file2 ).
 
-    put_file_in_bucket( iv_bucket = cv_bucket iv_file = cv_file1 ).
-    put_file_in_bucket( iv_bucket = cv_bucket iv_file = cv_file2 ).
+    put_file_in_bucket( iv_bucket = av_bucket
+                        iv_file = cv_file1 ).
+    put_file_in_bucket( iv_bucket = av_bucket
+                        iv_file = cv_file2 ).
 
-    ao_s3_actions->delete_object( iv_bucket_name =  cv_bucket iv_object_key = cv_file1 ).
-    ao_s3_actions->delete_object( iv_bucket_name =  cv_bucket iv_object_key = cv_file2 ).
+    ao_s3_actions->delete_object( iv_bucket_name = av_bucket
+                                  iv_object_key = cv_file1 ).
+    ao_s3_actions->delete_object( iv_bucket_name = av_bucket
+                                  iv_object_key = cv_file2 ).
 
-    DATA(lo_list) =  ao_s3->listobjects( iv_bucket = cv_bucket ).
+    DATA(lo_list) = ao_s3->listobjects( iv_bucket = av_bucket ).
     cl_abap_unit_assert=>assert_equals(
       exp = lines( lo_list->get_contents( ) )
       act = 0
-      msg = |Could not delete all objects in bucket { cv_bucket }|
-     ).
+      msg = |Could not delete all objects in bucket { av_bucket }| ).
 
-    ao_s3->deletebucket( iv_bucket = cv_bucket ).
-    delete_file( iv_file = cv_file1 ).
-    delete_file( iv_file = cv_file2 ).
+    delete_file( cv_file1 ).
+    delete_file( cv_file2 ).
 
   ENDMETHOD.
   METHOD delete_bucket.
-    CONSTANTS cv_bucket TYPE /aws1/s3_bucketname VALUE 'amzn-s3-demo-bucket'.
-    ao_s3->createbucket( iv_bucket = cv_bucket ).
-    ao_s3_actions->delete_bucket( iv_bucket_name =  cv_bucket ).
-
+    ao_s3_actions->delete_bucket( av_bucket_delete ).
     assert_bucket_exists(
-      iv_bucket = cv_bucket
       iv_exp = abap_false
-      iv_msg = |Bucket { cv_bucket } should have been deleted|
-    ).
+      iv_bucket = av_bucket_delete
+      iv_msg = |Bucket { av_bucket_delete } should have been deleted| ).
+
 
   ENDMETHOD.
   METHOD assert_bucket_exists.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
-    LOOP AT ao_s3->listbuckets( )->get_buckets( ) INTO DATA(lo_bucket).
-      IF lo_bucket->get_name( ) = iv_bucket.
-        lv_found = abap_true.
-      ENDIF.
-    ENDLOOP.
-
+    DATA(lv_found) = abap_true.
+    TRY.
+        ao_s3->headbucket( iv_bucket = av_bucket_delete ).
+      CATCH /aws1/cx_s3_nosuchbucket INTO DATA(lo_ex).
+        lv_found = abap_false.
+      CATCH /aws1/cx_s3_clientexc INTO DATA(lo_ex2).
+        IF lo_ex2->av_http_code = 404.
+          lv_found = abap_false.
+        ELSE.
+          RAISE EXCEPTION lo_ex2.
+        ENDIF.
+    ENDTRY.
     cl_abap_unit_assert=>assert_equals(
-      exp = iv_exp
       act = lv_found
-      msg = iv_msg
-    ).
+      exp = iv_exp
+      msg = iv_msg ).
+
   ENDMETHOD.
+
 ENDCLASS.

--- a/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.abap
@@ -1,22 +1,22 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_S3_SCENARIO definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_s3_scenario DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods GETTING_STARTED_WITH_S3
-    importing
-      !IV_BUCKET_NAME type /AWS1/S3_BUCKETNAME
-      !IV_KEY type /AWS1/S3_OBJECTKEY
-      !IV_COPY_TO_FOLDER type /AWS1/S3_BUCKETNAME
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_KNSPUTRECORDOUTPUT .
-protected section.
-private section.
+    METHODS getting_started_with_s3
+      IMPORTING
+      !iv_bucket_name TYPE /aws1/s3_bucketname
+      !iv_key TYPE /aws1/s3_objectkey
+      !iv_copy_to_folder TYPE /aws1/s3_bucketname
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_knsputrecordoutput .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -26,7 +26,7 @@ CLASS ZCL_AWS1_S3_SCENARIO IMPLEMENTATION.
 
   METHOD getting_started_with_s3.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     "snippet-start:[s3.abapv1.getting_started_with_s3]
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
@@ -34,9 +34,20 @@ CLASS ZCL_AWS1_S3_SCENARIO IMPLEMENTATION.
 
     " Create an Amazon Simple Storage Service (Amazon S3) bucket. "
     TRY.
+        " determine our region from our session
+        DATA(lv_region) = CONV /aws1/s3_bucketlocationcnstrnt( lo_session->get_region( ) ).
+        DATA lo_constraint TYPE REF TO /aws1/cl_s3_createbucketconf.
+        " When in the us-east-1 region, you must not specify a constraint
+        " In all other regions, specify the region as the constraint
+        IF lv_region = 'us-east-1'.
+          CLEAR lo_constraint.
+        ELSE.
+          lo_constraint = NEW /aws1/cl_s3_createbucketconf( lv_region ).
+        ENDIF.
+
         lo_s3->createbucket(
             iv_bucket = iv_bucket_name
-        ).
+            io_createbucketconfiguration  = lo_constraint ).
         MESSAGE 'S3 bucket created.' TYPE 'I'.
       CATCH /aws1/cx_s3_bucketalrdyexists.
         MESSAGE 'Bucket name already exists.' TYPE 'E'.
@@ -56,8 +67,7 @@ CLASS ZCL_AWS1_S3_SCENARIO IMPLEMENTATION.
         lo_s3->putobject(
             iv_bucket = iv_bucket_name
             iv_key = iv_key
-            iv_body = lv_file_content
-        ).
+            iv_body = lv_file_content ).
         MESSAGE 'Object uploaded to S3 bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.
@@ -67,8 +77,7 @@ CLASS ZCL_AWS1_S3_SCENARIO IMPLEMENTATION.
     TRY.
         DATA(lo_result) = lo_s3->getobject(
                    iv_bucket = iv_bucket_name
-                   iv_key = iv_key
-                ).
+                   iv_key = iv_key ).
         DATA(lv_object_data) = lo_result->get_body( ).
         MESSAGE 'Object retrieved from S3 bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
@@ -82,8 +91,7 @@ CLASS ZCL_AWS1_S3_SCENARIO IMPLEMENTATION.
         lo_s3->copyobject(
           iv_bucket = iv_bucket_name
           iv_key = |{ iv_copy_to_folder }/{ iv_key }|
-          iv_copysource = |{ iv_bucket_name }/{ iv_key }|
-        ).
+          iv_copysource = |{ iv_bucket_name }/{ iv_key }| ).
         MESSAGE 'Object copied to a subfolder.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.
@@ -94,8 +102,7 @@ CLASS ZCL_AWS1_S3_SCENARIO IMPLEMENTATION.
     " List objects in the bucket. "
     TRY.
         DATA(lo_list) = lo_s3->listobjects(
-           iv_bucket = iv_bucket_name
-         ).
+           iv_bucket = iv_bucket_name ).
         MESSAGE 'Retrieved list of objects in S3 bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.
@@ -112,12 +119,10 @@ CLASS ZCL_AWS1_S3_SCENARIO IMPLEMENTATION.
     TRY.
         lo_s3->deleteobject(
             iv_bucket = iv_bucket_name
-            iv_key = iv_key
-        ).
+            iv_key = iv_key ).
         lo_s3->deleteobject(
             iv_bucket = iv_bucket_name
-            iv_key = |{ iv_copy_to_folder }/{ iv_key }|
-        ).
+            iv_key = |{ iv_copy_to_folder }/{ iv_key }| ).
         MESSAGE 'Objects deleted from S3 bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.
@@ -127,8 +132,7 @@ CLASS ZCL_AWS1_S3_SCENARIO IMPLEMENTATION.
     " Delete the bucket. "
     TRY.
         lo_s3->deletebucket(
-            iv_bucket = iv_bucket_name
-        ).
+            iv_bucket = iv_bucket_name ).
         MESSAGE 'Deleted S3 bucket.' TYPE 'I'.
       CATCH /aws1/cx_s3_nosuchbucket.
         MESSAGE 'Bucket does not exist.' TYPE 'E'.

--- a/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.testclasses.abap
+++ b/sap-abap/services/s3/zcl_aws1_s3_scenario.clas.testclasses.abap
@@ -4,13 +4,14 @@
 CLASS ltc_zcl_aws1_s3_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_s3_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_s3_scenario.
 
-CLASS ltc_zcl_aws1_s3_scenario DEFINITION FOR TESTING  DURATION SHORT RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_s3_scenario DEFINITION FOR TESTING DURATION SHORT RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
     CONSTANTS: cv_pfl            TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO',
-               cv_bucket         TYPE /aws1/s3_bucketname VALUE 'amzn-s3-demo-bucket',
                cv_file           TYPE /aws1/s3_objectkey VALUE 's3_scenario_ex_file',
                cv_copy_to_folder TYPE /aws1/s3_bucketname VALUE 'code-example-scenario-folder'.
+
+    DATA av_bucket         TYPE /aws1/s3_bucketname.
 
     DATA ao_s3 TYPE REF TO /aws1/if_s3.
     DATA ao_session TYPE REF TO /aws1/cl_rt_session_base.
@@ -18,18 +19,23 @@ CLASS ltc_zcl_aws1_s3_scenario DEFINITION FOR TESTING  DURATION SHORT RISK LEVEL
 
     METHODS getting_started_scenario FOR TESTING RAISING /aws1/cx_rt_generic.
 
-    METHODS setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
+    METHODS teardown RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
 
 ENDCLASS.
 
 CLASS ltc_zcl_aws1_s3_scenario IMPLEMENTATION.
 
   METHOD setup.
+    DATA lv_param TYPE btcxpgpar.
     ao_session = /aws1/cl_rt_session_aws=>create( iv_profile_id = cv_pfl ).
+    DATA(lv_acct) = ao_session->get_account_id( ).
+    av_bucket = |sap-abap-s3-scenario-bucket-{ lv_acct }|.
+
     ao_s3 = /aws1/cl_s3_factory=>create( ao_session ).
     ao_s3_scenario = NEW zcl_aws1_s3_scenario( ).
 
-    DATA lv_param TYPE btcxpgpar.
+
     lv_param = |if=/dev/random of={ cv_file } bs=1M count=1 iflag=fullblock|.
     CALL FUNCTION 'SXPG_COMMAND_EXECUTE'
       EXPORTING
@@ -38,29 +44,35 @@ CLASS ltc_zcl_aws1_s3_scenario IMPLEMENTATION.
         operatingsystem       = 'ANYOS'
       EXCEPTIONS
         OTHERS                = 15.
-    /aws1/cl_rt_assert_abap=>assert_subrc( iv_exp = 0 iv_msg = |Could not create { cv_file }| ).
-
+    /aws1/cl_rt_assert_abap=>assert_subrc( iv_exp = 0
+                                           iv_msg = |Could not create { cv_file }| ).
 
   ENDMETHOD.
+
+  METHOD teardown.
+    zcl_aws1_ex_utils=>cleanup_bucket( io_s3 = ao_s3
+                                       iv_bucket = av_bucket ).
+
+  ENDMETHOD.
+
+
+
   METHOD getting_started_scenario.
     ao_s3_scenario->getting_started_with_s3(
-      EXPORTING
-        iv_bucket_name = cv_bucket
+      iv_bucket_name = av_bucket
         iv_key = cv_file
-        iv_copy_to_folder = cv_copy_to_folder
-    ).
+        iv_copy_to_folder = cv_copy_to_folder ).
 
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT ao_s3->listbuckets( )->get_buckets( ) INTO DATA(lo_bucket).
-      IF lo_bucket->get_name( ) = cv_bucket.
-        lv_found = abap_true.
+      IF lo_bucket->get_name( ) = av_bucket.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_equals(
       exp = abap_false
       act = lv_found
-      msg = |Bucket { cv_bucket } should have been deleted|
-    ).
+      msg = |Bucket { av_bucket } should have been deleted| ).
   ENDMETHOD.
 ENDCLASS.

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.abap
@@ -1,109 +1,109 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_SGM_ACTIONS definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_sgm_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods CREATE_ENDPOINT
-    importing
-      !IV_MODEL_NAME type /AWS1/SGMMODELNAME
-      !IV_ENDPOINT_NAME type /AWS1/SGMENDPOINTNAME
-      !IV_ENDPOINT_CONFIG_NAME type /AWS1/SGMENDPOINTCONFIGNAME
-      !IV_INSTANCE_TYPE type /AWS1/SGMINSTANCETYPE
-      !IV_INITIAL_INSTANCE_COUNT type /AWS1/SGMINITIALTASKCOUNT
-      !IV_VARIANT_NAME type /AWS1/SGMVARIANTNAME
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_SGMCREATEENDPTOUTPUT .
-  methods CREATE_MODEL
-    importing
-      !IV_MODEL_NAME type /AWS1/SGMMODELNAME
-      !IV_EXECUTION_ROLE_ARN type /AWS1/SGMROLEARN
-      !IV_MODEL_DATA_URL type /AWS1/SGMURL
-      !IV_CONTAINER_IMAGE type /AWS1/SGMCONTAINERMODE
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_SGMCREATEMODELOUTPUT .
-  methods CREATE_TRAINING_JOB
-    importing
-      !IV_TRAINING_JOB_NAME type /AWS1/SGMTRAININGJOBNAME
-      !IV_ROLE_ARN type /AWS1/SGMROLEARN
-      !IV_TRN_DATA_S3DATATYPE type /AWS1/SGMS3DATATYPE
-      !IV_TRN_DATA_S3DATADISTRIBUTION type /AWS1/SGMS3DATADISTRIBUTION
-      !IV_TRN_DATA_S3URI type /AWS1/SGMS3URI
-      !IV_TRN_DATA_COMPRESSIONTYPE type /AWS1/SGMCOMPRESSIONTYPE
-      !IV_TRN_DATA_CONTENTTYPE type /AWS1/SGMCONTENTTYPE
-      !IV_VAL_DATA_S3DATATYPE type /AWS1/SGMS3DATATYPE
-      !IV_VAL_DATA_S3DATADISTRIBUTION type /AWS1/SGMS3DATADISTRIBUTION
-      !IV_VAL_DATA_S3URI type /AWS1/SGMS3URI
-      !IV_VAL_DATA_COMPRESSIONTYPE type /AWS1/SGMCOMPRESSIONTYPE
-      !IV_VAL_DATA_CONTENTTYPE type /AWS1/SGMCONTENTTYPE
-      !IV_HP_MAX_DEPTH type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_SCALE_POS_WEIGHT type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_NUM_ROUND type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_OBJECTIVE type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_SUBSAMPLE type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_EVAL_METRIC type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_ETA type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_TRAINING_IMAGE type /AWS1/SGMALGORITHMIMAGE
-      !IV_TRAINING_INPUT_MODE type /AWS1/SGMTRAININGINPUTMODE
-      !IV_INSTANCE_COUNT type /AWS1/SGMTRAININGINSTANCECOUNT
-      !IV_INSTANCE_TYPE type /AWS1/SGMTRAININGINSTANCETYPE
-      !IV_VOLUME_SIZEINGB type /AWS1/SGMVOLUMESIZEINGB
-      !IV_S3_OUTPUT_PATH type /AWS1/SGMS3URI
-      !IV_MAX_RUNTIME_IN_SECONDS type /AWS1/SGMMAXRUNTIMEINSECONDS
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_SGMCREATETRNJOBRSP .
-  methods CREATE_TRANSFORM_JOB
-    importing
-      !IV_TF_JOB_NAME type /AWS1/SGMTRANSFORMJOBNAME
-      !IV_TF_DATA_S3DATATYPE type /AWS1/SGMS3DATATYPE
-      !IV_TF_DATA_S3URI type /AWS1/SGMS3URI
-      !IV_TF_DATA_COMPRESSIONTYPE type /AWS1/SGMCOMPRESSIONTYPE
-      !IV_TF_DATA_CONTENTTYPE type /AWS1/SGMCONTENTTYPE
-      !IV_INSTANCE_COUNT type /AWS1/SGMTRAININGINSTANCECOUNT
-      !IV_INSTANCE_TYPE type /AWS1/SGMTRAININGINSTANCETYPE
-      !IV_S3_OUTPUT_PATH type /AWS1/SGMS3URI
-      !IV_TF_MODEL_NAME type /AWS1/SGMMODELNAME
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_SGMCRETRANSFORMJOBRSP .
-  methods DELETE_ENDPOINT
-    importing
-      !IV_ENDPOINT_NAME type /AWS1/SGMENDPOINTNAME
-      !IV_ENDPOINT_CONFIG_NAME type /AWS1/SGMENDPOINTCONFIGNAME .
-  methods DELETE_MODEL
-    importing
-      !IV_MODEL_NAME type /AWS1/SGMMODELNAME .
-  methods DESCRIBE_TRAINING_JOB
-    importing
-      !IV_TRAINING_JOB_NAME type /AWS1/SGMTRAININGJOBNAME
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_SGMDESCRTRNJOBRSP .
-  methods LIST_ALGORITHMS
-    importing
-      !IV_NAME_CONTAINS type /AWS1/SGMNAMECONTAINS
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_SGMLISTALGSOUTPUT .
-  methods LIST_MODELS
-    importing
-      !IV_NAME_CONTAINS type /AWS1/SGMMODELNAMECONTAINS
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_SGMLISTMODELSOUTPUT .
-  methods LIST_NOTEBOOK_INSTANCES
-    importing
-      !IV_NAME_CONTAINS type /AWS1/SGMNOTEBOOKINSTNAMECON00
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_SGMLSTNOTEBOOKINSTS01 .
-  methods LIST_TRAINING_JOBS
-    importing
-      !IV_NAME_CONTAINS type /AWS1/SGMTRAININGJOBNAME
-      !IV_MAX_RESULTS type /AWS1/SGMMAXRESULTS
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_SGMLISTTRNJOBSRSP .
-protected section.
-private section.
+    METHODS create_endpoint
+      IMPORTING
+      !iv_model_name TYPE /aws1/sgmmodelname
+      !iv_endpoint_name TYPE /aws1/sgmendpointname
+      !iv_endpoint_config_name TYPE /aws1/sgmendpointconfigname
+      !iv_instance_type TYPE /aws1/sgminstancetype
+      !iv_initial_instance_count TYPE /aws1/sgminitialtaskcount
+      !iv_variant_name TYPE /aws1/sgmvariantname
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_sgmcreateendptoutput .
+    METHODS create_model
+      IMPORTING
+      !iv_model_name TYPE /aws1/sgmmodelname
+      !iv_execution_role_arn TYPE /aws1/sgmrolearn
+      !iv_model_data_url TYPE /aws1/sgmurl
+      !iv_container_image TYPE /aws1/sgmcontainermode
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_sgmcreatemodeloutput .
+    METHODS create_training_job
+      IMPORTING
+      !iv_training_job_name TYPE /aws1/sgmtrainingjobname
+      !iv_role_arn TYPE /aws1/sgmrolearn
+      !iv_trn_data_s3datatype TYPE /aws1/sgms3datatype
+      !iv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution
+      !iv_trn_data_s3uri TYPE /aws1/sgms3uri
+      !iv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype
+      !iv_trn_data_contenttype TYPE /aws1/sgmcontenttype
+      !iv_val_data_s3datatype TYPE /aws1/sgms3datatype
+      !iv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution
+      !iv_val_data_s3uri TYPE /aws1/sgms3uri
+      !iv_val_data_compressiontype TYPE /aws1/sgmcompressiontype
+      !iv_val_data_contenttype TYPE /aws1/sgmcontenttype
+      !iv_hp_max_depth TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_num_round TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_objective TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_subsample TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_eta TYPE /aws1/sgmhyperparametervalue
+      !iv_training_image TYPE /aws1/sgmalgorithmimage
+      !iv_training_input_mode TYPE /aws1/sgmtraininginputmode
+      !iv_instance_count TYPE /aws1/sgmtraininginstancecount
+      !iv_instance_type TYPE /aws1/sgmtraininginstancetype
+      !iv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb
+      !iv_s3_output_path TYPE /aws1/sgms3uri
+      !iv_max_runtime_in_seconds TYPE /aws1/sgmmaxruntimeinseconds
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_sgmcreatetrnjobrsp .
+    METHODS create_transform_job
+      IMPORTING
+      !iv_tf_job_name TYPE /aws1/sgmtransformjobname
+      !iv_tf_data_s3datatype TYPE /aws1/sgms3datatype
+      !iv_tf_data_s3uri TYPE /aws1/sgms3uri
+      !iv_tf_data_compressiontype TYPE /aws1/sgmcompressiontype
+      !iv_tf_data_contenttype TYPE /aws1/sgmcontenttype
+      !iv_instance_count TYPE /aws1/sgmtraininginstancecount
+      !iv_instance_type TYPE /aws1/sgmtraininginstancetype
+      !iv_s3_output_path TYPE /aws1/sgms3uri
+      !iv_tf_model_name TYPE /aws1/sgmmodelname
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_sgmcretransformjobrsp .
+    METHODS delete_endpoint
+      IMPORTING
+      !iv_endpoint_name TYPE /aws1/sgmendpointname
+      !iv_endpoint_config_name TYPE /aws1/sgmendpointconfigname .
+    METHODS delete_model
+      IMPORTING
+      !iv_model_name TYPE /aws1/sgmmodelname .
+    METHODS describe_training_job
+      IMPORTING
+      !iv_training_job_name TYPE /aws1/sgmtrainingjobname
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_sgmdescrtrnjobrsp .
+    METHODS list_algorithms
+      IMPORTING
+      !iv_name_contains TYPE /aws1/sgmnamecontains
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_sgmlistalgsoutput .
+    METHODS list_models
+      IMPORTING
+      !iv_name_contains TYPE /aws1/sgmmodelnamecontains
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_sgmlistmodelsoutput .
+    METHODS list_notebook_instances
+      IMPORTING
+      !iv_name_contains TYPE /aws1/sgmnotebookinstnamecon00
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_sgmlstnotebookinsts01 .
+    METHODS list_training_jobs
+      IMPORTING
+      !iv_name_contains TYPE /aws1/sgmtrainingjobname
+      !iv_max_results TYPE /aws1/sgmmaxresults
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_sgmlisttrnjobsrsp .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -112,7 +112,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
 
   METHOD create_endpoint.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -125,12 +125,10 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
     "Create a production variant as an ABAP object."
     "Identifies a model that you want to host and the resources chosen to deploy for hosting it."
-    CREATE OBJECT lo_production_variants
-      EXPORTING
-        iv_variantname          = iv_variant_name
-        iv_modelname            = iv_model_name
-        iv_initialinstancecount = iv_initial_instance_count
-        iv_instancetype         = iv_instance_type.
+    lo_production_variants = NEW #( iv_variantname = iv_variant_name
+                                    iv_modelname = iv_model_name
+                                    iv_initialinstancecount = iv_initial_instance_count
+                                    iv_instancetype = iv_instance_type ).
 
     INSERT lo_production_variants INTO TABLE lt_production_variants.
 
@@ -138,8 +136,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     TRY.
         oo_ep_config_result = lo_sgm->createendpointconfig(
           iv_endpointconfigname = iv_endpoint_config_name
-          it_productionvariants = lt_production_variants
-        ).
+          it_productionvariants = lt_production_variants ).
         MESSAGE 'Endpoint configuration created.' TYPE 'I'.
       CATCH /aws1/cx_sgmresourcelimitexcd.
         MESSAGE 'You have reached the limit on the number of resources.' TYPE 'E'.
@@ -149,8 +146,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     TRY.
         oo_result = lo_sgm->createendpoint(     " oo_result is returned for testing purposes. "
             iv_endpointconfigname = iv_endpoint_config_name
-            iv_endpointname = iv_endpoint_name
-        ).
+            iv_endpointname = iv_endpoint_name ).
         MESSAGE 'Endpoint created.' TYPE 'I'.
       CATCH /aws1/cx_sgmresourcelimitexcd.
         MESSAGE 'You have reached the limit on the number of resources.' TYPE 'E'.
@@ -162,7 +158,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
 
   METHOD create_model.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -172,18 +168,15 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     DATA lo_primarycontainer TYPE REF TO /aws1/cl_sgmcontainerdefn.
 
     "Create an ABAP object for the container image based on input variables."
-    CREATE OBJECT lo_primarycontainer
-      EXPORTING
-        iv_image        = iv_container_image
-        iv_modeldataurl = iv_model_data_url.
+    lo_primarycontainer = NEW #( iv_image = iv_container_image
+                                 iv_modeldataurl = iv_model_data_url ).
 
     "Create an Amazon SageMaker model."
     TRY.
         oo_result = lo_sgm->createmodel(        " oo_result is returned for testing purposes. "
           iv_executionrolearn = iv_execution_role_arn
           iv_modelname = iv_model_name
-          io_primarycontainer = lo_primarycontainer
-        ).
+          io_primarycontainer = lo_primarycontainer ).
         MESSAGE 'Model created.' TYPE 'I'.
       CATCH /aws1/cx_sgmresourcelimitexcd.
         MESSAGE 'You have reached the limit on the number of resources.' TYPE 'E'.
@@ -193,7 +186,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
 
   METHOD create_training_job.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -211,94 +204,74 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     DATA lo_val_s3datasource TYPE REF TO /aws1/cl_sgms3datasource.
     DATA lo_algorithm_specification TYPE REF TO /aws1/cl_sgmalgorithmspec.
     DATA lo_resource_config  TYPE REF TO /aws1/cl_sgmresourceconfig.
-    DATA lo_output_data_config TYPE REF TO  /aws1/cl_sgmoutputdataconfig.
-    DATA lo_stopping_condition TYPE REF TO  /aws1/cl_sgmstoppingcondition.
+    DATA lo_output_data_config TYPE REF TO /aws1/cl_sgmoutputdataconfig.
+    DATA lo_stopping_condition TYPE REF TO /aws1/cl_sgmstoppingcondition.
 
     "Create ABAP internal table for hyperparameters based on input variables."
     "These hyperparameters are based on the Amazon SageMaker built-in algorithm, XGBoost."
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_max_depth.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_max_depth ).
     INSERT VALUE #( key = 'max_depth' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_eta.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_eta ).
     INSERT VALUE #( key = 'eta' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_eval_metric.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_eval_metric ).
     INSERT VALUE #( key = 'eval_metric' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_scale_pos_weight.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_scale_pos_weight ).
     INSERT VALUE #( key = 'scale_pos_weight' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_subsample.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_subsample ).
     INSERT VALUE #( key = 'subsample' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_objective.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_objective ).
     INSERT VALUE #( key = 'objective' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_num_round.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_num_round ).
     INSERT VALUE #( key = 'num_round' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
     "Create ABAP objects for training data sources."
-    CREATE OBJECT lo_trn_s3datasource
-      EXPORTING
-        iv_s3datatype             = iv_trn_data_s3datatype
-        iv_s3datadistributiontype = iv_trn_data_s3datadistribution
-        iv_s3uri                  = iv_trn_data_s3uri.
+    lo_trn_s3datasource = NEW #( iv_s3datatype = iv_trn_data_s3datatype
+                                 iv_s3datadistributiontype = iv_trn_data_s3datadistribution
+                                 iv_s3uri = iv_trn_data_s3uri ).
 
-    CREATE OBJECT lo_trn_datasource
-      EXPORTING
-        io_s3datasource = lo_trn_s3datasource.
+    lo_trn_datasource = NEW #( io_s3datasource = lo_trn_s3datasource ).
 
-    CREATE OBJECT lo_trn_channel
-      EXPORTING
-        iv_channelname     = 'train'
-        io_datasource      = lo_trn_datasource
-        iv_compressiontype = iv_trn_data_compressiontype
-        iv_contenttype     = iv_trn_data_contenttype.
+    lo_trn_channel = NEW #( iv_channelname = 'train'
+                            io_datasource = lo_trn_datasource
+                            iv_compressiontype = iv_trn_data_compressiontype
+                            iv_contenttype = iv_trn_data_contenttype ).
 
     INSERT lo_trn_channel INTO TABLE lt_input_data_config.
 
     "Create ABAP objects for validation data sources."
-    CREATE OBJECT lo_val_s3datasource
-      EXPORTING
-        iv_s3datatype             = iv_val_data_s3datatype
-        iv_s3datadistributiontype = iv_val_data_s3datadistribution
-        iv_s3uri                  = iv_val_data_s3uri.
+    lo_val_s3datasource = NEW #( iv_s3datatype = iv_val_data_s3datatype
+                                 iv_s3datadistributiontype = iv_val_data_s3datadistribution
+                                 iv_s3uri = iv_val_data_s3uri ).
 
-    CREATE OBJECT lo_val_datasource
-      EXPORTING
-        io_s3datasource = lo_val_s3datasource.
+    lo_val_datasource = NEW #( io_s3datasource = lo_val_s3datasource ).
 
-    CREATE OBJECT lo_val_channel
-      EXPORTING
-        iv_channelname     = 'validation'
-        io_datasource      = lo_val_datasource
-        iv_compressiontype = iv_val_data_compressiontype
-        iv_contenttype     = iv_val_data_contenttype.
+    lo_val_channel = NEW #( iv_channelname = 'validation'
+                            io_datasource = lo_val_datasource
+                            iv_compressiontype = iv_val_data_compressiontype
+                            iv_contenttype = iv_val_data_contenttype ).
 
     INSERT lo_val_channel INTO TABLE lt_input_data_config.
 
     "Create an ABAP object for algorithm specification."
-    CREATE OBJECT lo_algorithm_specification
-      EXPORTING
-        iv_trainingimage     = iv_training_image
-        iv_traininginputmode = iv_training_input_mode.
+    lo_algorithm_specification = NEW #( iv_trainingimage = iv_training_image
+                                        iv_traininginputmode = iv_training_input_mode ).
 
     "Create an ABAP object for resource configuration."
-    CREATE OBJECT lo_resource_config
-      EXPORTING
-        iv_instancecount  = iv_instance_count
-        iv_instancetype   = iv_instance_type
-        iv_volumesizeingb = iv_volume_sizeingb.
+    lo_resource_config = NEW #( iv_instancecount = iv_instance_count
+                                iv_instancetype = iv_instance_type
+                                iv_volumesizeingb = iv_volume_sizeingb ).
 
     "Create an ABAP object for output data configuration."
-    CREATE OBJECT lo_output_data_config
-      EXPORTING
-        iv_s3outputpath = iv_s3_output_path.
+    lo_output_data_config = NEW #( iv_s3outputpath = iv_s3_output_path ).
 
     "Create an ABAP object for stopping condition."
-    CREATE OBJECT lo_stopping_condition
-      EXPORTING
-        iv_maxruntimeinseconds = iv_max_runtime_in_seconds.
+    lo_stopping_condition = NEW #( iv_maxruntimeinseconds = iv_max_runtime_in_seconds ).
 
     "Create a training job."
     TRY.
@@ -310,8 +283,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
           io_algorithmspecification    = lo_algorithm_specification
           io_outputdataconfig          = lo_output_data_config
           io_resourceconfig            = lo_resource_config
-          io_stoppingcondition         = lo_stopping_condition
-        ).
+          io_stoppingcondition         = lo_stopping_condition ).
         MESSAGE 'Training job created.' TYPE 'I'.
       CATCH /aws1/cx_sgmresourceinuse.
         MESSAGE 'Resource being accessed is in use.' TYPE 'E'.
@@ -326,7 +298,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
 
   METHOD create_transform_job.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -340,33 +312,23 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     DATA lo_s3datasource  TYPE REF TO /aws1/cl_sgmtransforms3datasrc.
 
     "Create an ABAP object for an Amazon Simple Storage Service (Amazon S3) data source."
-    CREATE OBJECT lo_s3datasource
-      EXPORTING
-        iv_s3uri      = iv_tf_data_s3uri
-        iv_s3datatype = iv_tf_data_s3datatype.
+    lo_s3datasource = NEW #( iv_s3uri = iv_tf_data_s3uri
+                             iv_s3datatype = iv_tf_data_s3datatype ).
 
     "Create an ABAP object for data source."
-    CREATE OBJECT lo_datasource
-      EXPORTING
-        io_s3datasource = lo_s3datasource.
+    lo_datasource = NEW #( io_s3datasource = lo_s3datasource ).
 
     "Create an ABAP object for transform data source."
-    CREATE OBJECT lo_transforminput
-      EXPORTING
-        io_datasource      = lo_datasource
-        iv_contenttype     = iv_tf_data_contenttype
-        iv_compressiontype = iv_tf_data_compressiontype.
+    lo_transforminput = NEW #( io_datasource = lo_datasource
+                               iv_contenttype = iv_tf_data_contenttype
+                               iv_compressiontype = iv_tf_data_compressiontype ).
 
     "Create an ABAP object for resource configuration."
-    CREATE OBJECT lo_transformresources
-      EXPORTING
-        iv_instancecount = iv_instance_count
-        iv_instancetype  = iv_instance_type.
+    lo_transformresources = NEW #( iv_instancecount = iv_instance_count
+                                   iv_instancetype = iv_instance_type ).
 
     "Create an ABAP object for output data configuration."
-    CREATE OBJECT lo_transformoutput
-      EXPORTING
-        iv_s3outputpath = iv_s3_output_path.
+    lo_transformoutput = NEW #( iv_s3outputpath = iv_s3_output_path ).
 
     "Create a transform job."
     TRY.
@@ -375,8 +337,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
             iv_transformjobname = iv_tf_job_name
             io_transforminput = lo_transforminput
             io_transformoutput = lo_transformoutput
-            io_transformresources = lo_transformresources
-        ).
+            io_transformresources = lo_transformresources ).
         MESSAGE 'Transform job created.' TYPE 'I'.
       CATCH /aws1/cx_sgmresourceinuse.
         MESSAGE 'Resource being accessed is in use.' TYPE 'E'.
@@ -391,7 +352,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
 
   METHOD delete_endpoint.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -400,8 +361,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     "Delete an endpoint."
     TRY.
         lo_sgm->deleteendpoint(
-            iv_endpointname = iv_endpoint_name
-        ).
+            iv_endpointname = iv_endpoint_name ).
         MESSAGE 'Endpoint configuration deleted.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_endpoint_exception).
         DATA(lv_endpoint_error) = |"{ lo_endpoint_exception->av_err_code }" - { lo_endpoint_exception->av_err_msg }|.
@@ -411,8 +371,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     "Delete an endpoint configuration."
     TRY.
         lo_sgm->deleteendpointconfig(
-          iv_endpointconfigname = iv_endpoint_config_name
-        ).
+          iv_endpointconfigname = iv_endpoint_config_name ).
         MESSAGE 'Endpoint deleted.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_endpointconfig_exception).
         DATA(lv_endpointconfig_error) = |"{ lo_endpointconfig_exception->av_err_code }" - { lo_endpointconfig_exception->av_err_msg }|.
@@ -424,7 +383,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
 
   METHOD delete_model.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -432,8 +391,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     "snippet-start:[sgm.abapv1.delete_model]
     TRY.
         lo_sgm->deletemodel(
-                  iv_modelname = iv_model_name
-                ).
+                  iv_modelname = iv_model_name ).
         MESSAGE 'Model deleted.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.
@@ -446,7 +404,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
 
   METHOD describe_training_job.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -454,8 +412,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     "snippet-start:[sgm.abapv1.describe_training_job]
     TRY.
         oo_result = lo_sgm->describetrainingjob(      " oo_result is returned for testing purposes. "
-          iv_trainingjobname = iv_training_job_name
-        ).
+          iv_trainingjobname = iv_training_job_name ).
         MESSAGE 'Retrieved description of training job.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.
@@ -467,7 +424,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
 
   METHOD list_algorithms.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -475,8 +432,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     "snippet-start:[sgm.abapv1.list_algorithms]
     TRY.
         oo_result = lo_sgm->listalgorithms(         " oo_result is returned for testing purposes. "
-          iv_namecontains = iv_name_contains
-        ).
+          iv_namecontains = iv_name_contains ).
         MESSAGE 'Retrieved list of algorithms.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.
@@ -488,7 +444,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
 
   METHOD list_models.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -496,8 +452,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     "snippet-start:[sgm.abapv1.list_models]
     TRY.
         oo_result = lo_sgm->listmodels(           " oo_result is returned for testing purposes. "
-          iv_namecontains = iv_name_contains
-        ).
+          iv_namecontains = iv_name_contains ).
         MESSAGE 'Retrieved list of models.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.
@@ -509,7 +464,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
 
   METHOD list_notebook_instances.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -517,8 +472,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     "snippet-start:[sgm.abapv1.list_notebook_instances]
     TRY.
         oo_result = lo_sgm->listnotebookinstances(        " oo_result is returned for testing purposes. "
-          iv_namecontains = iv_name_contains
-        ).
+          iv_namecontains = iv_name_contains ).
         MESSAGE 'Retrieved list of notebook instances.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.
@@ -529,7 +483,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
 
 
   METHOD list_training_jobs.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -538,8 +492,7 @@ CLASS ZCL_AWS1_SGM_ACTIONS IMPLEMENTATION.
     TRY.
         oo_result = lo_sgm->listtrainingjobs(       " oo_result is returned for testing purposes. "
           iv_namecontains = iv_name_contains
-          iv_maxresults = iv_max_results
-        ).
+          iv_maxresults = iv_max_results ).
         MESSAGE 'Retrieved list of training jobs.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_exception).
         DATA(lv_error) = |"{ lo_exception->av_err_code }" - { lo_exception->av_err_msg }|.

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.testclasses.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_actions.clas.testclasses.abap
@@ -1,11 +1,11 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-CLASS ltc_zcl_aws1_sgm_actions DEFINITION FOR TESTING DURATION MEDIUM RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_sgm_actions DEFINITION FOR TESTING DURATION MEDIUM RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA ao_sgm TYPE REF TO /aws1/if_sgm.
     DATA ao_s3 TYPE REF TO /aws1/if_s3.
@@ -14,7 +14,7 @@ CLASS ltc_zcl_aws1_sgm_actions DEFINITION FOR TESTING DURATION MEDIUM RISK LEVEL
     DATA av_lrole TYPE /aws1/sgmrolearn.
     DATA av_file_content TYPE /aws1/s3_streamingblob.
 
-    METHODS setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
     METHODS list_training_jobs FOR TESTING.
     METHODS list_notebook_instances FOR TESTING.
     METHODS list_models FOR TESTING.
@@ -138,8 +138,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
       |0 0:53 1:5.6 9:1 26:1 189:1 330:1\n| &&
       |1 0:98 1:7.7 8:1 29:1 42:1 330:1\n| &&
       |0 0:76 1:6.7 7:1 28:1 75:1 330:1\n| &&
-      |1 0:74 1:5.3 7:1 28:1 95:1 330:1\n|
-  ).
+      |1 0:74 1:5.3 7:1 28:1 95:1 330:1\n| ).
 
   ENDMETHOD.
 
@@ -147,7 +146,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     DATA lo_result TYPE REF TO /aws1/cl_sgmcreatetrnjobrsp.
     DATA lv_training_job_name TYPE /aws1/sgmtrainingjobname.
-    DATA lv_found TYPE abap_bool.
+
     DATA lv_bucket_name TYPE /aws1/s3_bucketname.
     DATA lv_file_content TYPE /aws1/s3_streamingblob.
     DATA lv_trn_data_s3uri TYPE /aws1/sgms3uri.
@@ -158,29 +157,29 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
     "Define hyperparameters.
-    CONSTANTS cv_hp_max_depth TYPE   /aws1/sgmhyperparametervalue    VALUE '3'.
-    CONSTANTS cv_hp_scale_pos_weight TYPE   /aws1/sgmhyperparametervalue    VALUE '2.0'.
-    CONSTANTS cv_hp_num_round TYPE   /aws1/sgmhyperparametervalue    VALUE '100'.
-    CONSTANTS cv_hp_objective  TYPE  /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
-    CONSTANTS cv_hp_subsample TYPE   /aws1/sgmhyperparametervalue    VALUE '0.5'.
-    CONSTANTS cv_hp_eta TYPE  /aws1/sgmhyperparametervalue    VALUE   '0.1'.
-    CONSTANTS cv_hp_eval_metric TYPE   /aws1/sgmhyperparametervalue    VALUE 'auc'.
+    CONSTANTS cv_hp_max_depth TYPE /aws1/sgmhyperparametervalue    VALUE '3'.
+    CONSTANTS cv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue    VALUE '2.0'.
+    CONSTANTS cv_hp_num_round TYPE /aws1/sgmhyperparametervalue    VALUE '100'.
+    CONSTANTS cv_hp_objective  TYPE /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
+    CONSTANTS cv_hp_subsample TYPE /aws1/sgmhyperparametervalue    VALUE '0.5'.
+    CONSTANTS cv_hp_eta TYPE /aws1/sgmhyperparametervalue    VALUE '0.1'.
+    CONSTANTS cv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue    VALUE 'auc'.
 
     "Define training data.
-    CONSTANTS cv_trn_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_trn_data_s3datadistribution TYPE  /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
-    CONSTANTS cv_trn_data_compressiontype TYPE  /aws1/sgmcompressiontype     VALUE 'None'.
-    CONSTANTS cv_trn_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_trn_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
+    CONSTANTS cv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype     VALUE 'None'.
+    CONSTANTS cv_trn_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define validation data.
-    CONSTANTS cv_val_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_val_data_s3datadistribution TYPE  /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
-    CONSTANTS cv_val_data_compressiontype TYPE   /aws1/sgmcompressiontype    VALUE 'None'.
-    CONSTANTS cv_val_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_val_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
+    CONSTANTS cv_val_data_compressiontype TYPE /aws1/sgmcompressiontype    VALUE 'None'.
+    CONSTANTS cv_val_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define training parameters.
     CONSTANTS cv_training_image TYPE /aws1/sgmalgorithmimage VALUE '123456789012.abc.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.5-1'.
-    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE  'File'.
+    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE 'File'.
     CONSTANTS cv_instance_count TYPE /aws1/sgmtraininginstancecount VALUE '1'.
     CONSTANTS cv_instance_type TYPE /aws1/sgmtraininginstancetype VALUE 'ml.c4.2xlarge'.
     CONSTANTS cv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb VALUE '10'.
@@ -191,7 +190,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Define role Amazon Resource Name (ARN).
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     "Define job name.
@@ -202,7 +201,10 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     "Create training data in Amazon Simple Storage Service (Amazon S3).
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
+
 
     lv_trn_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_train_key.
     lv_val_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_val_key.
@@ -212,14 +214,12 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ao_s3->putobject(
       iv_bucket = lv_bucket_name
       iv_key = cv_train_key
-      iv_body = av_file_content
-    ).
+      iv_body = av_file_content ).
 
     ao_s3->putobject(
           iv_bucket = lv_bucket_name
           iv_key = cv_val_key
-          iv_body = av_file_content
-    ).
+          iv_body = av_file_content ).
 
     "Testing.
     ao_sgm_actions->create_training_job(
@@ -251,18 +251,16 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
         iv_s3_output_path               = lv_s3_output_path
         iv_max_runtime_in_seconds       = cv_max_runtime_in_seconds
       IMPORTING
-       oo_result              = lo_result
-    ).
+       oo_result              = lo_result ).
 
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
     IF lo_result->has_trainingjobarn( ) = 'X'.
       lv_found               = abap_true.
     ENDIF.
 
     cl_abap_unit_assert=>assert_true(
        act                    = lv_found
-       msg                    = |Training Job cannot be found|
-    ).
+       msg                    = |Training Job cannot be found| ).
 
     "Wait for training job to be completed.
     lo_training_result = ao_sgm->describetrainingjob( iv_trainingjobname = lv_training_job_name ).
@@ -277,22 +275,18 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     "Clean up.
     ao_s3->deleteobject(
       iv_bucket = lv_bucket_name
-      iv_key = cv_train_key
-    ).
+      iv_key = cv_train_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_val_key
-    ).
+        iv_key = cv_val_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = lv_model_key
-    ).
+        iv_key = lv_model_key ).
 
     ao_s3->deletebucket(
-        iv_bucket = lv_bucket_name
-    ).
+        iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
@@ -307,13 +301,13 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_val_channel TYPE REF TO /aws1/cl_sgmchannel.
     DATA lo_val_datasource TYPE REF TO /aws1/cl_sgmdatasource.
     DATA lo_val_s3datasource TYPE REF TO /aws1/cl_sgms3datasource.
-    DATA lo_output_data_config TYPE REF TO  /aws1/cl_sgmoutputdataconfig.
+    DATA lo_output_data_config TYPE REF TO /aws1/cl_sgmoutputdataconfig.
     DATA lo_resource_config  TYPE REF TO /aws1/cl_sgmresourceconfig.
     DATA lo_algorithm_specification TYPE REF TO /aws1/cl_sgmalgorithmspec.
     DATA lo_list_result TYPE REF TO /aws1/cl_sgmlisttrnjobsrsp.
-    DATA lo_stopping_condition TYPE REF TO  /aws1/cl_sgmstoppingcondition.
+    DATA lo_stopping_condition TYPE REF TO /aws1/cl_sgmstoppingcondition.
     DATA lv_training_job_name TYPE /aws1/sgmtrainingjobname.
-    DATA lv_found TYPE abap_bool.
+
     DATA lv_bucket_name TYPE /aws1/s3_bucketname.
     DATA lv_file_content TYPE /aws1/s3_streamingblob.
     DATA lv_trn_data_s3uri TYPE /aws1/sgms3uri.
@@ -329,29 +323,29 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     CONSTANTS cv_val_key TYPE /aws1/s3_objectkey VALUE 'sagemaker/validation/validation.libsvm'.
 
     "Define hyperparameters.
-    CONSTANTS cv_hp_max_depth TYPE   /aws1/sgmhyperparametervalue    VALUE '3'.
-    CONSTANTS cv_hp_scale_pos_weight TYPE   /aws1/sgmhyperparametervalue    VALUE '2.0'.
-    CONSTANTS cv_hp_num_round TYPE   /aws1/sgmhyperparametervalue    VALUE '100'.
-    CONSTANTS cv_hp_objective  TYPE  /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
-    CONSTANTS cv_hp_subsample TYPE   /aws1/sgmhyperparametervalue    VALUE '0.5'.
-    CONSTANTS cv_hp_eta TYPE  /aws1/sgmhyperparametervalue    VALUE   '0.1'.
-    CONSTANTS cv_hp_eval_metric TYPE   /aws1/sgmhyperparametervalue    VALUE 'auc'.
+    CONSTANTS cv_hp_max_depth TYPE /aws1/sgmhyperparametervalue    VALUE '3'.
+    CONSTANTS cv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue    VALUE '2.0'.
+    CONSTANTS cv_hp_num_round TYPE /aws1/sgmhyperparametervalue    VALUE '100'.
+    CONSTANTS cv_hp_objective  TYPE /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
+    CONSTANTS cv_hp_subsample TYPE /aws1/sgmhyperparametervalue    VALUE '0.5'.
+    CONSTANTS cv_hp_eta TYPE /aws1/sgmhyperparametervalue    VALUE '0.1'.
+    CONSTANTS cv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue    VALUE 'auc'.
 
     "Define training data.
-    CONSTANTS cv_trn_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_trn_data_s3datadistribution TYPE  /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
-    CONSTANTS cv_trn_data_compressiontype TYPE  /aws1/sgmcompressiontype     VALUE 'None'.
-    CONSTANTS cv_trn_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_trn_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
+    CONSTANTS cv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype     VALUE 'None'.
+    CONSTANTS cv_trn_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define validation data.
-    CONSTANTS cv_val_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_val_data_s3datadistribution TYPE  /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
-    CONSTANTS cv_val_data_compressiontype TYPE   /aws1/sgmcompressiontype    VALUE 'None'.
-    CONSTANTS cv_val_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_val_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
+    CONSTANTS cv_val_data_compressiontype TYPE /aws1/sgmcompressiontype    VALUE 'None'.
+    CONSTANTS cv_val_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define training parameters.
     CONSTANTS cv_training_image TYPE /aws1/sgmalgorithmimage VALUE '123456789012.abc.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.5-1'.
-    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE  'File'.
+    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE 'File'.
     CONSTANTS cv_instance_count TYPE /aws1/sgmtraininginstancecount VALUE '1'.
     CONSTANTS cv_instance_type TYPE /aws1/sgmtraininginstancetype VALUE 'ml.c4.2xlarge'.
     CONSTANTS cv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb VALUE '10'.
@@ -360,7 +354,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Define role ARN.
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     "Define job name.
@@ -371,7 +365,10 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     "Create training data in Amazon S3.
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
+
 
     lv_trn_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_train_key.
     lv_val_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_val_key.
@@ -381,100 +378,78 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ao_s3->putobject(
       iv_bucket = lv_bucket_name
       iv_key = cv_train_key
-      iv_body = av_file_content
-    ).
+      iv_body = av_file_content ).
 
     ao_s3->putobject(
           iv_bucket = lv_bucket_name
           iv_key = cv_val_key
-          iv_body = av_file_content
-    ).
+          iv_body = av_file_content ).
 
     "Create ABAP internal table for hyperparameters based on input variables.
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_max_depth.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_max_depth ).
     INSERT VALUE #( key = 'max_depth' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eta.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eta ).
     INSERT VALUE #( key = 'eta' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eval_metric.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eval_metric ).
     INSERT VALUE #( key = 'eval_metric' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_scale_pos_weight.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_scale_pos_weight ).
     INSERT VALUE #( key = 'scale_pos_weight' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_subsample.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_subsample ).
     INSERT VALUE #( key = 'subsample' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_objective.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_objective ).
     INSERT VALUE #( key = 'objective' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_num_round.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_num_round ).
     INSERT VALUE #( key = 'num_round' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
     "Create ABAP objects for data based on input variables.
     "Training data.
-    CREATE OBJECT lo_trn_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_trn_data_s3datatype
-        iv_s3datadistributiontype = cv_trn_data_s3datadistribution
-        iv_s3uri                  = lv_trn_data_s3uri.
+    lo_trn_s3datasource = NEW #( iv_s3datatype = cv_trn_data_s3datatype
+                                 iv_s3datadistributiontype = cv_trn_data_s3datadistribution
+                                 iv_s3uri = lv_trn_data_s3uri ).
 
-    CREATE OBJECT lo_trn_datasource
-      EXPORTING
-        io_s3datasource = lo_trn_s3datasource.
+    lo_trn_datasource = NEW #( io_s3datasource = lo_trn_s3datasource ).
 
-    CREATE OBJECT lo_trn_channel
-      EXPORTING
-        iv_channelname     = 'train'
-        io_datasource      = lo_trn_datasource
-        iv_compressiontype = cv_trn_data_compressiontype
-        iv_contenttype     = cv_trn_data_contenttype.
+    lo_trn_channel = NEW #( iv_channelname = 'train'
+                            io_datasource = lo_trn_datasource
+                            iv_compressiontype = cv_trn_data_compressiontype
+                            iv_contenttype = cv_trn_data_contenttype ).
 
     INSERT lo_trn_channel INTO TABLE lt_input_data_config.
 
     "Validation data.
-    CREATE OBJECT lo_val_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_val_data_s3datatype
-        iv_s3datadistributiontype = cv_val_data_s3datadistribution
-        iv_s3uri                  = lv_val_data_s3uri.
+    lo_val_s3datasource = NEW #( iv_s3datatype = cv_val_data_s3datatype
+                                 iv_s3datadistributiontype = cv_val_data_s3datadistribution
+                                 iv_s3uri = lv_val_data_s3uri ).
 
-    CREATE OBJECT lo_val_datasource
-      EXPORTING
-        io_s3datasource = lo_val_s3datasource.
+    lo_val_datasource = NEW #( io_s3datasource = lo_val_s3datasource ).
 
-    CREATE OBJECT lo_val_channel
-      EXPORTING
-        iv_channelname     = 'validation'
-        io_datasource      = lo_val_datasource
-        iv_compressiontype = cv_val_data_compressiontype
-        iv_contenttype     = cv_val_data_contenttype.
+    lo_val_channel = NEW #( iv_channelname = 'validation'
+                            io_datasource = lo_val_datasource
+                            iv_compressiontype = cv_val_data_compressiontype
+                            iv_contenttype = cv_val_data_contenttype ).
 
     INSERT lo_val_channel INTO TABLE lt_input_data_config.
 
     "Create an ABAP object for algorithm specification based on input variables.
-    CREATE OBJECT lo_algorithm_specification
-      EXPORTING
-        iv_trainingimage     = cv_training_image
-        iv_traininginputmode = cv_training_input_mode.
+    lo_algorithm_specification = NEW #( iv_trainingimage = cv_training_image
+                                        iv_traininginputmode = cv_training_input_mode ).
 
     "Create an ABAP object for resource configuration.
-    CREATE OBJECT lo_resource_config
-      EXPORTING
-        iv_instancecount  = cv_instance_count
-        iv_instancetype   = cv_instance_type
-        iv_volumesizeingb = cv_volume_sizeingb.
+    lo_resource_config = NEW #( iv_instancecount = cv_instance_count
+                                iv_instancetype = cv_instance_type
+                                iv_volumesizeingb = cv_volume_sizeingb ).
 
     "Create an ABAP object for output data configuration.
-    CREATE OBJECT lo_output_data_config
-      EXPORTING
-        iv_s3outputpath = lv_s3_output_path.
+    lo_output_data_config = NEW #( iv_s3outputpath = lv_s3_output_path ).
 
     "Create an ABAP object for stopping condition.
-    CREATE OBJECT lo_stopping_condition
-      EXPORTING
-        iv_maxruntimeinseconds = cv_max_runtime_in_seconds.
+    lo_stopping_condition = NEW #( iv_maxruntimeinseconds = cv_max_runtime_in_seconds ).
 
     "Create a training job.
     ao_sgm->createtrainingjob(
@@ -485,8 +460,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
       io_algorithmspecification    = lo_algorithm_specification
       io_outputdataconfig          = lo_output_data_config
       io_resourceconfig            = lo_resource_config
-      io_stoppingcondition         = lo_stopping_condition
-    ).
+      io_stoppingcondition         = lo_stopping_condition ).
 
     "Testing.
     ao_sgm_actions->list_training_jobs(
@@ -494,11 +468,10 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
         iv_name_contains = lv_training_job_name
         iv_max_results = cv_max_results
       IMPORTING
-        oo_result = lo_list_result
-    ).
+        oo_result = lo_list_result ).
 
     "Validation.
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
     LOOP AT lo_list_result->get_trainingjobsummaries( ) INTO DATA(lo_job).
       IF lo_job->has_trainingjobname( ) = 'X'.
         lv_found = abap_true.
@@ -507,8 +480,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Training job cannot be found|
-    ).
+      msg = |Training job cannot be found| ).
 
     "Wait for training job to be completed.
     lo_training_result = ao_sgm->describetrainingjob( iv_trainingjobname = lv_training_job_name ).
@@ -523,22 +495,18 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     "Clean up.
     ao_s3->deleteobject(
       iv_bucket = lv_bucket_name
-      iv_key = cv_train_key
-    ).
+      iv_key = cv_train_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_val_key
-    ).
+        iv_key = cv_val_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = lv_model_key
-    ).
+        iv_key = lv_model_key ).
 
     ao_s3->deletebucket(
-        iv_bucket = lv_bucket_name
-    ).
+        iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
@@ -554,12 +522,12 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_val_channel TYPE REF TO /aws1/cl_sgmchannel.
     DATA lo_val_datasource TYPE REF TO /aws1/cl_sgmdatasource.
     DATA lo_val_s3datasource TYPE REF TO /aws1/cl_sgms3datasource.
-    DATA lo_stopping_condition TYPE REF TO  /aws1/cl_sgmstoppingcondition.
+    DATA lo_stopping_condition TYPE REF TO /aws1/cl_sgmstoppingcondition.
     DATA lo_algorithm_specification TYPE REF TO /aws1/cl_sgmalgorithmspec.
     DATA lo_resource_config  TYPE REF TO /aws1/cl_sgmresourceconfig.
-    DATA lo_output_data_config TYPE REF TO  /aws1/cl_sgmoutputdataconfig.
+    DATA lo_output_data_config TYPE REF TO /aws1/cl_sgmoutputdataconfig.
     DATA lo_list_result TYPE REF TO /aws1/cl_sgmdescrtrnjobrsp.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lv_bucket_name TYPE /aws1/s3_bucketname.
     DATA lv_file_content TYPE /aws1/s3_streamingblob.
     DATA lv_trn_data_s3uri TYPE /aws1/sgms3uri.
@@ -570,29 +538,29 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
     "Define hyperparameters.
-    CONSTANTS cv_hp_max_depth TYPE   /aws1/sgmhyperparametervalue    VALUE '3'.
-    CONSTANTS cv_hp_scale_pos_weight TYPE   /aws1/sgmhyperparametervalue    VALUE '2.0'.
-    CONSTANTS cv_hp_num_round TYPE   /aws1/sgmhyperparametervalue    VALUE '100'.
-    CONSTANTS cv_hp_objective  TYPE  /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
-    CONSTANTS cv_hp_subsample TYPE   /aws1/sgmhyperparametervalue    VALUE '0.5'.
-    CONSTANTS cv_hp_eta TYPE  /aws1/sgmhyperparametervalue    VALUE   '0.1'.
-    CONSTANTS cv_hp_eval_metric TYPE   /aws1/sgmhyperparametervalue    VALUE 'auc'.
+    CONSTANTS cv_hp_max_depth TYPE /aws1/sgmhyperparametervalue    VALUE '3'.
+    CONSTANTS cv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue    VALUE '2.0'.
+    CONSTANTS cv_hp_num_round TYPE /aws1/sgmhyperparametervalue    VALUE '100'.
+    CONSTANTS cv_hp_objective  TYPE /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
+    CONSTANTS cv_hp_subsample TYPE /aws1/sgmhyperparametervalue    VALUE '0.5'.
+    CONSTANTS cv_hp_eta TYPE /aws1/sgmhyperparametervalue    VALUE '0.1'.
+    CONSTANTS cv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue    VALUE 'auc'.
 
     "Define training data.
-    CONSTANTS cv_trn_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_trn_data_s3datadistribution TYPE  /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
-    CONSTANTS cv_trn_data_compressiontype TYPE  /aws1/sgmcompressiontype     VALUE 'None'.
-    CONSTANTS cv_trn_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_trn_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
+    CONSTANTS cv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype     VALUE 'None'.
+    CONSTANTS cv_trn_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define validation data.
-    CONSTANTS cv_val_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_val_data_s3datadistribution TYPE  /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
-    CONSTANTS cv_val_data_compressiontype TYPE   /aws1/sgmcompressiontype    VALUE 'None'.
-    CONSTANTS cv_val_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_val_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
+    CONSTANTS cv_val_data_compressiontype TYPE /aws1/sgmcompressiontype    VALUE 'None'.
+    CONSTANTS cv_val_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define training parameters.
     CONSTANTS cv_training_image TYPE /aws1/sgmalgorithmimage VALUE '123456789012.abc.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.5-1'.
-    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE  'File'.
+    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE 'File'.
     CONSTANTS cv_instance_count TYPE /aws1/sgmtraininginstancecount VALUE '1'.
     CONSTANTS cv_instance_type TYPE /aws1/sgmtraininginstancetype VALUE 'ml.c4.2xlarge'.
     CONSTANTS cv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb VALUE '10'.
@@ -604,7 +572,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Define role ARN.
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     "Define job name.
@@ -615,7 +583,10 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     "Create training data in Amazon S3.
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
+
 
     lv_trn_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_train_key.
     lv_val_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_val_key.
@@ -625,100 +596,78 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ao_s3->putobject(
       iv_bucket = lv_bucket_name
       iv_key = cv_train_key
-      iv_body = av_file_content
-    ).
+      iv_body = av_file_content ).
 
     ao_s3->putobject(
           iv_bucket = lv_bucket_name
           iv_key = cv_val_key
-          iv_body = av_file_content
-    ).
+          iv_body = av_file_content ).
 
     "Create ABAP internal table for hyperparameters based on input variables.
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_max_depth.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_max_depth ).
     INSERT VALUE #( key = 'max_depth' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eta.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eta ).
     INSERT VALUE #( key = 'eta' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eval_metric.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eval_metric ).
     INSERT VALUE #( key = 'eval_metric' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_scale_pos_weight.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_scale_pos_weight ).
     INSERT VALUE #( key = 'scale_pos_weight' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_subsample.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_subsample ).
     INSERT VALUE #( key = 'subsample' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_objective.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_objective ).
     INSERT VALUE #( key = 'objective' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_num_round.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_num_round ).
     INSERT VALUE #( key = 'num_round' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
     "Create ABAP objects for data based on input variables.
     "Training data.
-    CREATE OBJECT lo_trn_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_trn_data_s3datatype
-        iv_s3datadistributiontype = cv_trn_data_s3datadistribution
-        iv_s3uri                  = lv_trn_data_s3uri.
+    lo_trn_s3datasource = NEW #( iv_s3datatype = cv_trn_data_s3datatype
+                                 iv_s3datadistributiontype = cv_trn_data_s3datadistribution
+                                 iv_s3uri = lv_trn_data_s3uri ).
 
-    CREATE OBJECT lo_trn_datasource
-      EXPORTING
-        io_s3datasource = lo_trn_s3datasource.
+    lo_trn_datasource = NEW #( io_s3datasource = lo_trn_s3datasource ).
 
-    CREATE OBJECT lo_trn_channel
-      EXPORTING
-        iv_channelname     = 'train'
-        io_datasource      = lo_trn_datasource
-        iv_compressiontype = cv_trn_data_compressiontype
-        iv_contenttype     = cv_trn_data_contenttype.
+    lo_trn_channel = NEW #( iv_channelname = 'train'
+                            io_datasource = lo_trn_datasource
+                            iv_compressiontype = cv_trn_data_compressiontype
+                            iv_contenttype = cv_trn_data_contenttype ).
 
     INSERT lo_trn_channel INTO TABLE lt_input_data_config.
 
     "Validation data.
-    CREATE OBJECT lo_val_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_val_data_s3datatype
-        iv_s3datadistributiontype = cv_val_data_s3datadistribution
-        iv_s3uri                  = lv_val_data_s3uri.
+    lo_val_s3datasource = NEW #( iv_s3datatype = cv_val_data_s3datatype
+                                 iv_s3datadistributiontype = cv_val_data_s3datadistribution
+                                 iv_s3uri = lv_val_data_s3uri ).
 
-    CREATE OBJECT lo_val_datasource
-      EXPORTING
-        io_s3datasource = lo_val_s3datasource.
+    lo_val_datasource = NEW #( io_s3datasource = lo_val_s3datasource ).
 
-    CREATE OBJECT lo_val_channel
-      EXPORTING
-        iv_channelname     = 'validation'
-        io_datasource      = lo_val_datasource
-        iv_compressiontype = cv_val_data_compressiontype
-        iv_contenttype     = cv_val_data_contenttype.
+    lo_val_channel = NEW #( iv_channelname = 'validation'
+                            io_datasource = lo_val_datasource
+                            iv_compressiontype = cv_val_data_compressiontype
+                            iv_contenttype = cv_val_data_contenttype ).
 
     INSERT lo_val_channel INTO TABLE lt_input_data_config.
 
     "Create an ABAP object for algorithm specification based on input variables.
-    CREATE OBJECT lo_algorithm_specification
-      EXPORTING
-        iv_trainingimage     = cv_training_image
-        iv_traininginputmode = cv_training_input_mode.
+    lo_algorithm_specification = NEW #( iv_trainingimage = cv_training_image
+                                        iv_traininginputmode = cv_training_input_mode ).
 
     "Create an ABAP object for resource configuration.
-    CREATE OBJECT lo_resource_config
-      EXPORTING
-        iv_instancecount  = cv_instance_count
-        iv_instancetype   = cv_instance_type
-        iv_volumesizeingb = cv_volume_sizeingb.
+    lo_resource_config = NEW #( iv_instancecount = cv_instance_count
+                                iv_instancetype = cv_instance_type
+                                iv_volumesizeingb = cv_volume_sizeingb ).
 
     "Create an ABAP object for output data configuration.
-    CREATE OBJECT lo_output_data_config
-      EXPORTING
-        iv_s3outputpath = lv_s3_output_path.
+    lo_output_data_config = NEW #( iv_s3outputpath = lv_s3_output_path ).
 
     "Create an ABAP object for stopping condition.
-    CREATE OBJECT lo_stopping_condition
-      EXPORTING
-        iv_maxruntimeinseconds = cv_max_runtime_in_seconds.
+    lo_stopping_condition = NEW #( iv_maxruntimeinseconds = cv_max_runtime_in_seconds ).
 
     "Create a training job.
     ao_sgm->createtrainingjob(
@@ -729,17 +678,12 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
       io_algorithmspecification    = lo_algorithm_specification
       io_outputdataconfig          = lo_output_data_config
       io_resourceconfig            = lo_resource_config
-      io_stoppingcondition         = lo_stopping_condition
-    ).
+      io_stoppingcondition         = lo_stopping_condition ).
 
     "Testing describe training job method.
-    CALL METHOD ao_sgm_actions->describe_training_job
-      EXPORTING
-        iv_training_job_name = lv_training_job_name
-      IMPORTING
-        oo_result            = lo_list_result.
+    ao_sgm_actions->describe_training_job( EXPORTING iv_training_job_name = lv_training_job_name IMPORTING oo_result = lo_list_result ).
 
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     IF lo_list_result->get_trainingjobstatus( ) = cv_job_status.
       lv_found = abap_true.
@@ -747,8 +691,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Training job status is incorrect|
-    ).
+      msg = |Training job status is incorrect| ).
 
     "Wait for training job to be completed.
     lo_training_result = ao_sgm->describetrainingjob( iv_trainingjobname = lv_training_job_name ).
@@ -763,22 +706,18 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     "Clean up.
     ao_s3->deleteobject(
       iv_bucket = lv_bucket_name
-      iv_key = cv_train_key
-    ).
+      iv_key = cv_train_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_val_key
-    ).
+        iv_key = cv_val_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = lv_model_key
-    ).
+        iv_key = lv_model_key ).
 
     ao_s3->deletebucket(
-        iv_bucket = lv_bucket_name
-    ).
+        iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
@@ -793,13 +732,13 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_val_channel TYPE REF TO /aws1/cl_sgmchannel.
     DATA lo_val_datasource TYPE REF TO /aws1/cl_sgmdatasource.
     DATA lo_val_s3datasource TYPE REF TO /aws1/cl_sgms3datasource.
-    DATA lo_output_data_config TYPE REF TO  /aws1/cl_sgmoutputdataconfig.
+    DATA lo_output_data_config TYPE REF TO /aws1/cl_sgmoutputdataconfig.
     DATA lo_resource_config  TYPE REF TO /aws1/cl_sgmresourceconfig.
     DATA lo_algorithm_specification TYPE REF TO /aws1/cl_sgmalgorithmspec.
     DATA lo_list_result TYPE REF TO /aws1/cl_sgmlisttrnjobsrsp.
-    DATA lo_stopping_condition TYPE REF TO  /aws1/cl_sgmstoppingcondition.
+    DATA lo_stopping_condition TYPE REF TO /aws1/cl_sgmstoppingcondition.
     DATA lv_training_job_name TYPE /aws1/sgmtrainingjobname.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lo_result TYPE REF TO /aws1/cl_sgmcreatemodeloutput.
     DATA lv_model_name TYPE /aws1/sgmmodelname.
     DATA lv_model_data_url TYPE /aws1/sgmurl.
@@ -819,29 +758,29 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     CONSTANTS cv_val_key TYPE /aws1/s3_objectkey VALUE 'sagemaker/validation/validation.libsvm'.
 
     "Define hyperparameters.
-    CONSTANTS cv_hp_max_depth TYPE   /aws1/sgmhyperparametervalue    VALUE '3'.
-    CONSTANTS cv_hp_scale_pos_weight TYPE   /aws1/sgmhyperparametervalue    VALUE '2.0'.
-    CONSTANTS cv_hp_num_round TYPE   /aws1/sgmhyperparametervalue    VALUE '100'.
-    CONSTANTS cv_hp_objective  TYPE  /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
-    CONSTANTS cv_hp_subsample TYPE   /aws1/sgmhyperparametervalue    VALUE '0.5'.
-    CONSTANTS cv_hp_eta TYPE  /aws1/sgmhyperparametervalue    VALUE   '0.1'.
-    CONSTANTS cv_hp_eval_metric TYPE   /aws1/sgmhyperparametervalue    VALUE 'auc'.
+    CONSTANTS cv_hp_max_depth TYPE /aws1/sgmhyperparametervalue    VALUE '3'.
+    CONSTANTS cv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue    VALUE '2.0'.
+    CONSTANTS cv_hp_num_round TYPE /aws1/sgmhyperparametervalue    VALUE '100'.
+    CONSTANTS cv_hp_objective  TYPE /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
+    CONSTANTS cv_hp_subsample TYPE /aws1/sgmhyperparametervalue    VALUE '0.5'.
+    CONSTANTS cv_hp_eta TYPE /aws1/sgmhyperparametervalue    VALUE '0.1'.
+    CONSTANTS cv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue    VALUE 'auc'.
 
     "Define training data.
-    CONSTANTS cv_trn_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_trn_data_s3datadistribution TYPE  /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
-    CONSTANTS cv_trn_data_compressiontype TYPE  /aws1/sgmcompressiontype     VALUE 'None'.
-    CONSTANTS cv_trn_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_trn_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
+    CONSTANTS cv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype     VALUE 'None'.
+    CONSTANTS cv_trn_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define validation data.
-    CONSTANTS cv_val_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_val_data_s3datadistribution TYPE  /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
-    CONSTANTS cv_val_data_compressiontype TYPE   /aws1/sgmcompressiontype    VALUE 'None'.
-    CONSTANTS cv_val_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_val_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
+    CONSTANTS cv_val_data_compressiontype TYPE /aws1/sgmcompressiontype    VALUE 'None'.
+    CONSTANTS cv_val_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define training parameters.
     CONSTANTS cv_training_image TYPE /aws1/sgmalgorithmimage VALUE '123456789012.abc.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.5-1'.
-    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE  'File'.
+    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE 'File'.
     CONSTANTS cv_instance_count TYPE /aws1/sgmtraininginstancecount VALUE '1'.
     CONSTANTS cv_instance_type TYPE /aws1/sgmtraininginstancetype VALUE 'ml.c4.2xlarge'.
     CONSTANTS cv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb VALUE '10'.
@@ -850,7 +789,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Define role ARN.
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     "Define job name.
@@ -865,7 +804,10 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     "Create training data in Amazon S3.
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
+
 
     lv_trn_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_train_key.
     lv_val_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_val_key.
@@ -877,100 +819,78 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ao_s3->putobject(
       iv_bucket = lv_bucket_name
       iv_key = cv_train_key
-      iv_body = av_file_content
-    ).
+      iv_body = av_file_content ).
 
     ao_s3->putobject(
           iv_bucket = lv_bucket_name
           iv_key = cv_val_key
-          iv_body = av_file_content
-    ).
+          iv_body = av_file_content ).
 
     "Create ABAP internal table for hyperparameters based on input variables.
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_max_depth.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_max_depth ).
     INSERT VALUE #( key = 'max_depth' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eta.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eta ).
     INSERT VALUE #( key = 'eta' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eval_metric.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eval_metric ).
     INSERT VALUE #( key = 'eval_metric' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_scale_pos_weight.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_scale_pos_weight ).
     INSERT VALUE #( key = 'scale_pos_weight' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_subsample.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_subsample ).
     INSERT VALUE #( key = 'subsample' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_objective.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_objective ).
     INSERT VALUE #( key = 'objective' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_num_round.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_num_round ).
     INSERT VALUE #( key = 'num_round' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
     "Create ABAP objects for data based on input variables.
     "Training data.
-    CREATE OBJECT lo_trn_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_trn_data_s3datatype
-        iv_s3datadistributiontype = cv_trn_data_s3datadistribution
-        iv_s3uri                  = lv_trn_data_s3uri.
+    lo_trn_s3datasource = NEW #( iv_s3datatype = cv_trn_data_s3datatype
+                                 iv_s3datadistributiontype = cv_trn_data_s3datadistribution
+                                 iv_s3uri = lv_trn_data_s3uri ).
 
-    CREATE OBJECT lo_trn_datasource
-      EXPORTING
-        io_s3datasource = lo_trn_s3datasource.
+    lo_trn_datasource = NEW #( io_s3datasource = lo_trn_s3datasource ).
 
-    CREATE OBJECT lo_trn_channel
-      EXPORTING
-        iv_channelname     = 'train'
-        io_datasource      = lo_trn_datasource
-        iv_compressiontype = cv_trn_data_compressiontype
-        iv_contenttype     = cv_trn_data_contenttype.
+    lo_trn_channel = NEW #( iv_channelname = 'train'
+                            io_datasource = lo_trn_datasource
+                            iv_compressiontype = cv_trn_data_compressiontype
+                            iv_contenttype = cv_trn_data_contenttype ).
 
     INSERT lo_trn_channel INTO TABLE lt_input_data_config.
 
     "Validation data.
-    CREATE OBJECT lo_val_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_val_data_s3datatype
-        iv_s3datadistributiontype = cv_val_data_s3datadistribution
-        iv_s3uri                  = lv_val_data_s3uri.
+    lo_val_s3datasource = NEW #( iv_s3datatype = cv_val_data_s3datatype
+                                 iv_s3datadistributiontype = cv_val_data_s3datadistribution
+                                 iv_s3uri = lv_val_data_s3uri ).
 
-    CREATE OBJECT lo_val_datasource
-      EXPORTING
-        io_s3datasource = lo_val_s3datasource.
+    lo_val_datasource = NEW #( io_s3datasource = lo_val_s3datasource ).
 
-    CREATE OBJECT lo_val_channel
-      EXPORTING
-        iv_channelname     = 'validation'
-        io_datasource      = lo_val_datasource
-        iv_compressiontype = cv_val_data_compressiontype
-        iv_contenttype     = cv_val_data_contenttype.
+    lo_val_channel = NEW #( iv_channelname = 'validation'
+                            io_datasource = lo_val_datasource
+                            iv_compressiontype = cv_val_data_compressiontype
+                            iv_contenttype = cv_val_data_contenttype ).
 
     INSERT lo_val_channel INTO TABLE lt_input_data_config.
 
     "Create an ABAP object for algorithm specification based on input variables.
-    CREATE OBJECT lo_algorithm_specification
-      EXPORTING
-        iv_trainingimage     = cv_training_image
-        iv_traininginputmode = cv_training_input_mode.
+    lo_algorithm_specification = NEW #( iv_trainingimage = cv_training_image
+                                        iv_traininginputmode = cv_training_input_mode ).
 
     "Create an ABAP object for resource configuration.
-    CREATE OBJECT lo_resource_config
-      EXPORTING
-        iv_instancecount  = cv_instance_count
-        iv_instancetype   = cv_instance_type
-        iv_volumesizeingb = cv_volume_sizeingb.
+    lo_resource_config = NEW #( iv_instancecount = cv_instance_count
+                                iv_instancetype = cv_instance_type
+                                iv_volumesizeingb = cv_volume_sizeingb ).
 
     "Create an ABAP object for output data configuration.
-    CREATE OBJECT lo_output_data_config
-      EXPORTING
-        iv_s3outputpath = lv_s3_output_path.
+    lo_output_data_config = NEW #( iv_s3outputpath = lv_s3_output_path ).
 
     "Create an ABAP object for stopping condition.
-    CREATE OBJECT lo_stopping_condition
-      EXPORTING
-        iv_maxruntimeinseconds = cv_max_runtime_in_seconds.
+    lo_stopping_condition = NEW #( iv_maxruntimeinseconds = cv_max_runtime_in_seconds ).
 
     "Create a training job.
     ao_sgm->createtrainingjob(
@@ -981,8 +901,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
       io_algorithmspecification    = lo_algorithm_specification
       io_outputdataconfig          = lo_output_data_config
       io_resourceconfig            = lo_resource_config
-      io_stoppingcondition         = lo_stopping_condition
-    ).
+      io_stoppingcondition         = lo_stopping_condition ).
 
     "Wait for training job to be completed.
     lo_training_result = ao_sgm->describetrainingjob( iv_trainingjobname = lv_training_job_name ).
@@ -995,16 +914,12 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ENDWHILE.
 
     "Test the create_model method.
-    CALL METHOD ao_sgm_actions->create_model
-      EXPORTING
-        iv_model_name         = lv_model_name
-        iv_execution_role_arn = av_lrole
-        iv_model_data_url     = lv_model_data_url
-        iv_container_image    = cv_container_image
-      IMPORTING
-        oo_result             = lo_result.
+    ao_sgm_actions->create_model( EXPORTING iv_model_name = lv_model_name
+                                            iv_execution_role_arn = av_lrole
+                                            iv_model_data_url = lv_model_data_url
+                                            iv_container_image = cv_container_image IMPORTING oo_result = lo_result ).
 
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     IF lo_result->has_modelarn( ) = 'X'.
       lv_found               = abap_true.
@@ -1012,32 +927,26 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
        act                    = lv_found
-       msg                    = |Model cannot be found|
-    ).
+       msg                    = |Model cannot be found| ).
 
     "Clean up.
     ao_sgm->deletemodel(
-        iv_modelname = lv_model_name
-    ).
+        iv_modelname = lv_model_name ).
 
     ao_s3->deleteobject(
       iv_bucket = lv_bucket_name
-      iv_key = cv_train_key
-    ).
+      iv_key = cv_train_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_val_key
-    ).
+        iv_key = cv_val_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = lv_model_key
-    ).
+        iv_key = lv_model_key ).
 
     ao_s3->deletebucket(
-        iv_bucket = lv_bucket_name
-    ).
+        iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
@@ -1052,13 +961,13 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_val_channel TYPE REF TO /aws1/cl_sgmchannel.
     DATA lo_val_datasource TYPE REF TO /aws1/cl_sgmdatasource.
     DATA lo_val_s3datasource TYPE REF TO /aws1/cl_sgms3datasource.
-    DATA lo_output_data_config TYPE REF TO  /aws1/cl_sgmoutputdataconfig.
+    DATA lo_output_data_config TYPE REF TO /aws1/cl_sgmoutputdataconfig.
     DATA lo_resource_config  TYPE REF TO /aws1/cl_sgmresourceconfig.
     DATA lo_algorithm_specification TYPE REF TO /aws1/cl_sgmalgorithmspec.
     DATA lo_list_result TYPE REF TO /aws1/cl_sgmlisttrnjobsrsp.
-    DATA lo_stopping_condition TYPE REF TO  /aws1/cl_sgmstoppingcondition.
+    DATA lo_stopping_condition TYPE REF TO /aws1/cl_sgmstoppingcondition.
     DATA lv_training_job_name TYPE /aws1/sgmtrainingjobname.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lo_result TYPE REF TO /aws1/cl_sgmcreatemodeloutput.
     DATA lv_model_name TYPE /aws1/sgmmodelname.
     DATA lv_model_data_url TYPE /aws1/sgmurl.
@@ -1080,29 +989,29 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     CONSTANTS cv_val_key TYPE /aws1/s3_objectkey VALUE 'sagemaker/validation/validation.libsvm'.
 
     "Define hyperparameters.
-    CONSTANTS cv_hp_max_depth TYPE   /aws1/sgmhyperparametervalue    VALUE '3'.
-    CONSTANTS cv_hp_scale_pos_weight TYPE   /aws1/sgmhyperparametervalue    VALUE '2.0'.
-    CONSTANTS cv_hp_num_round TYPE   /aws1/sgmhyperparametervalue    VALUE '100'.
-    CONSTANTS cv_hp_objective  TYPE  /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
-    CONSTANTS cv_hp_subsample TYPE   /aws1/sgmhyperparametervalue    VALUE '0.5'.
-    CONSTANTS cv_hp_eta TYPE  /aws1/sgmhyperparametervalue    VALUE   '0.1'.
-    CONSTANTS cv_hp_eval_metric TYPE   /aws1/sgmhyperparametervalue    VALUE 'auc'.
+    CONSTANTS cv_hp_max_depth TYPE /aws1/sgmhyperparametervalue    VALUE '3'.
+    CONSTANTS cv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue    VALUE '2.0'.
+    CONSTANTS cv_hp_num_round TYPE /aws1/sgmhyperparametervalue    VALUE '100'.
+    CONSTANTS cv_hp_objective  TYPE /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
+    CONSTANTS cv_hp_subsample TYPE /aws1/sgmhyperparametervalue    VALUE '0.5'.
+    CONSTANTS cv_hp_eta TYPE /aws1/sgmhyperparametervalue    VALUE '0.1'.
+    CONSTANTS cv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue    VALUE 'auc'.
 
     "Define training data.
-    CONSTANTS cv_trn_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_trn_data_s3datadistribution TYPE  /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
-    CONSTANTS cv_trn_data_compressiontype TYPE  /aws1/sgmcompressiontype     VALUE 'None'.
-    CONSTANTS cv_trn_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_trn_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
+    CONSTANTS cv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype     VALUE 'None'.
+    CONSTANTS cv_trn_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define validation data.
-    CONSTANTS cv_val_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_val_data_s3datadistribution TYPE  /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
-    CONSTANTS cv_val_data_compressiontype TYPE   /aws1/sgmcompressiontype    VALUE 'None'.
-    CONSTANTS cv_val_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_val_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
+    CONSTANTS cv_val_data_compressiontype TYPE /aws1/sgmcompressiontype    VALUE 'None'.
+    CONSTANTS cv_val_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define training parameters.
     CONSTANTS cv_training_image TYPE /aws1/sgmalgorithmimage VALUE '123456789012.abc.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.5-1'.
-    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE  'File'.
+    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE 'File'.
     CONSTANTS cv_instance_count TYPE /aws1/sgmtraininginstancecount VALUE '1'.
     CONSTANTS cv_instance_type TYPE /aws1/sgmtraininginstancetype VALUE 'ml.c4.2xlarge'.
     CONSTANTS cv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb VALUE '10'.
@@ -1111,7 +1020,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Define role ARN.
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     "Define job name.
@@ -1126,7 +1035,10 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     "Create training data in Amazon S3.
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
+
 
     lv_trn_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_train_key.
     lv_val_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_val_key.
@@ -1137,100 +1049,78 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ao_s3->putobject(
       iv_bucket = lv_bucket_name
       iv_key = cv_train_key
-      iv_body = av_file_content
-    ).
+      iv_body = av_file_content ).
 
     ao_s3->putobject(
           iv_bucket = lv_bucket_name
           iv_key = cv_val_key
-          iv_body = av_file_content
-    ).
+          iv_body = av_file_content ).
 
     "Create ABAP internal table for hyperparameters based on input variables.
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_max_depth.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_max_depth ).
     INSERT VALUE #( key = 'max_depth' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eta.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eta ).
     INSERT VALUE #( key = 'eta' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eval_metric.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eval_metric ).
     INSERT VALUE #( key = 'eval_metric' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_scale_pos_weight.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_scale_pos_weight ).
     INSERT VALUE #( key = 'scale_pos_weight' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_subsample.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_subsample ).
     INSERT VALUE #( key = 'subsample' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_objective.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_objective ).
     INSERT VALUE #( key = 'objective' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_num_round.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_num_round ).
     INSERT VALUE #( key = 'num_round' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
     "Create ABAP objects for data based on input variables.
     "Training data.
-    CREATE OBJECT lo_trn_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_trn_data_s3datatype
-        iv_s3datadistributiontype = cv_trn_data_s3datadistribution
-        iv_s3uri                  = lv_trn_data_s3uri.
+    lo_trn_s3datasource = NEW #( iv_s3datatype = cv_trn_data_s3datatype
+                                 iv_s3datadistributiontype = cv_trn_data_s3datadistribution
+                                 iv_s3uri = lv_trn_data_s3uri ).
 
-    CREATE OBJECT lo_trn_datasource
-      EXPORTING
-        io_s3datasource = lo_trn_s3datasource.
+    lo_trn_datasource = NEW #( io_s3datasource = lo_trn_s3datasource ).
 
-    CREATE OBJECT lo_trn_channel
-      EXPORTING
-        iv_channelname     = 'train'
-        io_datasource      = lo_trn_datasource
-        iv_compressiontype = cv_trn_data_compressiontype
-        iv_contenttype     = cv_trn_data_contenttype.
+    lo_trn_channel = NEW #( iv_channelname = 'train'
+                            io_datasource = lo_trn_datasource
+                            iv_compressiontype = cv_trn_data_compressiontype
+                            iv_contenttype = cv_trn_data_contenttype ).
 
     INSERT lo_trn_channel INTO TABLE lt_input_data_config.
 
     "Validation data.
-    CREATE OBJECT lo_val_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_val_data_s3datatype
-        iv_s3datadistributiontype = cv_val_data_s3datadistribution
-        iv_s3uri                  = lv_val_data_s3uri.
+    lo_val_s3datasource = NEW #( iv_s3datatype = cv_val_data_s3datatype
+                                 iv_s3datadistributiontype = cv_val_data_s3datadistribution
+                                 iv_s3uri = lv_val_data_s3uri ).
 
-    CREATE OBJECT lo_val_datasource
-      EXPORTING
-        io_s3datasource = lo_val_s3datasource.
+    lo_val_datasource = NEW #( io_s3datasource = lo_val_s3datasource ).
 
-    CREATE OBJECT lo_val_channel
-      EXPORTING
-        iv_channelname     = 'validation'
-        io_datasource      = lo_val_datasource
-        iv_compressiontype = cv_val_data_compressiontype
-        iv_contenttype     = cv_val_data_contenttype.
+    lo_val_channel = NEW #( iv_channelname = 'validation'
+                            io_datasource = lo_val_datasource
+                            iv_compressiontype = cv_val_data_compressiontype
+                            iv_contenttype = cv_val_data_contenttype ).
 
     INSERT lo_val_channel INTO TABLE lt_input_data_config.
 
     "Create an ABAP object for algorithm specification based on input variables.
-    CREATE OBJECT lo_algorithm_specification
-      EXPORTING
-        iv_trainingimage     = cv_training_image
-        iv_traininginputmode = cv_training_input_mode.
+    lo_algorithm_specification = NEW #( iv_trainingimage = cv_training_image
+                                        iv_traininginputmode = cv_training_input_mode ).
 
     "Create an ABAP object for resource configuration.
-    CREATE OBJECT lo_resource_config
-      EXPORTING
-        iv_instancecount  = cv_instance_count
-        iv_instancetype   = cv_instance_type
-        iv_volumesizeingb = cv_volume_sizeingb.
+    lo_resource_config = NEW #( iv_instancecount = cv_instance_count
+                                iv_instancetype = cv_instance_type
+                                iv_volumesizeingb = cv_volume_sizeingb ).
 
     "Create an ABAP object for output data configuration.
-    CREATE OBJECT lo_output_data_config
-      EXPORTING
-        iv_s3outputpath = lv_s3_output_path.
+    lo_output_data_config = NEW #( iv_s3outputpath = lv_s3_output_path ).
 
     "Create an ABAP object for stopping condition.
-    CREATE OBJECT lo_stopping_condition
-      EXPORTING
-        iv_maxruntimeinseconds = cv_max_runtime_in_seconds.
+    lo_stopping_condition = NEW #( iv_maxruntimeinseconds = cv_max_runtime_in_seconds ).
 
     "Run method to create a training job.
     ao_sgm->createtrainingjob(
@@ -1241,8 +1131,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
       io_algorithmspecification    = lo_algorithm_specification
       io_outputdataconfig          = lo_output_data_config
       io_resourceconfig            = lo_resource_config
-      io_stoppingcondition         = lo_stopping_condition
-    ).
+      io_stoppingcondition         = lo_stopping_condition ).
 
     "Wait for training job to be completed.
     lo_training_result = ao_sgm->describetrainingjob( iv_trainingjobname = lv_training_job_name ).
@@ -1255,26 +1144,18 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ENDWHILE.
 
     "Create an ABAP internal table for the container image based on input variables.
-    CREATE OBJECT lo_primarycontainer
-      EXPORTING
-        iv_image        = cv_container_image
-        iv_modeldataurl = lv_model_data_url.
+    lo_primarycontainer = NEW #( iv_image = cv_container_image
+                                 iv_modeldataurl = lv_model_data_url ).
 
     "Create a new model via so_sgm.
-    CALL METHOD ao_sgm->createmodel
-      EXPORTING
-        iv_modelname        = lv_model_name
-        iv_executionrolearn = av_lrole
-        io_primarycontainer = lo_primarycontainer.
+    ao_sgm->createmodel( iv_modelname = lv_model_name
+                                   iv_executionrolearn = av_lrole
+                                   io_primarycontainer = lo_primarycontainer ).
 
     "Call list_models via so_sgm_actions.
-    CALL METHOD ao_sgm_actions->list_models
-      EXPORTING
-        iv_name_contains = lv_model_name
-      IMPORTING
-        oo_result        = lo_model_list_result.
+    ao_sgm_actions->list_models( EXPORTING iv_name_contains = lv_model_name IMPORTING oo_result = lo_model_list_result ).
 
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     LOOP AT lo_model_list_result->get_models( ) INTO DATA(lo_models).
       IF lo_models->get_modelname( ) = lv_model_name.
@@ -1284,32 +1165,26 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Model cannot be found|
-    ).
+      msg = |Model cannot be found| ).
 
     "Clean up.
     ao_sgm->deletemodel(
-        iv_modelname = lv_model_name
-    ).
+        iv_modelname = lv_model_name ).
 
     ao_s3->deleteobject(
       iv_bucket = lv_bucket_name
-      iv_key = cv_train_key
-    ).
+      iv_key = cv_train_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_val_key
-    ).
+        iv_key = cv_val_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = lv_model_key
-    ).
+        iv_key = lv_model_key ).
 
     ao_s3->deletebucket(
-        iv_bucket = lv_bucket_name
-    ).
+        iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
@@ -1324,13 +1199,13 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_val_channel TYPE REF TO /aws1/cl_sgmchannel.
     DATA lo_val_datasource TYPE REF TO /aws1/cl_sgmdatasource.
     DATA lo_val_s3datasource TYPE REF TO /aws1/cl_sgms3datasource.
-    DATA lo_output_data_config TYPE REF TO  /aws1/cl_sgmoutputdataconfig.
+    DATA lo_output_data_config TYPE REF TO /aws1/cl_sgmoutputdataconfig.
     DATA lo_resource_config  TYPE REF TO /aws1/cl_sgmresourceconfig.
     DATA lo_algorithm_specification TYPE REF TO /aws1/cl_sgmalgorithmspec.
     DATA lo_list_result TYPE REF TO /aws1/cl_sgmlisttrnjobsrsp.
-    DATA lo_stopping_condition TYPE REF TO  /aws1/cl_sgmstoppingcondition.
+    DATA lo_stopping_condition TYPE REF TO /aws1/cl_sgmstoppingcondition.
     DATA lv_training_job_name TYPE /aws1/sgmtrainingjobname.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lo_result TYPE REF TO /aws1/cl_sgmcreatemodeloutput.
     DATA lv_model_name TYPE /aws1/sgmmodelname.
     DATA lv_model_data_url TYPE /aws1/sgmurl.
@@ -1352,29 +1227,29 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     CONSTANTS cv_val_key TYPE /aws1/s3_objectkey VALUE 'sagemaker/validation/validation.libsvm'.
 
     "Define hyperparameters.
-    CONSTANTS cv_hp_max_depth TYPE   /aws1/sgmhyperparametervalue    VALUE '3'.
-    CONSTANTS cv_hp_scale_pos_weight TYPE   /aws1/sgmhyperparametervalue    VALUE '2.0'.
-    CONSTANTS cv_hp_num_round TYPE   /aws1/sgmhyperparametervalue    VALUE '100'.
-    CONSTANTS cv_hp_objective  TYPE  /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
-    CONSTANTS cv_hp_subsample TYPE   /aws1/sgmhyperparametervalue    VALUE '0.5'.
-    CONSTANTS cv_hp_eta TYPE  /aws1/sgmhyperparametervalue    VALUE   '0.1'.
-    CONSTANTS cv_hp_eval_metric TYPE   /aws1/sgmhyperparametervalue    VALUE 'auc'.
+    CONSTANTS cv_hp_max_depth TYPE /aws1/sgmhyperparametervalue    VALUE '3'.
+    CONSTANTS cv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue    VALUE '2.0'.
+    CONSTANTS cv_hp_num_round TYPE /aws1/sgmhyperparametervalue    VALUE '100'.
+    CONSTANTS cv_hp_objective  TYPE /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
+    CONSTANTS cv_hp_subsample TYPE /aws1/sgmhyperparametervalue    VALUE '0.5'.
+    CONSTANTS cv_hp_eta TYPE /aws1/sgmhyperparametervalue    VALUE '0.1'.
+    CONSTANTS cv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue    VALUE 'auc'.
 
     "Define training data.
-    CONSTANTS cv_trn_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_trn_data_s3datadistribution TYPE  /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
-    CONSTANTS cv_trn_data_compressiontype TYPE  /aws1/sgmcompressiontype     VALUE 'None'.
-    CONSTANTS cv_trn_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_trn_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
+    CONSTANTS cv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype     VALUE 'None'.
+    CONSTANTS cv_trn_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define validation data.
-    CONSTANTS cv_val_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_val_data_s3datadistribution TYPE  /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
-    CONSTANTS cv_val_data_compressiontype TYPE   /aws1/sgmcompressiontype    VALUE 'None'.
-    CONSTANTS cv_val_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_val_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
+    CONSTANTS cv_val_data_compressiontype TYPE /aws1/sgmcompressiontype    VALUE 'None'.
+    CONSTANTS cv_val_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define training parameters.
     CONSTANTS cv_training_image TYPE /aws1/sgmalgorithmimage VALUE '123456789012.abc.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.5-1'.
-    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE  'File'.
+    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE 'File'.
     CONSTANTS cv_instance_count TYPE /aws1/sgmtraininginstancecount VALUE '1'.
     CONSTANTS cv_instance_type TYPE /aws1/sgmtraininginstancetype VALUE 'ml.c4.2xlarge'.
     CONSTANTS cv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb VALUE '10'.
@@ -1383,7 +1258,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Define role ARN.
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     "Define job name.
@@ -1398,7 +1273,10 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     "Create training data in Amazon S3.
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
+
 
     lv_trn_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_train_key.
     lv_val_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_val_key.
@@ -1409,100 +1287,78 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ao_s3->putobject(
       iv_bucket = lv_bucket_name
       iv_key = cv_train_key
-      iv_body = av_file_content
-    ).
+      iv_body = av_file_content ).
 
     ao_s3->putobject(
           iv_bucket = lv_bucket_name
           iv_key = cv_val_key
-          iv_body = av_file_content
-    ).
+          iv_body = av_file_content ).
 
     "Create ABAP internal table for hyperparameters based on input variables.
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_max_depth.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_max_depth ).
     INSERT VALUE #( key = 'max_depth' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eta.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eta ).
     INSERT VALUE #( key = 'eta' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eval_metric.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eval_metric ).
     INSERT VALUE #( key = 'eval_metric' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_scale_pos_weight.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_scale_pos_weight ).
     INSERT VALUE #( key = 'scale_pos_weight' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_subsample.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_subsample ).
     INSERT VALUE #( key = 'subsample' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_objective.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_objective ).
     INSERT VALUE #( key = 'objective' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_num_round.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_num_round ).
     INSERT VALUE #( key = 'num_round' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
     "Create ABAP objects for data based on input variables.
     "Training data.
-    CREATE OBJECT lo_trn_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_trn_data_s3datatype
-        iv_s3datadistributiontype = cv_trn_data_s3datadistribution
-        iv_s3uri                  = lv_trn_data_s3uri.
+    lo_trn_s3datasource = NEW #( iv_s3datatype = cv_trn_data_s3datatype
+                                 iv_s3datadistributiontype = cv_trn_data_s3datadistribution
+                                 iv_s3uri = lv_trn_data_s3uri ).
 
-    CREATE OBJECT lo_trn_datasource
-      EXPORTING
-        io_s3datasource = lo_trn_s3datasource.
+    lo_trn_datasource = NEW #( io_s3datasource = lo_trn_s3datasource ).
 
-    CREATE OBJECT lo_trn_channel
-      EXPORTING
-        iv_channelname     = 'train'
-        io_datasource      = lo_trn_datasource
-        iv_compressiontype = cv_trn_data_compressiontype
-        iv_contenttype     = cv_trn_data_contenttype.
+    lo_trn_channel = NEW #( iv_channelname = 'train'
+                            io_datasource = lo_trn_datasource
+                            iv_compressiontype = cv_trn_data_compressiontype
+                            iv_contenttype = cv_trn_data_contenttype ).
 
     INSERT lo_trn_channel INTO TABLE lt_input_data_config.
 
     "Validation data.
-    CREATE OBJECT lo_val_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_val_data_s3datatype
-        iv_s3datadistributiontype = cv_val_data_s3datadistribution
-        iv_s3uri                  = lv_val_data_s3uri.
+    lo_val_s3datasource = NEW #( iv_s3datatype = cv_val_data_s3datatype
+                                 iv_s3datadistributiontype = cv_val_data_s3datadistribution
+                                 iv_s3uri = lv_val_data_s3uri ).
 
-    CREATE OBJECT lo_val_datasource
-      EXPORTING
-        io_s3datasource = lo_val_s3datasource.
+    lo_val_datasource = NEW #( io_s3datasource = lo_val_s3datasource ).
 
-    CREATE OBJECT lo_val_channel
-      EXPORTING
-        iv_channelname     = 'validation'
-        io_datasource      = lo_val_datasource
-        iv_compressiontype = cv_val_data_compressiontype
-        iv_contenttype     = cv_val_data_contenttype.
+    lo_val_channel = NEW #( iv_channelname = 'validation'
+                            io_datasource = lo_val_datasource
+                            iv_compressiontype = cv_val_data_compressiontype
+                            iv_contenttype = cv_val_data_contenttype ).
 
     INSERT lo_val_channel INTO TABLE lt_input_data_config.
 
     "Create an ABAP object for algorithm specification based on input variables.
-    CREATE OBJECT lo_algorithm_specification
-      EXPORTING
-        iv_trainingimage     = cv_training_image
-        iv_traininginputmode = cv_training_input_mode.
+    lo_algorithm_specification = NEW #( iv_trainingimage = cv_training_image
+                                        iv_traininginputmode = cv_training_input_mode ).
 
     "Create an ABAP object for resource configuration.
-    CREATE OBJECT lo_resource_config
-      EXPORTING
-        iv_instancecount  = cv_instance_count
-        iv_instancetype   = cv_instance_type
-        iv_volumesizeingb = cv_volume_sizeingb.
+    lo_resource_config = NEW #( iv_instancecount = cv_instance_count
+                                iv_instancetype = cv_instance_type
+                                iv_volumesizeingb = cv_volume_sizeingb ).
 
     "Create an ABAP object for output data configuration.
-    CREATE OBJECT lo_output_data_config
-      EXPORTING
-        iv_s3outputpath = lv_s3_output_path.
+    lo_output_data_config = NEW #( iv_s3outputpath = lv_s3_output_path ).
 
     "Create an ABAP object for stopping condition.
-    CREATE OBJECT lo_stopping_condition
-      EXPORTING
-        iv_maxruntimeinseconds = cv_max_runtime_in_seconds.
+    lo_stopping_condition = NEW #( iv_maxruntimeinseconds = cv_max_runtime_in_seconds ).
 
     "Create a training job.
     ao_sgm->createtrainingjob(
@@ -1513,8 +1369,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
       io_algorithmspecification    = lo_algorithm_specification
       io_outputdataconfig          = lo_output_data_config
       io_resourceconfig            = lo_resource_config
-      io_stoppingcondition         = lo_stopping_condition
-    ).
+      io_stoppingcondition         = lo_stopping_condition ).
 
     "Wait for training job to be completed.
     lo_training_result = ao_sgm->describetrainingjob( iv_trainingjobname = lv_training_job_name ).
@@ -1527,29 +1382,22 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ENDWHILE.
 
     "Create an ABAP internal table for the container image based on input variables.
-    CREATE OBJECT lo_primarycontainer
-      EXPORTING
-        iv_image        = cv_container_image
-        iv_modeldataurl = lv_model_data_url.
+    lo_primarycontainer = NEW #( iv_image = cv_container_image
+                                 iv_modeldataurl = lv_model_data_url ).
 
     "Create a new model via so_sgm.
-    CALL METHOD ao_sgm->createmodel
-      EXPORTING
-        iv_modelname        = lv_model_name
-        iv_executionrolearn = av_lrole
-        io_primarycontainer = lo_primarycontainer.
+    ao_sgm->createmodel( iv_modelname = lv_model_name
+                                   iv_executionrolearn = av_lrole
+                                   io_primarycontainer = lo_primarycontainer ).
 
     "Test the ao_sgm_actions delete_model method.
-    CALL METHOD ao_sgm_actions->delete_model
-      EXPORTING
-        iv_model_name = lv_model_name.
+    ao_sgm_actions->delete_model( lv_model_name ).
 
     "List the deleted model via so_sgm.
     lo_model_list_result = ao_sgm->listmodels(
-      iv_namecontains = lv_model_name
-    ).
+      iv_namecontains = lv_model_name ).
 
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     "The model should be deleted.
     LOOP AT lo_model_list_result->get_models( ) INTO DATA(lo_models).
@@ -1560,28 +1408,23 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_false(
       act = lv_found
-      msg = |Model was not deleted|
-    ).
+      msg = |Model was not deleted| ).
 
     "Clean up.
     ao_s3->deleteobject(
       iv_bucket = lv_bucket_name
-      iv_key = cv_train_key
-    ).
+      iv_key = cv_train_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_val_key
-    ).
+        iv_key = cv_val_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = lv_model_key
-    ).
+        iv_key = lv_model_key ).
 
     ao_s3->deletebucket(
-        iv_bucket = lv_bucket_name
-    ).
+        iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
@@ -1596,13 +1439,13 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_val_channel TYPE REF TO /aws1/cl_sgmchannel.
     DATA lo_val_datasource TYPE REF TO /aws1/cl_sgmdatasource.
     DATA lo_val_s3datasource TYPE REF TO /aws1/cl_sgms3datasource.
-    DATA lo_output_data_config TYPE REF TO  /aws1/cl_sgmoutputdataconfig.
+    DATA lo_output_data_config TYPE REF TO /aws1/cl_sgmoutputdataconfig.
     DATA lo_resource_config  TYPE REF TO /aws1/cl_sgmresourceconfig.
     DATA lo_algorithm_specification TYPE REF TO /aws1/cl_sgmalgorithmspec.
     DATA lo_list_result TYPE REF TO /aws1/cl_sgmlisttrnjobsrsp.
-    DATA lo_stopping_condition TYPE REF TO  /aws1/cl_sgmstoppingcondition.
+    DATA lo_stopping_condition TYPE REF TO /aws1/cl_sgmstoppingcondition.
     DATA lv_training_job_name TYPE /aws1/sgmtrainingjobname.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lo_result TYPE REF TO /aws1/cl_sgmcreatemodeloutput.
     DATA lv_model_name TYPE /aws1/sgmmodelname.
     DATA lv_model_data_url TYPE /aws1/sgmurl.
@@ -1629,29 +1472,29 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     CONSTANTS cv_val_key TYPE /aws1/s3_objectkey VALUE 'sagemaker/validation/validation.libsvm'.
 
     "Define hyperparameters.
-    CONSTANTS cv_hp_max_depth TYPE   /aws1/sgmhyperparametervalue    VALUE '3'.
-    CONSTANTS cv_hp_scale_pos_weight TYPE   /aws1/sgmhyperparametervalue    VALUE '2.0'.
-    CONSTANTS cv_hp_num_round TYPE   /aws1/sgmhyperparametervalue    VALUE '100'.
-    CONSTANTS cv_hp_objective  TYPE  /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
-    CONSTANTS cv_hp_subsample TYPE   /aws1/sgmhyperparametervalue    VALUE '0.5'.
-    CONSTANTS cv_hp_eta TYPE  /aws1/sgmhyperparametervalue    VALUE   '0.1'.
-    CONSTANTS cv_hp_eval_metric TYPE   /aws1/sgmhyperparametervalue    VALUE 'auc'.
+    CONSTANTS cv_hp_max_depth TYPE /aws1/sgmhyperparametervalue    VALUE '3'.
+    CONSTANTS cv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue    VALUE '2.0'.
+    CONSTANTS cv_hp_num_round TYPE /aws1/sgmhyperparametervalue    VALUE '100'.
+    CONSTANTS cv_hp_objective  TYPE /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
+    CONSTANTS cv_hp_subsample TYPE /aws1/sgmhyperparametervalue    VALUE '0.5'.
+    CONSTANTS cv_hp_eta TYPE /aws1/sgmhyperparametervalue    VALUE '0.1'.
+    CONSTANTS cv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue    VALUE 'auc'.
 
     "Define training data.
-    CONSTANTS cv_trn_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_trn_data_s3datadistribution TYPE  /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
-    CONSTANTS cv_trn_data_compressiontype TYPE  /aws1/sgmcompressiontype     VALUE 'None'.
-    CONSTANTS cv_trn_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_trn_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
+    CONSTANTS cv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype     VALUE 'None'.
+    CONSTANTS cv_trn_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define validation data.
-    CONSTANTS cv_val_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_val_data_s3datadistribution TYPE  /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
-    CONSTANTS cv_val_data_compressiontype TYPE   /aws1/sgmcompressiontype    VALUE 'None'.
-    CONSTANTS cv_val_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_val_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
+    CONSTANTS cv_val_data_compressiontype TYPE /aws1/sgmcompressiontype    VALUE 'None'.
+    CONSTANTS cv_val_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define training parameters.
     CONSTANTS cv_training_image TYPE /aws1/sgmalgorithmimage VALUE '123456789012.abc.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.5-1'.
-    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE  'File'.
+    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE 'File'.
     CONSTANTS cv_instance_count TYPE /aws1/sgmtraininginstancecount VALUE '1'.
     CONSTANTS cv_instance_type TYPE /aws1/sgmtraininginstancetype VALUE 'ml.c4.2xlarge'.
     CONSTANTS cv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb VALUE '10'.
@@ -1659,12 +1502,12 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     CONSTANTS cv_max_results TYPE /aws1/sgmmaxresults VALUE '1'.
 
     "Define endpoint parameters.
-    CONSTANTS cv_ep_instance_type TYPE  /aws1/sgminstancetype VALUE 'ml.m4.xlarge'.
-    CONSTANTS cv_ep_initial_instance_count  TYPE  /aws1/sgminitialtaskcount VALUE  '1'.
+    CONSTANTS cv_ep_instance_type TYPE /aws1/sgminstancetype VALUE 'ml.m4.xlarge'.
+    CONSTANTS cv_ep_initial_instance_count  TYPE /aws1/sgminitialtaskcount VALUE '1'.
 
     "Define role ARN.
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     "Define job name.
@@ -1678,13 +1521,16 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Define endpoint name.
     lv_endpoint_name = 'code-example-endpoint-' && lv_uuid_16.
-    lv_endpoint_config_name =  'code-example-endpoint-cfg-' && lv_uuid_16.
-    lv_endpoint_variant_name =  'code-example-endpoint-variant-' && lv_uuid_16.
+    lv_endpoint_config_name = 'code-example-endpoint-cfg-' && lv_uuid_16.
+    lv_endpoint_variant_name = 'code-example-endpoint-variant-' && lv_uuid_16.
 
     "Create training data in Amazon S3.
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
+
 
     lv_trn_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_train_key.
     lv_val_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_val_key.
@@ -1695,100 +1541,78 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ao_s3->putobject(
       iv_bucket = lv_bucket_name
       iv_key = cv_train_key
-      iv_body = av_file_content
-    ).
+      iv_body = av_file_content ).
 
     ao_s3->putobject(
           iv_bucket = lv_bucket_name
           iv_key = cv_val_key
-          iv_body = av_file_content
-    ).
+          iv_body = av_file_content ).
 
     "Create ABAP internal table for hyperparameters based on input variables.
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_max_depth.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_max_depth ).
     INSERT VALUE #( key = 'max_depth' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eta.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eta ).
     INSERT VALUE #( key = 'eta' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eval_metric.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eval_metric ).
     INSERT VALUE #( key = 'eval_metric' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_scale_pos_weight.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_scale_pos_weight ).
     INSERT VALUE #( key = 'scale_pos_weight' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_subsample.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_subsample ).
     INSERT VALUE #( key = 'subsample' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_objective.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_objective ).
     INSERT VALUE #( key = 'objective' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_num_round.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_num_round ).
     INSERT VALUE #( key = 'num_round' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
     "Create ABAP objects for data based on input variables.
     "Training data.
-    CREATE OBJECT lo_trn_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_trn_data_s3datatype
-        iv_s3datadistributiontype = cv_trn_data_s3datadistribution
-        iv_s3uri                  = lv_trn_data_s3uri.
+    lo_trn_s3datasource = NEW #( iv_s3datatype = cv_trn_data_s3datatype
+                                 iv_s3datadistributiontype = cv_trn_data_s3datadistribution
+                                 iv_s3uri = lv_trn_data_s3uri ).
 
-    CREATE OBJECT lo_trn_datasource
-      EXPORTING
-        io_s3datasource = lo_trn_s3datasource.
+    lo_trn_datasource = NEW #( io_s3datasource = lo_trn_s3datasource ).
 
-    CREATE OBJECT lo_trn_channel
-      EXPORTING
-        iv_channelname     = 'train'
-        io_datasource      = lo_trn_datasource
-        iv_compressiontype = cv_trn_data_compressiontype
-        iv_contenttype     = cv_trn_data_contenttype.
+    lo_trn_channel = NEW #( iv_channelname = 'train'
+                            io_datasource = lo_trn_datasource
+                            iv_compressiontype = cv_trn_data_compressiontype
+                            iv_contenttype = cv_trn_data_contenttype ).
 
     INSERT lo_trn_channel INTO TABLE lt_input_data_config.
 
     "Validation data.
-    CREATE OBJECT lo_val_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_val_data_s3datatype
-        iv_s3datadistributiontype = cv_val_data_s3datadistribution
-        iv_s3uri                  = lv_val_data_s3uri.
+    lo_val_s3datasource = NEW #( iv_s3datatype = cv_val_data_s3datatype
+                                 iv_s3datadistributiontype = cv_val_data_s3datadistribution
+                                 iv_s3uri = lv_val_data_s3uri ).
 
-    CREATE OBJECT lo_val_datasource
-      EXPORTING
-        io_s3datasource = lo_val_s3datasource.
+    lo_val_datasource = NEW #( io_s3datasource = lo_val_s3datasource ).
 
-    CREATE OBJECT lo_val_channel
-      EXPORTING
-        iv_channelname     = 'validation'
-        io_datasource      = lo_val_datasource
-        iv_compressiontype = cv_val_data_compressiontype
-        iv_contenttype     = cv_val_data_contenttype.
+    lo_val_channel = NEW #( iv_channelname = 'validation'
+                            io_datasource = lo_val_datasource
+                            iv_compressiontype = cv_val_data_compressiontype
+                            iv_contenttype = cv_val_data_contenttype ).
 
     INSERT lo_val_channel INTO TABLE lt_input_data_config.
 
     "Create an ABAP object for algorithm specification based on input variables.
-    CREATE OBJECT lo_algorithm_specification
-      EXPORTING
-        iv_trainingimage     = cv_training_image
-        iv_traininginputmode = cv_training_input_mode.
+    lo_algorithm_specification = NEW #( iv_trainingimage = cv_training_image
+                                        iv_traininginputmode = cv_training_input_mode ).
 
     "Create an ABAP object for resource configuration.
-    CREATE OBJECT lo_resource_config
-      EXPORTING
-        iv_instancecount  = cv_instance_count
-        iv_instancetype   = cv_instance_type
-        iv_volumesizeingb = cv_volume_sizeingb.
+    lo_resource_config = NEW #( iv_instancecount = cv_instance_count
+                                iv_instancetype = cv_instance_type
+                                iv_volumesizeingb = cv_volume_sizeingb ).
 
     "Create an ABAP object for output data configuration.
-    CREATE OBJECT lo_output_data_config
-      EXPORTING
-        iv_s3outputpath = lv_s3_output_path.
+    lo_output_data_config = NEW #( iv_s3outputpath = lv_s3_output_path ).
 
     "Create an ABAP object for stopping condition.
-    CREATE OBJECT lo_stopping_condition
-      EXPORTING
-        iv_maxruntimeinseconds = cv_max_runtime_in_seconds.
+    lo_stopping_condition = NEW #( iv_maxruntimeinseconds = cv_max_runtime_in_seconds ).
 
     "Run method to create a training job.
     ao_sgm->createtrainingjob(
@@ -1799,8 +1623,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
       io_algorithmspecification    = lo_algorithm_specification
       io_outputdataconfig          = lo_output_data_config
       io_resourceconfig            = lo_resource_config
-      io_stoppingcondition         = lo_stopping_condition
-    ).
+      io_stoppingcondition         = lo_stopping_condition ).
 
     "Wait for training job to be completed.
     lo_training_result = ao_sgm->describetrainingjob( iv_trainingjobname = lv_training_job_name ).
@@ -1813,31 +1636,23 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ENDWHILE.
 
     "Create an ABAP internal table for the container image based on input variables.
-    CREATE OBJECT lo_primarycontainer
-      EXPORTING
-        iv_image        = cv_container_image
-        iv_modeldataurl = lv_model_data_url.
+    lo_primarycontainer = NEW #( iv_image = cv_container_image
+                                 iv_modeldataurl = lv_model_data_url ).
 
     "Create a new model via so_sgm.
-    CALL METHOD ao_sgm->createmodel
-      EXPORTING
-        iv_modelname        = lv_model_name
-        iv_executionrolearn = av_lrole
-        io_primarycontainer = lo_primarycontainer.
+    ao_sgm->createmodel( iv_modelname = lv_model_name
+                                   iv_executionrolearn = av_lrole
+                                   io_primarycontainer = lo_primarycontainer ).
 
     "Test the create_endpoint method.
-    CALL METHOD ao_sgm_actions->create_endpoint
-      EXPORTING
-        iv_model_name             = lv_model_name
-        iv_endpoint_config_name   = lv_endpoint_config_name
-        iv_endpoint_name          = lv_endpoint_name
-        iv_instance_type          = cv_ep_instance_type
-        iv_variant_name           = lv_endpoint_variant_name
-        iv_initial_instance_count = cv_ep_initial_instance_count
-      IMPORTING
-        oo_result                 = lo_endpoint_output.
+    ao_sgm_actions->create_endpoint( EXPORTING iv_model_name = lv_model_name
+                                               iv_endpoint_config_name = lv_endpoint_config_name
+                                               iv_endpoint_name = lv_endpoint_name
+                                               iv_instance_type = cv_ep_instance_type
+                                               iv_variant_name = lv_endpoint_variant_name
+                                               iv_initial_instance_count = cv_ep_initial_instance_count IMPORTING oo_result = lo_endpoint_output ).
 
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     IF lo_endpoint_output->has_endpointarn( ) = 'X'.
       lv_found               = abap_true.
@@ -1845,8 +1660,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Endpoint not found|
-    ).
+      msg = |Endpoint not found| ).
 
     "Wait for endpoint creation to be completed.
     lo_endpoint_result = ao_sgm->describeendpoint( iv_endpointname = lv_endpoint_name ).
@@ -1860,35 +1674,28 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Clean up.
     ao_sgm->deleteendpoint(
-        iv_endpointname = lv_endpoint_name
-    ).
+        iv_endpointname = lv_endpoint_name ).
 
     ao_sgm->deleteendpointconfig(
-      iv_endpointconfigname = lv_endpoint_config_name
-    ).
+      iv_endpointconfigname = lv_endpoint_config_name ).
 
     ao_sgm->deletemodel(
-        iv_modelname = lv_model_name
-    ).
+        iv_modelname = lv_model_name ).
 
     ao_s3->deleteobject(
       iv_bucket = lv_bucket_name
-      iv_key = cv_train_key
-    ).
+      iv_key = cv_train_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_val_key
-    ).
+        iv_key = cv_val_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = lv_model_key
-    ).
+        iv_key = lv_model_key ).
 
     ao_s3->deletebucket(
-        iv_bucket = lv_bucket_name
-    ).
+        iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
@@ -1903,13 +1710,13 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_val_channel TYPE REF TO /aws1/cl_sgmchannel.
     DATA lo_val_datasource TYPE REF TO /aws1/cl_sgmdatasource.
     DATA lo_val_s3datasource TYPE REF TO /aws1/cl_sgms3datasource.
-    DATA lo_output_data_config TYPE REF TO  /aws1/cl_sgmoutputdataconfig.
+    DATA lo_output_data_config TYPE REF TO /aws1/cl_sgmoutputdataconfig.
     DATA lo_resource_config  TYPE REF TO /aws1/cl_sgmresourceconfig.
     DATA lo_algorithm_specification TYPE REF TO /aws1/cl_sgmalgorithmspec.
     DATA lo_list_result TYPE REF TO /aws1/cl_sgmlisttrnjobsrsp.
-    DATA lo_stopping_condition TYPE REF TO  /aws1/cl_sgmstoppingcondition.
+    DATA lo_stopping_condition TYPE REF TO /aws1/cl_sgmstoppingcondition.
     DATA lv_training_job_name TYPE /aws1/sgmtrainingjobname.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lo_result TYPE REF TO /aws1/cl_sgmcreatemodeloutput.
     DATA lv_model_name TYPE /aws1/sgmmodelname.
     DATA lv_model_data_url TYPE /aws1/sgmurl.
@@ -1937,29 +1744,29 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     CONSTANTS cv_val_key TYPE /aws1/s3_objectkey VALUE 'sagemaker/validation/validation.libsvm'.
 
     "Define hyperparameters.
-    CONSTANTS cv_hp_max_depth TYPE   /aws1/sgmhyperparametervalue    VALUE '3'.
-    CONSTANTS cv_hp_scale_pos_weight TYPE   /aws1/sgmhyperparametervalue    VALUE '2.0'.
-    CONSTANTS cv_hp_num_round TYPE   /aws1/sgmhyperparametervalue    VALUE '100'.
-    CONSTANTS cv_hp_objective  TYPE  /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
-    CONSTANTS cv_hp_subsample TYPE   /aws1/sgmhyperparametervalue    VALUE '0.5'.
-    CONSTANTS cv_hp_eta TYPE  /aws1/sgmhyperparametervalue    VALUE   '0.1'.
-    CONSTANTS cv_hp_eval_metric TYPE   /aws1/sgmhyperparametervalue    VALUE 'auc'.
+    CONSTANTS cv_hp_max_depth TYPE /aws1/sgmhyperparametervalue    VALUE '3'.
+    CONSTANTS cv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue    VALUE '2.0'.
+    CONSTANTS cv_hp_num_round TYPE /aws1/sgmhyperparametervalue    VALUE '100'.
+    CONSTANTS cv_hp_objective  TYPE /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
+    CONSTANTS cv_hp_subsample TYPE /aws1/sgmhyperparametervalue    VALUE '0.5'.
+    CONSTANTS cv_hp_eta TYPE /aws1/sgmhyperparametervalue    VALUE '0.1'.
+    CONSTANTS cv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue    VALUE 'auc'.
 
     "Define training data.
-    CONSTANTS cv_trn_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_trn_data_s3datadistribution TYPE  /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
-    CONSTANTS cv_trn_data_compressiontype TYPE  /aws1/sgmcompressiontype     VALUE 'None'.
-    CONSTANTS cv_trn_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_trn_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
+    CONSTANTS cv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype     VALUE 'None'.
+    CONSTANTS cv_trn_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define validation data.
-    CONSTANTS cv_val_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_val_data_s3datadistribution TYPE  /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
-    CONSTANTS cv_val_data_compressiontype TYPE   /aws1/sgmcompressiontype    VALUE 'None'.
-    CONSTANTS cv_val_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_val_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
+    CONSTANTS cv_val_data_compressiontype TYPE /aws1/sgmcompressiontype    VALUE 'None'.
+    CONSTANTS cv_val_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define training parameters.
     CONSTANTS cv_training_image TYPE /aws1/sgmalgorithmimage VALUE '123456789012.abc.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.5-1'.
-    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE  'File'.
+    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE 'File'.
     CONSTANTS cv_instance_count TYPE /aws1/sgmtraininginstancecount VALUE '1'.
     CONSTANTS cv_instance_type TYPE /aws1/sgmtraininginstancetype VALUE 'ml.c4.2xlarge'.
     CONSTANTS cv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb VALUE '10'.
@@ -1967,12 +1774,12 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     CONSTANTS cv_max_results TYPE /aws1/sgmmaxresults VALUE '1'.
 
     "Define endpoint parameters.
-    CONSTANTS cv_ep_instance_type TYPE  /aws1/sgminstancetype VALUE 'ml.m4.xlarge'.
-    CONSTANTS cv_ep_initial_instance_count  TYPE  /aws1/sgminitialtaskcount VALUE  '1'.
+    CONSTANTS cv_ep_instance_type TYPE /aws1/sgminstancetype VALUE 'ml.m4.xlarge'.
+    CONSTANTS cv_ep_initial_instance_count  TYPE /aws1/sgminitialtaskcount VALUE '1'.
 
     "Define role ARN.
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     "Define job name.
@@ -1986,13 +1793,16 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Define endpoint name.
     lv_endpoint_name = 'code-example-endpoint-' && lv_uuid_16.
-    lv_endpoint_config_name =  'code-example-endpoint-cfg-' && lv_uuid_16.
-    lv_endpoint_variant_name =  'code-example-endpoint-variant-' && lv_uuid_16.
+    lv_endpoint_config_name = 'code-example-endpoint-cfg-' && lv_uuid_16.
+    lv_endpoint_variant_name = 'code-example-endpoint-variant-' && lv_uuid_16.
 
     "Create training data in Amazon S3.
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
+
 
     lv_trn_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_train_key.
     lv_val_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_val_key.
@@ -2003,100 +1813,78 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ao_s3->putobject(
       iv_bucket = lv_bucket_name
       iv_key = cv_train_key
-      iv_body = av_file_content
-    ).
+      iv_body = av_file_content ).
 
     ao_s3->putobject(
           iv_bucket = lv_bucket_name
           iv_key = cv_val_key
-          iv_body = av_file_content
-    ).
+          iv_body = av_file_content ).
 
     "Create ABAP internal table for hyperparameters based on input variables.
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_max_depth.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_max_depth ).
     INSERT VALUE #( key = 'max_depth' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eta.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eta ).
     INSERT VALUE #( key = 'eta' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eval_metric.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eval_metric ).
     INSERT VALUE #( key = 'eval_metric' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_scale_pos_weight.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_scale_pos_weight ).
     INSERT VALUE #( key = 'scale_pos_weight' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_subsample.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_subsample ).
     INSERT VALUE #( key = 'subsample' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_objective.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_objective ).
     INSERT VALUE #( key = 'objective' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_num_round.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_num_round ).
     INSERT VALUE #( key = 'num_round' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
     "Create ABAP objects for data based on input variables.
     "Training data.
-    CREATE OBJECT lo_trn_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_trn_data_s3datatype
-        iv_s3datadistributiontype = cv_trn_data_s3datadistribution
-        iv_s3uri                  = lv_trn_data_s3uri.
+    lo_trn_s3datasource = NEW #( iv_s3datatype = cv_trn_data_s3datatype
+                                 iv_s3datadistributiontype = cv_trn_data_s3datadistribution
+                                 iv_s3uri = lv_trn_data_s3uri ).
 
-    CREATE OBJECT lo_trn_datasource
-      EXPORTING
-        io_s3datasource = lo_trn_s3datasource.
+    lo_trn_datasource = NEW #( io_s3datasource = lo_trn_s3datasource ).
 
-    CREATE OBJECT lo_trn_channel
-      EXPORTING
-        iv_channelname     = 'train'
-        io_datasource      = lo_trn_datasource
-        iv_compressiontype = cv_trn_data_compressiontype
-        iv_contenttype     = cv_trn_data_contenttype.
+    lo_trn_channel = NEW #( iv_channelname = 'train'
+                            io_datasource = lo_trn_datasource
+                            iv_compressiontype = cv_trn_data_compressiontype
+                            iv_contenttype = cv_trn_data_contenttype ).
 
     INSERT lo_trn_channel INTO TABLE lt_input_data_config.
 
     "Validation data.
-    CREATE OBJECT lo_val_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_val_data_s3datatype
-        iv_s3datadistributiontype = cv_val_data_s3datadistribution
-        iv_s3uri                  = lv_val_data_s3uri.
+    lo_val_s3datasource = NEW #( iv_s3datatype = cv_val_data_s3datatype
+                                 iv_s3datadistributiontype = cv_val_data_s3datadistribution
+                                 iv_s3uri = lv_val_data_s3uri ).
 
-    CREATE OBJECT lo_val_datasource
-      EXPORTING
-        io_s3datasource = lo_val_s3datasource.
+    lo_val_datasource = NEW #( io_s3datasource = lo_val_s3datasource ).
 
-    CREATE OBJECT lo_val_channel
-      EXPORTING
-        iv_channelname     = 'validation'
-        io_datasource      = lo_val_datasource
-        iv_compressiontype = cv_val_data_compressiontype
-        iv_contenttype     = cv_val_data_contenttype.
+    lo_val_channel = NEW #( iv_channelname = 'validation'
+                            io_datasource = lo_val_datasource
+                            iv_compressiontype = cv_val_data_compressiontype
+                            iv_contenttype = cv_val_data_contenttype ).
 
     INSERT lo_val_channel INTO TABLE lt_input_data_config.
 
     "Create an ABAP object for algorithm specification based on input variables.
-    CREATE OBJECT lo_algorithm_specification
-      EXPORTING
-        iv_trainingimage     = cv_training_image
-        iv_traininginputmode = cv_training_input_mode.
+    lo_algorithm_specification = NEW #( iv_trainingimage = cv_training_image
+                                        iv_traininginputmode = cv_training_input_mode ).
 
     "Create an ABAP object for resource configuration.
-    CREATE OBJECT lo_resource_config
-      EXPORTING
-        iv_instancecount  = cv_instance_count
-        iv_instancetype   = cv_instance_type
-        iv_volumesizeingb = cv_volume_sizeingb.
+    lo_resource_config = NEW #( iv_instancecount = cv_instance_count
+                                iv_instancetype = cv_instance_type
+                                iv_volumesizeingb = cv_volume_sizeingb ).
 
     "Create an ABAP object for output data configuration.
-    CREATE OBJECT lo_output_data_config
-      EXPORTING
-        iv_s3outputpath = lv_s3_output_path.
+    lo_output_data_config = NEW #( iv_s3outputpath = lv_s3_output_path ).
 
     "Create an ABAP object for stopping condition.
-    CREATE OBJECT lo_stopping_condition
-      EXPORTING
-        iv_maxruntimeinseconds = cv_max_runtime_in_seconds.
+    lo_stopping_condition = NEW #( iv_maxruntimeinseconds = cv_max_runtime_in_seconds ).
 
     "Run method to create a training job.
     ao_sgm->createtrainingjob(
@@ -2107,8 +1895,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
       io_algorithmspecification    = lo_algorithm_specification
       io_outputdataconfig          = lo_output_data_config
       io_resourceconfig            = lo_resource_config
-      io_stoppingcondition         = lo_stopping_condition
-    ).
+      io_stoppingcondition         = lo_stopping_condition ).
 
     "Wait for training job to be completed.
     lo_training_result = ao_sgm->describetrainingjob( iv_trainingjobname = lv_training_job_name ).
@@ -2121,17 +1908,13 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ENDWHILE.
 
     "Create an ABAP internal table for the container image based on input variables.
-    CREATE OBJECT lo_primarycontainer
-      EXPORTING
-        iv_image        = cv_container_image
-        iv_modeldataurl = lv_model_data_url.
+    lo_primarycontainer = NEW #( iv_image = cv_container_image
+                                 iv_modeldataurl = lv_model_data_url ).
 
     "Create a new model via so_sgm.
-    CALL METHOD ao_sgm->createmodel
-      EXPORTING
-        iv_modelname        = lv_model_name
-        iv_executionrolearn = av_lrole
-        io_primarycontainer = lo_primarycontainer.
+    ao_sgm->createmodel( iv_modelname = lv_model_name
+                                   iv_executionrolearn = av_lrole
+                                   io_primarycontainer = lo_primarycontainer ).
 
     "Create an endpoint.
     DATA lt_production_variants TYPE /aws1/cl_sgmproductionvariant=>tt_productionvariantlist.
@@ -2139,28 +1922,24 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_ep_config_result TYPE REF TO /aws1/cl_sgmcreateendptcfgout.
 
 
-    CREATE OBJECT lo_production_variants
-      EXPORTING
-        iv_variantname          = lv_endpoint_variant_name
-        iv_modelname            = lv_model_name
-        iv_initialinstancecount = cv_ep_initial_instance_count
-        iv_instancetype         = cv_ep_instance_type.
+    lo_production_variants = NEW #( iv_variantname = lv_endpoint_variant_name
+                                    iv_modelname = lv_model_name
+                                    iv_initialinstancecount = cv_ep_initial_instance_count
+                                    iv_instancetype = cv_ep_instance_type ).
 
     INSERT lo_production_variants INTO TABLE lt_production_variants.
 
     "Create an endpoint configuration.
     lo_ep_config_result = ao_sgm->createendpointconfig(
       iv_endpointconfigname = lv_endpoint_config_name
-      it_productionvariants = lt_production_variants
-    ).
+      it_productionvariants = lt_production_variants ).
 
     "Create an endpoint.
     lo_endpoint_output = ao_sgm->createendpoint(
         iv_endpointconfigname = lv_endpoint_config_name
-        iv_endpointname = lv_endpoint_name
-    ).
+        iv_endpointname = lv_endpoint_name ).
 
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     IF lo_endpoint_output->has_endpointarn( ) = 'X'.
       lv_found               = abap_true.
@@ -2168,8 +1947,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Endpoint not found|
-    ).
+      msg = |Endpoint not found| ).
 
     "Wait for endpoint creation to be completed.
     lo_endpoint_result = ao_sgm->describeendpoint( iv_endpointname = lv_endpoint_name ).
@@ -2184,15 +1962,13 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     "Testing.
     ao_sgm_actions->delete_endpoint(
         iv_endpoint_name = lv_endpoint_name
-        iv_endpoint_config_name = lv_endpoint_config_name
-    ).
+        iv_endpoint_config_name = lv_endpoint_config_name ).
 
     WAIT UP TO 30 SECONDS.
 
     "Check if endpoint exists.
     lo_endpoint_list_result = ao_sgm->listendpoints(
-      iv_namecontains = lv_endpoint_name
-    ).
+      iv_namecontains = lv_endpoint_name ).
 
     lv_found = abap_false.
 
@@ -2205,32 +1981,26 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_false(
       act = lv_found
-      msg = |Endpoint was not deleted|
-    ).
+      msg = |Endpoint was not deleted| ).
 
     "Cleaning up via ao_sgm.
     ao_sgm->deletemodel(
-        iv_modelname = lv_model_name
-    ).
+        iv_modelname = lv_model_name ).
 
     ao_s3->deleteobject(
       iv_bucket = lv_bucket_name
-      iv_key = cv_train_key
-    ).
+      iv_key = cv_train_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_val_key
-    ).
+        iv_key = cv_val_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = lv_model_key
-    ).
+        iv_key = lv_model_key ).
 
     ao_s3->deletebucket(
-        iv_bucket = lv_bucket_name
-    ).
+        iv_bucket = lv_bucket_name ).
 
 
   ENDMETHOD.
@@ -2240,27 +2010,25 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_list_result TYPE REF TO /aws1/cl_sgmlstnotebookinsts01.
     DATA lv_notebook_name TYPE /aws1/sgmnotebookinstancename.
     DATA lo_notebook_result TYPE REF TO /aws1/cl_sgmdscnotebookinstout.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
     CONSTANTS cv_instancetype TYPE /aws1/sgminstancetype VALUE 'ml.t3.medium'.
 
     "Define ARN.
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     "Define notebook name.
     lv_uuid_16 = cl_system_uuid=>create_uuid_x16_static( ).
-    lv_notebook_name =  'code-example-sgm-notebook-' && lv_uuid_16.
+    lv_notebook_name = 'code-example-sgm-notebook-' && lv_uuid_16.
 
     "Create a notebook instance.
     ao_sgm->createnotebookinstance(
-      EXPORTING
-        iv_notebookinstancename = lv_notebook_name
+      iv_notebookinstancename = lv_notebook_name
         iv_instancetype         = cv_instancetype
-        iv_rolearn              = av_lrole
-    ).
+        iv_rolearn              = av_lrole ).
 
     "Waiter.
     lo_notebook_result = ao_sgm->describenotebookinstance( iv_notebookinstancename = lv_notebook_name ).
@@ -2277,10 +2045,9 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
       EXPORTING
         iv_name_contains = lv_notebook_name
       IMPORTING
-        oo_result = lo_list_result
-    ).
+        oo_result = lo_list_result ).
 
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     LOOP AT lo_list_result->get_notebookinstances( ) INTO DATA(lo_notebook).
       IF lo_notebook->get_notebookinstancename( ) = lv_notebook_name.
@@ -2290,13 +2057,11 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Notebook cannot be found|
-    ).
+      msg = |Notebook cannot be found| ).
 
     "Stop notebook instance before deletion.
     ao_sgm->stopnotebookinstance(
-        iv_notebookinstancename = lv_notebook_name
-        ).
+        iv_notebookinstancename = lv_notebook_name ).
 
     "Waiter.
     lo_notebook_result = ao_sgm->describenotebookinstance( iv_notebookinstancename = lv_notebook_name ).
@@ -2310,8 +2075,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Delete notebook.
     ao_sgm->deletenotebookinstance(
-       iv_notebookinstancename = lv_notebook_name
-        ).
+       iv_notebookinstancename = lv_notebook_name ).
 
   ENDMETHOD.
 
@@ -2326,13 +2090,13 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_val_channel TYPE REF TO /aws1/cl_sgmchannel.
     DATA lo_val_datasource TYPE REF TO /aws1/cl_sgmdatasource.
     DATA lo_val_s3datasource TYPE REF TO /aws1/cl_sgms3datasource.
-    DATA lo_output_data_config TYPE REF TO  /aws1/cl_sgmoutputdataconfig.
+    DATA lo_output_data_config TYPE REF TO /aws1/cl_sgmoutputdataconfig.
     DATA lo_resource_config  TYPE REF TO /aws1/cl_sgmresourceconfig.
     DATA lo_algorithm_specification TYPE REF TO /aws1/cl_sgmalgorithmspec.
     DATA lo_list_result TYPE REF TO /aws1/cl_sgmlisttrnjobsrsp.
-    DATA lo_stopping_condition TYPE REF TO  /aws1/cl_sgmstoppingcondition.
+    DATA lo_stopping_condition TYPE REF TO /aws1/cl_sgmstoppingcondition.
     DATA lv_training_job_name TYPE /aws1/sgmtrainingjobname.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lo_result TYPE REF TO /aws1/cl_sgmcreatemodeloutput.
     DATA lv_model_name TYPE /aws1/sgmmodelname.
     DATA lv_model_data_url TYPE /aws1/sgmurl.
@@ -2348,7 +2112,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_model_list_result TYPE REF TO /aws1/cl_sgmlistmodelsoutput.
     DATA lo_tf_result TYPE REF TO /aws1/cl_sgmcretransformjobrsp.
     DATA lv_transform_job_name TYPE /aws1/sgmtransformjobname.
-    DATA lv_transform_data_s3uri TYPE   /aws1/sgms3uri.
+    DATA lv_transform_data_s3uri TYPE /aws1/sgms3uri.
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
     "Define Amazon S3 parameters.
@@ -2359,29 +2123,29 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     CONSTANTS cv_val_key TYPE /aws1/s3_objectkey VALUE 'sagemaker/validation/validation.libsvm'.
 
     "Define hyperparameters.
-    CONSTANTS cv_hp_max_depth TYPE   /aws1/sgmhyperparametervalue    VALUE '3'.
-    CONSTANTS cv_hp_scale_pos_weight TYPE   /aws1/sgmhyperparametervalue    VALUE '2.0'.
-    CONSTANTS cv_hp_num_round TYPE   /aws1/sgmhyperparametervalue    VALUE '100'.
-    CONSTANTS cv_hp_objective  TYPE  /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
-    CONSTANTS cv_hp_subsample TYPE   /aws1/sgmhyperparametervalue    VALUE '0.5'.
-    CONSTANTS cv_hp_eta TYPE  /aws1/sgmhyperparametervalue    VALUE   '0.1'.
-    CONSTANTS cv_hp_eval_metric TYPE   /aws1/sgmhyperparametervalue    VALUE 'auc'.
+    CONSTANTS cv_hp_max_depth TYPE /aws1/sgmhyperparametervalue    VALUE '3'.
+    CONSTANTS cv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue    VALUE '2.0'.
+    CONSTANTS cv_hp_num_round TYPE /aws1/sgmhyperparametervalue    VALUE '100'.
+    CONSTANTS cv_hp_objective  TYPE /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
+    CONSTANTS cv_hp_subsample TYPE /aws1/sgmhyperparametervalue    VALUE '0.5'.
+    CONSTANTS cv_hp_eta TYPE /aws1/sgmhyperparametervalue    VALUE '0.1'.
+    CONSTANTS cv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue    VALUE 'auc'.
 
     "Define training data.
-    CONSTANTS cv_trn_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_trn_data_s3datadistribution TYPE  /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
-    CONSTANTS cv_trn_data_compressiontype TYPE  /aws1/sgmcompressiontype     VALUE 'None'.
-    CONSTANTS cv_trn_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_trn_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
+    CONSTANTS cv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype     VALUE 'None'.
+    CONSTANTS cv_trn_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define validation data.
-    CONSTANTS cv_val_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_val_data_s3datadistribution TYPE  /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
-    CONSTANTS cv_val_data_compressiontype TYPE   /aws1/sgmcompressiontype    VALUE 'None'.
-    CONSTANTS cv_val_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_val_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
+    CONSTANTS cv_val_data_compressiontype TYPE /aws1/sgmcompressiontype    VALUE 'None'.
+    CONSTANTS cv_val_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define training parameters.
     CONSTANTS cv_training_image TYPE /aws1/sgmalgorithmimage VALUE '123456789012.abc.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.5-1'.
-    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE  'File'.
+    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE 'File'.
     CONSTANTS cv_instance_count TYPE /aws1/sgmtraininginstancecount VALUE '1'.
     CONSTANTS cv_instance_type TYPE /aws1/sgmtraininginstancetype VALUE 'ml.c4.2xlarge'.
     CONSTANTS cv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb VALUE '10'.
@@ -2389,9 +2153,9 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     CONSTANTS cv_max_results TYPE /aws1/sgmmaxresults VALUE '1'.
 
     "Define transform data.
-    CONSTANTS cv_tf_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_tf_data_compressiontype TYPE  /aws1/sgmcompressiontype     VALUE 'None'.
-    CONSTANTS cv_tf_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_tf_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_tf_data_compressiontype TYPE /aws1/sgmcompressiontype     VALUE 'None'.
+    CONSTANTS cv_tf_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define transform parameters.
     CONSTANTS cv_tf_instance_count TYPE /aws1/sgmtraininginstancecount VALUE '1'.
@@ -2399,7 +2163,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Define role ARN.
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     "Define job name.
@@ -2418,7 +2182,10 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     "Create training data in Amazon S3.
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
+
 
     lv_trn_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_train_key.
     lv_val_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_val_key.
@@ -2431,106 +2198,83 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ao_s3->putobject(
       iv_bucket = lv_bucket_name
       iv_key = cv_train_key
-      iv_body = av_file_content
-    ).
+      iv_body = av_file_content ).
 
     ao_s3->putobject(
           iv_bucket = lv_bucket_name
           iv_key = cv_val_key
-          iv_body = av_file_content
-    ).
+          iv_body = av_file_content ).
 
     ao_s3->putobject(
           iv_bucket = lv_bucket_name
           iv_key = cv_transform_key
-          iv_body = av_file_content
-    ).
+          iv_body = av_file_content ).
 
     "Create ABAP internal table for hyperparameters based on input variables.
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_max_depth.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_max_depth ).
     INSERT VALUE #( key = 'max_depth' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eta.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eta ).
     INSERT VALUE #( key = 'eta' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_eval_metric.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_eval_metric ).
     INSERT VALUE #( key = 'eval_metric' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_scale_pos_weight.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_scale_pos_weight ).
     INSERT VALUE #( key = 'scale_pos_weight' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_subsample.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_subsample ).
     INSERT VALUE #( key = 'subsample' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_objective.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_objective ).
     INSERT VALUE #( key = 'objective' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = cv_hp_num_round.
+    lo_hyperparameters_w = NEW #( iv_value = cv_hp_num_round ).
     INSERT VALUE #( key = 'num_round' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
     "Create ABAP internal table for data based on input variables.
     "Training data.
-    CREATE OBJECT lo_trn_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_trn_data_s3datatype
-        iv_s3datadistributiontype = cv_trn_data_s3datadistribution
-        iv_s3uri                  = lv_trn_data_s3uri.
+    lo_trn_s3datasource = NEW #( iv_s3datatype = cv_trn_data_s3datatype
+                                 iv_s3datadistributiontype = cv_trn_data_s3datadistribution
+                                 iv_s3uri = lv_trn_data_s3uri ).
 
-    CREATE OBJECT lo_trn_datasource
-      EXPORTING
-        io_s3datasource = lo_trn_s3datasource.
+    lo_trn_datasource = NEW #( io_s3datasource = lo_trn_s3datasource ).
 
-    CREATE OBJECT lo_trn_channel
-      EXPORTING
-        iv_channelname     = 'train'
-        io_datasource      = lo_trn_datasource
-        iv_compressiontype = cv_trn_data_compressiontype
-        iv_contenttype     = cv_trn_data_contenttype.
+    lo_trn_channel = NEW #( iv_channelname = 'train'
+                            io_datasource = lo_trn_datasource
+                            iv_compressiontype = cv_trn_data_compressiontype
+                            iv_contenttype = cv_trn_data_contenttype ).
 
     INSERT lo_trn_channel INTO TABLE lt_input_data_config.
 
     "Validation data.
-    CREATE OBJECT lo_val_s3datasource
-      EXPORTING
-        iv_s3datatype             = cv_val_data_s3datatype
-        iv_s3datadistributiontype = cv_val_data_s3datadistribution
-        iv_s3uri                  = lv_val_data_s3uri.
+    lo_val_s3datasource = NEW #( iv_s3datatype = cv_val_data_s3datatype
+                                 iv_s3datadistributiontype = cv_val_data_s3datadistribution
+                                 iv_s3uri = lv_val_data_s3uri ).
 
-    CREATE OBJECT lo_val_datasource
-      EXPORTING
-        io_s3datasource = lo_val_s3datasource.
+    lo_val_datasource = NEW #( io_s3datasource = lo_val_s3datasource ).
 
-    CREATE OBJECT lo_val_channel
-      EXPORTING
-        iv_channelname     = 'validation'
-        io_datasource      = lo_val_datasource
-        iv_compressiontype = cv_val_data_compressiontype
-        iv_contenttype     = cv_val_data_contenttype.
+    lo_val_channel = NEW #( iv_channelname = 'validation'
+                            io_datasource = lo_val_datasource
+                            iv_compressiontype = cv_val_data_compressiontype
+                            iv_contenttype = cv_val_data_contenttype ).
 
     INSERT lo_val_channel INTO TABLE lt_input_data_config.
 
     "Create an ABAP object for algorithm specification based on input variables.
-    CREATE OBJECT lo_algorithm_specification
-      EXPORTING
-        iv_trainingimage     = cv_training_image
-        iv_traininginputmode = cv_training_input_mode.
+    lo_algorithm_specification = NEW #( iv_trainingimage = cv_training_image
+                                        iv_traininginputmode = cv_training_input_mode ).
 
     "Create an ABAP object for resource configuration.
-    CREATE OBJECT lo_resource_config
-      EXPORTING
-        iv_instancecount  = cv_instance_count
-        iv_instancetype   = cv_instance_type
-        iv_volumesizeingb = cv_volume_sizeingb.
+    lo_resource_config = NEW #( iv_instancecount = cv_instance_count
+                                iv_instancetype = cv_instance_type
+                                iv_volumesizeingb = cv_volume_sizeingb ).
 
     "Create an ABAP object for output data configuration.
-    CREATE OBJECT lo_output_data_config
-      EXPORTING
-        iv_s3outputpath = lv_s3_output_path.
+    lo_output_data_config = NEW #( iv_s3outputpath = lv_s3_output_path ).
 
     "Create an ABAP object for stopping condition.
-    CREATE OBJECT lo_stopping_condition
-      EXPORTING
-        iv_maxruntimeinseconds = cv_max_runtime_in_seconds.
+    lo_stopping_condition = NEW #( iv_maxruntimeinseconds = cv_max_runtime_in_seconds ).
 
     "Create a training job.
     ao_sgm->createtrainingjob(
@@ -2541,8 +2285,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
       io_algorithmspecification    = lo_algorithm_specification
       io_outputdataconfig          = lo_output_data_config
       io_resourceconfig            = lo_resource_config
-      io_stoppingcondition         = lo_stopping_condition
-    ).
+      io_stoppingcondition         = lo_stopping_condition ).
 
     "Wait for training job to be completed.
     lo_training_result = ao_sgm->describetrainingjob( iv_trainingjobname = lv_training_job_name ).
@@ -2555,17 +2298,13 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     ENDWHILE.
 
     "Create an ABAP object for the container image based on input variables.
-    CREATE OBJECT lo_primarycontainer
-      EXPORTING
-        iv_image        = cv_container_image
-        iv_modeldataurl = lv_model_data_url.
+    lo_primarycontainer = NEW #( iv_image = cv_container_image
+                                 iv_modeldataurl = lv_model_data_url ).
 
     "Create a new model.
-    CALL METHOD ao_sgm->createmodel
-      EXPORTING
-        iv_modelname        = lv_model_name
-        iv_executionrolearn = av_lrole
-        io_primarycontainer = lo_primarycontainer.
+    ao_sgm->createmodel( iv_modelname = lv_model_name
+                                   iv_executionrolearn = av_lrole
+                                   io_primarycontainer = lo_primarycontainer ).
 
     ao_sgm_actions->create_transform_job(
       EXPORTING
@@ -2579,10 +2318,9 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
         iv_instance_type            = cv_tf_instance_type
         iv_s3_output_path           = lv_s3_transform_output_path
       IMPORTING
-       oo_result              = lo_tf_result
-    ).
+       oo_result              = lo_tf_result ).
 
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     IF lo_tf_result->has_transformjobarn( ) = 'X'.
       lv_found               = abap_true.
@@ -2590,39 +2328,32 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
        act                    = lv_found
-       msg                    = |Transform Job cannot be found|
-    ).
+       msg                    = |Transform Job cannot be found| ).
 
     "Transform jobs and logs cannot be deleted and are retained indefinitely.
 
     "Clean up.
     ao_sgm->deletemodel(
-        iv_modelname = lv_model_name
-    ).
+        iv_modelname = lv_model_name ).
 
     ao_s3->deleteobject(
       iv_bucket = lv_bucket_name
-      iv_key = cv_train_key
-    ).
+      iv_key = cv_train_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_val_key
-    ).
+        iv_key = cv_val_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_transform_key
-    ).
+        iv_key = cv_transform_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = lv_model_key
-    ).
+        iv_key = lv_model_key ).
 
     ao_s3->deletebucket(
-        iv_bucket = lv_bucket_name
-    ).
+        iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 
@@ -2631,9 +2362,9 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lv_algorithm_name TYPE /aws1/sgmentityname.
     DATA lo_trainingspecification  TYPE REF TO /aws1/cl_sgmtrainingspec.
     DATA lo_sgmchannelspec TYPE REF TO /aws1/cl_sgmchannelspec.
-    DATA lt_sgmchannelspec  TYPE  /aws1/cl_sgmchannelspec=>tt_channelspecifications.
+    DATA lt_sgmchannelspec  TYPE /aws1/cl_sgmchannelspec=>tt_channelspecifications.
     DATA lo_sgmtrninstancetypes_w TYPE REF TO /aws1/cl_sgmtrninstancetypes_w.
-    DATA lt_supportedtrninstancetypes TYPE  /aws1/cl_sgmtrninstancetypes_w=>tt_traininginstancetypes.
+    DATA lt_supportedtrninstancetypes TYPE /aws1/cl_sgmtrninstancetypes_w=>tt_traininginstancetypes.
     DATA lo_algorithms_result TYPE REF TO /aws1/cl_sgmlistalgsoutput.
     DATA lv_instance_type TYPE /aws1/sgmtraininginstancetype.
     DATA lo_sgmcontenttypes_w TYPE REF TO /aws1/cl_sgmcontenttypes_w.
@@ -2643,7 +2374,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     DATA lo_supportedinputmodes TYPE REF TO /aws1/cl_sgminputmodes_w.
     DATA lt_supportedinputmodes TYPE /aws1/cl_sgminputmodes_w=>tt_inputmodes.
     DATA lo_des_algorithm_result TYPE REF TO /aws1/cl_sgmdescribealgoutput.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lv_uuid_16 TYPE sysuuid_x16.
 
     CONSTANTS cv_container_image TYPE /aws1/sgmcontainerimage VALUE '123456789012.abc.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.5-1'.
@@ -2654,50 +2385,44 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
     TRANSLATE lv_algorithm_name TO LOWER CASE.
 
     "Define training specification.
-    CREATE OBJECT lo_sgmtrninstancetypes_w EXPORTING iv_value = 'ml.m5.large'.
+    lo_sgmtrninstancetypes_w = NEW #( iv_value = 'ml.m5.large' ).
     INSERT lo_sgmtrninstancetypes_w  INTO TABLE lt_supportedtrninstancetypes.
 
-    CREATE OBJECT lo_sgmcontenttypes_w EXPORTING iv_value = 'S3Prefix'.
+    lo_sgmcontenttypes_w = NEW #( iv_value = 'S3Prefix' ).
     INSERT lo_sgmcontenttypes_w  INTO TABLE lt_supportedcontenttypes.
 
-    CREATE OBJECT lo_sgmcompressiontypes_w EXPORTING iv_value = 'None'.
+    lo_sgmcompressiontypes_w = NEW #( iv_value = 'None' ).
     INSERT lo_sgmcompressiontypes_w  INTO TABLE lt_supportedcompressiontypes.
 
-    CREATE OBJECT lo_supportedinputmodes EXPORTING iv_value = 'File'.
-    INSERT lo_supportedinputmodes  INTO TABLE lt_supportedinputmodes .
+    lo_supportedinputmodes = NEW #( iv_value = 'File' ).
+    INSERT lo_supportedinputmodes  INTO TABLE lt_supportedinputmodes.
 
-    CREATE OBJECT lo_sgmchannelspec
-      EXPORTING
-        iv_name                      = 'train'
-        it_supportedcontenttypes     = lt_supportedcontenttypes
-        it_supportedcompressiontypes = lt_supportedcompressiontypes
-        it_supportedinputmodes       = lt_supportedinputmodes
-        iv_isrequired                = ' '.
+    lo_sgmchannelspec = NEW #( iv_name = 'train'
+                               it_supportedcontenttypes = lt_supportedcontenttypes
+                               it_supportedcompressiontypes = lt_supportedcompressiontypes
+                               it_supportedinputmodes = lt_supportedinputmodes
+                               iv_isrequired = ' ' ).
 
     INSERT lo_sgmchannelspec INTO TABLE lt_sgmchannelspec.
 
-    CREATE OBJECT lo_trainingspecification
-      EXPORTING
-        iv_trainingimage             = cv_container_image
-        it_supportedtrninstancetypes = lt_supportedtrninstancetypes
-        it_trainingchannels          = lt_sgmchannelspec.
+    lo_trainingspecification = NEW #( iv_trainingimage = cv_container_image
+                                      it_supportedtrninstancetypes = lt_supportedtrninstancetypes
+                                      it_trainingchannels = lt_sgmchannelspec ).
 
     "Create algorithm.
     ao_sgm->createalgorithm(
           iv_algorithmname           = lv_algorithm_name
-          io_trainingspecification   = lo_trainingspecification
-      ).
+          io_trainingspecification   = lo_trainingspecification ).
 
     "Testing list algorithm.
     ao_sgm_actions->list_algorithms(
-     EXPORTING
+      EXPORTING
       iv_name_contains       = lv_algorithm_name
-     IMPORTING
-      oo_result             = lo_algorithms_result
-      ).
+      IMPORTING
+      oo_result             = lo_algorithms_result ).
 
     "Validation.
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     LOOP AT lo_algorithms_result->get_algorithmsummarylist( ) INTO DATA(lo_algorithms).
       IF lo_algorithms->get_algorithmname( ) = lv_algorithm_name.
@@ -2707,8 +2432,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Algorithm cannot be found|
-    ).
+      msg = |Algorithm cannot be found| ).
 
     "Waiter.
     lo_des_algorithm_result = ao_sgm->describealgorithm( iv_algorithmname = lv_algorithm_name ).
@@ -2722,9 +2446,7 @@ CLASS ltc_zcl_aws1_sgm_actions IMPLEMENTATION.
 
     "Clean up.
     ao_sgm->deletealgorithm(
-     EXPORTING
-      iv_algorithmname       = lv_algorithm_name
-      ).
+      iv_algorithmname       = lv_algorithm_name ).
 
   ENDMETHOD.
 

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.abap
@@ -1,51 +1,51 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_SGM_SCENARIO definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_sgm_scenario DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods GETTING_STARTED_WITH_SGM
-    importing
-      !IV_TRAINING_JOB_NAME type /AWS1/SGMTRAININGJOBNAME
-      !IV_ROLE_ARN type /AWS1/SGMROLEARN
-      !IV_TRN_DATA_S3DATATYPE type /AWS1/SGMS3DATATYPE
-      !IV_TRN_DATA_S3DATADISTRIBUTION type /AWS1/SGMS3DATADISTRIBUTION
-      !IV_TRN_DATA_S3URI type /AWS1/SGMS3URI
-      !IV_TRN_DATA_COMPRESSIONTYPE type /AWS1/SGMCOMPRESSIONTYPE
-      !IV_TRN_DATA_CONTENTTYPE type /AWS1/SGMCONTENTTYPE
-      !IV_VAL_DATA_S3DATATYPE type /AWS1/SGMS3DATATYPE
-      !IV_VAL_DATA_S3DATADISTRIBUTION type /AWS1/SGMS3DATADISTRIBUTION
-      !IV_VAL_DATA_S3URI type /AWS1/SGMS3URI
-      !IV_VAL_DATA_COMPRESSIONTYPE type /AWS1/SGMCOMPRESSIONTYPE
-      !IV_VAL_DATA_CONTENTTYPE type /AWS1/SGMCONTENTTYPE
-      !IV_HP_MAX_DEPTH type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_SCALE_POS_WEIGHT type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_NUM_ROUND type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_OBJECTIVE type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_SUBSAMPLE type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_EVAL_METRIC type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_HP_ETA type /AWS1/SGMHYPERPARAMETERVALUE
-      !IV_TRAINING_IMAGE type /AWS1/SGMALGORITHMIMAGE
-      !IV_TRAINING_INPUT_MODE type /AWS1/SGMTRAININGINPUTMODE
-      !IV_INSTANCE_COUNT type /AWS1/SGMTRAININGINSTANCECOUNT
-      !IV_INSTANCE_TYPE type /AWS1/SGMTRAININGINSTANCETYPE
-      !IV_VOLUME_SIZEINGB type /AWS1/SGMVOLUMESIZEINGB
-      !IV_S3_OUTPUT_PATH type /AWS1/SGMS3URI
-      !IV_MAX_RUNTIME_IN_SECONDS type /AWS1/SGMMAXRUNTIMEINSECONDS
-      !IV_EP_INSTANCE_TYPE type /AWS1/SGMINSTANCETYPE
-      !IV_EP_INITIAL_INSTANCE_COUNT type /AWS1/SGMINITIALTASKCOUNT
-      !IV_MODEL_NAME type /AWS1/SGMMODELNAME
-      !IV_EP_NAME type /AWS1/SGMENDPOINTNAME
-      !IV_EP_CFG_NAME type /AWS1/SGMENDPOINTCONFIGNAME
-      !IV_EP_VARIANT_NAME type /AWS1/SGMVARIANTNAME
-    exporting
-      !OO_EP_OUTPUT type ref to /AWS1/CL_SGMCREATEENDPTOUTPUT .
-protected section.
-private section.
+    METHODS getting_started_with_sgm
+      IMPORTING
+      !iv_training_job_name TYPE /aws1/sgmtrainingjobname
+      !iv_role_arn TYPE /aws1/sgmrolearn
+      !iv_trn_data_s3datatype TYPE /aws1/sgms3datatype
+      !iv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution
+      !iv_trn_data_s3uri TYPE /aws1/sgms3uri
+      !iv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype
+      !iv_trn_data_contenttype TYPE /aws1/sgmcontenttype
+      !iv_val_data_s3datatype TYPE /aws1/sgms3datatype
+      !iv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution
+      !iv_val_data_s3uri TYPE /aws1/sgms3uri
+      !iv_val_data_compressiontype TYPE /aws1/sgmcompressiontype
+      !iv_val_data_contenttype TYPE /aws1/sgmcontenttype
+      !iv_hp_max_depth TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_num_round TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_objective TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_subsample TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue
+      !iv_hp_eta TYPE /aws1/sgmhyperparametervalue
+      !iv_training_image TYPE /aws1/sgmalgorithmimage
+      !iv_training_input_mode TYPE /aws1/sgmtraininginputmode
+      !iv_instance_count TYPE /aws1/sgmtraininginstancecount
+      !iv_instance_type TYPE /aws1/sgmtraininginstancetype
+      !iv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb
+      !iv_s3_output_path TYPE /aws1/sgms3uri
+      !iv_max_runtime_in_seconds TYPE /aws1/sgmmaxruntimeinseconds
+      !iv_ep_instance_type TYPE /aws1/sgminstancetype
+      !iv_ep_initial_instance_count TYPE /aws1/sgminitialtaskcount
+      !iv_model_name TYPE /aws1/sgmmodelname
+      !iv_ep_name TYPE /aws1/sgmendpointname
+      !iv_ep_cfg_name TYPE /aws1/sgmendpointconfigname
+      !iv_ep_variant_name TYPE /aws1/sgmvariantname
+      EXPORTING
+      !oo_ep_output TYPE REF TO /aws1/cl_sgmcreateendptoutput .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -54,7 +54,7 @@ CLASS ZCL_AWS1_SGM_SCENARIO IMPLEMENTATION.
 
 
   METHOD getting_started_with_sgm.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sgm) = /aws1/cl_sgm_factory=>create( lo_session ).
@@ -79,8 +79,8 @@ CLASS ZCL_AWS1_SGM_SCENARIO IMPLEMENTATION.
     DATA lo_val_s3datasource TYPE REF TO /aws1/cl_sgms3datasource.
     DATA lo_algorithm_specification TYPE REF TO /aws1/cl_sgmalgorithmspec.
     DATA lo_resource_config  TYPE REF TO /aws1/cl_sgmresourceconfig.
-    DATA lo_output_data_config TYPE REF TO  /aws1/cl_sgmoutputdataconfig.
-    DATA lo_stopping_condition TYPE REF TO  /aws1/cl_sgmstoppingcondition.
+    DATA lo_output_data_config TYPE REF TO /aws1/cl_sgmoutputdataconfig.
+    DATA lo_stopping_condition TYPE REF TO /aws1/cl_sgmstoppingcondition.
     DATA lo_primarycontainer TYPE REF TO /aws1/cl_sgmcontainerdefn.
     DATA lo_production_variants TYPE REF TO /aws1/cl_sgmproductionvariant.
     DATA lo_ep_config_result TYPE REF TO /aws1/cl_sgmcreateendptcfgout.
@@ -94,80 +94,68 @@ CLASS ZCL_AWS1_SGM_SCENARIO IMPLEMENTATION.
 
     "Create ABAP internal table for hyperparameters based on input variables."
     "These hyperparameters are based on Amazon SageMaker built-in algorithm - XGBoost"
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_max_depth.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_max_depth ).
     INSERT VALUE #( key = 'max_depth' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_eta.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_eta ).
     INSERT VALUE #( key = 'eta' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_eval_metric.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_eval_metric ).
     INSERT VALUE #( key = 'eval_metric' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_scale_pos_weight.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_scale_pos_weight ).
     INSERT VALUE #( key = 'scale_pos_weight' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_subsample.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_subsample ).
     INSERT VALUE #( key = 'subsample' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_objective.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_objective ).
     INSERT VALUE #( key = 'objective' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
-    CREATE OBJECT lo_hyperparameters_w EXPORTING iv_value = iv_hp_num_round.
+    lo_hyperparameters_w = NEW #( iv_value = iv_hp_num_round ).
     INSERT VALUE #( key = 'num_round' value = lo_hyperparameters_w )  INTO TABLE lt_hyperparameters.
 
     "Create ABAP internal table for data based on input variables."
     "Training data."
-    CREATE OBJECT lo_trn_s3datasource
-      EXPORTING
-        iv_s3datatype             = iv_trn_data_s3datatype
-        iv_s3datadistributiontype = iv_trn_data_s3datadistribution
-        iv_s3uri                  = iv_trn_data_s3uri.
+    lo_trn_s3datasource = NEW #( iv_s3datatype = iv_trn_data_s3datatype
+                                 iv_s3datadistributiontype = iv_trn_data_s3datadistribution
+                                 iv_s3uri = iv_trn_data_s3uri ).
 
-    CREATE OBJECT lo_trn_datasource EXPORTING io_s3datasource = lo_trn_s3datasource.
+    lo_trn_datasource = NEW #( io_s3datasource = lo_trn_s3datasource ).
 
-    CREATE OBJECT lo_trn_channel
-      EXPORTING
-        iv_channelname     = 'train'
-        io_datasource      = lo_trn_datasource
-        iv_compressiontype = iv_trn_data_compressiontype
-        iv_contenttype     = iv_trn_data_contenttype.
+    lo_trn_channel = NEW #( iv_channelname = 'train'
+                            io_datasource = lo_trn_datasource
+                            iv_compressiontype = iv_trn_data_compressiontype
+                            iv_contenttype = iv_trn_data_contenttype ).
     INSERT lo_trn_channel INTO TABLE lt_input_data_config.
 
     "Validation data."
-    CREATE OBJECT lo_val_s3datasource
-      EXPORTING
-        iv_s3datatype             = iv_val_data_s3datatype
-        iv_s3datadistributiontype = iv_val_data_s3datadistribution
-        iv_s3uri                  = iv_val_data_s3uri.
+    lo_val_s3datasource = NEW #( iv_s3datatype = iv_val_data_s3datatype
+                                 iv_s3datadistributiontype = iv_val_data_s3datadistribution
+                                 iv_s3uri = iv_val_data_s3uri ).
 
-    CREATE OBJECT lo_val_datasource EXPORTING io_s3datasource = lo_val_s3datasource.
+    lo_val_datasource = NEW #( io_s3datasource = lo_val_s3datasource ).
 
-    CREATE OBJECT lo_val_channel
-      EXPORTING
-        iv_channelname     = 'validation'
-        io_datasource      = lo_val_datasource
-        iv_compressiontype = iv_val_data_compressiontype
-        iv_contenttype     = iv_val_data_contenttype.
+    lo_val_channel = NEW #( iv_channelname = 'validation'
+                            io_datasource = lo_val_datasource
+                            iv_compressiontype = iv_val_data_compressiontype
+                            iv_contenttype = iv_val_data_contenttype ).
     INSERT lo_val_channel INTO TABLE lt_input_data_config.
 
     "Create an ABAP object for algorithm specification based on input variables."
-    CREATE OBJECT lo_algorithm_specification
-      EXPORTING
-        iv_trainingimage     = iv_training_image
-        iv_traininginputmode = iv_training_input_mode.
+    lo_algorithm_specification = NEW #( iv_trainingimage = iv_training_image
+                                        iv_traininginputmode = iv_training_input_mode ).
 
     "Create an ABAP object for resource configuration."
-    CREATE OBJECT lo_resource_config
-      EXPORTING
-        iv_instancecount  = iv_instance_count
-        iv_instancetype   = iv_instance_type
-        iv_volumesizeingb = iv_volume_sizeingb.
+    lo_resource_config = NEW #( iv_instancecount = iv_instance_count
+                                iv_instancetype = iv_instance_type
+                                iv_volumesizeingb = iv_volume_sizeingb ).
 
     "Create an ABAP object for output data configuration."
-    CREATE OBJECT lo_output_data_config EXPORTING iv_s3outputpath = iv_s3_output_path.
+    lo_output_data_config = NEW #( iv_s3outputpath = iv_s3_output_path ).
 
     "Create an ABAP object for stopping condition."
-    CREATE OBJECT lo_stopping_condition EXPORTING iv_maxruntimeinseconds = iv_max_runtime_in_seconds.
+    lo_stopping_condition = NEW #( iv_maxruntimeinseconds = iv_max_runtime_in_seconds ).
 
     TRY.
         lo_sgm->createtrainingjob(
@@ -178,8 +166,7 @@ CLASS ZCL_AWS1_SGM_SCENARIO IMPLEMENTATION.
           io_algorithmspecification    = lo_algorithm_specification
           io_outputdataconfig          = lo_output_data_config
           io_resourceconfig            = lo_resource_config
-          io_stoppingcondition         = lo_stopping_condition
-        ).
+          io_stoppingcondition         = lo_stopping_condition ).
         MESSAGE 'Training job created.' TYPE 'I'.
       CATCH /aws1/cx_sgmresourceinuse.
         MESSAGE 'Resource being accessed is in use.' TYPE 'E'.
@@ -200,45 +187,38 @@ CLASS ZCL_AWS1_SGM_SCENARIO IMPLEMENTATION.
     ENDWHILE.
 
     "Create ABAP object for the container image based on input variables."
-    CREATE OBJECT lo_primarycontainer
-      EXPORTING
-        iv_image        = iv_training_image
-        iv_modeldataurl = lv_model_data_url.
+    lo_primarycontainer = NEW #( iv_image = iv_training_image
+                                 iv_modeldataurl = lv_model_data_url ).
 
     "Create an Amazon SageMaker model."
     TRY.
         lo_sgm->createmodel(
           iv_executionrolearn = iv_role_arn
           iv_modelname = iv_model_name
-          io_primarycontainer = lo_primarycontainer
-        ).
+          io_primarycontainer = lo_primarycontainer ).
         MESSAGE 'Model created.' TYPE 'I'.
       CATCH /aws1/cx_sgmresourcelimitexcd.
         MESSAGE 'You have reached the limit on the number of resources.' TYPE 'E'.
     ENDTRY.
 
     "Create an endpoint production variant."
-    CREATE OBJECT lo_production_variants
-      EXPORTING
-        iv_variantname          = iv_ep_variant_name
-        iv_modelname            = iv_model_name
-        iv_initialinstancecount = iv_ep_initial_instance_count
-        iv_instancetype         = iv_ep_instance_type.
+    lo_production_variants = NEW #( iv_variantname = iv_ep_variant_name
+                                    iv_modelname = iv_model_name
+                                    iv_initialinstancecount = iv_ep_initial_instance_count
+                                    iv_instancetype = iv_ep_instance_type ).
     INSERT lo_production_variants INTO TABLE lt_production_variants.
 
     TRY.
         "Create an endpoint configuration."
         lo_ep_config_result = lo_sgm->createendpointconfig(
           iv_endpointconfigname = iv_ep_cfg_name
-          it_productionvariants = lt_production_variants
-        ).
+          it_productionvariants = lt_production_variants ).
         MESSAGE 'Endpoint configuration created.' TYPE 'I'.
 
         "Create an endpoint."
         oo_ep_output = lo_sgm->createendpoint(        " oo_ep_output is returned for testing purposes. "
             iv_endpointconfigname = iv_ep_cfg_name
-            iv_endpointname = iv_ep_name
-        ).
+            iv_endpointname = iv_ep_name ).
         MESSAGE 'Endpoint created.' TYPE 'I'.
       CATCH /aws1/cx_sgmresourcelimitexcd.
         MESSAGE 'You have reached the limit on the number of resources.' TYPE 'E'.
@@ -257,20 +237,17 @@ CLASS ZCL_AWS1_SGM_SCENARIO IMPLEMENTATION.
     TRY.
         "Delete an endpoint."
         lo_sgm->deleteendpoint(
-            iv_endpointname = iv_ep_name
-        ).
+            iv_endpointname = iv_ep_name ).
         MESSAGE 'Endpoint deleted' TYPE 'I'.
 
         "Delete an endpoint configuration."
         lo_sgm->deleteendpointconfig(
-          iv_endpointconfigname = iv_ep_cfg_name
-        ).
+          iv_endpointconfigname = iv_ep_cfg_name ).
         MESSAGE 'Endpoint configuration deleted.' TYPE 'I'.
 
         "Delete model."
         lo_sgm->deletemodel(
-                  iv_modelname = iv_model_name
-                ).
+                  iv_modelname = iv_model_name ).
         MESSAGE 'Model deleted.' TYPE 'I'.
       CATCH /aws1/cx_rt_service_generic INTO DATA(lo_endpointconfig_exception).
         DATA(lv_endpointconfig_error) = |"{ lo_endpointconfig_exception->av_err_code }" - { lo_endpointconfig_exception->av_err_msg }|.

--- a/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.testclasses.abap
+++ b/sap-abap/services/sagemaker/zcl_aws1_sgm_scenario.clas.testclasses.abap
@@ -4,11 +4,11 @@
 CLASS ltc_zcl_aws1_sgm_scenario DEFINITION DEFERRED.
 CLASS zcl_aws1_sgm_scenario DEFINITION LOCAL FRIENDS ltc_zcl_aws1_sgm_scenario.
 
-CLASS ltc_zcl_aws1_sgm_scenario DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_sgm_scenario DEFINITION FOR TESTING DURATION LONG RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA ao_sgm TYPE REF TO /aws1/if_sgm.
     DATA ao_s3 TYPE REF TO /aws1/if_s3.
@@ -17,7 +17,7 @@ CLASS ltc_zcl_aws1_sgm_scenario DEFINITION FOR TESTING DURATION LONG RISK LEVEL 
     DATA av_lrole TYPE /aws1/sgmrolearn.
 
     METHODS getting_started_scenario FOR TESTING RAISING /aws1/cx_rt_generic.
-    METHODS setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
 
 ENDCLASS.       "ltc_Zcl_Aws1_Sgm_Scenario
 
@@ -35,7 +35,7 @@ CLASS ltc_zcl_aws1_sgm_scenario IMPLEMENTATION.
 
     "This test case runs a training job for sales prediction using the built-in algorithm XGBoost.
 
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     DATA lv_timestamp TYPE timestamp.
     DATA lo_ep_output TYPE REF TO /aws1/cl_sgmcreateendptoutput.
     DATA lv_endpoint_name TYPE /aws1/sgmendpointname.
@@ -53,30 +53,30 @@ CLASS ltc_zcl_aws1_sgm_scenario IMPLEMENTATION.
     CONSTANTS cv_training_job_name TYPE /aws1/sgmtrainingjobname VALUE 'code-example-trn-job-'.
 
     "Define hyperparameters.
-    CONSTANTS cv_hp_max_depth TYPE   /aws1/sgmhyperparametervalue    VALUE '3'.
-    CONSTANTS cv_hp_scale_pos_weight TYPE   /aws1/sgmhyperparametervalue    VALUE '2.0'.
-    CONSTANTS cv_hp_num_round TYPE   /aws1/sgmhyperparametervalue    VALUE '100'.
-    CONSTANTS cv_hp_objective	TYPE  /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
-    CONSTANTS cv_hp_subsample TYPE   /aws1/sgmhyperparametervalue    VALUE '0.5'.
-    CONSTANTS cv_hp_eta TYPE  /aws1/sgmhyperparametervalue    VALUE	 '0.1'.
-    CONSTANTS cv_hp_eval_metric TYPE   /aws1/sgmhyperparametervalue    VALUE 'auc'.
+    CONSTANTS cv_hp_max_depth TYPE /aws1/sgmhyperparametervalue    VALUE '3'.
+    CONSTANTS cv_hp_scale_pos_weight TYPE /aws1/sgmhyperparametervalue    VALUE '2.0'.
+    CONSTANTS cv_hp_num_round TYPE /aws1/sgmhyperparametervalue    VALUE '100'.
+    CONSTANTS cv_hp_objective TYPE /aws1/sgmhyperparametervalue     VALUE 'binary:logistic'.
+    CONSTANTS cv_hp_subsample TYPE /aws1/sgmhyperparametervalue    VALUE '0.5'.
+    CONSTANTS cv_hp_eta TYPE /aws1/sgmhyperparametervalue    VALUE '0.1'.
+    CONSTANTS cv_hp_eval_metric TYPE /aws1/sgmhyperparametervalue    VALUE 'auc'.
 
     "Define training data.
-    CONSTANTS cv_trn_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_trn_data_s3datadistribution TYPE  /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
-    CONSTANTS cv_trn_data_compressiontype TYPE  /aws1/sgmcompressiontype     VALUE 'None'.
-    CONSTANTS cv_trn_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_trn_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_trn_data_s3datadistribution TYPE /aws1/sgms3datadistribution        VALUE 'FullyReplicated'.
+    CONSTANTS cv_trn_data_compressiontype TYPE /aws1/sgmcompressiontype     VALUE 'None'.
+    CONSTANTS cv_trn_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define validation data.
-    CONSTANTS cv_val_data_s3datatype TYPE  /aws1/sgms3datatype       VALUE 'S3Prefix'.
-    CONSTANTS cv_val_data_s3datadistribution TYPE  /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
-    CONSTANTS cv_val_data_compressiontype TYPE   /aws1/sgmcompressiontype    VALUE 'None'.
-    CONSTANTS cv_val_data_contenttype TYPE   /aws1/sgmcontenttype    VALUE 'libsvm'.
+    CONSTANTS cv_val_data_s3datatype TYPE /aws1/sgms3datatype       VALUE 'S3Prefix'.
+    CONSTANTS cv_val_data_s3datadistribution TYPE /aws1/sgms3datadistribution      VALUE 'FullyReplicated'.
+    CONSTANTS cv_val_data_compressiontype TYPE /aws1/sgmcompressiontype    VALUE 'None'.
+    CONSTANTS cv_val_data_contenttype TYPE /aws1/sgmcontenttype    VALUE 'libsvm'.
 
     "Define training parameters.
     "SGM public training image ref to https://docs.aws.amazon.com/sagemaker/latest/dg/ecr-us-east-1.html#xgboost-us-east-1.title
     CONSTANTS cv_training_image TYPE /aws1/sgmalgorithmimage VALUE '123456789012.abc.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.5-1'.
-    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE  'File'.
+    CONSTANTS cv_training_input_mode TYPE /aws1/sgmtraininginputmode VALUE 'File'.
     CONSTANTS cv_instance_count TYPE /aws1/sgmtraininginstancecount VALUE '1'.
     CONSTANTS cv_instance_type TYPE /aws1/sgmtraininginstancetype VALUE 'ml.c4.2xlarge'.
     CONSTANTS cv_volume_sizeingb TYPE /aws1/sgmvolumesizeingb VALUE '10'.
@@ -88,9 +88,9 @@ CLASS ltc_zcl_aws1_sgm_scenario IMPLEMENTATION.
     "Define endpoint parameters.
     CONSTANTS cv_endpoint_name TYPE /aws1/sgmendpointname VALUE 'code-example-endpoint-'.
     CONSTANTS cv_endpoint_config_name TYPE /aws1/sgmendpointconfigname VALUE 'code-example-endpoint-cfg-'.
-    CONSTANTS cv_endpoint_variant_name TYPE /aws1/sgmvariantname VALUE  'code-example-endpoint-variant-'.
-    CONSTANTS cv_ep_instance_type TYPE  /aws1/sgminstancetype VALUE 'ml.m4.xlarge'.
-    CONSTANTS cv_ep_initial_instance_count  TYPE  /aws1/sgminitialtaskcount VALUE  '1'.
+    CONSTANTS cv_endpoint_variant_name TYPE /aws1/sgmvariantname VALUE 'code-example-endpoint-variant-'.
+    CONSTANTS cv_ep_instance_type TYPE /aws1/sgminstancetype VALUE 'ml.m4.xlarge'.
+    CONSTANTS cv_ep_initial_instance_count  TYPE /aws1/sgminitialtaskcount VALUE '1'.
 
     "Create training data in Amazon Simple Storage Service (Amazon S3).
     CONSTANTS cv_bucket_name TYPE /aws1/s3_bucketname VALUE 'code-example-sgm-'.
@@ -99,14 +99,16 @@ CLASS ltc_zcl_aws1_sgm_scenario IMPLEMENTATION.
 
     "Define role Amazon Resource Name (ARN).
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     lv_uuid_16 = cl_system_uuid=>create_uuid_x16_static( ).
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
 
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
 
     lv_trn_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_train_key.
     lv_val_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_val_key.
@@ -225,20 +227,17 @@ CLASS ltc_zcl_aws1_sgm_scenario IMPLEMENTATION.
         |0 0:53 1:5.6 9:1 26:1 189:1 330:1\n| &&
         |1 0:98 1:7.7 8:1 29:1 42:1 330:1\n| &&
         |0 0:76 1:6.7 7:1 28:1 75:1 330:1\n| &&
-        |1 0:74 1:5.3 7:1 28:1 95:1 330:1\n|
-    ).
+        |1 0:74 1:5.3 7:1 28:1 95:1 330:1\n| ).
 
     ao_s3->putobject(
             iv_bucket = lv_bucket_name
             iv_key = cv_train_key
-            iv_body = lv_file_content
-    ).
+            iv_body = lv_file_content ).
 
     ao_s3->putobject(
             iv_bucket = lv_bucket_name
             iv_key = cv_val_key
-            iv_body = lv_file_content
-    ).
+            iv_body = lv_file_content ).
 
     ao_sgm_scenario->getting_started_with_sgm(
       EXPORTING
@@ -275,10 +274,9 @@ CLASS ltc_zcl_aws1_sgm_scenario IMPLEMENTATION.
         iv_ep_cfg_name                  = lv_endpoint_config_name
         iv_ep_variant_name              = lv_endpoint_variant_name
       IMPORTING
-        oo_ep_output = lo_ep_output
-    ).
+        oo_ep_output = lo_ep_output ).
 
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
 
     IF lo_ep_output->has_endpointarn( ) = 'X'.
       lv_found               = abap_true.
@@ -286,12 +284,10 @@ CLASS ltc_zcl_aws1_sgm_scenario IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Endpoint not found|
-    ).
+      msg = |Endpoint not found| ).
 
     DATA(lo_model_list_result) = ao_sgm->listmodels(
-         iv_namecontains = lv_model_name
-       ).
+         iv_namecontains = lv_model_name ).
     lv_found = abap_false.
 
     "The model should be deleted.
@@ -303,27 +299,22 @@ CLASS ltc_zcl_aws1_sgm_scenario IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_false(
       act = lv_found
-      msg = |Model was not deleted|
-    ).
+      msg = |Model was not deleted| ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_train_key
-    ).
+        iv_key = cv_train_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = cv_val_key
-    ).
+        iv_key = cv_val_key ).
 
     ao_s3->deleteobject(
         iv_bucket = lv_bucket_name
-        iv_key = lv_model_key
-    ).
+        iv_key = lv_model_key ).
 
     ao_s3->deletebucket(
-        iv_bucket = lv_bucket_name
-    ).
+        iv_bucket = lv_bucket_name ).
 
   ENDMETHOD.
 

--- a/sap-abap/services/sns/zcl_aws1_sns_actions.clas.abap
+++ b/sap-abap/services/sns/zcl_aws1_sns_actions.clas.abap
@@ -1,54 +1,54 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_SNS_ACTIONS definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_sns_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods CREATE_TOPIC
-    importing
-      !IV_TOPIC_NAME type /AWS1/SNSTOPICNAME
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SNSCREATETOPICRSP .
-  methods DELETE_TOPIC
-    importing
-      !IV_TOPIC_ARN type /AWS1/SNSTOPICARN .
-  methods GET_TOPIC_ATTRIBUTES
-    importing
-      !IV_TOPIC_ARN type /AWS1/SNSTOPICARN
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SNSGETTOPICATTRSRSP .
-  methods SUBSCRIBE_EMAIL
-    importing
-      !IV_TOPIC_ARN type /AWS1/SNSTOPICARN
-      !IV_EMAIL_ADDRESS type /AWS1/SNSENDPOINT2
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SNSSUBSCRIBERESPONSE .
-  methods UNSUBSCRIBE
-    importing
-      !IV_SUBSCRIPTION_ARN type /AWS1/SNSSUBSCRIPTIONARN .
-  methods LIST_SUBSCRIPTIONS
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SNSLSTSUBSCRIPTIONS01 .
-  methods LIST_TOPICS
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SNSLISTTOPICSRESPONSE .
-  methods PUBLISH_TO_TOPIC
-    importing
-      !IV_TOPIC_ARN type /AWS1/SNSSTRING
-      !IV_MESSAGE type /AWS1/SNSMESSAGE
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SNSPUBLISHRESPONSE .
-  methods SET_TOPIC_ATTRIBUTES
-    importing
-      !IV_TOPIC_ARN type /AWS1/SNSTOPICARN
-      !IV_ATTRIBUTE_NAME type /AWS1/SNSATTRIBUTENAME
-      !IV_ATTRIBUTE_VALUE type /AWS1/SNSATTRIBUTEVALUE .
-protected section.
-private section.
+    METHODS create_topic
+      IMPORTING
+      !iv_topic_name TYPE /aws1/snstopicname
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_snscreatetopicrsp .
+    METHODS delete_topic
+      IMPORTING
+      !iv_topic_arn TYPE /aws1/snstopicarn .
+    METHODS get_topic_attributes
+      IMPORTING
+      !iv_topic_arn TYPE /aws1/snstopicarn
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_snsgettopicattrsrsp .
+    METHODS subscribe_email
+      IMPORTING
+      !iv_topic_arn TYPE /aws1/snstopicarn
+      !iv_email_address TYPE /aws1/snsendpoint2
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_snssubscriberesponse .
+    METHODS unsubscribe
+      IMPORTING
+      !iv_subscription_arn TYPE /aws1/snssubscriptionarn .
+    METHODS list_subscriptions
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_snslstsubscriptions01 .
+    METHODS list_topics
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_snslisttopicsresponse .
+    METHODS publish_to_topic
+      IMPORTING
+      !iv_topic_arn TYPE /aws1/snsstring
+      !iv_message TYPE /aws1/snsmessage
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_snspublishresponse .
+    METHODS set_topic_attributes
+      IMPORTING
+      !iv_topic_arn TYPE /aws1/snstopicarn
+      !iv_attribute_name TYPE /aws1/snsattributename
+      !iv_attribute_value TYPE /aws1/snsattributevalue .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -57,7 +57,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
 
 
   METHOD create_topic.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sns) = /aws1/cl_sns_factory=>create( lo_session ).
@@ -74,7 +74,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
 
 
   METHOD delete_topic.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sns) = /aws1/cl_sns_factory=>create( lo_session ).
@@ -91,7 +91,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
 
 
   METHOD get_topic_attributes.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sns) = /aws1/cl_sns_factory=>create( lo_session ).
@@ -109,7 +109,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
 
 
   METHOD list_subscriptions.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sns) = /aws1/cl_sns_factory=>create( lo_session ).
@@ -127,7 +127,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
 
 
   METHOD list_topics.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sns) = /aws1/cl_sns_factory=>create( lo_session ).
@@ -145,7 +145,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
 
 
   METHOD publish_to_topic.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sns) = /aws1/cl_sns_factory=>create( lo_session ).
@@ -154,8 +154,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
     TRY.
         oo_result = lo_sns->publish(              " oo_result is returned for testing purposes. "
           iv_topicarn = iv_topic_arn
-          iv_message = iv_message
-        ).
+          iv_message = iv_message ).
         MESSAGE 'Message published to SNS topic.' TYPE 'I'.
       CATCH /aws1/cx_snsnotfoundexception.
         MESSAGE 'Topic does not exist.' TYPE 'E'.
@@ -165,7 +164,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
 
 
   METHOD set_topic_attributes.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sns) = /aws1/cl_sns_factory=>create( lo_session ).
@@ -175,8 +174,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
         lo_sns->settopicattributes(
             iv_topicarn = iv_topic_arn
             iv_attributename  = iv_attribute_name
-            iv_attributevalue = iv_attribute_value
-        ).
+            iv_attributevalue = iv_attribute_value ).
         MESSAGE 'Set/updated SNS topic attributes.' TYPE 'I'.
       CATCH /aws1/cx_snsnotfoundexception.
         MESSAGE 'Topic does not exist.' TYPE 'E'.
@@ -186,7 +184,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
 
 
   METHOD subscribe_email.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sns) = /aws1/cl_sns_factory=>create( lo_session ).
@@ -197,8 +195,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
                 iv_topicarn = iv_topic_arn
                 iv_protocol = 'email'
                 iv_endpoint = iv_email_address
-                iv_returnsubscriptionarn = abap_true
-            ).
+                iv_returnsubscriptionarn = abap_true ).
         MESSAGE 'Email address subscribed to SNS topic.' TYPE 'I'.
       CATCH /aws1/cx_snsnotfoundexception.
         MESSAGE 'Topic does not exist.' TYPE 'E'.
@@ -210,7 +207,7 @@ CLASS ZCL_AWS1_SNS_ACTIONS IMPLEMENTATION.
 
 
   METHOD unsubscribe.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sns) = /aws1/cl_sns_factory=>create( lo_session ).

--- a/sap-abap/services/sns/zcl_aws1_sns_actions.clas.testclasses.abap
+++ b/sap-abap/services/sns/zcl_aws1_sns_actions.clas.testclasses.abap
@@ -4,10 +4,10 @@
 CLASS ltc_zcl_aws1_sns_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_sns_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_sns_actions.
 
-CLASS ltc_zcl_aws1_sns_actions DEFINITION FOR TESTING  DURATION SHORT RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_sns_actions DEFINITION FOR TESTING DURATION SHORT RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA ao_sns TYPE REF TO /aws1/if_sns.
     DATA ao_session TYPE REF TO /aws1/cl_rt_session_base.
@@ -23,7 +23,7 @@ CLASS ltc_zcl_aws1_sns_actions DEFINITION FOR TESTING  DURATION SHORT RISK LEVEL
       publish_to_topic FOR TESTING RAISING /aws1/cx_rt_generic,
       set_topic_attributes FOR TESTING RAISING /aws1/cx_rt_generic.
 
-    METHODS setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
 
     METHODS assert_subscription_exists
       IMPORTING
@@ -48,215 +48,199 @@ CLASS ltc_zcl_aws1_sns_actions IMPLEMENTATION.
     ao_sns_actions = NEW zcl_aws1_sns_actions( ).
   ENDMETHOD.
   METHOD create_topic.
-    CONSTANTS: cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-create-topic'.
-    DATA(lo_result) = ao_sns_actions->create_topic( iv_topic_name = cv_topic_name ).
+    CONSTANTS cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-create-topic'.
+    DATA(lo_result) = ao_sns_actions->create_topic( cv_topic_name ).
     assert_topic_exists(
       iv_topic_arn = lo_result->get_topicarn( )
       iv_exp = abap_true
-      iv_msg = |Topic { cv_topic_name } was not created|
-    ).
+      iv_msg = |Topic { cv_topic_name } was not created| ).
     ao_sns->deletetopic( iv_topicarn = lo_result->get_topicarn( ) ).
   ENDMETHOD.
   METHOD delete_topic.
-    CONSTANTS: cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-delete-topic'.
+    CONSTANTS cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-delete-topic'.
     DATA(lo_result) = ao_sns->createtopic( iv_name = cv_topic_name ).
     DATA(lv_topic_arn) = lo_result->get_topicarn( ).
 
-    ao_sns_actions->delete_topic( iv_topic_arn = lv_topic_arn ).
+    ao_sns_actions->delete_topic( lv_topic_arn ).
     assert_topic_exists(
-    iv_topic_arn = lv_topic_arn
-    iv_exp = abap_false
-    iv_msg = |Topic { cv_topic_name } should have been deleted|
-  ).
+      iv_topic_arn = lv_topic_arn
+      iv_exp = abap_false
+      iv_msg = |Topic { cv_topic_name } should have been deleted| ).
   ENDMETHOD.
   METHOD get_topic_attributes.
-    CONSTANTS: cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-get-topic-attributes'.
+    CONSTANTS cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-get-topic-attributes'.
     DATA(lo_create_result) = ao_sns->createtopic( iv_name = cv_topic_name ).
     DATA(lv_topic_arn) = lo_create_result->get_topicarn( ).
-    DATA(lo_get_attributes_result) = ao_sns_actions->get_topic_attributes( iv_topic_arn = lv_topic_arn ).
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+    DATA(lo_get_attributes_result) = ao_sns_actions->get_topic_attributes( lv_topic_arn ).
+
     LOOP AT lo_get_attributes_result->get_attributes( ) INTO DATA(wa_attribute).
       IF wa_attribute-key = 'TopicArn' AND wa_attribute-value->get_value( ) = lv_topic_arn.
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
     cl_abap_unit_assert=>assert_true(
- act = lv_found
-       msg = |Couldn't retrive attributes for topic { cv_topic_name }|
-    ).
+      act = lv_found
+       msg = |Couldn't retrive attributes for topic { cv_topic_name }| ).
     ao_sns->deletetopic( iv_topicarn = lv_topic_arn ).
   ENDMETHOD.
   METHOD subscribe_email.
-    CONSTANTS: cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-subscribe-email'.
-    CONSTANTS: cv_email_address TYPE /aws1/snsendpoint2 VALUE 'dummyemail@example.com'.
+    CONSTANTS cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-subscribe-email'.
+    CONSTANTS cv_email_address TYPE /aws1/snsendpoint2 VALUE 'dummyemail@example.com'.
 
     DATA(lo_create_result) = ao_sns->createtopic( iv_name = cv_topic_name ).
     DATA(lv_topic_arn) = lo_create_result->get_topicarn( ).
-    DATA(lo_subscribe_result) =  ao_sns_actions->subscribe_email(
+    DATA(lo_subscribe_result) = ao_sns_actions->subscribe_email(
         iv_topic_arn = lv_topic_arn
-        iv_email_address = cv_email_address
-    ).
+        iv_email_address = cv_email_address ).
     cl_abap_unit_assert=>assert_not_initial(
           act = lo_subscribe_result->get_subscriptionarn( )
-          msg = |Unable to subcribe email address { cv_email_address } to SNS topic { cv_topic_name }|
-        ).
+          msg = |Unable to subcribe email address { cv_email_address } to SNS topic { cv_topic_name }| ).
     assert_subscription_exists(
         iv_topic_arn = lv_topic_arn
         iv_subscription_arn = 'PendingConfirmation'
         iv_exp = abap_true
-        iv_msg = |Email { cv_email_address } should have been subscribed|
-      ).
+        iv_msg = |Email { cv_email_address } should have been subscribed| ).
     ao_sns->deletetopic( iv_topicarn = lv_topic_arn ).
   ENDMETHOD.
   METHOD unsubscribe.
-    CONSTANTS: cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-unsubscribe'.
-    CONSTANTS: cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-unsubscribe-queue'.
+    CONSTANTS cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-unsubscribe'.
+    CONSTANTS cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-unsubscribe-queue'.
 
     DATA(lo_create_result) = ao_sns->createtopic( iv_name = cv_topic_name ).
     DATA(lv_topic_arn) = lo_create_result->get_topicarn( ).
 
     DATA(ao_sqs) = /aws1/cl_sqs_factory=>create( ao_session ).
     DATA(lo_create_queue_result) = ao_sqs->createqueue( iv_queuename = cv_queue_name ).
-    DATA(lv_queue_url) =  lo_create_queue_result->get_queueurl( ).
+    DATA(lv_queue_url) = lo_create_queue_result->get_queueurl( ).
     DATA lt_required_attributes TYPE /aws1/cl_sqsattrnamelist_w=>tt_attributenamelist.
     APPEND NEW /aws1/cl_sqsattrnamelist_w( iv_value = 'QueueArn' ) TO lt_required_attributes.
-    DATA(lt_queueattributes) = ao_sqs->getqueueattributes( iv_queueurl = lv_queue_url it_attributenames = lt_required_attributes )->get_attributes( ).
+    DATA(lt_queueattributes) = ao_sqs->getqueueattributes( iv_queueurl = lv_queue_url
+                                                           it_attributenames = lt_required_attributes )->get_attributes( ).
     READ TABLE lt_queueattributes INTO DATA(ls_queueattribute) WITH TABLE KEY key = 'QueueArn'.
     DATA(lv_queue_arn) = ls_queueattribute-value->get_value( ).
 
-    DATA(lo_subscribe_result) =  ao_sns->subscribe(
+    DATA(lo_subscribe_result) = ao_sns->subscribe(
        iv_topicarn = lv_topic_arn
        iv_protocol = 'sqs'
        iv_endpoint = lv_queue_arn
-       iv_returnsubscriptionarn = abap_true
-    ).
+       iv_returnsubscriptionarn = abap_true ).
     DATA(lv_subscription_arn) = lo_subscribe_result->get_subscriptionarn( ).
-    ao_sns_actions->unsubscribe( iv_subscription_arn = lv_subscription_arn ).
+    ao_sns_actions->unsubscribe( lv_subscription_arn ).
     assert_subscription_exists(
        iv_topic_arn = lv_topic_arn
        iv_subscription_arn = lv_subscription_arn
        iv_exp = abap_false
-       iv_msg = |Subscriptionl { lv_subscription_arn } should have been subscribed|
-     ).
+       iv_msg = |Subscriptionl { lv_subscription_arn } should have been subscribed| ).
     ao_sqs->deletequeue( iv_queueurl = lv_queue_url ).
     ao_sns->deletetopic( iv_topicarn = lv_topic_arn ).
   ENDMETHOD.
   METHOD list_subscriptions.
-    CONSTANTS: cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-list-subscriptions'.
-    CONSTANTS: cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-list-queue'.
+    CONSTANTS cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-list-subscriptions'.
+    CONSTANTS cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-list-queue'.
 
     DATA(lo_create_result) = ao_sns->createtopic( iv_name = cv_topic_name ).
     DATA(lv_topic_arn) = lo_create_result->get_topicarn( ).
 
     DATA(ao_sqs) = /aws1/cl_sqs_factory=>create( ao_session ).
     DATA(lo_create_queue_result) = ao_sqs->createqueue( iv_queuename = cv_queue_name ).
-    DATA(lv_queue_url) =  lo_create_queue_result->get_queueurl( ).
+    DATA(lv_queue_url) = lo_create_queue_result->get_queueurl( ).
     DATA lt_required_attributes TYPE /aws1/cl_sqsattrnamelist_w=>tt_attributenamelist.
     APPEND NEW /aws1/cl_sqsattrnamelist_w( iv_value = 'QueueArn' ) TO lt_required_attributes.
-    DATA(lt_queueattributes) = ao_sqs->getqueueattributes( iv_queueurl = lv_queue_url it_attributenames = lt_required_attributes )->get_attributes( ).
+    DATA(lt_queueattributes) = ao_sqs->getqueueattributes( iv_queueurl = lv_queue_url
+                                                           it_attributenames = lt_required_attributes )->get_attributes( ).
     READ TABLE lt_queueattributes INTO DATA(ls_queueattribute) WITH TABLE KEY key = 'QueueArn'.
     DATA(lv_queue_arn) = ls_queueattribute-value->get_value( ).
 
-    DATA(lo_subscribe_result) =  ao_sns->subscribe(
+    DATA(lo_subscribe_result) = ao_sns->subscribe(
        iv_topicarn = lv_topic_arn
        iv_protocol = 'sqs'
        iv_endpoint = lv_queue_arn
-       iv_returnsubscriptionarn = abap_true
-    ).
+       iv_returnsubscriptionarn = abap_true ).
     DATA(lv_subscription_arn) = lo_subscribe_result->get_subscriptionarn( ).
     DATA(lo_list_result) = ao_sns_actions->list_subscriptions( ).
     cl_abap_unit_assert=>assert_not_initial(
       act = lo_list_result->get_subscriptions( )
-      msg = |Subscription List should not be empty|
-    ).
+      msg = |Subscription List should not be empty| ).
     ao_sns->unsubscribe( iv_subscriptionarn = lv_subscription_arn ).
     ao_sqs->deletequeue( iv_queueurl = lv_queue_url ).
     ao_sns->deletetopic( iv_topicarn = lv_topic_arn ).
   ENDMETHOD.
   METHOD list_topics.
-    CONSTANTS: cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-list-topics'.
+    CONSTANTS cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-list-topics'.
     DATA(lo_create_result) = ao_sns->createtopic( iv_name = cv_topic_name ).
     DATA(lv_topic_arn) = lo_create_result->get_topicarn( ).
     DATA(lo_list_result) = ao_sns_actions->list_topics( ).
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT lo_list_result->get_topics( ) INTO DATA(lo_topic).
       IF lo_topic->get_topicarn( ) = lv_topic_arn.
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Topic { cv_topic_name } should have been included in topic list|
-    ).
+      msg = |Topic { cv_topic_name } should have been included in topic list| ).
     ao_sns->deletetopic( iv_topicarn = lv_topic_arn ).
   ENDMETHOD.
   METHOD publish_to_topic.
-    CONSTANTS: cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-publish-to-topic'.
-    CONSTANTS: cv_message TYPE /aws1/snsmessage VALUE 'Sample message published to a topic'.
+    CONSTANTS cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-publish-to-topic'.
+    CONSTANTS cv_message TYPE /aws1/snsmessage VALUE 'Sample message published to a topic'.
     DATA(lo_create_result) = ao_sns->createtopic( iv_name = cv_topic_name ).
     DATA(lv_topic_arn) = lo_create_result->get_topicarn( ).
     DATA(lo_publish_result) = ao_sns_actions->publish_to_topic(
                            iv_topic_arn = lv_topic_arn
-                           iv_message   = cv_message
-                       ).
+                           iv_message   = cv_message ).
     cl_abap_unit_assert=>assert_not_initial(
                  act = lo_publish_result->get_messageid( )
-                 msg = |Failed to publish message SNS topint  { lv_topic_arn }|
-               ).
+                 msg = |Failed to publish message SNS topint  { lv_topic_arn }| ).
     ao_sns->deletetopic( iv_topicarn = lv_topic_arn ).
   ENDMETHOD.
   METHOD set_topic_attributes.
-    CONSTANTS: cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-set-topic-attributes'.
-    CONSTANTS: cv_attribute_name TYPE /aws1/snsmessage VALUE 'DisplayName'.
-    CONSTANTS: cv_attribute_value TYPE /aws1/snsattributevalue VALUE 'TestDisplayName'.
+    CONSTANTS cv_topic_name TYPE /aws1/snstopicname VALUE 'code-example-set-topic-attributes'.
+    CONSTANTS cv_attribute_name TYPE /aws1/snsmessage VALUE 'DisplayName'.
+    CONSTANTS cv_attribute_value TYPE /aws1/snsattributevalue VALUE 'TestDisplayName'.
     DATA(lo_create_result) = ao_sns->createtopic( iv_name = cv_topic_name ).
     DATA(lv_topic_arn) = lo_create_result->get_topicarn( ).
     DATA(lt_attributes) = ao_sns->gettopicattributes( iv_topicarn = lv_topic_arn )->get_attributes( ).
     READ TABLE lt_attributes INTO DATA(ls_attributes) WITH TABLE KEY key = cv_attribute_name.
     cl_abap_unit_assert=>assert_initial(
        act = ls_attributes-value->get_value( )
-       msg = |Display Name for SNS topic { cv_topic_name } should have be empty |
-     ).
+       msg = |Display Name for SNS topic { cv_topic_name } should have be empty | ).
     ao_sns_actions->set_topic_attributes(
         iv_topic_arn       = lv_topic_arn
         iv_attribute_name  = cv_attribute_name
-        iv_attribute_value = cv_attribute_value
-    ).
+        iv_attribute_value = cv_attribute_value ).
     CLEAR ls_attributes.
     CLEAR lt_attributes.
     lt_attributes = ao_sns->gettopicattributes( iv_topicarn = lv_topic_arn )->get_attributes( ).
     READ TABLE lt_attributes INTO ls_attributes WITH TABLE KEY key = cv_attribute_name.
     cl_abap_unit_assert=>assert_equals(
-    exp = ls_attributes-value->get_value( )
+      exp = ls_attributes-value->get_value( )
                  act = cv_attribute_value
-                 msg = |{ cv_attribute_name } for topic { cv_topic_name } did not match the expected value { cv_attribute_value }|
-               ).
+                 msg = |{ cv_attribute_name } for topic { cv_topic_name } did not match the expected value { cv_attribute_value }| ).
     ao_sns->deletetopic( iv_topicarn = lv_topic_arn ).
   ENDMETHOD.
   METHOD assert_topic_exists.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT ao_sns->listtopics( )->get_topics( ) INTO DATA(lo_topic).
       IF lo_topic->get_topicarn( ) = iv_topic_arn.
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
     cl_abap_unit_assert=>assert_equals(
       exp = iv_exp
       act = lv_found
-      msg = iv_msg
-    ).
+      msg = iv_msg ).
   ENDMETHOD.
   METHOD assert_subscription_exists.
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+
     LOOP AT ao_sns->listsubscriptionsbytopic( iv_topicarn = iv_topic_arn )->get_subscriptions( ) INTO DATA(lo_subscription).
       IF lo_subscription->get_subscriptionarn( ) = iv_subscription_arn.
-        lv_found = abap_true.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
     cl_abap_unit_assert=>assert_equals(
       exp = iv_exp
       act = lv_found
-      msg = iv_msg
-    ).
+      msg = iv_msg ).
   ENDMETHOD.
 ENDCLASS.

--- a/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.abap
+++ b/sap-abap/services/sns/zcl_aws1_sns_scenario.clas.abap
@@ -1,23 +1,23 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_SNS_SCENARIO definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_sns_scenario DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods PUBLISH_MESSAGE_TO_FIFO_TOPIC
-    importing
-      !IV_TOPIC_NAME type /AWS1/SNSTOPICNAME
-      !IV_QUEUE_ARN type /AWS1/SQSSTRING
-    exporting
-      !OV_TOPIC_ARN type /AWS1/SNSTOPICARN
-      !OV_SUBSCRIPTION_ARN type /AWS1/SNSSUBSCRIPTIONARN
-      !OV_MESSAGE_ID type /AWS1/SNSMESSAGEID .
-protected section.
-private section.
+    METHODS publish_message_to_fifo_topic
+      IMPORTING
+      !iv_topic_name TYPE /aws1/snstopicname
+      !iv_queue_arn TYPE /aws1/sqsstring
+      EXPORTING
+      !ov_topic_arn TYPE /aws1/snstopicarn
+      !ov_subscription_arn TYPE /aws1/snssubscriptionarn
+      !ov_message_id TYPE /aws1/snsmessageid .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -26,7 +26,7 @@ CLASS ZCL_AWS1_SNS_SCENARIO IMPLEMENTATION.
 
 
   METHOD publish_message_to_fifo_topic.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sns) = /aws1/cl_sns_factory=>create( lo_session ).
@@ -43,8 +43,7 @@ CLASS ZCL_AWS1_SNS_SCENARIO IMPLEMENTATION.
     TRY.
         DATA(lo_create_result) = lo_sns->createtopic(
                iv_name = iv_topic_name
-               it_attributes = lt_tpc_attributes
-        ).
+               it_attributes = lt_tpc_attributes ).
         DATA(lv_topic_arn) = lo_create_result->get_topicarn( ).
         ov_topic_arn = lv_topic_arn.                                    " ov_topic_arn is returned for testing purposes. "
         MESSAGE 'FIFO topic created' TYPE 'I'.
@@ -58,8 +57,7 @@ CLASS ZCL_AWS1_SNS_SCENARIO IMPLEMENTATION.
         DATA(lo_subscribe_result) = lo_sns->subscribe(
                iv_topicarn = lv_topic_arn
                iv_protocol = 'sqs'
-               iv_endpoint = iv_queue_arn
-           ).
+               iv_endpoint = iv_queue_arn ).
         DATA(lv_subscription_arn) = lo_subscribe_result->get_subscriptionarn( ).
         ov_subscription_arn = lv_subscription_arn.                      " ov_subscription_arn is returned for testing purposes. "
         MESSAGE 'SQS queue was subscribed to SNS topic.' TYPE 'I'.
@@ -74,7 +72,8 @@ CLASS ZCL_AWS1_SNS_SCENARIO IMPLEMENTATION.
         DATA lt_msg_attributes TYPE /aws1/cl_snsmessageattrvalue=>tt_messageattributemap.
         DATA ls_msg_attributes TYPE /aws1/cl_snsmessageattrvalue=>ts_messageattributemap_maprow.
         ls_msg_attributes-key = 'Importance'.
-        ls_msg_attributes-value = NEW /aws1/cl_snsmessageattrvalue( iv_datatype = 'String' iv_stringvalue = 'High' ).
+        ls_msg_attributes-value = NEW /aws1/cl_snsmessageattrvalue( iv_datatype = 'String'
+                                                                    iv_stringvalue = 'High' ).
         INSERT ls_msg_attributes INTO TABLE lt_msg_attributes.
 
         DATA(lo_result) = lo_sns->publish(
@@ -83,8 +82,7 @@ CLASS ZCL_AWS1_SNS_SCENARIO IMPLEMENTATION.
              iv_subject = 'Changes to mobile plan'
              iv_messagegroupid = 'Update-2'
              iv_messagededuplicationid = 'Update-2.1'
-             it_messageattributes = lt_msg_attributes
-      ).
+             it_messageattributes = lt_msg_attributes ).
         ov_message_id = lo_result->get_messageid( ).                    " ov_message_id is returned for testing purposes. "
         MESSAGE 'Message was published to SNS topic.' TYPE 'I'.
       CATCH /aws1/cx_snsnotfoundexception.

--- a/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.abap
+++ b/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.abap
@@ -1,54 +1,54 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_SQS_ACTIONS definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_sqs_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
-protected section.
-private section.
+  PUBLIC SECTION.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 
-  methods CREATE_QUEUE
-    importing
-      !IV_QUEUE_NAME type /AWS1/SQSSTRING
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SQSCREATEQUEUERESULT .
-  methods DELETE_QUEUE
-    importing
-      !IV_QUEUE_URL type /AWS1/SQSSTRING .
-  methods SEND_MESSAGE
-    importing
-      !IV_QUEUE_URL type /AWS1/SQSSTRING
-      !IV_MESSAGE type /AWS1/SQSSTRING
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SQSSENDMESSAGERESULT .
-  methods RECEIVE_MESSAGE
-    importing
-      !IV_QUEUE_URL type /AWS1/SQSSTRING
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SQSRECEIVEMSGRESULT .
-  methods GET_QUEUE_URL
-    importing
-      !IV_QUEUE_NAME type /AWS1/SQSSTRING
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SQSGETQUEUEURLRESULT .
-  methods LIST_QUEUES
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SQSLISTQUEUESRESULT .
-  methods LONG_POLLING_ON_MSG_RECEIPT
-    importing
-      !IV_QUEUE_URL type /AWS1/SQSSTRING
-      !IV_WAIT_TIME type /AWS1/SQSINTEGER
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SQSRECEIVEMSGRESULT .
-  methods LONG_POLLING_ON_CREATE_QUEUE
-    importing
-      !IV_QUEUE_NAME type /AWS1/SQSSTRING
-      !IV_WAIT_TIME type /AWS1/SQSSTRING
-    returning
-      value(OO_RESULT) type ref to /AWS1/CL_SQSCREATEQUEUERESULT .
+    METHODS create_queue
+      IMPORTING
+      !iv_queue_name TYPE /aws1/sqsstring
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_sqscreatequeueresult .
+    METHODS delete_queue
+      IMPORTING
+      !iv_queue_url TYPE /aws1/sqsstring .
+    METHODS send_message
+      IMPORTING
+      !iv_queue_url TYPE /aws1/sqsstring
+      !iv_message TYPE /aws1/sqsstring
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_sqssendmessageresult .
+    METHODS receive_message
+      IMPORTING
+      !iv_queue_url TYPE /aws1/sqsstring
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_sqsreceivemsgresult .
+    METHODS get_queue_url
+      IMPORTING
+      !iv_queue_name TYPE /aws1/sqsstring
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_sqsgetqueueurlresult .
+    METHODS list_queues
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_sqslistqueuesresult .
+    METHODS long_polling_on_msg_receipt
+      IMPORTING
+      !iv_queue_url TYPE /aws1/sqsstring
+      !iv_wait_time TYPE /aws1/sqsinteger
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_sqsreceivemsgresult .
+    METHODS long_polling_on_create_queue
+      IMPORTING
+      !iv_queue_name TYPE /aws1/sqsstring
+      !iv_wait_time TYPE /aws1/sqsstring
+      RETURNING
+      VALUE(oo_result) TYPE REF TO /aws1/cl_sqscreatequeueresult .
 ENDCLASS.
 
 
@@ -57,7 +57,7 @@ CLASS ZCL_AWS1_SQS_ACTIONS IMPLEMENTATION.
 
 
   METHOD create_queue.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sqs) = /aws1/cl_sqs_factory=>create( lo_session ).
@@ -76,7 +76,7 @@ CLASS ZCL_AWS1_SQS_ACTIONS IMPLEMENTATION.
 
 
   METHOD delete_queue.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sqs) = /aws1/cl_sqs_factory=>create( lo_session ).
@@ -91,7 +91,7 @@ CLASS ZCL_AWS1_SQS_ACTIONS IMPLEMENTATION.
 
 
   METHOD get_queue_url.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sqs) = /aws1/cl_sqs_factory=>create( lo_session ).
@@ -108,7 +108,7 @@ CLASS ZCL_AWS1_SQS_ACTIONS IMPLEMENTATION.
 
 
   METHOD list_queues.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sqs) = /aws1/cl_sqs_factory=>create( lo_session ).
@@ -123,7 +123,7 @@ CLASS ZCL_AWS1_SQS_ACTIONS IMPLEMENTATION.
 
 
   METHOD long_polling_on_create_queue.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sqs) = /aws1/cl_sqs_factory=>create( lo_session ).
@@ -137,8 +137,7 @@ CLASS ZCL_AWS1_SQS_ACTIONS IMPLEMENTATION.
         INSERT ls_attribute INTO TABLE lt_attributes.
         oo_result = lo_sqs->createqueue(                  " oo_result is returned for testing purposes. "
                 iv_queuename = iv_queue_name
-                it_attributes = lt_attributes
-            ).
+                it_attributes = lt_attributes ).
         MESSAGE 'SQS queue created.' TYPE 'I'.
       CATCH /aws1/cx_sqsqueuedeldrecently.
         MESSAGE 'After deleting a queue, wait 60 seconds before creating another queue with the same name.' TYPE 'E'.
@@ -150,7 +149,7 @@ CLASS ZCL_AWS1_SQS_ACTIONS IMPLEMENTATION.
 
 
   METHOD long_polling_on_msg_receipt.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sqs) = /aws1/cl_sqs_factory=>create( lo_session ).
@@ -159,8 +158,7 @@ CLASS ZCL_AWS1_SQS_ACTIONS IMPLEMENTATION.
     TRY.
         oo_result = lo_sqs->receivemessage(           " oo_result is returned for testing purposes. "
                 iv_queueurl = iv_queue_url
-                iv_waittimeseconds = iv_wait_time     " Time in seconds for long polling, such as how long the call waits for a message to arrive in the queue before returning. "
-            ).
+                iv_waittimeseconds = iv_wait_time ).    " Time in seconds for long polling, such as how long the call waits for a message to arrive in the queue before returning. " ).
         DATA(lt_messages) = oo_result->get_messages( ).
         MESSAGE 'Message received from SQS queue.' TYPE 'I'.
       CATCH /aws1/cx_sqsoverlimit.
@@ -171,7 +169,7 @@ CLASS ZCL_AWS1_SQS_ACTIONS IMPLEMENTATION.
 
 
   METHOD receive_message.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sqs) = /aws1/cl_sqs_factory=>create( lo_session ).
@@ -189,7 +187,7 @@ CLASS ZCL_AWS1_SQS_ACTIONS IMPLEMENTATION.
 
 
   METHOD send_message.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_sqs) = /aws1/cl_sqs_factory=>create( lo_session ).
@@ -198,8 +196,7 @@ CLASS ZCL_AWS1_SQS_ACTIONS IMPLEMENTATION.
     TRY.
         oo_result = lo_sqs->sendmessage(              " oo_result is returned for testing purposes. "
            iv_queueurl = iv_queue_url
-           iv_messagebody = iv_message
-        ).
+           iv_messagebody = iv_message ).
         MESSAGE 'Message sent to SQS queue.' TYPE 'I'.
       CATCH /aws1/cx_sqsinvalidmsgconts.
         MESSAGE 'Message contains non-valid characters.' TYPE 'E'.

--- a/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.testclasses.abap
+++ b/sap-abap/services/sqs/zcl_aws1_sqs_actions.clas.testclasses.abap
@@ -4,10 +4,10 @@
 CLASS ltc_zcl_aws1_sqs_actions DEFINITION DEFERRED.
 CLASS zcl_aws1_sqs_actions DEFINITION LOCAL FRIENDS ltc_zcl_aws1_sqs_actions.
 
-CLASS ltc_zcl_aws1_sqs_actions DEFINITION FOR TESTING  DURATION MEDIUM RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_sqs_actions DEFINITION FOR TESTING DURATION MEDIUM RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA ao_sqs TYPE REF TO /aws1/if_sqs.
     DATA ao_session TYPE REF TO /aws1/cl_rt_session_base.
@@ -22,9 +22,9 @@ CLASS ltc_zcl_aws1_sqs_actions DEFINITION FOR TESTING  DURATION MEDIUM RISK LEVE
       long_polling_on_msg_receipt FOR TESTING RAISING /aws1/cx_rt_generic,
       long_polling_on_create_queue FOR TESTING RAISING /aws1/cx_rt_generic.
 
-    METHODS: setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
 
-    METHODS: assert_queue_exists
+    METHODS assert_queue_exists
       IMPORTING
                 iv_queue_url TYPE /aws1/sqsstring
                 iv_msg       TYPE string
@@ -40,133 +40,119 @@ CLASS ltc_zcl_aws1_sqs_actions IMPLEMENTATION.
     ao_sqs_actions = NEW zcl_aws1_sqs_actions( ).
   ENDMETHOD.
   METHOD create_queue.
-    CONSTANTS: cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-create-queue'.
-    DATA(lo_result) = ao_sqs_actions->create_queue( iv_queue_name = cv_queue_name ).
+    CONSTANTS cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-create-queue'.
+    DATA(lo_result) = ao_sqs_actions->create_queue( cv_queue_name ).
     assert_queue_exists(
           iv_queue_url = lo_result->get_queueurl( )
-          iv_msg = |Queue { cv_queue_name } was not created|
-        ).
+          iv_msg = |Queue { cv_queue_name } was not created| ).
     ao_sqs->deletequeue( iv_queueurl = lo_result->get_queueurl( ) ).
   ENDMETHOD.
   METHOD send_message.
-    CONSTANTS: cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-send-message'.
-    CONSTANTS: cv_message TYPE /aws1/sqsstring VALUE 'Sample text message to test send message action'.
+    CONSTANTS cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-send-message'.
+    CONSTANTS cv_message TYPE /aws1/sqsstring VALUE 'Sample text message to test send message action'.
     DATA(lo_create_result) = ao_sqs->createqueue( iv_queuename = cv_queue_name ).
     DATA(lo_send_result) = ao_sqs_actions->send_message(
             iv_queue_url = lo_create_result->get_queueurl( )
-            iv_message = cv_message
-        ).
+            iv_message = cv_message ).
     cl_abap_unit_assert=>assert_not_initial(
         act = lo_send_result->get_messageid( )
-        msg = |Message sending failed|
-  ).
+        msg = |Message sending failed| ).
     DATA(lo_receive_result) = ao_sqs->receivemessage( iv_queueurl = lo_create_result->get_queueurl( ) ).
-    DATA lv_found TYPE abap_bool VALUE abap_false.
-    LOOP AT  lo_receive_result->get_messages( ) INTO DATA(lo_message).
-      IF  lo_message->get_messageid( ) = lo_send_result->get_messageid( ) AND lo_message->get_body( ) = cv_message.
-        lv_found = abap_true.
+
+    LOOP AT lo_receive_result->get_messages( ) INTO DATA(lo_message).
+      IF lo_message->get_messageid( ) = lo_send_result->get_messageid( ) AND lo_message->get_body( ) = cv_message.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_true(
         act = lv_found
-        msg = |Did not receive message { cv_message }|
-  ).
+        msg = |Did not receive message { cv_message }| ).
     ao_sqs->deletequeue( iv_queueurl = lo_create_result->get_queueurl( ) ).
 
   ENDMETHOD.
   METHOD receive_message.
-    CONSTANTS: cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-receive-message'.
-    CONSTANTS: cv_message TYPE /aws1/sqsstring VALUE 'Sample text message to test receive message action'.
+    CONSTANTS cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-receive-message'.
+    CONSTANTS cv_message TYPE /aws1/sqsstring VALUE 'Sample text message to test receive message action'.
     DATA(lo_create_result) = ao_sqs->createqueue( iv_queuename = cv_queue_name ).
     DATA(lo_send_result) = ao_sqs->sendmessage(
             iv_queueurl = lo_create_result->get_queueurl( )
-            iv_messagebody = cv_message
-        ).
-    DATA(lo_receive_result) = ao_sqs_actions->receive_message( iv_queue_url = lo_create_result->get_queueurl( ) ).
-    DATA lv_found TYPE abap_bool VALUE abap_false.
-    LOOP AT  lo_receive_result->get_messages( ) INTO DATA(lo_message).
-      IF  lo_message->get_messageid( ) = lo_send_result->get_messageid( ) AND lo_message->get_body( ) = cv_message.
-        lv_found = abap_true.
+            iv_messagebody = cv_message ).
+    DATA(lo_receive_result) = ao_sqs_actions->receive_message( lo_create_result->get_queueurl( ) ).
+
+    LOOP AT lo_receive_result->get_messages( ) INTO DATA(lo_message).
+      IF lo_message->get_messageid( ) = lo_send_result->get_messageid( ) AND lo_message->get_body( ) = cv_message.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_true(
         act = lv_found
-        msg = |Did not receive message { cv_message }|
-  ).
+        msg = |Did not receive message { cv_message }| ).
     ao_sqs->deletequeue( iv_queueurl = lo_create_result->get_queueurl( ) ).
 
   ENDMETHOD.
   METHOD long_polling_on_msg_receipt.
-    CONSTANTS: cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-long-polling-on-msg-receipt'.
-    CONSTANTS: cv_message TYPE /aws1/sqsstring VALUE 'Sample text message to test long polling on message receipt'.
-    CONSTANTS: cv_wait_time TYPE /aws1/sqsinteger VALUE 10.
+    CONSTANTS cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-long-polling-on-msg-receipt'.
+    CONSTANTS cv_message TYPE /aws1/sqsstring VALUE 'Sample text message to test long polling on message receipt'.
+    CONSTANTS cv_wait_time TYPE /aws1/sqsinteger VALUE 10.
     DATA(lo_create_result) = ao_sqs->createqueue( iv_queuename = cv_queue_name ).
     DATA(lo_send_result) = ao_sqs->sendmessage(
             iv_queueurl = lo_create_result->get_queueurl( )
-            iv_messagebody = cv_message
-        ).
+            iv_messagebody = cv_message ).
     DATA(lo_polling_result) = ao_sqs_actions->long_polling_on_msg_receipt(
                               iv_queue_url = lo_create_result->get_queueurl( )
-                              iv_wait_time = cv_wait_time
-                          ).
-    DATA lv_found TYPE abap_bool VALUE abap_false.
+                              iv_wait_time = cv_wait_time ).
+
     LOOP AT lo_polling_result->get_messages( ) INTO DATA(lo_message).
-      IF  lo_message->get_messageid( ) = lo_send_result->get_messageid( ) AND lo_message->get_body( ) = cv_message.
-        lv_found = abap_true.
+      IF lo_message->get_messageid( ) = lo_send_result->get_messageid( ) AND lo_message->get_body( ) = cv_message.
+        DATA(lv_found) = abap_true.
       ENDIF.
     ENDLOOP.
 
     cl_abap_unit_assert=>assert_true(
         act = lv_found
-        msg = |Did not receive message { cv_message }|
-  ).
+        msg = |Did not receive message { cv_message }| ).
     ao_sqs->deletequeue( iv_queueurl = lo_create_result->get_queueurl( ) ).
 
   ENDMETHOD.
   METHOD long_polling_on_create_queue.
-    CONSTANTS: cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-long-polling-on-create-queue'.
-    CONSTANTS: cv_wait_time TYPE /aws1/sqsstring VALUE '10'.
+    CONSTANTS cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-long-polling-on-create-queue'.
+    CONSTANTS cv_wait_time TYPE /aws1/sqsstring VALUE '10'.
     DATA(lo_create_result) = ao_sqs_actions->long_polling_on_create_queue(
                       iv_queue_name = cv_queue_name
-                      iv_wait_time  = cv_wait_time
-                  ).
+                      iv_wait_time  = cv_wait_time ).
     assert_queue_exists(
           iv_queue_url = lo_create_result->get_queueurl( )
-          iv_msg = |Queue { cv_queue_name } was not created|
-        ).
+          iv_msg = |Queue { cv_queue_name } was not created| ).
 
     DATA lt_attributes TYPE /aws1/cl_sqsattrnamelist_w=>tt_attributenamelist.
     APPEND NEW /aws1/cl_sqsattrnamelist_w( iv_value = 'ReceiveMessageWaitTimeSeconds' ) TO lt_attributes.
     DATA(lo_get_result) = ao_sqs->getqueueattributes(
                           iv_queueurl = lo_create_result->get_queueurl( )
-                          it_attributenames = lt_attributes
-                      ).
+                          it_attributenames = lt_attributes ).
     LOOP AT lo_get_result->get_attributes( ) INTO DATA(lo_attribute).
       IF lo_attribute-key = 'ReceiveMessageWaitTimeSeconds'.
         cl_abap_unit_assert=>assert_equals(
              act = cv_wait_time
              exp = lo_attribute-value->get_value( )
-             msg = |ReceiveMessageWaitTimeSeconds attribute for queue { cv_queue_name } did not match the expected value|
-         ).
+             msg = |ReceiveMessageWaitTimeSeconds attribute for queue { cv_queue_name } did not match the expected value| ).
       ENDIF.
     ENDLOOP.
     ao_sqs->deletequeue( iv_queueurl = lo_create_result->get_queueurl( ) ).
   ENDMETHOD.
   METHOD get_queue_url.
-    CONSTANTS: cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-get-queue-url'.
+    CONSTANTS cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-get-queue-url'.
     DATA(lo_create_result) = ao_sqs->createqueue( iv_queuename = cv_queue_name ).
-    DATA(lo_get_result) = ao_sqs_actions->get_queue_url( iv_queue_name = cv_queue_name ).
+    DATA(lo_get_result) = ao_sqs_actions->get_queue_url( cv_queue_name ).
     cl_abap_unit_assert=>assert_equals(
         act = lo_create_result->get_queueurl( )
         exp = lo_get_result->get_queueurl( )
-        msg = |Queue URL { lo_get_result->get_queueurl( ) } did not match expected value { lo_create_result->get_queueurl( ) }|
-    ).
+        msg = |Queue URL { lo_get_result->get_queueurl( ) } did not match expected value { lo_create_result->get_queueurl( ) }| ).
     ao_sqs->deletequeue( iv_queueurl = lo_create_result->get_queueurl( ) ).
   ENDMETHOD.
   METHOD list_queues.
-    CONSTANTS: cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-list-queues'.
+    CONSTANTS cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-list-queues'.
     DATA(lo_create_result) = ao_sqs->createqueue( iv_queuename = cv_queue_name ).
 
     DATA lv_found TYPE abap_bool VALUE abap_false.
@@ -183,14 +169,13 @@ CLASS ltc_zcl_aws1_sqs_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
       act = lv_found
-      msg = |Queue { cv_queue_name } should have been included in queue list|
-    ).
+      msg = |Queue { cv_queue_name } should have been included in queue list| ).
     ao_sqs->deletequeue( iv_queueurl = lo_create_result->get_queueurl( ) ).
   ENDMETHOD.
   METHOD delete_queue.
-    CONSTANTS: cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-delete-queue'.
+    CONSTANTS cv_queue_name TYPE /aws1/sqsstring VALUE 'code-example-delete-queue'.
     DATA(lo_create_result) = ao_sqs->createqueue( iv_queuename = cv_queue_name ).
-    ao_sqs_actions->delete_queue( iv_queue_url = lo_create_result->get_queueurl( ) ).
+    ao_sqs_actions->delete_queue( lo_create_result->get_queueurl( ) ).
 
     DATA lv_found TYPE abap_bool VALUE abap_true.
     DATA lo_list_result TYPE REF TO /aws1/cl_sqslistqueuesresult.
@@ -207,8 +192,7 @@ CLASS ltc_zcl_aws1_sqs_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_false(
           act = lv_found
-          msg = |Queue { cv_queue_name } should have been deleted|
-        ).
+          msg = |Queue { cv_queue_name } should have been deleted| ).
   ENDMETHOD.
   METHOD assert_queue_exists.
     DATA lv_found TYPE abap_bool VALUE abap_false.
@@ -225,8 +209,7 @@ CLASS ltc_zcl_aws1_sqs_actions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_true(
           act = lv_found
-          msg = iv_msg
-        ).
+          msg = iv_msg ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/sap-abap/services/textract/zcl_aws1_tex_actions.clas.testclasses.abap
+++ b/sap-abap/services/textract/zcl_aws1_tex_actions.clas.testclasses.abap
@@ -1,7 +1,7 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-CLASS ltc_zcl_aws1_tex_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_tex_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
 
@@ -12,7 +12,7 @@ CLASS ltc_zcl_aws1_tex_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL H
     DATA ao_session TYPE REF TO /aws1/cl_rt_session_base.
     DATA ao_tex_actions TYPE REF TO zcl_aws1_tex_actions.
 
-    METHODS setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
     METHODS analyze_document FOR TESTING.
     METHODS detect_document_text FOR TESTING.
     METHODS start_document_analysis FOR TESTING.

--- a/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.testclasses.abap
+++ b/sap-abap/services/textract/zcl_aws1_tex_scenario.clas.testclasses.abap
@@ -1,7 +1,7 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-CLASS ltc_zcl_aws1_tex_scenario DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_tex_scenario DEFINITION FOR TESTING DURATION SHORT RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
 
@@ -12,7 +12,7 @@ CLASS ltc_zcl_aws1_tex_scenario DEFINITION FOR TESTING DURATION SHORT RISK LEVEL
     DATA ao_tex_scenario TYPE REF TO zcl_aws1_tex_scenario.
     DATA lv_found TYPE abap_bool VALUE abap_false.
 
-    METHODS setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
     METHODS getting_started_with_tex FOR TESTING.
 
 ENDCLASS.       "ltc_Zcl_Aws1_Tex_Scenario

--- a/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.abap
+++ b/sap-abap/services/translate/zcl_aws1_xl8_actions.clas.abap
@@ -1,48 +1,48 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_XL8_ACTIONS definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_xl8_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods DESCRIBE_TEXT_TRANSLATION_JOB
-    importing
-      !IV_JOBID type /AWS1/XL8JOBID
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_XL8DSCTEXTXLATJOBRSP .
-  methods LIST_TEXT_TRANSLATION_JOBS
-    importing
-      !IV_JOBNAME type /AWS1/XL8JOBNAME
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_XL8LSTTEXTXLATJOBSRSP .
-  methods START_TEXT_TRANSLATION_JOB
-    importing
-      !IV_SOURCELANGUAGECODE type /AWS1/XL8LANGUAGECODESTRING optional
-      !IV_TARGETLANGUAGECODE type /AWS1/XL8LANGUAGECODESTRING optional
-      !IV_JOBNAME type /AWS1/XL8JOBNAME
-      !IV_INPUT_DATA_S3URI type /AWS1/XL8S3URI
-      !IV_INPUT_DATA_CONTENTTYPE type /AWS1/XL8CONTENTTYPE
-      !IV_OUTPUT_DATA_S3URI type /AWS1/XL8S3URI
-      !IV_DATAACCESSROLEARN type /AWS1/XL8IAMROLEARN
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_XL8STRTTEXTXLATJOBRSP .
-  methods STOP_TEXT_TRANSLATION_JOB
-    importing
-      !IV_JOBID type /AWS1/XL8JOBID
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_XL8STOPTEXTXLATJOBRSP .
-  methods TRANSLATE_TEXT
-    importing
-      !IV_SOURCELANGUAGECODE type /AWS1/XL8LANGUAGECODESTRING optional
-      !IV_TARGETLANGUAGECODE type /AWS1/XL8LANGUAGECODESTRING optional
-      !IV_TEXT type /AWS1/XL8BOUNDEDLENGTHSTRING
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_XL8TRANSLATETEXTRSP .
-protected section.
-private section.
+    METHODS describe_text_translation_job
+      IMPORTING
+      !iv_jobid TYPE /aws1/xl8jobid
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_xl8dsctextxlatjobrsp .
+    METHODS list_text_translation_jobs
+      IMPORTING
+      !iv_jobname TYPE /aws1/xl8jobname
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_xl8lsttextxlatjobsrsp .
+    METHODS start_text_translation_job
+      IMPORTING
+      !iv_sourcelanguagecode TYPE /aws1/xl8languagecodestring OPTIONAL
+      !iv_targetlanguagecode TYPE /aws1/xl8languagecodestring OPTIONAL
+      !iv_jobname TYPE /aws1/xl8jobname
+      !iv_input_data_s3uri TYPE /aws1/xl8s3uri
+      !iv_input_data_contenttype TYPE /aws1/xl8contenttype
+      !iv_output_data_s3uri TYPE /aws1/xl8s3uri
+      !iv_dataaccessrolearn TYPE /aws1/xl8iamrolearn
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_xl8strttextxlatjobrsp .
+    METHODS stop_text_translation_job
+      IMPORTING
+      !iv_jobid TYPE /aws1/xl8jobid
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_xl8stoptextxlatjobrsp .
+    METHODS translate_text
+      IMPORTING
+      !iv_sourcelanguagecode TYPE /aws1/xl8languagecodestring OPTIONAL
+      !iv_targetlanguagecode TYPE /aws1/xl8languagecodestring OPTIONAL
+      !iv_text TYPE /aws1/xl8boundedlengthstring
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_xl8translatetextrsp .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -52,7 +52,7 @@ CLASS ZCL_AWS1_XL8_ACTIONS IMPLEMENTATION.
 
   METHOD describe_text_translation_job.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_xl8) = /aws1/cl_xl8_factory=>create( lo_session ).
 
@@ -62,13 +62,11 @@ CLASS ZCL_AWS1_XL8_ACTIONS IMPLEMENTATION.
     "Includes properties such as name, ID, status, source and target languages, and input/output Amazon Simple Storage Service (Amazon S3) buckets."
     TRY.
         oo_result = lo_xl8->describetexttranslationjob(      "oo_result is returned for testing purposes."
-          EXPORTING
-            iv_jobid        = iv_jobid
-          ).
+          iv_jobid        = iv_jobid ).
         MESSAGE 'Job description retrieved.' TYPE 'I'.
-      CATCH /aws1/cx_xl8internalserverex .
+      CATCH /aws1/cx_xl8internalserverex.
         MESSAGE 'An internal server error occurred. Retry your request.' TYPE 'E'.
-      CATCH /aws1/cx_xl8resourcenotfoundex .
+      CATCH /aws1/cx_xl8resourcenotfoundex.
         MESSAGE 'The resource you are looking for has not been found.' TYPE 'E'.
       CATCH /aws1/cx_xl8toomanyrequestsex.
         MESSAGE 'You have made too many requests within a short period of time.' TYPE 'E'.
@@ -79,7 +77,7 @@ CLASS ZCL_AWS1_XL8_ACTIONS IMPLEMENTATION.
 
   METHOD list_text_translation_jobs.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_xl8) = /aws1/cl_xl8_factory=>create( lo_session ).
 
@@ -89,21 +87,17 @@ CLASS ZCL_AWS1_XL8_ACTIONS IMPLEMENTATION.
     DATA lo_filter TYPE REF TO /aws1/cl_xl8textxlationjobfilt.
 
     "Create an ABAP object for filtering using jobname."
-    CREATE OBJECT lo_filter
-      EXPORTING
-        iv_jobname = iv_jobname.
+    lo_filter = NEW #( iv_jobname = iv_jobname ).
 
     TRY.
         oo_result = lo_xl8->listtexttranslationjobs(      "oo_result is returned for testing purposes."
-          EXPORTING
-            io_filter        = lo_filter
-          ).
+          io_filter        = lo_filter ).
         MESSAGE 'Jobs retrieved.' TYPE 'I'.
-      CATCH /aws1/cx_xl8internalserverex .
+      CATCH /aws1/cx_xl8internalserverex.
         MESSAGE 'An internal server error occurred. Retry your request.' TYPE 'E'.
-      CATCH /aws1/cx_xl8invalidfilterex .
+      CATCH /aws1/cx_xl8invalidfilterex.
         MESSAGE 'The filter specified for the operation is not valid. Specify a different filter.' TYPE 'E'.
-      CATCH /aws1/cx_xl8invalidrequestex .
+      CATCH /aws1/cx_xl8invalidrequestex.
         MESSAGE 'The request that you made is not valid.' TYPE 'E'.
       CATCH /aws1/cx_xl8toomanyrequestsex.
         MESSAGE 'You have made too many requests within a short period of time.' TYPE 'E'.
@@ -114,9 +108,9 @@ CLASS ZCL_AWS1_XL8_ACTIONS IMPLEMENTATION.
 
   METHOD start_text_translation_job.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
-    DATA(lo_xl8) =     /aws1/cl_xl8_factory=>create( lo_session ).
+    DATA(lo_xl8) = /aws1/cl_xl8_factory=>create( lo_session ).
 
     "snippet-start:[xl8.abapv1.start_text_translation_job]
     "Starts an asynchronous batch translation job."
@@ -128,44 +122,36 @@ CLASS ZCL_AWS1_XL8_ACTIONS IMPLEMENTATION.
     DATA lo_targetlanguagecodes TYPE REF TO /aws1/cl_xl8tgtlanguagecodes00.
 
     "Create an ABAP object for the input data config."
-    CREATE OBJECT lo_inputdataconfig
-      EXPORTING
-        iv_s3uri       = iv_input_data_s3uri
-        iv_contenttype = iv_input_data_contenttype.
+    lo_inputdataconfig = NEW #( iv_s3uri = iv_input_data_s3uri
+                                iv_contenttype = iv_input_data_contenttype ).
 
     "Create an ABAP object for the output data config."
-    CREATE OBJECT lo_outputdataconfig
-      EXPORTING
-        iv_s3uri = iv_output_data_s3uri.
+    lo_outputdataconfig = NEW #( iv_s3uri = iv_output_data_s3uri ).
 
     "Create an internal table for target languages."
-    CREATE OBJECT lo_targetlanguagecodes
-      EXPORTING
-        iv_value = iv_targetlanguagecode.
+    lo_targetlanguagecodes = NEW #( iv_value = iv_targetlanguagecode ).
     INSERT lo_targetlanguagecodes  INTO TABLE lt_targetlanguagecodes.
 
     TRY.
         oo_result = lo_xl8->starttexttranslationjob(      "oo_result is returned for testing purposes."
-          EXPORTING
-            io_inputdataconfig = lo_inputdataconfig
+          io_inputdataconfig = lo_inputdataconfig
             io_outputdataconfig = lo_outputdataconfig
             it_targetlanguagecodes = lt_targetlanguagecodes
             iv_dataaccessrolearn = iv_dataaccessrolearn
             iv_jobname = iv_jobname
-            iv_sourcelanguagecode = iv_sourcelanguagecode
-          ).
+            iv_sourcelanguagecode = iv_sourcelanguagecode ).
         MESSAGE 'Translation job started.' TYPE 'I'.
-      CATCH /aws1/cx_xl8internalserverex .
+      CATCH /aws1/cx_xl8internalserverex.
         MESSAGE 'An internal server error occurred. Retry your request.' TYPE 'E'.
-      CATCH /aws1/cx_xl8invparamvalueex .
+      CATCH /aws1/cx_xl8invparamvalueex.
         MESSAGE 'The value of the parameter is not valid.' TYPE 'E'.
       CATCH /aws1/cx_xl8invalidrequestex.
         MESSAGE 'The request that you made is not valid.' TYPE 'E'.
-      CATCH /aws1/cx_xl8resourcenotfoundex .
+      CATCH /aws1/cx_xl8resourcenotfoundex.
         MESSAGE 'The resource you are looking for has not been found.' TYPE 'E'.
       CATCH /aws1/cx_xl8toomanyrequestsex.
         MESSAGE 'You have made too many requests within a short period of time.' TYPE 'E'.
-      CATCH /aws1/cx_xl8unsuppedlanguage00 .
+      CATCH /aws1/cx_xl8unsuppedlanguage00.
         MESSAGE 'Amazon Translate does not support translation from the language of the source text into the requested target language.' TYPE 'E'.
     ENDTRY.
     "snippet-end:[xl8.abapv1.start_text_translation_job]
@@ -174,22 +160,20 @@ CLASS ZCL_AWS1_XL8_ACTIONS IMPLEMENTATION.
 
   METHOD stop_text_translation_job.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
-    DATA(lo_xl8) =     /aws1/cl_xl8_factory=>create( lo_session ).
+    DATA(lo_xl8) = /aws1/cl_xl8_factory=>create( lo_session ).
 
     "snippet-start:[xl8.abapv1.stop_text_translation_job]
     "Stops an asynchronous batch translation job that is in progress."
 
     TRY.
         oo_result = lo_xl8->stoptexttranslationjob(      "oo_result is returned for testing purposes."
-          EXPORTING
-            iv_jobid        = iv_jobid
-          ).
+          iv_jobid        = iv_jobid ).
         MESSAGE 'Translation job stopped.' TYPE 'I'.
-      CATCH /aws1/cx_xl8internalserverex .
+      CATCH /aws1/cx_xl8internalserverex.
         MESSAGE 'An internal server error occurred.' TYPE 'E'.
-      CATCH /aws1/cx_xl8resourcenotfoundex .
+      CATCH /aws1/cx_xl8resourcenotfoundex.
         MESSAGE 'The resource you are looking for has not been found.' TYPE 'E'.
       CATCH /aws1/cx_xl8toomanyrequestsex.
         MESSAGE 'You have made too many requests within a short period of time.' TYPE 'E'.
@@ -200,35 +184,33 @@ CLASS ZCL_AWS1_XL8_ACTIONS IMPLEMENTATION.
 
   METHOD translate_text.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
-    DATA(lo_xl8) =     /aws1/cl_xl8_factory=>create( lo_session ).
+    DATA(lo_xl8) = /aws1/cl_xl8_factory=>create( lo_session ).
 
     "snippet-start:[xl8.abapv1.translate_text]
     "Translates input text from the source language to the target language."
     TRY.
         oo_result = lo_xl8->translatetext(      "oo_result is returned for testing purposes."
-          EXPORTING
-            iv_text        = iv_text
+          iv_text        = iv_text
             iv_sourcelanguagecode = iv_sourcelanguagecode
-            iv_targetlanguagecode = iv_targetlanguagecode
-          ).
+            iv_targetlanguagecode = iv_targetlanguagecode ).
         MESSAGE 'Translation completed.' TYPE 'I'.
-      CATCH /aws1/cx_xl8detectedlanguage00 .
+      CATCH /aws1/cx_xl8detectedlanguage00.
         MESSAGE 'The confidence that Amazon Comprehend accurately detected the source language is low.' TYPE 'E'.
-      CATCH /aws1/cx_xl8internalserverex .
+      CATCH /aws1/cx_xl8internalserverex.
         MESSAGE 'An internal server error occurred.' TYPE 'E'.
-      CATCH /aws1/cx_xl8invalidrequestex .
+      CATCH /aws1/cx_xl8invalidrequestex.
         MESSAGE 'The request that you made is not valid.' TYPE 'E'.
-      CATCH /aws1/cx_xl8resourcenotfoundex .
+      CATCH /aws1/cx_xl8resourcenotfoundex.
         MESSAGE 'The resource you are looking for has not been found.' TYPE 'E'.
-      CATCH /aws1/cx_xl8serviceunavailex .
+      CATCH /aws1/cx_xl8serviceunavailex.
         MESSAGE 'The Amazon Translate service is temporarily unavailable.' TYPE 'E'.
-      CATCH /aws1/cx_xl8textsizelmtexcdex .
+      CATCH /aws1/cx_xl8textsizelmtexcdex.
         MESSAGE 'The size of the text you submitted exceeds the size limit. ' TYPE 'E'.
-      CATCH /aws1/cx_xl8toomanyrequestsex .
+      CATCH /aws1/cx_xl8toomanyrequestsex.
         MESSAGE 'You have made too many requests within a short period of time.' TYPE 'E'.
-      CATCH /aws1/cx_xl8unsuppedlanguage00 .
+      CATCH /aws1/cx_xl8unsuppedlanguage00.
         MESSAGE 'Amazon Translate does not support translation from the language of the source text into the requested target language. ' TYPE 'E'.
     ENDTRY.
     "snippet-end:[xl8.abapv1.translate_text]

--- a/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.abap
+++ b/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.abap
@@ -1,26 +1,26 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-class ZCL_AWS1_XL8_SCENARIO definition
-  public
-  final
-  create public .
+CLASS zcl_aws1_xl8_scenario DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods GETTING_STARTED_WITH_XL8
-    importing
-      !IV_SOURCELANGUAGECODE type /AWS1/XL8LANGUAGECODESTRING optional
-      !IV_TARGETLANGUAGECODE type /AWS1/XL8LANGUAGECODESTRING optional
-      !IV_JOBNAME type /AWS1/XL8JOBNAME
-      !IV_INPUT_DATA_S3URI type /AWS1/XL8S3URI
-      !IV_INPUT_DATA_CONTENTTYPE type /AWS1/XL8CONTENTTYPE
-      !IV_OUTPUT_DATA_S3URI type /AWS1/XL8S3URI
-      !IV_DATAACCESSROLEARN type /AWS1/XL8IAMROLEARN
-    exporting
-      !OO_RESULT type ref to /AWS1/CL_XL8DSCTEXTXLATJOBRSP .
-protected section.
-private section.
+    METHODS getting_started_with_xl8
+      IMPORTING
+      !iv_sourcelanguagecode TYPE /aws1/xl8languagecodestring OPTIONAL
+      !iv_targetlanguagecode TYPE /aws1/xl8languagecodestring OPTIONAL
+      !iv_jobname TYPE /aws1/xl8jobname
+      !iv_input_data_s3uri TYPE /aws1/xl8s3uri
+      !iv_input_data_contenttype TYPE /aws1/xl8contenttype
+      !iv_output_data_s3uri TYPE /aws1/xl8s3uri
+      !iv_dataaccessrolearn TYPE /aws1/xl8iamrolearn
+      EXPORTING
+      !oo_result TYPE REF TO /aws1/cl_xl8dsctextxlatjobrsp .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -30,9 +30,9 @@ CLASS ZCL_AWS1_XL8_SCENARIO IMPLEMENTATION.
 
   METHOD getting_started_with_xl8.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
-    DATA(lo_xl8) =     /aws1/cl_xl8_factory=>create( lo_session ).
+    DATA(lo_xl8) = /aws1/cl_xl8_factory=>create( lo_session ).
 
     "1. Start an asynchronous batch translation job."
     "2. Wait for the asynchronous job to complete."
@@ -46,44 +46,36 @@ CLASS ZCL_AWS1_XL8_SCENARIO IMPLEMENTATION.
     DATA lo_targetlanguagecodes TYPE REF TO /aws1/cl_xl8tgtlanguagecodes00.
 
     "Create an ABAP object for the input data config."
-    CREATE OBJECT lo_inputdataconfig
-      EXPORTING
-        iv_s3uri       = iv_input_data_s3uri
-        iv_contenttype = iv_input_data_contenttype.
+    lo_inputdataconfig = NEW #( iv_s3uri = iv_input_data_s3uri
+                                iv_contenttype = iv_input_data_contenttype ).
 
     "Create an ABAP object for the output data config."
-    CREATE OBJECT lo_outputdataconfig
-      EXPORTING
-        iv_s3uri = iv_output_data_s3uri.
+    lo_outputdataconfig = NEW #( iv_s3uri = iv_output_data_s3uri ).
 
     "Create an internal table for target languages."
-    CREATE OBJECT lo_targetlanguagecodes
-      EXPORTING
-        iv_value = iv_targetlanguagecode.
+    lo_targetlanguagecodes = NEW #( iv_value = iv_targetlanguagecode ).
     INSERT lo_targetlanguagecodes  INTO TABLE lt_targetlanguagecodes.
 
     TRY.
         DATA(lo_translationjob_result) = lo_xl8->starttexttranslationjob(
-          EXPORTING
-            io_inputdataconfig = lo_inputdataconfig
+          io_inputdataconfig = lo_inputdataconfig
             io_outputdataconfig = lo_outputdataconfig
             it_targetlanguagecodes = lt_targetlanguagecodes
             iv_dataaccessrolearn = iv_dataaccessrolearn
             iv_jobname = iv_jobname
-            iv_sourcelanguagecode = iv_sourcelanguagecode
-          ).
+            iv_sourcelanguagecode = iv_sourcelanguagecode ).
         MESSAGE 'Translation job started.' TYPE 'I'.
-      CATCH /aws1/cx_xl8internalserverex .
+      CATCH /aws1/cx_xl8internalserverex.
         MESSAGE 'An internal server error occurred. Retry your request.' TYPE 'E'.
-      CATCH /aws1/cx_xl8invparamvalueex .
+      CATCH /aws1/cx_xl8invparamvalueex.
         MESSAGE 'The value of the parameter is not valid.' TYPE 'E'.
       CATCH /aws1/cx_xl8invalidrequestex.
         MESSAGE 'The request that you made is not valid.' TYPE 'E'.
-      CATCH /aws1/cx_xl8resourcenotfoundex .
+      CATCH /aws1/cx_xl8resourcenotfoundex.
         MESSAGE 'The resource you are looking for has not been found.' TYPE 'E'.
       CATCH /aws1/cx_xl8toomanyrequestsex.
         MESSAGE 'You have made too many requests within a short period of time. ' TYPE 'E'.
-      CATCH /aws1/cx_xl8unsuppedlanguage00 .
+      CATCH /aws1/cx_xl8unsuppedlanguage00.
         MESSAGE 'Amazon Translate does not support translation from the language of the source text into the requested target language.' TYPE 'E'.
     ENDTRY.
 
@@ -102,13 +94,11 @@ CLASS ZCL_AWS1_XL8_SCENARIO IMPLEMENTATION.
 
     TRY.
         oo_result = lo_xl8->describetexttranslationjob(      "oo_result is returned for testing purposes."
-          EXPORTING
-            iv_jobid        = lv_jobid
-          ).
+          iv_jobid        = lv_jobid ).
         MESSAGE 'Job description retrieved.' TYPE 'I'.
-      CATCH /aws1/cx_xl8internalserverex .
+      CATCH /aws1/cx_xl8internalserverex.
         MESSAGE 'An internal server error occurred. Retry your request.' TYPE 'E'.
-      CATCH /aws1/cx_xl8resourcenotfoundex .
+      CATCH /aws1/cx_xl8resourcenotfoundex.
         MESSAGE 'The resource you are looking for has not been found.' TYPE 'E'.
       CATCH /aws1/cx_xl8toomanyrequestsex.
         MESSAGE 'You have made too many requests within a short period of time.' TYPE 'E'.

--- a/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.testclasses.abap
+++ b/sap-abap/services/translate/zcl_aws1_xl8_scenario.clas.testclasses.abap
@@ -1,11 +1,11 @@
 " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 " SPDX-License-Identifier: Apache-2.0
 
-CLASS ltc_zcl_aws1_xl8_scenario DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
+CLASS ltc_zcl_aws1_xl8_scenario DEFINITION FOR TESTING DURATION LONG RISK LEVEL DANGEROUS.
 
   PRIVATE SECTION.
 
-    CONSTANTS: cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
 
     DATA ao_xl8 TYPE REF TO /aws1/if_xl8.
     DATA ao_s3 TYPE REF TO /aws1/if_s3.
@@ -15,7 +15,7 @@ CLASS ltc_zcl_aws1_xl8_scenario DEFINITION FOR TESTING DURATION LONG RISK LEVEL 
     DATA av_file_content TYPE /aws1/s3_streamingblob.
 
     METHODS getting_started_with_xl8 FOR TESTING.
-    METHODS setup RAISING /aws1/cx_rt_generic ycx_aws1_mit_generic.
+    METHODS setup RAISING /aws1/cx_rt_generic zcx_aws1_ex_generic.
 
 
 ENDCLASS.       "ltc_Zcl_Aws1_Xl8_Scenario
@@ -38,8 +38,7 @@ CLASS ltc_zcl_aws1_xl8_scenario IMPLEMENTATION.
       |Obtenez plus de flexibilité et de valeur à partir de vos investissements SAP grâce à l'infrastructure cloud la plus sécurisée, | &&
       |fiable et évolutive au monde, aux plus de 200 services AWS qui vous permettent d'innover, | &&
       |et aux outils d'automatisation de SAP spécialement conçus, | &&
-      |afin de réduire les risques et de simplifier les opérations. |
-    ).
+      |afin de réduire les risques et de simplifier les opérations. | ).
   ENDMETHOD.
 
   METHOD getting_started_with_xl8.
@@ -50,7 +49,7 @@ CLASS ltc_zcl_aws1_xl8_scenario IMPLEMENTATION.
     DATA lv_input_data_s3uri TYPE /aws1/xl8s3uri.
     DATA lv_output_data_s3uri TYPE /aws1/xl8s3uri.
     DATA lv_output_folder TYPE /aws1/xl8s3uri.
-    DATA lv_found TYPE abap_bool.
+
     DATA lv_jobid TYPE /aws1/xl8jobid.
     DATA lo_des_translation_result TYPE REF TO /aws1/cl_xl8dsctextxlatjobrsp.
     DATA lv_out_key1 TYPE /aws1/s3_objectkey.
@@ -74,7 +73,7 @@ CLASS ltc_zcl_aws1_xl8_scenario IMPLEMENTATION.
 
     "Define role Amazon Resource Name (ARN).
     DATA(lt_roles) = ao_session->get_configuration( )->get_logical_iam_roles( ).
-    READ TABLE lt_roles WITH KEY profile_id = cv_pfl INTO DATA(lo_role).
+    READ TABLE lt_roles INDEX 1 INTO DATA(lo_role).  " take first role from the logical role mapping
     av_lrole = lo_role-iam_role_arn.
 
     "Define job name.
@@ -85,16 +84,16 @@ CLASS ltc_zcl_aws1_xl8_scenario IMPLEMENTATION.
     "Create training data in Amazon Simple Storage Service (Amazon S3).
     lv_bucket_name = cv_bucket_name && lv_uuid_16.
     TRANSLATE lv_bucket_name TO LOWER CASE.
-    ao_s3->createbucket( iv_bucket = lv_bucket_name ).
-
+    zcl_aws1_ex_utils=>create_bucket( iv_bucket = lv_bucket_name
+                                      io_s3 = ao_s3
+                                      io_session = ao_session ).
     lv_input_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_input_folder.
     lv_output_data_s3uri = 's3://' && lv_bucket_name && '/' && cv_output_folder.
 
     ao_s3->putobject(
       iv_bucket = lv_bucket_name
       iv_key = cv_input_key
-      iv_body = av_file_content
-    ).
+      iv_body = av_file_content ).
 
     "Testing.
     ao_xl8_scenario->getting_started_with_xl8(
@@ -107,27 +106,24 @@ CLASS ltc_zcl_aws1_xl8_scenario IMPLEMENTATION.
         iv_sourcelanguagecode              = cv_sourcelanguagecode
         iv_targetlanguagecode              = cv_targetlanguagecode
       IMPORTING
-       oo_result                           = lo_des_translation_result
-    ).
+       oo_result                           = lo_des_translation_result ).
 
     "Validation.
-    lv_found = abap_false.
+    DATA(lv_found) = abap_false.
     IF lo_des_translation_result->get_textxlationjobproperties( )->get_jobstatus( ) = 'COMPLETED'.
       lv_found               = abap_true.
     ENDIF.
 
     cl_abap_unit_assert=>assert_true(
        act                    = lv_found
-       msg                    = |Describe job failed|
-    ).
+       msg                    = |Describe job failed| ).
 
     "Clean up.
     DATA(lo_list) = ao_s3->listobjectsv2( iv_bucket = lv_bucket_name ).
     LOOP AT lo_list->get_contents( ) INTO DATA(lo_object).
       ao_s3->deleteobject(
           iv_bucket = lv_bucket_name
-          iv_key = lo_object->get_key( )
-      ).
+          iv_key = lo_object->get_key( ) ).
     ENDLOOP.
 
     ao_s3->deletebucket( iv_bucket = lv_bucket_name ).

--- a/sap-abap/util/package.devc.xml
+++ b/sap-abap/util/package.devc.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DEVC>
+    <CTEXT>Utilities for example code</CTEXT>
+   </DEVC>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/sap-abap/util/zaws1_ex_exc.msag.xml
+++ b/sap-abap/util/zaws1_ex_exc.msag.xml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_MSAG" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <T100A>
+    <ARBGB>ZAWS1_EX_EXC</ARBGB>
+    <MASTERLANG>E</MASTERLANG>
+    <STEXT>Example Exceptions</STEXT>
+   </T100A>
+   <T100>
+    <T100>
+     <SPRSL>E</SPRSL>
+     <ARBGB>ZAWS1_EX_EXC</ARBGB>
+     <MSGNR>001</MSGNR>
+     <TEXT>&amp;1</TEXT>
+    </T100>
+   </T100>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/sap-abap/util/zcl_aws1_ex_utils.clas.abap
+++ b/sap-abap/util/zcl_aws1_ex_utils.clas.abap
@@ -1,3 +1,5 @@
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 CLASS zcl_aws1_ex_utils DEFINITION
   PUBLIC
   FINAL

--- a/sap-abap/util/zcl_aws1_ex_utils.clas.abap
+++ b/sap-abap/util/zcl_aws1_ex_utils.clas.abap
@@ -1,0 +1,83 @@
+CLASS zcl_aws1_ex_utils DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    CONSTANTS cv_asset_prefix TYPE string VALUE 'aws-example' ##NO_TEXT.
+
+    CLASS-METHODS get_random_string
+      RETURNING
+      VALUE(ov_str) TYPE string .
+    CLASS-METHODS cleanup_bucket
+      IMPORTING
+      !iv_bucket TYPE /aws1/s3_bucketname
+      !io_s3 TYPE REF TO /aws1/if_s3
+      RAISING
+      /aws1/cx_rt_generic .
+    CLASS-METHODS create_bucket
+      IMPORTING
+      !iv_bucket TYPE /aws1/s3_bucketname
+      !io_s3 TYPE REF TO /aws1/if_s3
+      !io_session TYPE REF TO /aws1/cl_rt_session_base
+      RAISING
+      /aws1/cx_rt_generic .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS ZCL_AWS1_EX_UTILS IMPLEMENTATION.
+
+
+  METHOD cleanup_bucket.
+    TRY.
+        DATA lt_obj TYPE /aws1/cl_s3_objectidentifier=>tt_objectidentifierlist.
+        LOOP AT io_s3->listobjectsv2( iv_bucket = iv_bucket )->get_contents( ) ASSIGNING FIELD-SYMBOL(<obj>).
+          APPEND NEW /aws1/cl_s3_objectidentifier( iv_key = <obj>->get_key( ) ) TO lt_obj.
+        ENDLOOP.
+        IF lines( lt_obj ) > 0.
+          io_s3->deleteobjects(
+               iv_bucket                     = iv_bucket
+               io_delete                     = NEW /aws1/cl_s3_delete( it_objects = lt_obj ) ).
+        ENDIF.
+        io_s3->deletebucket( iv_bucket = iv_bucket ).
+      CATCH /aws1/cx_s3_nosuchbucket INTO DATA(lo_ex).
+      CATCH /aws1/cx_s3_clientexc INTO DATA(lo_ex2).
+        IF lo_ex2->av_err_code = 'InvalidBucketName'.
+          " do nothing
+        ELSE.
+          RAISE EXCEPTION lo_ex2.
+        ENDIF.
+    ENDTRY.
+  ENDMETHOD.
+
+
+  METHOD create_bucket.
+    " determine our region from our session
+    DATA(lv_region) = CONV /aws1/s3_bucketlocationcnstrnt( io_session->get_region( ) ).
+    DATA lo_constraint TYPE REF TO /aws1/cl_s3_createbucketconf.
+    " When in the us-east-1 region, you must not specify a constraint
+    " In all other regions, specify the region as the constraint
+    IF lv_region = 'us-east-1'.
+      CLEAR lo_constraint.
+    ELSE.
+      lo_constraint = NEW /aws1/cl_s3_createbucketconf( lv_region ).
+    ENDIF.
+
+    io_s3->createbucket(
+        iv_bucket = iv_bucket
+        io_createbucketconfiguration  = lo_constraint ).
+  ENDMETHOD.
+
+
+  METHOD get_random_string.
+    CALL FUNCTION 'GENERAL_GET_RANDOM_STRING'
+      EXPORTING
+        number_chars  = 10
+      IMPORTING
+        random_string = ov_str.
+  ENDMETHOD.
+ENDCLASS.

--- a/sap-abap/util/zcl_aws1_ex_utils.clas.xml
+++ b/sap-abap/util/zcl_aws1_ex_utils.clas.xml
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_AWS1_EX_UTILS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Misc Utilities]</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS_SUB>
+    <SEOSUBCOTX>
+     <CMPNAME>CLEANUP_BUCKET</CMPNAME>
+     <SCONAME>/AWS1/CX_RT_GENERIC</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>AWS SDK Generic Exception</DESCRIPT>
+    </SEOSUBCOTX>
+    <SEOSUBCOTX>
+     <CMPNAME>CLEANUP_BUCKET</CMPNAME>
+     <SCONAME>IO_S3</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Client for AmazonS3</DESCRIPT>
+    </SEOSUBCOTX>
+    <SEOSUBCOTX>
+     <CMPNAME>CLEANUP_BUCKET</CMPNAME>
+     <SCONAME>IV_BUCKET</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Bucket Name</DESCRIPT>
+    </SEOSUBCOTX>
+    <SEOSUBCOTX>
+     <CMPNAME>CREATE_BUCKET</CMPNAME>
+     <SCONAME>/AWS1/CX_RT_GENERIC</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>AWS SDK Generic Exception</DESCRIPT>
+    </SEOSUBCOTX>
+    <SEOSUBCOTX>
+     <CMPNAME>CREATE_BUCKET</CMPNAME>
+     <SCONAME>IO_S3</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Client for AmazonS3</DESCRIPT>
+    </SEOSUBCOTX>
+    <SEOSUBCOTX>
+     <CMPNAME>CREATE_BUCKET</CMPNAME>
+     <SCONAME>IO_SESSION</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Abstract Interface AWS API Session</DESCRIPT>
+    </SEOSUBCOTX>
+    <SEOSUBCOTX>
+     <CMPNAME>CREATE_BUCKET</CMPNAME>
+     <SCONAME>IV_BUCKET</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Bucket Name</DESCRIPT>
+    </SEOSUBCOTX>
+   </DESCRIPTIONS_SUB>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/sap-abap/util/zcx_aws1_ex_generic.clas.abap
+++ b/sap-abap/util/zcx_aws1_ex_generic.clas.abap
@@ -1,0 +1,48 @@
+class ZCX_AWS1_EX_GENERIC definition
+  public
+  inheriting from CX_STATIC_CHECK
+  create public .
+
+public section.
+
+  interfaces IF_T100_MESSAGE .
+
+  constants:
+    begin of ZCX_AWS1_EX_GENERIC,
+      msgid type symsgid value 'ZAWS1_EX_EXC',
+      msgno type symsgno value '001',
+      attr1 type scx_attrname value 'AV_MSG',
+      attr2 type scx_attrname value '',
+      attr3 type scx_attrname value '',
+      attr4 type scx_attrname value '',
+    end of ZCX_AWS1_EX_GENERIC .
+  data AV_MSG type STRING .
+
+  methods CONSTRUCTOR
+    importing
+      !TEXTID like IF_T100_MESSAGE=>T100KEY optional
+      !PREVIOUS like PREVIOUS optional
+      !AV_MSG type STRING optional .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCX_AWS1_EX_GENERIC IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+PREVIOUS = PREVIOUS
+.
+me->AV_MSG = AV_MSG .
+clear me->textid.
+if textid is initial.
+  IF_T100_MESSAGE~T100KEY = ZCX_AWS1_EX_GENERIC .
+else.
+  IF_T100_MESSAGE~T100KEY = TEXTID.
+endif.
+  endmethod.
+ENDCLASS.

--- a/sap-abap/util/zcx_aws1_ex_generic.clas.abap
+++ b/sap-abap/util/zcx_aws1_ex_generic.clas.abap
@@ -1,3 +1,5 @@
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
 class ZCX_AWS1_EX_GENERIC definition
   public
   inheriting from CX_STATIC_CHECK

--- a/sap-abap/util/zcx_aws1_ex_generic.clas.xml
+++ b/sap-abap/util/zcx_aws1_ex_generic.clas.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_AWS1_EX_GENERIC</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Generic example exception</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
This pull request

* adds an example for bedrock agents runtime
* updates the S3 bucket creation in the examples and in unit tests to accomodate any region
* various other improvements to test cases
* mark test cases as DANGEROUS to help customers filter out these tests from their standard test suite since AWS assets will be created and deleted and charges may be incurred
* applies some automatic formatting from abaplint to make our whitespace and capitalization consistent (more linting to come...)
---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
