### PR TITLE
PHP: [Bug#7535] : Fix message and logic

### DIFF
--- a/php/example_code/s3/GettingStartedWithS3.php
+++ b/php/example_code/s3/GettingStartedWithS3.php
@@ -148,7 +148,7 @@ class GettingStartedWithS3 implements RunnableExample
             $check = $this->s3client->listObjectsV2([
                 'Bucket' => $this->bucketName,
             ]);
-            if (count($check) <= 0) {
+            if (isset($check['Contents']) && count($check['Contents']) > 0) {
                 throw new Exception("Bucket wasn't empty.");
             }
             echo "Deleted all objects and folders from $this->bucketName.\n";


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

[Bug#7535](https://github.com/awsdocs/aws-doc-sdk-examples/issues/7535)

This pull request is for 
1. `$check` is the result of $this->s3client->listObjectsV2(), which returns an array with metadata about the bucket and, if present, a Contents key containing the objects.
2. `count($check)` will always be at least 1 (because it's an array with metadata), even if the bucket is empty.
3. To check if the bucket is empty, you should check if the Contents key exists and if it contains any objects.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
