### PR TITLE
Fix: Tools - Add yamllint and typer to .tools/base_requirements.txt

### DIFF
--- a/.tools/base_requirements.txt
+++ b/.tools/base_requirements.txt
@@ -4,5 +4,7 @@ mypy-extensions==1.0.0
 pathspec==0.11.2
 PyYAML==6.0.1
 requests==2.32.0
+typer==0.15.2
 types-PyYAML==6.0.12.12
 yamale==4.0.4
+yamllint==1.37.0


### PR DESCRIPTION
This pull request ads typer and yamllint to base_requirements.txt

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
