### PR TITLE
Use on-demand mode in DDB scenario example

### DIFF
--- a/swift/example_code/dynamodb/basics/MovieList/MovieTable.swift
+++ b/swift/example_code/dynamodb/basics/MovieList/MovieTable.swift
@@ -74,14 +74,11 @@ public class MovieTable {
                     DynamoDBClientTypes.AttributeDefinition(attributeName: "year", attributeType: .n),
                     DynamoDBClientTypes.AttributeDefinition(attributeName: "title", attributeType: .s)
                 ],
+                billingMode: DynamoDBClientTypes.BillingMode.payPerRequest,
                 keySchema: [
                     DynamoDBClientTypes.KeySchemaElement(attributeName: "year", keyType: .hash),
                     DynamoDBClientTypes.KeySchemaElement(attributeName: "title", keyType: .range)
                 ],
-                provisionedThroughput: DynamoDBClientTypes.ProvisionedThroughput(
-                    readCapacityUnits: 10,
-                    writeCapacityUnits: 10
-                ),
                 tableName: self.tableName
             )
             let output = try await client.createTable(input: input)


### PR DESCRIPTION
This updates the Swift DynamoDB basics/scenario example to use on-demand mode instead of provisioned mode.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
