### PR TITLE
Multi: Clean up duplicate snippet tags

### DIFF
--- a/python/example_code/bedrock-agent-runtime/README.md
+++ b/python/example_code/bedrock-agent-runtime/README.md
@@ -38,7 +38,7 @@ python -m pip install -r requirements.txt
 
 Code examples that show you how to perform the essential operations within a service.
 
-- [Learn the basics](../bedrock-agent/flows/flow-conversation.py)
+- [Learn the basics](flows/flow-conversation.py)
 
 
 ### Single actions
@@ -79,7 +79,7 @@ This example shows you how to use InvokeFlow to converse with an Amazon Bedrock 
 Start the example by running the following at a command prompt:
 
 ```
-python ../bedrock-agent/flows/flow-conversation.py
+python flows/flow-conversation.py
 ```
 
 

--- a/python/example_code/bedrock-agent/flows/flow-conversation.py
+++ b/python/example_code/bedrock-agent/flows/flow-conversation.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# snippet-start:[python.example_code.bedrock-agent-runtime.flow_conversation.complete]
+# snippet-start:[python.example_code.bedrock-agent.flow_conversation.complete]
 
 
 """
@@ -179,4 +179,4 @@ def main():
 if __name__ == "__main__":
     main()
 
- # snippet-end:[python.example_code.bedrock-agent-runtime.flow_conversation.complete]
+ # snippet-end:[python.example_code.bedrock-agent.flow_conversation.complete]

--- a/swift/example_code/swift-sdk/http-config/Package.swift
+++ b/swift/example_code/swift-sdk/http-config/Package.swift
@@ -5,7 +5,7 @@
 // (swift-tools-version has two lines here because it needs to be the first
 // line in the file, but it should also appear in the snippet below)
 //
-// snippet-start:[swift.cognito-identity-provider.scenario.package]
+// snippet-start:[swift.httpconfig.scenario.package]
 // swift-tools-version: 5.9
 //
 // The swift-tools-version declares the minimum version of Swift required to
@@ -44,4 +44,4 @@ let package = Package(
 
     ]
 )
-// snippet-end:[swift.cognito-identity-provider.scenario.package]
+// snippet-end:[swift.httpconfig.scenario.package]


### PR DESCRIPTION
This pull request fixes some unintentional snippet duplication that causes repeatability issues with Writeme.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
