### PR TITLE
Java: Replaced getStackTrace() calls with printStackTrace() calls

### DIFF
--- a/java/example_code/dynamodb/src/main/java/aws/example/dynamodb/DynamoDBScanItems.java
+++ b/java/example_code/dynamodb/src/main/java/aws/example/dynamodb/DynamoDBScanItems.java
@@ -60,7 +60,7 @@ public class DynamoDBScanItems {
             }
 
         } catch (AmazonDynamoDBException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
 
         // snippet-end:[dynamodb.java.dynamoDB_scan.main]

--- a/java/example_code/dynamodb/src/main/java/aws/example/dynamodb/UseDynamoMapping.java
+++ b/java/example_code/dynamodb/src/main/java/aws/example/dynamodb/UseDynamoMapping.java
@@ -79,7 +79,7 @@ public class UseDynamoMapping {
 
             System.out.print("Done");
         } catch (AmazonDynamoDBException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 

--- a/java/example_code/ec2/src/main/java/aws/example/ec2/DescribeAccount.java
+++ b/java/example_code/ec2/src/main/java/aws/example/ec2/DescribeAccount.java
@@ -39,7 +39,7 @@ public class DescribeAccount {
             }
             System.out.print("Done");
         } catch (Exception e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
         // snippet-end:[ec2.java1.describe_account.main]
     }

--- a/java/example_code/ec2/src/main/java/aws/example/ec2/FindRunningInstances.java
+++ b/java/example_code/ec2/src/main/java/aws/example/ec2/FindRunningInstances.java
@@ -56,7 +56,7 @@ public class FindRunningInstances {
             System.out.print("Done");
 
         } catch (SdkClientException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
         // snippet-end:[ec2.java1.running_instances.main]
     }

--- a/java/example_code/ssm/src/main/java/aws/example/ssm/GetSimpleSystemsManagementOps.java
+++ b/java/example_code/ssm/src/main/java/aws/example/ssm/GetSimpleSystemsManagementOps.java
@@ -47,7 +47,7 @@ public class GetSimpleSystemsManagementOps {
             System.out.println(item.getSource());
 
         } catch (AmazonServiceException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
         // snippet-end:[ssm.Java1.get_ops.main]
     }

--- a/java/example_code/ssm/src/main/java/aws/example/ssm/GetSimpleSystemsManagementParas.java
+++ b/java/example_code/ssm/src/main/java/aws/example/ssm/GetSimpleSystemsManagementParas.java
@@ -43,7 +43,7 @@ public class GetSimpleSystemsManagementParas {
             }
 
         } catch (AmazonServiceException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
         // snippet-end:[ssm.Java1.get_params.main]
     }

--- a/javav2/example_code/s3/src/main/java/com/example/s3/GetObjectPresignedUrl.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/GetObjectPresignedUrl.java
@@ -107,7 +107,7 @@ public class GetObjectPresignedUrl {
             }
 
         } catch (S3Exception | IOException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 }

--- a/javav2/example_code/ses/src/main/java/com/example/ses/SendMessage.java
+++ b/javav2/example_code/ses/src/main/java/com/example/ses/SendMessage.java
@@ -73,7 +73,7 @@ public class SendMessage {
             System.out.println("Done");
 
         } catch (IOException | MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 

--- a/javav2/example_code/ses/src/main/java/com/example/ses/SendMessageAttachment.java
+++ b/javav2/example_code/ses/src/main/java/com/example/ses/SendMessageAttachment.java
@@ -83,7 +83,7 @@ public class SendMessageAttachment {
             System.out.println("Done");
 
         } catch (IOException | MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 

--- a/javav2/example_code/ses/src/main/java/com/example/ses/SendMessageEmailRequest.java
+++ b/javav2/example_code/ses/src/main/java/com/example/ses/SendMessageEmailRequest.java
@@ -62,7 +62,7 @@ public class SendMessageEmailRequest {
             System.out.println("Done");
 
         } catch (MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 

--- a/javav2/example_code/ssm/src/main/java/com/example/ssm/DescribeParameters.java
+++ b/javav2/example_code/ssm/src/main/java/com/example/ssm/DescribeParameters.java
@@ -48,7 +48,7 @@ public class DescribeParameters {
             }
 
         } catch (SsmException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 }

--- a/javav2/usecases/Creating_rds_item_tracker/README.md
+++ b/javav2/usecases/Creating_rds_item_tracker/README.md
@@ -326,7 +326,7 @@ public class ConnectionHelper {
             return DriverManager.getConnection(url2, user, password);
 
         } catch (SQLException | ClassNotFoundException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
         return null;
     }

--- a/javav2/usecases/Creating_rds_item_tracker/src/main/java/com/aws/rest/ConnectionHelper.java
+++ b/javav2/usecases/Creating_rds_item_tracker/src/main/java/com/aws/rest/ConnectionHelper.java
@@ -16,7 +16,7 @@ public class ConnectionHelper {
             return DriverManager.getConnection(url2, user, password);
 
         } catch (SQLException | ClassNotFoundException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
         return null;
     }

--- a/javav2/usecases/create_workflow_redshift/README.md
+++ b/javav2/usecases/create_workflow_redshift/README.md
@@ -350,7 +350,7 @@ public class HandlerSES implements RequestHandler<String, String> {
 
         } catch (javax.mail.MessagingException e)
         {
-            e.getStackTrace();
+            e.printStackTrace();
         }
 
         return "Ok" ;

--- a/javav2/usecases/create_workflow_redshift/src/main/java/redshift/HandlerSES.java
+++ b/javav2/usecases/create_workflow_redshift/src/main/java/redshift/HandlerSES.java
@@ -34,7 +34,7 @@ public class HandlerSES implements RequestHandler<String, String> {
             msg.sendMessage(client, sender, recipient, subject, bodyHTML);
 
         } catch (javax.mail.MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
 
         return "Ok";

--- a/javav2/usecases/creating_message_application/README.md
+++ b/javav2/usecases/creating_message_application/README.md
@@ -324,7 +324,7 @@ public class SendReceiveMessages {
             return allMessages;
 
         } catch (SqsException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
         return null;
     }
@@ -372,7 +372,7 @@ public class SendReceiveMessages {
             sqsClient.sendMessage(sendMsgRequest);
 
         } catch (SqsException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 }

--- a/javav2/usecases/creating_message_application/src/main/java/com/example/sqs/SendReceiveMessages.java
+++ b/javav2/usecases/creating_message_application/src/main/java/com/example/sqs/SendReceiveMessages.java
@@ -94,7 +94,7 @@ public class SendReceiveMessages {
             return allMessages;
 
         } catch (SqsException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
         return null;
     }
@@ -142,7 +142,7 @@ public class SendReceiveMessages {
             sqsClient.sendMessage(sendMsgRequest);
 
         } catch (SqsException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 }

--- a/javav2/usecases/creating_photo_analyzer_app/README.md
+++ b/javav2/usecases/creating_photo_analyzer_app/README.md
@@ -642,7 +642,7 @@ public class SendMessages {
         try {
             send(fileContent,emailAddress);
         } catch (MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 

--- a/javav2/usecases/creating_photo_analyzer_app/src/main/java/com/example/photo/SendMessages.java
+++ b/javav2/usecases/creating_photo_analyzer_app/src/main/java/com/example/photo/SendMessages.java
@@ -36,7 +36,7 @@ public class SendMessages {
         try {
             send(fileContent, emailAddress);
         } catch (MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 

--- a/javav2/usecases/creating_photo_analyzer_async/README.md
+++ b/javav2/usecases/creating_photo_analyzer_async/README.md
@@ -750,7 +750,7 @@ The following Java code represents the **SendMessage** class. This class uses th
         try {
             send(fileContent,emailAddress);
         } catch (MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
      }
 

--- a/javav2/usecases/creating_photo_analyzer_async/src/main/java/com/example/photo/SendMessages.java
+++ b/javav2/usecases/creating_photo_analyzer_async/src/main/java/com/example/photo/SendMessages.java
@@ -36,7 +36,7 @@ public class SendMessages {
         try {
             send(fileContent, emailAddress);
         } catch (MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 

--- a/javav2/usecases/creating_workflows_stepfunctions/README.md
+++ b/javav2/usecases/creating_workflows_stepfunctions/README.md
@@ -314,7 +314,7 @@ The **Handler3** class is the third step in the workflow and creates a **SendMes
 
        } catch (IOException e)
        {
-           e.getStackTrace();
+           e.printStackTrace();
        }
 
         return "";
@@ -491,7 +491,7 @@ The following Java class represents the **SendMessage** class. This class uses t
             send(client, sender,email, subject,bodyText,bodyHTML);
 
         } catch (IOException | MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
       }
 

--- a/javav2/usecases/creating_workflows_stepfunctions/src/main/java/example/Handler3.java
+++ b/javav2/usecases/creating_workflows_stepfunctions/src/main/java/example/Handler3.java
@@ -24,7 +24,7 @@ public class Handler3 implements RequestHandler<String, String> {
             msg.sendMessage(email);
 
         } catch (IOException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
 
         return "";

--- a/javav2/usecases/creating_workflows_stepfunctions/src/main/java/example/SendMessage.java
+++ b/javav2/usecases/creating_workflows_stepfunctions/src/main/java/example/SendMessage.java
@@ -46,7 +46,7 @@ public class SendMessage {
             send(client, sender, email, subject, bodyText, bodyHTML);
 
         } catch (IOException | MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 

--- a/javav2/usecases/video_analyzer_application/README.md
+++ b/javav2/usecases/video_analyzer_application/README.md
@@ -446,7 +446,7 @@ The following Java code represents the **SendMessage** class. This class uses th
         try {
             send(fileContent,emailAddress);
         } catch (MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
      }
 

--- a/javav2/usecases/video_analyzer_application/src/main/java/com/example/video/SendMessages.java
+++ b/javav2/usecases/video_analyzer_application/src/main/java/com/example/video/SendMessages.java
@@ -52,7 +52,7 @@ public class SendMessages {
         try {
             send(fileContent, emailAddress);
         } catch (MessagingException e) {
-            e.getStackTrace();
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
I noticed that in some places `getStackTrace()` is called instead of `printStackTrace()`. `getStackTrace()` returns an array while `printStackTrace()` goes about actually printing it to System.err. So essentially, in instances where `getStackTrace()` is called, an array is returned yet not stored, and the pertinent stack trace is never output.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
