### PR TITLE
Java v2: Update S3 examples of uploading from a stream of unknown size to remove use of `BlockingInputStreamAsyncRequestBody`

### DIFF
--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -3294,13 +3294,15 @@ s3_Scenario_UploadStream:
             - description: Use the <ulink url="sdk-for-java/latest/developer-guide/crt-based-s3-client.html" type="documentation">&AWS;
                 CRT-based S3 Client</ulink>.
               snippet_tags:
-                - s3.java2.async_stream.import
-                - s3.java2.async_stream.main
+                - s3.java2.async_stream.complete
+            - description: Use the standard <ulink url="sdk-for-java/latest/developer-guide/s3-async-client-multipart.html#s3-async-client-mp-on" type="documentation">
+                asynchronous S3 client with multipart upload enabled</ulink>.
+              snippet_tags:
+                - s3.java2.async_stream_mp.complete
             - description: Use the <ulink url="sdk-for-java/latest/developer-guide/transfer-manager.html" type="documentation">&S3;
                 Transfer Manager</ulink>.
               snippet_tags:
-                - s3.tm.java2.upload_stream.import
-                - s3.tm.java2.upload_stream.main
+                - s3.tm.java2.upload_stream.complete
     Swift:
       versions:
         - sdk_version: 1

--- a/javav2/example_code/s3/src/main/java/com/example/s3/async/PutObjectFromStreamAsync.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/async/PutObjectFromStreamAsync.java
@@ -25,7 +25,7 @@ public class PutObjectFromStreamAsync {
     private static final Logger logger = LoggerFactory.getLogger(PutObjectFromStreamAsync.class);
 
     public static void main(String[] args) {
-        String bucketName = "qamzn-s3-demo-bucket-" + UUID.randomUUID(); // Change bucket name.
+        String bucketName = "amzn-s3-demo-bucket-" + UUID.randomUUID(); // Change bucket name.
         String key = UUID.randomUUID().toString();
 
         AsyncExampleUtils.createBucket(bucketName);

--- a/javav2/example_code/s3/src/main/java/com/example/s3/async/PutObjectFromStreamAsyncMp.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/async/PutObjectFromStreamAsyncMp.java
@@ -25,7 +25,7 @@ public class PutObjectFromStreamAsyncMp {
     private static final Logger logger = LoggerFactory.getLogger(PutObjectFromStreamAsyncMp.class);
 
     public static void main(String[] args) {
-        String bucketName = "qamzn-s3-demo-bucket-" + UUID.randomUUID(); // Change bucket name.
+        String bucketName = "amzn-s3-demo-bucket-" + UUID.randomUUID(); // Change bucket name.
         String key = UUID.randomUUID().toString();
 
         AsyncExampleUtils.createBucket(bucketName);

--- a/javav2/example_code/s3/src/main/java/com/example/s3/async/PutObjectFromStreamAsyncMp.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/async/PutObjectFromStreamAsyncMp.java
@@ -21,8 +21,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 // snippet-end:[s3.java2.async_stream.import]
 
-public class PutObjectFromStreamAsync {
-    private static final Logger logger = LoggerFactory.getLogger(PutObjectFromStreamAsync.class);
+public class PutObjectFromStreamAsyncMp {
+    private static final Logger logger = LoggerFactory.getLogger(PutObjectFromStreamAsyncMp.class);
 
     public static void main(String[] args) {
         String bucketName = "qamzn-s3-demo-bucket-" + UUID.randomUUID(); // Change bucket name.
@@ -30,9 +30,9 @@ public class PutObjectFromStreamAsync {
 
         AsyncExampleUtils.createBucket(bucketName);
         try {
-            PutObjectFromStreamAsync example = new PutObjectFromStreamAsync();
-            S3AsyncClient s3AsyncClientCrt = S3AsyncClient.crtCreate();
-            PutObjectResponse putObjectResponse = example.putObjectFromStreamCrt(s3AsyncClientCrt, bucketName, key);
+            PutObjectFromStreamAsyncMp example = new PutObjectFromStreamAsyncMp();
+            S3AsyncClient s3AsyncClientMp = S3AsyncClient.builder().multipartEnabled(true).build();
+            PutObjectResponse putObjectResponse = example.putObjectFromStreamMp(s3AsyncClientMp, bucketName, key);
             logger.info("Object {} etag: {}", key, putObjectResponse.eTag());
             logger.info("Object {} uploaded to bucket {}.", key, bucketName);
         } catch (SdkException e) {
@@ -45,12 +45,12 @@ public class PutObjectFromStreamAsync {
 
 // snippet-start:[s3.java2.async_stream.main]
     /**
-     * @param s33CrtAsyncClient - To upload content from a stream of unknown size, use can the AWS CRT-based S3 client.
+     * @param s3AsyncClientMp - To upload content from a stream of unknown size, use can the S3 asynchronous client with multipart enabled.
      * @param bucketName - The name of the bucket.
      * @param key - The name of the object.
      * @return software.amazon.awssdk.services.s3.model.PutObjectResponse - Returns metadata pertaining to the put object operation.
      */
-    public PutObjectResponse putObjectFromStreamCrt(S3AsyncClient s33CrtAsyncClient, String bucketName, String key) {
+    public PutObjectResponse putObjectFromStreamMp(S3AsyncClient s3AsyncClientMp, String bucketName, String key) {
 
         // AsyncExampleUtils.randomString() returns a random string up to 100 characters.
         String randomString = AsyncExampleUtils.randomString();
@@ -63,7 +63,7 @@ public class PutObjectFromStreamAsync {
         AsyncRequestBody body = AsyncRequestBody.fromInputStream(inputStream, null, executor);
 
         CompletableFuture<PutObjectResponse> responseFuture =
-                s33CrtAsyncClient.putObject(r -> r.bucket(bucketName).key(key), body);
+                s3AsyncClientMp.putObject(r -> r.bucket(bucketName).key(key), body);
 
         PutObjectResponse response = responseFuture.join(); // Wait for the response.
         logger.info("Object {} uploaded to bucket {}.", key, bucketName);

--- a/javav2/example_code/s3/src/main/java/com/example/s3/async/PutObjectFromStreamAsyncMp.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/async/PutObjectFromStreamAsyncMp.java
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.example.s3.async;
 
-// snippet-start:[s3.java2.async_stream.complete]
-// snippet-start:[s3.java2.async_stream.import]
+// snippet-start:[s3.java2.async_stream_mp.complete]
+// snippet-start:[s3.java2.async_stream_mp.import]
 
 import com.example.s3.util.AsyncExampleUtils;
 import org.slf4j.Logger;
@@ -19,7 +19,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-// snippet-end:[s3.java2.async_stream.import]
+// snippet-end:[s3.java2.async_stream_mp.import]
 
 public class PutObjectFromStreamAsyncMp {
     private static final Logger logger = LoggerFactory.getLogger(PutObjectFromStreamAsyncMp.class);
@@ -43,7 +43,7 @@ public class PutObjectFromStreamAsyncMp {
         }
     }
 
-// snippet-start:[s3.java2.async_stream.main]
+// snippet-start:[s3.java2.async_stream_mp.main]
     /**
      * @param s3AsyncClientMp - To upload content from a stream of unknown size, use can the S3 asynchronous client with multipart enabled.
      * @param bucketName - The name of the bucket.
@@ -71,5 +71,5 @@ public class PutObjectFromStreamAsyncMp {
         return response;
     }
 }
-// snippet-end:[s3.java2.async_stream.main]
-// snippet-end:[s3.java2.async_stream.complete]
+// snippet-end:[s3.java2.async_stream_mp.main]
+// snippet-end:[s3.java2.async_stream_mp.complete]

--- a/javav2/example_code/s3/src/main/java/com/example/s3/transfermanager/UploadStream.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/transfermanager/UploadStream.java
@@ -25,7 +25,7 @@ public class UploadStream {
     private static final Logger logger = LoggerFactory.getLogger(UploadStream.class);
 
     public static void main(String[] args) {
-        String bucketName = "qamzn-s3-demo-bucket" + UUID.randomUUID();
+        String bucketName = "amzn-s3-demo-bucket" + UUID.randomUUID();
         String key = UUID.randomUUID().toString();
 
         AsyncExampleUtils.createBucket(bucketName);

--- a/javav2/example_code/s3/src/main/java/com/example/s3/transfermanager/UploadStream.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/transfermanager/UploadStream.java
@@ -4,25 +4,28 @@ package com.example.s3.transfermanager;
 
 // snippet-start:[s3.tm.java2.upload_stream.complete]
 // snippet-start:[s3.tm.java2.upload_stream.import]
+
 import com.example.s3.util.AsyncExampleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
-import software.amazon.awssdk.core.async.BlockingInputStreamAsyncRequestBody;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.CompletedUpload;
 import software.amazon.awssdk.transfer.s3.model.Upload;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 // snippet-end:[s3.tm.java2.upload_stream.import]
 
 public class UploadStream {
     private static final Logger logger = LoggerFactory.getLogger(UploadStream.class);
 
     public static void main(String[] args) {
-        String bucketName = "amzn-s3-demo-bucket" + UUID.randomUUID();
+        String bucketName = "qamzn-s3-demo-bucket" + UUID.randomUUID();
         String key = UUID.randomUUID().toString();
 
         AsyncExampleUtils.createBucket(bucketName);
@@ -41,30 +44,31 @@ public class UploadStream {
 
 // snippet-start:[s3.tm.java2.upload_stream.main]
     /**
-     * @param transferManager - To upload content from a stream of unknown size, use the S3TransferManager based on the AWS CRT-based S3 client.
-     *                       For more information, see https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/transfer-manager.html.
+     * @param transferManager - To upload content from a stream of unknown size, you can use the S3TransferManager based on the AWS CRT-based S3 client.
      * @param bucketName - The name of the bucket.
      * @param key - The name of the object.
      * @return - software.amazon.awssdk.transfer.s3.model.CompletedUpload - The result of the completed upload.
      */
     public CompletedUpload uploadStream(S3TransferManager transferManager, String bucketName, String key) {
 
-        BlockingInputStreamAsyncRequestBody body =
-                AsyncRequestBody.forBlockingInputStream(null); // 'null' indicates a stream will be provided later.
+        // AsyncExampleUtils.randomString() returns a random string up to 100 characters.
+        String randomString = AsyncExampleUtils.randomString();
+        logger.info("random string to upload: {}: length={}", randomString, randomString.length());
+        InputStream inputStream = new ByteArrayInputStream(randomString.getBytes());
+
+        // Executor required to handle reading from the InputStream on a separate thread so the main upload is not blocked.
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        // Specify `null` for the content length when you don't know the content length.
+        AsyncRequestBody body = AsyncRequestBody.fromInputStream(inputStream, null, executor);
 
         Upload upload = transferManager.upload(builder -> builder
                 .requestBody(body)
                 .putObjectRequest(req -> req.bucket(bucketName).key(key))
                 .build());
 
-        // AsyncExampleUtils.randomString() returns a random string up to 100 characters.
-        String randomString = AsyncExampleUtils.randomString();
-        logger.info("random string to upload: {}: length={}", randomString, randomString.length());
-
-        // Provide the stream of data to be uploaded.
-        body.writeInputStream(new ByteArrayInputStream(randomString.getBytes()));
-
-        return upload.completionFuture().join();
+        CompletedUpload completedUpload = upload.completionFuture().join();
+        executor.shutdown();
+        return completedUpload;
     }
 }
 // snippet-end:[s3.tm.java2.upload_stream.main]

--- a/javav2/example_code/s3/src/test/java/com/example/s3/async/AsyncTests.java
+++ b/javav2/example_code/s3/src/test/java/com/example/s3/async/AsyncTests.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 import java.util.UUID;
@@ -34,9 +35,17 @@ class AsyncTests {
 
     @Test
     @Tag("IntegrationTest")
-    void putObjectFromStream() {
+    void putObjectFromStreamTest() {
         PutObjectFromStreamAsync example = new PutObjectFromStreamAsync();
-        PutObjectResponse putObjectResponse = example.putObjectFromStream(AsyncExampleUtils.client, bucketName, key);
+        PutObjectResponse putObjectResponse = example.putObjectFromStreamCrt(AsyncExampleUtils.client, bucketName, key);
+        Assertions.assertNotNull(putObjectResponse.eTag());
+    }
+
+    @Test
+    @Tag("IntegrationTest")
+    void putObjectFromStreamMpTest() {
+        PutObjectFromStreamAsyncMp example = new PutObjectFromStreamAsyncMp();
+        PutObjectResponse putObjectResponse = example.putObjectFromStreamMp(S3AsyncClient.builder().multipartEnabled(true).build(), bucketName, key);
         Assertions.assertNotNull(putObjectResponse.eTag());
     }
 }


### PR DESCRIPTION
This pull request updates [two S3 code examples](https://docs.aws.amazon.com/code-library/latest/ug/s3_example_s3_Scenario_UploadStream_section.html) that show the use of `BlockingInputStreamAsyncRequestBody` when uploading content from a stream of unknown size. It turns out that this approach is 'dangerous' according to the Java SDK team and an update was recommended.

This PR also adds an one more example that uses same upload approach using the standard S3 async client with multipart enabled that users can alternatively use to upload.

There are now 3 examples using different clients.

CDD build is [here](http://tkhill2-clouddesk.aka.corp.amazon.com/sos-s3/build/AWSCodeExampleUsageDocs/AWSCodeExampleUsageDocs-3.0/AL2_x86_64/DEV.STD.PTHREAD/build/server-root/code-library/latest/ug/s3_example_s3_Scenario_UploadStream_section.html).

Addresses [this](https://issues.amazon.com/issues/V1827262060) ticket.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
