### PR TITLE
JS: Adds WORKDIR directive to JSv3 Dockerfile

### DIFF
--- a/javascriptv3/Dockerfile
+++ b/javascriptv3/Dockerfile
@@ -20,6 +20,8 @@ COPY --chown=automation:automation ./resources /resources
 COPY --chown=automation:automation ./python/example_code/glue/flight_etl_job_script.py /python/example_code/glue/flight_etl_job_script.py
 COPY --chown=automation:automation ./scenarios/features /scenarios/features
 
+WORKDIR /javascriptv3
+
 # Set default command
 # `npm i` needs to be run in the container. Otherwise it causes a dependency issue: https://github.com/evanw/esbuild/issues/1646#issuecomment-1238080595
 # `aws-cdk` is required by some integration tests in order to deploy resources


### PR DESCRIPTION
This fixes a problem in Weathertop JS due to a change in how default working directories get decided in Docker.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
