### PR TITLE
Add Cognito ListUsers example for Swift

### DIFF
--- a/.doc_gen/metadata/cognito-identity-provider_metadata.yaml
+++ b/.doc_gen/metadata/cognito-identity-provider_metadata.yaml
@@ -429,6 +429,14 @@ cognito-identity-provider_ListUsers:
             - description:
               snippet_tags:
                 - javascript.v3.cognito-idp.actions.ListUsers
+    Swift:
+      versions:
+        - sdk_version: 1
+          github: swift/example_code/cognito-identity-provider
+          excerpts:
+            - description:
+              snippet_tags:
+                - swift.cognito-identity-provider.ListUsers
   services:
     cognito-identity-provider: {ListUsers}
 cognito-identity-provider_AdminInitiateAuth:

--- a/swift/example_code/cognito-identity-provider/ListUsers/Package.swift
+++ b/swift/example_code/cognito-identity-provider/ListUsers/Package.swift
@@ -1,0 +1,47 @@
+// swift-tools-version: 5.9
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// (swift-tools-version has two lines here because it needs to be the first
+// line in the file, but it should also appear in the snippet below)
+//
+// snippet-start:[swift.cognito-identity-provider.scenario.package]
+// swift-tools-version: 5.9
+//
+// The swift-tools-version declares the minimum version of Swift required to
+// build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "listusers",
+    // Let Xcode know the minimum Apple platforms supported.
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v15)
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(
+            url: "https://github.com/awslabs/aws-sdk-swift",
+            from: "1.0.0"),
+        .package(
+            url: "https://github.com/apple/swift-argument-parser.git",
+            branch: "main"
+        )
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products
+        // from dependencies.
+        .executableTarget(
+            name: "listusers",
+            dependencies: [
+                .product(name: "AWSCognitoIdentityProvider", package: "aws-sdk-swift"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
+            path: "Sources")
+
+    ]
+)
+// snippet-end:[swift.cognito-identity-provider.scenario.package]

--- a/swift/example_code/cognito-identity-provider/ListUsers/Sources/entry.swift
+++ b/swift/example_code/cognito-identity-provider/ListUsers/Sources/entry.swift
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// An example demonstrating how to get a list of the users in an Amazon
+// Cognito User Pool.
+import ArgumentParser
+import Foundation
+import AWSClientRuntime
+import AWSCognitoIdentityProvider
+
+struct ExampleCommand: ParsableCommand {
+    @Argument(help: "The user pool ID to use.")
+    var poolId: String
+    @Option(help: "Name of the Amazon Region to use.")
+    var region = "us-east-1"
+
+    static var configuration = CommandConfiguration(
+        commandName: "listusers",
+        abstract: """
+        Lists the users in the specified user pool.
+        """,
+        discussion: """
+        """
+    )
+
+    /// Called by ``main()`` to run the bulk of the example.
+    func runAsync() async throws {
+        let config = try await CognitoIdentityProviderClient.CognitoIdentityProviderClientConfiguration(region: region)
+        let cognitoClient = CognitoIdentityProviderClient(config: config)
+
+        // snippet-start:[swift.cognito-identity-provider.ListUsers]
+        do {
+            let output = try await cognitoClient.listUsers(
+                input: ListUsersInput(
+                    userPoolId: poolId
+                )
+            )
+            
+            guard let users = output.users else {
+                print("No users found.")
+                return
+            }
+
+            print("\(users.count) user(s) found.")
+            for user in users {
+                print("  \(user.username ?? "<unknown>")")
+            }
+        } catch _ as NotAuthorizedException {
+            print("*** Please authenticate with AWS before using this command.")
+            return
+        } catch _ as ResourceNotFoundException {
+            print("*** The specified User Pool was not found.")
+            return
+        } catch {
+            print("*** An unexpected type of error occurred.")
+            return
+        }
+        // snippet-end:[swift.cognito-identity-provider.ListUsers]
+    }
+}
+
+/// The program's asynchronous entry point.
+@main
+struct Main {
+    static func main() async {
+        let args = Array(CommandLine.arguments.dropFirst())
+
+        do {
+            let command = try ExampleCommand.parse(args)
+            try await command.runAsync()
+        } catch {
+            ExampleCommand.exit(withError: error)
+        }
+    }    
+}

--- a/swift/example_code/cognito-identity-provider/README.md
+++ b/swift/example_code/cognito-identity-provider/README.md
@@ -38,6 +38,7 @@ Code excerpts that show you how to call individual service functions.
 - [AdminRespondToAuthChallenge](scenario/Sources/entry.swift#L377)
 - [AssociateSoftwareToken](scenario/Sources/entry.swift#L298)
 - [ConfirmSignUp](scenario/Sources/entry.swift#L215)
+- [ListUsers](ListUsers/Sources/entry.swift#L31)
 - [ResendConfirmationCode](scenario/Sources/entry.swift#L180)
 - [SignUp](scenario/Sources/entry.swift#L131)
 - [VerifySoftwareToken](scenario/Sources/entry.swift#L334)
@@ -47,7 +48,7 @@ Code excerpts that show you how to call individual service functions.
 Code examples that show you how to accomplish a specific task by calling multiple
 functions within the same service.
 
-- [Sign up a user with a user pool that requires MFA](scenario/Package.swift)
+- [Sign up a user with a user pool that requires MFA](../swift-sdk/http-config/Package.swift)
 
 
 <!--custom.examples.start-->

--- a/swift/example_code/cognito-identity-provider/scenario/Sources/entry.swift
+++ b/swift/example_code/cognito-identity-provider/scenario/Sources/entry.swift
@@ -33,10 +33,10 @@
 // 9. Invokes the AdminRespondToAuthChallenge to get back a token.
 
 import ArgumentParser
-import AWSClientRuntime
 import Foundation
 
 // snippet-start:[swift.cognito-identity-provider.import]
+import AWSClientRuntime
 import AWSCognitoIdentityProvider
 // snippet-end:[swift.cognito-identity-provider.import]
 


### PR DESCRIPTION
In addition, this PR makes a minor change to a previous Cognito example to adjust which lines are embedded when an SoS tag is used.

A buiild is available here: http://sheppycloud.aka.corp.amazon.com:4301/build-more-cognito/swift_1_cognito-identity-provider_code_examples.html

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
