### PR TITLE
Fix SoS tags for example for Swift

### DIFF
--- a/swift/example_code/swift-sdk/http-config/Sources/entry.swift
+++ b/swift/example_code/swift-sdk/http-config/Sources/entry.swift
@@ -49,7 +49,7 @@ struct ExampleCommand: ParsableCommand {
 
         print("*** Getting bucket list with custom timeouts...")
         
-        // snippet-start: [swift.http-config.timeouts]
+        // snippet-start:[swift.http-config.timeouts]
         do {
             let config = try await S3Client.S3ClientConfiguration(
                 region: region,
@@ -66,7 +66,7 @@ struct ExampleCommand: ParsableCommand {
         } catch {
             print("*** Unexpected error occurred requesting the bucket list.")
         }
-        // snippet-end: [swift.http-config.timeouts]
+        // snippet-end:[swift.http-config.timeouts]
 
     }
 }


### PR DESCRIPTION
This pull request fixes the syntax of two SoS tags so the example can be embedded..

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
