### PR TITLE
Update validate-doc-metadata.yml to -tools @ 2025.10.1

### DIFF
--- a/.github/workflows/validate-doc-metadata.yml
+++ b/.github/workflows/validate-doc-metadata.yml
@@ -16,7 +16,7 @@ jobs:
       - name: checkout repo content
         uses: actions/checkout@v4
       - name: validate metadata
-        uses: awsdocs/aws-doc-sdk-examples-tools@2025.10.0
+        uses: awsdocs/aws-doc-sdk-examples-tools@2025.10.1
         with:
           doc_gen_only: "False"
           strict_titles: "True"


### PR DESCRIPTION
This pull request bumps the -tools validator to @2025.10.1 release

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
