### PR TITLE
JavaScript v3: Prepare JavaScript v3 item tracker for updates.

### DIFF
--- a/.doc_gen/metadata/cross_metadata.yaml
+++ b/.doc_gen/metadata/cross_metadata.yaml
@@ -170,10 +170,6 @@ cross_RDSDataTracker:
         - sdk_version: 3
           github: python/cross_service/aurora_item_tracker
           block_content: cross_RDSDataTracker_Python_block.xml
-    JavaScript:
-      versions:
-        - sdk_version: 3
-          block_content: cross_RDSDataTracker_JavaScriptV3_block.xml
     C++:
       versions:
         - sdk_version: 1


### PR DESCRIPTION
This pull request temporarily removes the JavaScript v3 item tracker's metadata until the SQL usage is updated.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
