### PR TITLE
Add model access prerequisite to Swift readme

### DIFF
--- a/swift/example_code/bedrock-runtime/README.md
+++ b/swift/example_code/bedrock-runtime/README.md
@@ -27,6 +27,9 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `swift
 
 
 <!--custom.prerequisites.start-->
+> ⚠ You must request access to a model before you can use it. If you try to use the model (with the API or console)
+> before you have requested access to it, you will receive an error message. For more information,
+> see [Model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html).
 <!--custom.prerequisites.end-->
 ### Amazon Nova
 


### PR DESCRIPTION
This pull request adds a custom prerequisite to the Swift README for Bedrock-Runtime

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
