### PR TITLE
GitHub: Update automerge-approved-prs.yml

### DIFF
--- a/.github/workflows/automerge-approved-prs.yml
+++ b/.github/workflows/automerge-approved-prs.yml
@@ -9,7 +9,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    if: ${{ github.event.review.state == 'approved' && github.repository == 'awsdocs/aws-doc-sdk-examples' && (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.user.login == 'aws-sdk-osds') }}
+    if: ${{ github.event.review.state == 'approved' && github.event.repository == 'awsdocs/aws-doc-sdk-examples' && (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.user.login == 'aws-sdk-osds') }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
This value should be `github.event.repository` instead of `github.event`. This is why there are no runs on this workflow.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
