### PR TITLE
Java V2: migrate v1 sqs example that compares single messaging to batch messaging

### DIFF
--- a/.doc_gen/metadata/sqs_metadata.yaml
+++ b/.doc_gen/metadata/sqs_metadata.yaml
@@ -890,10 +890,10 @@ sqs_Scenario_SendReceiveBatch:
                 <para>Use explicit batching when you need fine-grained control over batch composition and
                   error handling. Use automatic batching when you want to optimize performance with minimal
                   code changes.</para>
-                <para><emphasis role="strong">SendRecvBatch.java</emphasis> - Uses explicit batch operations with messages.
+                <para>SendRecvBatch.java - Uses explicit batch operations with messages.
               snippet_tags:
                 - sqs.java2.sendRecvBatch.main
-            - description: <emphasis role="strong">SimpleProducerConsumer.java</emphasis> - Uses automatic batching of messages.
+            - description: SimpleProducerConsumer.java - Uses automatic batching of messages.
               snippet_tags:
                 - sqs.java2.batch_demo.main
   services:

--- a/.doc_gen/metadata/sqs_metadata.yaml
+++ b/.doc_gen/metadata/sqs_metadata.yaml
@@ -867,6 +867,15 @@ sqs_Scenario_SendReceiveBatch:
             - description: Use the wrapper functions to send and receive messages in batches.
               snippet_tags:
                 - python.example_code.sqs.Scenario_SendReceiveBatch
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/sqs
+          sdkguide:
+          excerpts:
+            - description: Compare single-message SQS operations with automatic batching.
+              snippet_tags:
+                - sqs.java2.batch_demo.main
   services:
     sqs: {CreateQueue, DeleteQueue, SendMessageBatch, ReceiveMessage, DeleteMessageBatch}
 sqs_GetQueueAttributes:

--- a/.doc_gen/metadata/sqs_metadata.yaml
+++ b/.doc_gen/metadata/sqs_metadata.yaml
@@ -876,6 +876,9 @@ sqs_Scenario_SendReceiveBatch:
             - description: Compare single-message SQS operations with automatic batching.
               snippet_tags:
                 - sqs.java2.batch_demo.main
+            - description: Create functions to wrap &SQS; message functions and use them to send and receive messages in batches.
+              snippet_tags:
+                - sqs.java2.sendRecvBatch.main
   services:
     sqs: {CreateQueue, DeleteQueue, SendMessageBatch, SendMessage, ReceiveMessage, DeleteMessageBatch, DeleteMessage}
 sqs_GetQueueAttributes:

--- a/.doc_gen/metadata/sqs_metadata.yaml
+++ b/.doc_gen/metadata/sqs_metadata.yaml
@@ -877,7 +877,7 @@ sqs_Scenario_SendReceiveBatch:
               snippet_tags:
                 - sqs.java2.batch_demo.main
   services:
-    sqs: {CreateQueue, DeleteQueue, SendMessageBatch, ReceiveMessage, DeleteMessageBatch}
+    sqs: {CreateQueue, DeleteQueue, SendMessageBatch, SendMessage, ReceiveMessage, DeleteMessageBatch, DeleteMessage}
 sqs_GetQueueAttributes:
   languages:
     .NET:

--- a/.doc_gen/metadata/sqs_metadata.yaml
+++ b/.doc_gen/metadata/sqs_metadata.yaml
@@ -890,10 +890,10 @@ sqs_Scenario_SendReceiveBatch:
                 <para>Use explicit batching when you need fine-grained control over batch composition and
                   error handling. Use automatic batching when you want to optimize performance with minimal
                   code changes.</para>
-                <para>Use explicit batch operations with messages.
+                <para><emphasis role="strong">SendRecvBatch.java</emphasis> - Uses explicit batch operations with messages.
               snippet_tags:
                 - sqs.java2.sendRecvBatch.main
-            - description: Use automatic batching of messages.
+            - description: <emphasis role="strong">SimpleProducerConsumer.java</emphasis> - Uses automatic batching of messages.
               snippet_tags:
                 - sqs.java2.batch_demo.main
   services:

--- a/.doc_gen/metadata/sqs_metadata.yaml
+++ b/.doc_gen/metadata/sqs_metadata.yaml
@@ -873,12 +873,29 @@ sqs_Scenario_SendReceiveBatch:
           github: javav2/example_code/sqs
           sdkguide:
           excerpts:
-            - description: Compare single-message SQS operations with automatic batching.
-              snippet_tags:
-                - sqs.java2.batch_demo.main
-            - description: Create functions to wrap &SQS; message functions and use them to send and receive messages in batches.
+            - description: >-
+                You can handle batch message operations with Amazon SQS using two different approaches
+                  with the &JavaV2long;:</para>
+                <para><emphasis role="strong">SendRecvBatch.java</emphasis> uses explicit batch operations.
+                  You manually create message batches and call <code>sendMessageBatch()</code> and
+                  <code>deleteMessageBatch()</code> directly. You also handle batch responses, including any
+                  failed messages. This approach gives you full control over batch sizing and error handling.
+                  However, it requires more code to manage the batching logic.</para>
+                <para><emphasis role="strong">SimpleProducerConsumer.java</emphasis> uses the high-level
+                  <code>SqsAsyncBatchManager</code> library for automatic request batching. You make
+                  individual <code>sendMessage()</code> and <code>deleteMessage()</code> calls with the same
+                  method signatures as the standard client. The SDK automatically buffers these calls and
+                  sends them as batch operations. This approach requires minimal code changes while providing
+                  batching performance benefits.</para>
+                <para>Use explicit batching when you need fine-grained control over batch composition and
+                  error handling. Use automatic batching when you want to optimize performance with minimal
+                  code changes.</para>
+                <para>Use explicit batch operations with messages.
               snippet_tags:
                 - sqs.java2.sendRecvBatch.main
+            - description: Use automatic batching of messages.
+              snippet_tags:
+                - sqs.java2.batch_demo.main
   services:
     sqs: {CreateQueue, DeleteQueue, SendMessageBatch, SendMessage, ReceiveMessage, DeleteMessageBatch, DeleteMessage}
 sqs_GetQueueAttributes:

--- a/javav2/example_code/sqs/README.md
+++ b/javav2/example_code/sqs/README.md
@@ -57,6 +57,7 @@ functions within the same service.
 - [Manage large messages using S3](src/main/java/com/example/sqs/SqsExtendedClientExample.java)
 - [Process S3 event notifications](../s3/src/main/java/com/example/s3/ProcessS3EventNotification.java)
 - [Publish messages to queues](../../usecases/topics_and_queues/src/main/java/com/example/sns/SNSWorkflow.java)
+- [Send and receive batches of messages](src/main/java/com/example/sqs/SimpleProducerConsumer.java)
 - [Use the Amazon SQS Java Messaging Library to work with the JMS interface](../sqs-jms/src/main/java/com/example/sqs/jms/stdqueue/TextMessageSender.java)
 - [Work with queue tags](src/main/java/com/example/sqs/TagExamples.java)
 
@@ -129,6 +130,22 @@ This example shows you how to do the following:
 
 <!--custom.scenarios.sqs_Scenario_TopicsAndQueues.start-->
 <!--custom.scenarios.sqs_Scenario_TopicsAndQueues.end-->
+
+#### Send and receive batches of messages
+
+This example shows you how to do the following:
+
+- Create an Amazon SQS queue.
+- Send batches of messages to the queue.
+- Receive batches of messages from the queue.
+- Delete batches of messages from the queue.
+
+<!--custom.scenario_prereqs.sqs_Scenario_SendReceiveBatch.start-->
+<!--custom.scenario_prereqs.sqs_Scenario_SendReceiveBatch.end-->
+
+
+<!--custom.scenarios.sqs_Scenario_SendReceiveBatch.start-->
+<!--custom.scenarios.sqs_Scenario_SendReceiveBatch.end-->
 
 #### Use the Amazon SQS Java Messaging Library to work with the JMS interface
 

--- a/javav2/example_code/sqs/README.md
+++ b/javav2/example_code/sqs/README.md
@@ -57,7 +57,7 @@ functions within the same service.
 - [Manage large messages using S3](src/main/java/com/example/sqs/SqsExtendedClientExample.java)
 - [Process S3 event notifications](../s3/src/main/java/com/example/s3/ProcessS3EventNotification.java)
 - [Publish messages to queues](../../usecases/topics_and_queues/src/main/java/com/example/sns/SNSWorkflow.java)
-- [Send and receive batches of messages](src/main/java/com/example/sqs/SimpleProducerConsumer.java)
+- [Send and receive batches of messages](src/main/java/com/example/sqs/SendRecvBatch.java)
 - [Use the Amazon SQS Java Messaging Library to work with the JMS interface](../sqs-jms/src/main/java/com/example/sqs/jms/stdqueue/TextMessageSender.java)
 - [Work with queue tags](src/main/java/com/example/sqs/TagExamples.java)
 

--- a/javav2/example_code/sqs/src/main/java/com/example/sqs/SendRecvBatch.java
+++ b/javav2/example_code/sqs/src/main/java/com/example/sqs/SendRecvBatch.java
@@ -1,0 +1,333 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.sqs;
+
+// snippet-start:[sqs.java2.sendRecvBatch.main]
+// snippet-start:[sqs.java2.sendRecvBatch.import]
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+// snippet-end:[sqs.java2.sendRecvBatch.import]
+
+
+/**
+ * Before running this Java V2 code example, set up your development
+ * environment, including your credentials.
+ *
+ * For more information, see the following documentation topic:
+ *
+ * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+
+/**
+ * This code demonstrates basic message operations in Amazon Simple Queue Service (Amazon SQS).
+ */
+
+public class SendRecvBatch {
+    private static final Logger logger = Logger.getLogger(SendRecvBatch.class.getName());
+    static {
+        Logger rootLogger = Logger.getLogger("");
+        rootLogger.setLevel(Level.WARNING);
+    }
+    private static final SqsClient sqsClient = SqsClient.builder()
+            .region(Region.US_WEST_2)
+            .build();
+
+    // snippet-start:[sqs.java2.sendRecvBatch.sendBatch]
+    /**
+     * Send a batch of messages in a single request to an SQS queue.
+     * This request may return overall success even when some messages were not sent.
+     * The caller must inspect the Successful and Failed lists in the response and
+     * resend any failed messages.
+     *
+     * @param queueUrl  The URL of the queue to receive the messages.
+     * @param messages  The messages to send to the queue. Each message contains a body and attributes.
+     * @return The response from SQS that contains the list of successful and failed messages.
+     */
+    public static SendMessageBatchResponse sendMessages(
+            String queueUrl, List<MessageEntry> messages) {
+
+        try {
+            List<SendMessageBatchRequestEntry> entries = new ArrayList<>();
+
+            for (int i = 0; i < messages.size(); i++) {
+                MessageEntry message = messages.get(i);
+                entries.add(SendMessageBatchRequestEntry.builder()
+                        .id(String.valueOf(i))
+                        .messageBody(message.getBody())
+                        .messageAttributes(message.getAttributes())
+                        .build());
+            }
+
+            SendMessageBatchRequest sendBatchRequest = SendMessageBatchRequest.builder()
+                    .queueUrl(queueUrl)
+                    .entries(entries)
+                    .build();
+
+            SendMessageBatchResponse response = sqsClient.sendMessageBatch(sendBatchRequest);
+
+            if (!response.successful().isEmpty()) {
+                for (SendMessageBatchResultEntry resultEntry : response.successful()) {
+                    logger.info("Message sent: " + resultEntry.messageId() + ": " +
+                            messages.get(Integer.parseInt(resultEntry.id())).getBody());
+                }
+            }
+
+            if (!response.failed().isEmpty()) {
+                for (BatchResultErrorEntry errorEntry : response.failed()) {
+                    logger.warning("Failed to send: " + errorEntry.id() + ": " +
+                            messages.get(Integer.parseInt(errorEntry.id())).getBody());
+                }
+            }
+
+            return response;
+
+        } catch (SqsException e) {
+            logger.log(Level.SEVERE, "Send messages failed to queue: " + queueUrl, e);
+            throw e;
+        }
+    }
+    // snippet-end:[sqs.java2.sendRecvBatch.sendBatch]
+
+    // snippet-start:[sqs.java2.sendRecvBatch.recvBatch]
+    /**
+     * Receive a batch of messages in a single request from an SQS queue.
+     *
+     * @param queueUrl   The URL of the queue from which to receive messages.
+     * @param maxNumber  The maximum number of messages to receive. The actual number
+     *                   of messages received might be less.
+     * @param waitTime   The maximum time to wait (in seconds) before returning. When
+     *                   this number is greater than zero, long polling is used. This
+     *                   can result in reduced costs and fewer false empty responses.
+     * @return The list of Message objects received. These each contain the body
+     *         of the message and metadata and custom attributes.
+     */
+    public static List<Message> receiveMessages(String queueUrl, int maxNumber, int waitTime) {
+        try {
+            ReceiveMessageRequest receiveRequest = ReceiveMessageRequest.builder()
+                    .queueUrl(queueUrl)
+                    .maxNumberOfMessages(maxNumber)
+                    .waitTimeSeconds(waitTime)
+                    .messageAttributeNames("All")
+                    .build();
+
+            List<Message> messages = sqsClient.receiveMessage(receiveRequest).messages();
+
+            for (Message message : messages) {
+                logger.info("Received message: " + message.messageId() + ": " + message.body());
+            }
+
+            return messages;
+
+        } catch (SqsException e) {
+            logger.log(Level.SEVERE, "Couldn't receive messages from queue: " + queueUrl, e);
+            throw e;
+        }
+    }
+    // snippet-end:[sqs.java2.sendRecvBatch.recvBatch]
+
+    // snippet-start:[sqs.java2.sendRecvBatch.delBatch]
+    /**
+     * Delete a batch of messages from a queue in a single request.
+     *
+     * @param queueUrl  The URL of the queue from which to delete the messages.
+     * @param messages  The list of messages to delete.
+     * @return The response from SQS that contains the list of successful and failed
+     *         message deletions.
+     */
+    public static DeleteMessageBatchResponse deleteMessages(String queueUrl, List<Message> messages) {
+        try {
+            List<DeleteMessageBatchRequestEntry> entries = new ArrayList<>();
+
+            for (int i = 0; i < messages.size(); i++) {
+                entries.add(DeleteMessageBatchRequestEntry.builder()
+                        .id(String.valueOf(i))
+                        .receiptHandle(messages.get(i).receiptHandle())
+                        .build());
+            }
+
+            DeleteMessageBatchRequest deleteRequest = DeleteMessageBatchRequest.builder()
+                    .queueUrl(queueUrl)
+                    .entries(entries)
+                    .build();
+
+            DeleteMessageBatchResponse response = sqsClient.deleteMessageBatch(deleteRequest);
+
+            if (!response.successful().isEmpty()) {
+                for (DeleteMessageBatchResultEntry resultEntry : response.successful()) {
+                    logger.info("Deleted " + messages.get(Integer.parseInt(resultEntry.id())).receiptHandle());
+                }
+            }
+
+            if (!response.failed().isEmpty()) {
+                for (BatchResultErrorEntry errorEntry : response.failed()) {
+                    logger.warning("Could not delete " + messages.get(Integer.parseInt(errorEntry.id())).receiptHandle());
+                }
+            }
+
+            return response;
+
+        } catch (SqsException e) {
+            logger.log(Level.SEVERE, "Couldn't delete messages from queue " + queueUrl, e);
+            throw e;
+        }
+    }
+    // snippet-end:[sqs.java2.sendRecvBatch.delBatch]
+
+    // snippet-start:[sqs.java2.sendRecvBatch.scenario]
+    /**
+     * Helper class to represent a message with body and attributes.
+     */
+    public static class MessageEntry {
+        private final String body;
+        private final Map<String, MessageAttributeValue> attributes;
+
+        public MessageEntry(String body, Map<String, MessageAttributeValue> attributes) {
+            this.body = body;
+            this.attributes = attributes != null ? attributes : new HashMap<>();
+        }
+
+        public String getBody() {
+            return body;
+        }
+
+        public Map<String, MessageAttributeValue> getAttributes() {
+            return attributes;
+        }
+    }
+
+    /**
+     * Shows how to:
+     * * Read the lines from this Java file and send the lines in
+     *   batches of 10 as messages to a queue.
+     * * Receive the messages in batches until the queue is empty.
+     * * Reassemble the lines of the file and verify they match the original file.
+     */
+    public static void usageDemo() {
+        System.out.println("-".repeat(88));
+        System.out.println("Welcome to the Amazon Simple Queue Service (Amazon SQS) demo!");
+        System.out.println("-".repeat(88));
+
+        // Create a queue for the demo.
+        String queueName = "sqs-usage-demo-message-wrapper-"+System.currentTimeMillis();
+        CreateQueueRequest createRequest = CreateQueueRequest.builder()
+                .queueName(queueName)
+                .build();
+        String queueUrl = sqsClient.createQueue(createRequest).queueUrl();
+        System.out.println("Created queue: " + queueUrl);
+
+        try {
+            // Read the lines from this Java file.
+            Path projectRoot = Paths.get(System.getProperty("user.dir"));
+            Path filePath = projectRoot.resolve("src/main/java/com/example/sqs/SendRecvBatch.java");
+            List<String> lines = Files.readAllLines(filePath);
+
+
+            // Send file lines in batches.
+            int batchSize = 10;
+            System.out.println("Sending file lines in batches of " + batchSize + " as messages.");
+
+            for (int i = 0; i < lines.size(); i += batchSize) {
+                List<MessageEntry> messageBatch = new ArrayList<>();
+
+                for (int j = i; j < Math.min(i + batchSize, lines.size()); j++) {
+                    String line = lines.get(j);
+                    if (line == null || line.trim().isEmpty()) {
+                        continue; // Skip empty lines.
+                    }
+
+                    Map<String, MessageAttributeValue> attributes = new HashMap<>();
+                    attributes.put("path", MessageAttributeValue.builder()
+                            .dataType("String")
+                            .stringValue(filePath.toString())
+                            .build());
+                    attributes.put("line", MessageAttributeValue.builder()
+                            .dataType("String")
+                            .stringValue(String.valueOf(j))
+                            .build());
+
+                    messageBatch.add(new MessageEntry(lines.get(j), attributes));
+                }
+
+                sendMessages(queueUrl, messageBatch);
+                System.out.print(".");
+                System.out.flush();
+            }
+
+            System.out.println("\nDone. Sent " + lines.size() + " messages.");
+
+            // Receive and process messages.
+            System.out.println("Receiving, handling, and deleting messages in batches of " + batchSize + ".");
+            String[] receivedLines = new String[lines.size()];
+            boolean moreMessages = true;
+
+            while (moreMessages) {
+                List<Message> receivedMessages = receiveMessages(queueUrl, batchSize, 5);
+                System.out.print(".");
+                System.out.flush();
+
+                for (Message message : receivedMessages) {
+                    int lineNumber = Integer.parseInt(message.messageAttributes().get("line").stringValue());
+                    receivedLines[lineNumber] = message.body();
+                }
+
+                if (!receivedMessages.isEmpty()) {
+                    deleteMessages(queueUrl, receivedMessages);
+                } else {
+                    moreMessages = false;
+                }
+            }
+
+            System.out.println("\nDone.");
+
+            // Verify all lines were received correctly.
+            boolean allLinesMatch = true;
+            for (int i = 0; i < lines.size(); i++) {
+                String originalLine = lines.get(i);
+                String receivedLine = receivedLines[i] == null ? "" : receivedLines[i];
+
+                if (!originalLine.equals(receivedLine)) {
+                    allLinesMatch = false;
+                    break;
+                }
+            }
+
+            if (allLinesMatch) {
+                System.out.println("Successfully reassembled all file lines!");
+            } else {
+                System.out.println("Uh oh, some lines were missed!");
+            }
+
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Error reading file", e);
+        } finally {
+            // Clean up by deleting the queue.
+            DeleteQueueRequest deleteQueueRequest = DeleteQueueRequest.builder()
+                    .queueUrl(queueUrl)
+                    .build();
+            sqsClient.deleteQueue(deleteQueueRequest);
+            System.out.println("Deleted queue: " + queueUrl);
+        }
+
+        System.out.println("Thanks for watching!");
+        System.out.println("-".repeat(88));
+    }
+
+    public static void main(String[] args) {
+        usageDemo();
+    }
+}
+// snippet-end:[sqs.java2.sendRecvBatch.scenario]
+// snippet-end:[sqs.java2.sendRecvBatch.main]

--- a/javav2/example_code/sqs/src/main/java/com/example/sqs/SimpleProducerConsumer.java
+++ b/javav2/example_code/sqs/src/main/java/com/example/sqs/SimpleProducerConsumer.java
@@ -1,0 +1,494 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.sqs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.core.exception.SdkException;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Random;
+import java.util.Scanner;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Demonstrates SQS action batching for improved throughput and cost efficiency.
+ * 
+ * This example compares single-message operations with batch operations to show 
+ * the performance benefits of batching SQS actions. You can configure batch sizes, 
+ * thread counts, and message characteristics to test how batching affects throughput 
+ * in your specific use case.
+ * 
+ * Batching benefits demonstrated:
+ * - Reduced API calls through batch send and receive operations
+ * - Lower costs by consolidating multiple actions
+ * - Higher throughput with the SqsAsyncBatchManager
+ * - Efficient resource utilization with fewer network round trips
+ * 
+ * Use this example to:
+ * - Compare batch versus single-message performance
+ * - Test optimal batch sizes for your workload
+ * - Understand concurrent processing patterns with batching
+ * - Measure throughput improvements in your environment
+ * 
+ * Prerequisites:
+ * - An existing SQS queue
+ * - Valid AWS credentials configured
+ * 
+ * Set batch size to 1 for single-message operations or higher values to enable 
+ * batching. The program displays real-time metrics to help you compare the 
+ * performance difference between batching strategies.
+ */
+public class SimpleProducerConsumer {
+
+    // The maximum runtime of the program.
+    private final static int MAX_RUNTIME_MINUTES = 60;
+    private final static Logger log = LoggerFactory.getLogger(SimpleProducerConsumer.class);
+
+    /**
+     * Runs the SQS batching demonstration with user-configured parameters.
+     * 
+     * Prompts for queue name, thread counts, batch size, message size, and runtime.
+     * Creates producer and consumer threads to demonstrate batching performance.
+     * 
+     * @param args command line arguments (not used)
+     * @throws InterruptedException if thread operations are interrupted
+     */
+    public static void main(String[] args) throws InterruptedException {
+
+        final Scanner input = new Scanner(System.in);
+
+        System.out.print("Enter the queue name: ");
+        final String queueName = input.nextLine();
+
+        System.out.print("Enter the number of producers: ");
+        final int producerCount = input.nextInt();
+
+        System.out.print("Enter the number of consumers: ");
+        final int consumerCount = input.nextInt();
+
+        System.out.print("Enter the number of messages per batch: ");
+        final int batchSize = input.nextInt();
+
+        System.out.print("Enter the message size in bytes: ");
+        final int messageSizeByte = input.nextInt();
+
+        System.out.print("Enter the run time in minutes: ");
+        final int runTimeMinutes = input.nextInt();
+
+        // Create SQS async client and batch manager for all operations.
+        final SqsAsyncClient sqsAsyncClient = SqsAsyncClient.create();
+        final SqsAsyncBatchManager batchManager = sqsAsyncClient.batchManager();
+
+        final String queueUrl = sqsAsyncClient.getQueueUrl(GetQueueUrlRequest.builder()
+                .queueName(queueName)
+                .build()).join().queueUrl();
+
+        // The flag used to stop producer, consumer, and monitor threads.
+        final AtomicBoolean stop = new AtomicBoolean(false);
+
+        // Start the producers.
+        final AtomicInteger producedCount = new AtomicInteger();
+        final Thread[] producers = new Thread[producerCount];
+        for (int i = 0; i < producerCount; i++) {
+            if (batchSize == 1) {
+                producers[i] = new Producer(sqsAsyncClient, queueUrl, messageSizeByte,
+                        producedCount, stop);
+            } else {
+                producers[i] = new BatchProducer(batchManager, queueUrl, batchSize,
+                        messageSizeByte, producedCount, stop);
+            }
+            producers[i].start();
+        }
+
+        // Start the consumers.
+        final AtomicInteger consumedCount = new AtomicInteger();
+        final Thread[] consumers = new Thread[consumerCount];
+        for (int i = 0; i < consumerCount; i++) {
+            if (batchSize == 1) {
+                consumers[i] = new Consumer(sqsAsyncClient, queueUrl, consumedCount, stop);
+            } else {
+                consumers[i] = new BatchConsumer(batchManager, queueUrl, batchSize,
+                        consumedCount, stop);
+            }
+            consumers[i].start();
+        }
+
+        // Start the monitor thread.
+        final Thread monitor = new Monitor(producedCount, consumedCount, stop);
+        monitor.start();
+
+        // Wait for the specified amount of time then stop.
+        Thread.sleep(TimeUnit.MINUTES.toMillis(Math.min(runTimeMinutes,
+                MAX_RUNTIME_MINUTES)));
+        stop.set(true);
+
+        // Join all threads.
+        for (int i = 0; i < producerCount; i++) {
+            producers[i].join();
+        }
+
+        for (int i = 0; i < consumerCount; i++) {
+            consumers[i].join();
+        }
+
+        monitor.interrupt();
+        monitor.join();
+
+        // Close resources
+        batchManager.close();
+        sqsAsyncClient.close();
+    }
+
+    /**
+     * Creates a random string of approximately the specified size in bytes.
+     * 
+     * @param sizeByte the target size in bytes for the generated string
+     * @return a random string encoded in base-32
+     */
+    private static String makeRandomString(int sizeByte) {
+        final byte[] bs = new byte[(int) Math.ceil(sizeByte * 5 / 8)];
+        new Random().nextBytes(bs);
+        bs[0] = (byte) ((bs[0] | 64) & 127);
+        return new BigInteger(bs).toString(32);
+    }
+
+    /**
+     * Sends messages individually using SqsAsyncClient.
+     * 
+     * This thread continuously sends single messages until stopped.
+     * Use this class to measure baseline performance without batching.
+     */
+    private static class Producer extends Thread {
+        final SqsAsyncClient sqsAsyncClient;
+        final String queueUrl;
+        final AtomicInteger producedCount;
+        final AtomicBoolean stop;
+        final String theMessage;
+
+        /**
+         * Creates a producer thread for single-message operations.
+         * 
+         * @param sqsAsyncClient the SQS client for sending messages
+         * @param queueUrl the URL of the target queue
+         * @param messageSizeByte the size of messages to generate
+         * @param producedCount shared counter for tracking sent messages
+         * @param stop shared flag to signal thread termination
+         */
+        Producer(SqsAsyncClient sqsAsyncClient, String queueUrl, int messageSizeByte,
+                 AtomicInteger producedCount, AtomicBoolean stop) {
+            this.sqsAsyncClient = sqsAsyncClient;
+            this.queueUrl = queueUrl;
+            this.producedCount = producedCount;
+            this.stop = stop;
+            this.theMessage = makeRandomString(messageSizeByte);
+        }
+
+        /**
+         * Continuously sends messages until the stop flag is set.
+         * 
+         * Tracks the total number of messages sent across all producer threads.
+         * Exits the program if an error occurs during message sending.
+         */
+        public void run() {
+            try {
+                while (!stop.get()) {
+                    sqsAsyncClient.sendMessage(SendMessageRequest.builder()
+                            .queueUrl(queueUrl)
+                            .messageBody(theMessage)
+                            .build()).join();
+                    producedCount.incrementAndGet();
+                }
+            } catch (SdkException | java.util.concurrent.CompletionException e) {
+                // Handle both SdkException and CompletionException from async operations.
+                // If this unlikely condition occurs, stop.
+                log.error("Producer: " + e.getMessage());
+                System.exit(1);
+            }
+        }
+    }
+
+    /**
+     * Sends messages using SqsAsyncBatchManager for improved throughput.
+     * 
+     * This thread sends multiple messages per batch cycle to demonstrate
+     * the performance benefits of batching operations.
+     */
+    private static class BatchProducer extends Thread {
+        final SqsAsyncBatchManager batchManager;
+        final String queueUrl;
+        final int batchSize;
+        final AtomicInteger producedCount;
+        final AtomicBoolean stop;
+        final String theMessage;
+
+        /**
+         * Creates a producer thread for batch operations.
+         * 
+         * @param batchManager the batch manager for efficient message sending
+         * @param queueUrl the URL of the target queue
+         * @param batchSize the number of messages to send per batch
+         * @param messageSizeByte the size of messages to generate
+         * @param producedCount shared counter for tracking sent messages
+         * @param stop shared flag to signal thread termination
+         */
+        BatchProducer(SqsAsyncBatchManager batchManager, String queueUrl, int batchSize,
+                      int messageSizeByte, AtomicInteger producedCount,
+                      AtomicBoolean stop) {
+            this.batchManager = batchManager;
+            this.queueUrl = queueUrl;
+            this.batchSize = batchSize;
+            this.producedCount = producedCount;
+            this.stop = stop;
+            this.theMessage = makeRandomString(messageSizeByte);
+        }
+
+        /**
+         * Continuously sends batches of messages until the stop flag is set.
+         * 
+         * Sends multiple messages per batch cycle using the batch manager.
+         * Handles responses asynchronously and tracks successful sends.
+         */
+        public void run() {
+            try {
+                while (!stop.get()) {
+                    // Send multiple messages using batch manager
+                    for (int i = 0; i < batchSize; i++) {
+                        CompletableFuture<SendMessageResponse> future = batchManager.sendMessage(
+                                SendMessageRequest.builder()
+                                        .queueUrl(queueUrl)
+                                        .messageBody(theMessage)
+                                        .build());
+                        
+                        // Handle the response asynchronously
+                        future.whenComplete((response, throwable) -> {
+                            if (throwable == null) {
+                                producedCount.incrementAndGet();
+                            } else if (!(throwable instanceof java.util.concurrent.CancellationException) &&
+                                      !(throwable.getMessage() != null && throwable.getMessage().contains("executor not accepting a task"))) {
+                                log.error("BatchProducer: Failed to send message", throwable);
+                            }
+                            // Ignore CancellationException and executor shutdown errors - expected during shutdown
+                        });
+                    }
+                    
+                    // Small delay to allow batching to occur
+                    Thread.sleep(10);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("BatchProducer interrupted: " + e.getMessage());
+            } catch (SdkException | java.util.concurrent.CompletionException e) {
+                log.error("BatchProducer: " + e.getMessage());
+                System.exit(1);
+            }
+        }
+    }
+
+    /**
+     * Receives and deletes messages individually using SqsAsyncClient.
+     * 
+     * This thread continuously processes single messages until stopped.
+     * Use this class to measure baseline performance without batching.
+     */
+    private static class Consumer extends Thread {
+        final SqsAsyncClient sqsAsyncClient;
+        final String queueUrl;
+        final AtomicInteger consumedCount;
+        final AtomicBoolean stop;
+
+        /**
+         * Creates a consumer thread for single-message operations.
+         * 
+         * @param sqsAsyncClient the SQS client for receiving messages
+         * @param queueUrl the URL of the source queue
+         * @param consumedCount shared counter for tracking processed messages
+         * @param stop shared flag to signal thread termination
+         */
+        Consumer(SqsAsyncClient sqsAsyncClient, String queueUrl, AtomicInteger consumedCount,
+                 AtomicBoolean stop) {
+            this.sqsAsyncClient = sqsAsyncClient;
+            this.queueUrl = queueUrl;
+            this.consumedCount = consumedCount;
+            this.stop = stop;
+        }
+
+        /**
+         * Continuously receives and deletes messages until the stop flag is set.
+         * 
+         * Processes messages one at a time and tracks the total number consumed
+         * across all consumer threads. Logs errors but continues processing.
+         */
+        public void run() {
+            try {
+                while (!stop.get()) {
+                    try {
+                        final ReceiveMessageResponse result = sqsAsyncClient.receiveMessage(
+                                ReceiveMessageRequest.builder()
+                                        .queueUrl(queueUrl)
+                                        .build()).join();
+
+                        if (!result.messages().isEmpty()) {
+                            final Message m = result.messages().get(0);
+                            sqsAsyncClient.deleteMessage(DeleteMessageRequest.builder()
+                                    .queueUrl(queueUrl)
+                                    .receiptHandle(m.receiptHandle())
+                                    .build()).join();
+                            consumedCount.incrementAndGet();
+                        }
+                    } catch (SdkException | java.util.concurrent.CompletionException e) {
+                        log.error(e.getMessage());
+                    }
+                }
+            } catch (SdkException | java.util.concurrent.CompletionException e) {
+                // Handle both SdkException and CompletionException from async operations.
+                // If this unlikely condition occurs, stop.
+                log.error("Consumer: " + e.getMessage());
+                System.exit(1);
+            }
+        }
+    }
+
+    /**
+     * Receives and deletes messages using SqsAsyncBatchManager.
+     * 
+     * This thread processes multiple messages per batch cycle to demonstrate
+     * the performance benefits of batching operations.
+     */
+    private static class BatchConsumer extends Thread {
+        final SqsAsyncBatchManager batchManager;
+        final String queueUrl;
+        final int batchSize;
+        final AtomicInteger consumedCount;
+        final AtomicBoolean stop;
+
+        /**
+         * Creates a consumer thread for batch operations.
+         * 
+         * @param batchManager the batch manager for efficient message processing
+         * @param queueUrl the URL of the source queue
+         * @param batchSize the maximum number of messages to receive per batch
+         * @param consumedCount shared counter for tracking processed messages
+         * @param stop shared flag to signal thread termination
+         */
+        BatchConsumer(SqsAsyncBatchManager batchManager, String queueUrl, int batchSize,
+                      AtomicInteger consumedCount, AtomicBoolean stop) {
+            this.batchManager = batchManager;
+            this.queueUrl = queueUrl;
+            this.batchSize = batchSize;
+            this.consumedCount = consumedCount;
+            this.stop = stop;
+        }
+
+        /**
+         * Continuously receives and deletes batches of messages until stopped.
+         * 
+         * Receives multiple messages per batch and deletes them using the batch manager.
+         * Handles responses asynchronously and tracks successful deletions.
+         */
+        public void run() {
+            try {
+                while (!stop.get()) {
+                    final ReceiveMessageResponse result = batchManager.receiveMessage(
+                            ReceiveMessageRequest.builder()
+                                    .queueUrl(queueUrl)
+                                    .maxNumberOfMessages(Math.min(batchSize, 10))
+                                    .build()).join();
+
+                    if (!result.messages().isEmpty()) {
+                        final List<Message> messages = result.messages();
+                        
+                        // Delete messages using batch manager
+                        for (Message message : messages) {
+                            CompletableFuture<DeleteMessageResponse> future = batchManager.deleteMessage(
+                                    DeleteMessageRequest.builder()
+                                            .queueUrl(queueUrl)
+                                            .receiptHandle(message.receiptHandle())
+                                            .build());
+                            
+                            future.whenComplete((response, throwable) -> {
+                                if (throwable == null) {
+                                    consumedCount.incrementAndGet();
+                                } else if (!(throwable instanceof java.util.concurrent.CancellationException) &&
+                                          !(throwable.getMessage() != null && throwable.getMessage().contains("executor not accepting a task"))) {
+                                    log.error("BatchConsumer: Failed to delete message", throwable);
+                                }
+                                // Ignore CancellationException and executor shutdown errors - expected during shutdown
+                            });
+                        }
+                    }
+                    
+                    // Small delay to prevent tight polling
+                    Thread.sleep(10);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("BatchConsumer interrupted: " + e.getMessage());
+            } catch (SdkException | java.util.concurrent.CompletionException e) {
+                // Handle both SdkException and CompletionException from async operations.
+                // If this unlikely condition occurs, stop.
+                log.error("BatchConsumer: " + e.getMessage());
+                System.exit(1);
+            }
+        }
+    }
+
+    /**
+     * Displays real-time throughput statistics every second.
+     * 
+     * This thread logs the current count of produced and consumed messages
+     * to help you monitor the performance comparison.
+     */
+    private static class Monitor extends Thread {
+        private final AtomicInteger producedCount;
+        private final AtomicInteger consumedCount;
+        private final AtomicBoolean stop;
+
+        /**
+         * Creates a monitoring thread that displays throughput statistics.
+         * 
+         * @param producedCount shared counter for messages sent
+         * @param consumedCount shared counter for messages processed
+         * @param stop shared flag to signal thread termination
+         */
+        Monitor(AtomicInteger producedCount, AtomicInteger consumedCount,
+                AtomicBoolean stop) {
+            this.producedCount = producedCount;
+            this.consumedCount = consumedCount;
+            this.stop = stop;
+        }
+
+        /**
+         * Logs throughput statistics every second until stopped.
+         * 
+         * Displays the current count of produced and consumed messages
+         * to help monitor the performance comparison between batching strategies.
+         */
+        public void run() {
+            try {
+                while (!stop.get()) {
+                    Thread.sleep(1000);
+                    log.info("produced messages = " + producedCount.get()
+                            + ", consumed messages = " + consumedCount.get());
+                }
+            } catch (InterruptedException e) {
+                // Allow the thread to exit.
+            }
+        }
+    }
+}

--- a/javav2/example_code/sqs/src/main/java/com/example/sqs/SimpleProducerConsumer.java
+++ b/javav2/example_code/sqs/src/main/java/com/example/sqs/SimpleProducerConsumer.java
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
+// snippet-start:[sqs.java2.batch_demo.main]
 package com.example.sqs;
 
 import org.slf4j.Logger;
@@ -492,3 +492,4 @@ public class SimpleProducerConsumer {
         }
     }
 }
+// snippet-end:[sqs.java2.batch_demo.main]

--- a/javav2/example_code/sqs/src/test/java/com/example/sqs/SendRecvBatchTest.java
+++ b/javav2/example_code/sqs/src/test/java/com/example/sqs/SendRecvBatchTest.java
@@ -1,0 +1,139 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.sqs;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class SendRecvBatchTest {
+    private static final Logger logger = LoggerFactory.getLogger(SendRecvBatchTest.class);
+    private static final SqsClient sqsClient = SqsClient.create();
+    private String queueUrl = "";
+
+    @BeforeEach
+    void setUp() {
+        String queueName = "SendRecvBatch-queue-" + UUID.randomUUID().toString().replace("-", "").substring(0, 20);
+        queueUrl = sqsClient.createQueue(b -> b.queueName(queueName)).queueUrl();
+        logger.info("Created test queue: {}", queueUrl);
+    }
+
+    @AfterEach
+    void tearDown() {
+        sqsClient.deleteQueue(b -> b.queueUrl(queueUrl));
+        logger.info("Deleted test queue: {}", queueUrl);
+    }
+
+    private static Stream<Arguments> sendMessageBatchTestData() {
+        return Stream.of(
+                Arguments.of(List.of(
+                        new SendRecvBatch.MessageEntry("Message 1", Collections.emptyMap()),
+                        new SendRecvBatch.MessageEntry("Message 2", Collections.emptyMap())
+                )),
+                Arguments.of(List.of(
+                        new SendRecvBatch.MessageEntry("Message with attributes", Map.of(
+                                "type", MessageAttributeValue.builder()
+                                        .stringValue("test")
+                                        .dataType("String")
+                                        .build()
+                        ))
+                ))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("sendMessageBatchTestData")
+    @Order(1)
+    void testSendMessages(List<SendRecvBatch.MessageEntry> messages) {
+        logger.info("Testing send messages with {} messages", messages.size());
+        SendMessageBatchResponse response = SendRecvBatch.sendMessages(queueUrl, messages);
+        assertEquals(messages.size(), response.successful().size());
+        logger.info("Successfully sent {} messages", response.successful().size());
+    }
+
+    @Test
+    @Order(2)
+    void testReceiveMessages() {
+        logger.info("Testing receive messages");
+        // First send some messages
+        List<SendRecvBatch.MessageEntry> messages = List.of(
+                new SendRecvBatch.MessageEntry("Test message 1", Collections.emptyMap()),
+                new SendRecvBatch.MessageEntry("Test message 2", Collections.emptyMap())
+        );
+        SendRecvBatch.sendMessages(queueUrl, messages);
+        logger.info("Sent {} messages for receive test", messages.size());
+
+        List<Message> receivedMessages = SendRecvBatch.receiveMessages(queueUrl, 10, 5);
+        assertFalse(receivedMessages.isEmpty());
+        logger.info("Received {} messages", receivedMessages.size());
+    }
+
+    @Test
+    @Order(3)
+    void testDeleteMessages() {
+        logger.info("Testing delete messages");
+        // First send and receive messages
+        List<SendRecvBatch.MessageEntry> messages = List.of(
+                new SendRecvBatch.MessageEntry("Test message", Collections.emptyMap())
+        );
+        SendRecvBatch.sendMessages(queueUrl, messages);
+        logger.info("Sent {} messages for delete test", messages.size());
+
+        List<Message> receivedMessages = SendRecvBatch.receiveMessages(queueUrl, 10, 5);
+        assertFalse(receivedMessages.isEmpty());
+        logger.info("Received {} messages to delete", receivedMessages.size());
+
+        DeleteMessageBatchResponse response = SendRecvBatch.deleteMessages(queueUrl, receivedMessages);
+        assertEquals(receivedMessages.size(), response.successful().size());
+        logger.info("Successfully deleted {} messages", response.successful().size());
+    }
+
+    @Test
+    @Order(4)
+    void testMessageEntry() {
+        logger.info("Testing MessageEntry with attributes");
+        Map<String, MessageAttributeValue> attributes = Map.of(
+                "test", MessageAttributeValue.builder()
+                        .stringValue("value")
+                        .dataType("String")
+                        .build()
+        );
+
+        SendRecvBatch.MessageEntry entry = new SendRecvBatch.MessageEntry("Test body", attributes);
+
+        assertEquals("Test body", entry.getBody());
+        assertEquals(attributes, entry.getAttributes());
+        logger.info("MessageEntry test passed with body: {}", entry.getBody());
+    }
+
+    @Test
+    @Order(5)
+    void testMessageEntryWithNullAttributes() {
+        logger.info("Testing MessageEntry with null attributes");
+        SendRecvBatch.MessageEntry entry = new SendRecvBatch.MessageEntry("Test body", null);
+
+        assertEquals("Test body", entry.getBody());
+        assertNotNull(entry.getAttributes());
+        assertTrue(entry.getAttributes().isEmpty());
+        logger.info("MessageEntry null attributes test passed");
+    }
+}

--- a/javav2/example_code/sqs/src/test/java/com/example/sqs/SimpleProducerConsumerIntegrationTest.java
+++ b/javav2/example_code/sqs/src/test/java/com/example/sqs/SimpleProducerConsumerIntegrationTest.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.example.sqs;
 
 import org.apache.logging.log4j.Level;

--- a/javav2/example_code/sqs/src/test/java/com/example/sqs/SimpleProducerConsumerIntegrationTest.java
+++ b/javav2/example_code/sqs/src/test/java/com/example/sqs/SimpleProducerConsumerIntegrationTest.java
@@ -1,0 +1,255 @@
+package com.example.sqs;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteQueueRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for SimpleProducerConsumer that verifies the program works end-to-end.
+ * 
+ * This test creates a temporary SQS queue and captures Log4J2 messages to verify message processing.
+ */
+public class SimpleProducerConsumerIntegrationTest {
+    
+    private String testQueueName;
+    private SqsAsyncClient sqsClient;
+    private String queueUrl;
+    private TestAppender testAppender;
+    private Logger logger;
+    
+    /**
+     * Custom Log4J2 appender to capture log events for testing
+     */
+    private static class TestAppender extends AbstractAppender {
+        private final List<LogEvent> logEvents = new ArrayList<>();
+        
+        protected TestAppender() {
+            super("TestAppender", null, null, true, Property.EMPTY_ARRAY);
+        }
+        
+        @Override
+        public void append(LogEvent event) {
+            logEvents.add(event.toImmutable());
+        }
+        
+        public List<LogEvent> getLogEvents() {
+            return new ArrayList<>(logEvents);
+        }
+        
+        public void clear() {
+            logEvents.clear();
+        }
+    }
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        // Generate unique queue name for each test
+        testQueueName = "test-queue-" + System.currentTimeMillis() + "-" + Thread.currentThread().getId();
+        
+        // Create SQS client and test queue
+        sqsClient = SqsAsyncClient.create();
+        
+        // Create queue
+        sqsClient.createQueue(CreateQueueRequest.builder()
+                .queueName(testQueueName)
+                .build()).join();
+        
+        // Get queue URL
+        queueUrl = sqsClient.getQueueUrl(GetQueueUrlRequest.builder()
+                .queueName(testQueueName)
+                .build()).join().queueUrl();
+        
+        // Set up log capture
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        logger = context.getLogger(SimpleProducerConsumer.class.getName());
+        testAppender = new TestAppender();
+        testAppender.start();
+        logger.addAppender(testAppender);
+        logger.setLevel(Level.INFO);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        // Clean up log appender
+        if (logger != null && testAppender != null) {
+            logger.removeAppender(testAppender);
+            testAppender.stop();
+        }
+        
+        // Clean up queue
+        if (sqsClient != null && queueUrl != null) {
+            try {
+                sqsClient.deleteQueue(DeleteQueueRequest.builder()
+                        .queueUrl(queueUrl)
+                        .build()).join();
+            } catch (Exception e) {
+                // Ignore cleanup errors
+            }
+            sqsClient.close();
+        }
+    }
+    
+
+    
+    /**
+     * Tests that the SimpleProducerConsumer program executes successfully with single-message operations.
+     * 
+     * Verifies that:
+     * - The program accepts user input and starts without errors
+     * - At least one message is produced by the producer thread
+     * - Monitor thread logs message counts showing program activity
+     * - Program completes within the expected timeframe
+     * 
+     * Uses configuration: 1 producer, 1 consumer, batch size 1, 100-byte messages, 1-minute runtime
+     */
+    @Test
+    void testSimpleProducerConsumerExecutesSuccessfully() throws Exception {
+        // Simulate user input: queueName + producers + consumers + batchSize + messageSize + runtime
+        String simulatedInput = testQueueName + "\n1\n1\n1\n100\n1\n";
+        
+        InputStream originalSystemIn = System.in;
+        
+        try {
+            System.setIn(new ByteArrayInputStream(simulatedInput.getBytes()));
+            
+            // Run the program in a separate thread with timeout
+            CompletableFuture<Void> programExecution = CompletableFuture.runAsync(() -> {
+                try {
+                    SimpleProducerConsumer.main(new String[]{});
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            
+            // Wait for program to complete or timeout after 70 seconds (1 minute runtime + 10 second buffer)
+            final int TIMEOUT_SECONDS = 70;
+            programExecution.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            // Verify log messages were captured
+            List<LogEvent> logEvents = testAppender.getLogEvents();
+            assertFalse(logEvents.isEmpty(), "Expected log messages to be captured");
+            
+            // Parse monitor log messages to extract message counts
+            MessageCounts counts = parseMessageCounts(logEvents);
+            
+            // Verify that messages were actually processed
+            assertTrue(counts.foundMessages, "Expected to find monitor log messages");
+            assertTrue(counts.maxProduced > 0, "Expected messages to be produced, but got: " + counts.maxProduced);
+            assertTrue(counts.maxConsumed >= 0, "Expected non-negative consumed count, but got: " + counts.maxConsumed);
+            
+            System.out.println("Test passed - Produced: " + counts.maxProduced + ", Consumed: " + counts.maxConsumed);
+            
+        } finally {
+            System.setIn(originalSystemIn);
+        }
+    }
+    
+    /**
+     * Tests that the SimpleProducerConsumer program works correctly with batch operations.
+     * 
+     * Verifies that:
+     * - The program can handle multiple producers and consumers concurrently
+     * - Batch operations (batch size > 1) produce messages successfully
+     * - Multiple threads coordinate properly without conflicts
+     * - Batching configuration is processed correctly
+     * 
+     * Uses configuration: 2 producers, 2 consumers, batch size 5, 200-byte messages, 1-minute runtime
+     */
+    @Test
+    void testMessageProcessingWithBatching() throws Exception {
+        // Simulate user input: queueName + producers + consumers + batchSize + messageSize + runtime
+        String simulatedInput = testQueueName + "\n2\n2\n5\n200\n1\n";
+        
+        InputStream originalSystemIn = System.in;
+        
+        try {
+            System.setIn(new ByteArrayInputStream(simulatedInput.getBytes()));
+            
+            CompletableFuture<Void> programExecution = CompletableFuture.runAsync(() -> {
+                try {
+                    SimpleProducerConsumer.main(new String[]{});
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            
+            final int TIMEOUT_SECONDS = 70;
+            programExecution.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            // Verify batching produced messages
+            List<LogEvent> logEvents = testAppender.getLogEvents();
+            MessageCounts counts = parseMessageCounts(logEvents);
+            
+            assertTrue(counts.maxProduced > 0, "Expected messages to be produced with batching");
+            System.out.println("Batching test passed - Produced: " + counts.maxProduced + " messages");
+            
+        } finally {
+            System.setIn(originalSystemIn);
+        }
+    }
+    
+    /**
+     * Helper method to parse message counts from log events.
+     * 
+     * @param logEvents the log events to parse
+     * @return MessageCounts object containing parsed counts and status
+     */
+    private MessageCounts parseMessageCounts(List<LogEvent> logEvents) {
+        Pattern messagePattern = Pattern.compile("produced messages = (\\d+), consumed messages = (\\d+)");
+        int maxProduced = 0;
+        int maxConsumed = 0;
+        boolean foundMessages = false;
+        
+        for (LogEvent event : logEvents) {
+            String message = event.getMessage().getFormattedMessage();
+            Matcher matcher = messagePattern.matcher(message);
+            if (matcher.find()) {
+                foundMessages = true;
+                int produced = Integer.parseInt(matcher.group(1));
+                int consumed = Integer.parseInt(matcher.group(2));
+                maxProduced = Math.max(maxProduced, produced);
+                maxConsumed = Math.max(maxConsumed, consumed);
+            }
+        }
+        
+        return new MessageCounts(maxProduced, maxConsumed, foundMessages);
+    }
+    
+    /**
+     * Data class to hold parsed message count results.
+     */
+    private static class MessageCounts {
+        final int maxProduced;
+        final int maxConsumed;
+        final boolean foundMessages;
+        
+        MessageCounts(int maxProduced, int maxConsumed, boolean foundMessages) {
+            this.maxProduced = maxProduced;
+            this.maxConsumed = maxConsumed;
+            this.foundMessages = foundMessages;
+        }
+    }
+}

--- a/javav2/example_code/sqs/src/test/java/com/example/sqs/SimpleProducerConsumerIntegrationTest.java
+++ b/javav2/example_code/sqs/src/test/java/com/example/sqs/SimpleProducerConsumerIntegrationTest.java
@@ -67,7 +67,7 @@ public class SimpleProducerConsumerIntegrationTest {
     }
     
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         // Generate unique queue name for each test
         testQueueName = "test-queue-" + System.currentTimeMillis() + "-" + Thread.currentThread().getId();
         


### PR DESCRIPTION
~This pull request migrates the [hard-code v1 example](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-throughput-horizontal-scaling-and-batching.html#batch-request-java-example-code) that exists in the SQS Developer guide.~

~Since Java V2 also offers the drop-in replacement `SqsAsyncBatchManager` for the `SqsAsyncClient`, which offers automatic batching, this approach was also highlighted in the example.~

These code example demonstrate two approaches to working with SQS messages in batches using the Java SDK. This PR combines the code examples from this original PR and this [PR](https://github.com/awsdocs/aws-doc-sdk-examples/pull/7508). It turned out that the two PRs were worked on concurrently without knowledge of the other. It made sense to combine them into one PR. The other [PR](https://github.com/awsdocs/aws-doc-sdk-examples/pull/7508) can be canceled at this point.

~CDD build is [here](http://tkhill2-clouddesk.aka.corp.amazon.com/sos-metadata/build/AWSCodeExampleUsageDocs/AWSCodeExampleUsageDocs-3.0/AL2_x86_64/DEV.STD.PTHREAD/build/server-root/code-library/latest/ug/sqs_example_sqs_Scenario_SendReceiveBatch_section.html).~
CDD build is [here](http://tkhill2-clouddesk.aka.corp.amazon.com/sos-sqs-batch-3/build/AWSCodeExampleUsageDocs/AWSCodeExampleUsageDocs-3.0/AL2_x86_64/DEV.STD.PTHREAD/build/server-root/code-library/latest/ug/sqs_example_sqs_Scenario_SendReceiveBatch_section.html).

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
