### PR TITLE
Update "bad" bucket names in PHP examples displayed in the PHP Dev. guide

### DIFF
--- a/php/example_code/class_examples/CommandPool.php
+++ b/php/example_code/class_examples/CommandPool.php
@@ -37,7 +37,7 @@ $client = new S3Client([]);
 
 $s3Service = new S3Service($client, true);
 
-$bucket = 'my-bucket-' . uniqid(); // This bucket will be deleted at the end of this example.
+$bucket = 'amzn-s3-demo-bucket-' . uniqid(); // This bucket will be deleted at the end of this example.
 
 $client->createBucket([
     "Bucket" => $bucket,

--- a/php/example_code/cloudfront/CreateDistributionS3.php
+++ b/php/example_code/cloudfront/CreateDistributionS3.php
@@ -50,7 +50,7 @@ function createS3Distribution($cloudFrontClient, $distribution)
 function createsTheS3Distribution()
 {
     $originName = 'my-unique-origin-name';
-    $s3BucketURL = 'my-bucket-name.s3.amazonaws.com';
+    $s3BucketURL = 'amzn-s3-demo-bucket.s3.amazonaws.com';
     $callerReference = 'my-unique-caller-reference';
     $comment = 'my-comment-about-this-distribution';
     $defaultCacheBehavior = [

--- a/php/example_code/cloudfront/old_tests/CreateDistributionS3Test.php
+++ b/php/example_code/cloudfront/old_tests/CreateDistributionS3Test.php
@@ -24,7 +24,7 @@ class CreateDistributionS3Test extends TestCase
         require(__DIR__ . '/../CreateDistributionS3.php');
 
         $originName = 'my-unique-origin-name';
-        $s3BucketURL = 'my-bucket-name.s3.amazonaws.com';
+        $s3BucketURL = 'amzn-s3-demo-bucket.s3.amazonaws.com';
         $callerReference = 'my-unique-caller-reference';
         $comment = 'my-comment-about-this-distribution';
         $defaultCacheBehavior = [

--- a/php/example_code/cloudfront/old_tests/DisableDistributionS3Test.php
+++ b/php/example_code/cloudfront/old_tests/DisableDistributionS3Test.php
@@ -82,7 +82,7 @@ class DisableDistributionTest extends TestCase
             'Origins' => [
                 'Items' => [
                     [
-                        'DomainName' => 'my-bucket-name.s3.amazonaws.com',
+                        'DomainName' => 'amzn-s3-demo-bucket.s3.amazonaws.com',
                         'Id' => 'my-unique-origin-name',
                         'OriginPath' => '',
                         'CustomHeaders' => [

--- a/php/example_code/cloudfront/old_tests/UpdateDistributionS3Test.php
+++ b/php/example_code/cloudfront/old_tests/UpdateDistributionS3Test.php
@@ -82,7 +82,7 @@ class UpdateDistributionTest extends TestCase
             'Origins' => [
                 'Items' => [
                     [
-                        'DomainName' => 'my-bucket-name.s3.amazonaws.com',
+                        'DomainName' => 'amzn-s3-demo-bucket.s3.amazonaws.com',
                         'Id' => 'my-unique-origin-name',
                         'OriginPath' => '',
                         'CustomHeaders' => [

--- a/php/example_code/cloudwatch/DescribeAlarmsForMetric.php
+++ b/php/example_code/cloudwatch/DescribeAlarmsForMetric.php
@@ -79,7 +79,7 @@ function describeTheAlarmsForMetric()
         ],
         [
             'Name' => 'BucketName',
-            'Value' => 'my-bucket'
+            'Value' => 'amzn-s3-demo-bucket'
         ]
     ];
 

--- a/php/example_code/cloudwatch/GetMetricStatistics.php
+++ b/php/example_code/cloudwatch/GetMetricStatistics.php
@@ -147,7 +147,7 @@ function getTheMetricStatistics()
         ],
         [
             'Name' => 'BucketName',
-            'Value' => 'my-bucket'
+            'Value' => 'amzn-s3-demo-bucket'
         ]
     ];
     $startTime = strtotime('-3 days');

--- a/php/example_code/cloudwatch/old_tests/DescribeAlarmsForMetricTest.php
+++ b/php/example_code/cloudwatch/old_tests/DescribeAlarmsForMetricTest.php
@@ -32,7 +32,7 @@ class DescribeAlarmsForMetricTest extends TestCase
             ],
             [
                 'Name' => 'BucketName',
-                'Value' => 'my-bucket'
+                'Value' => 'amzn-s3-demo-bucket'
             ]
         ];
 

--- a/php/example_code/lambda/GettingStartedWithLambda.php
+++ b/php/example_code/lambda/GettingStartedWithLambda.php
@@ -53,7 +53,7 @@ class GettingStartedWithLambda
         echo "Attached the AWSLambdaBasicExecutionRole to {$role['RoleName']}.\n";
 
         echo "\nNow let's create an S3 bucket and upload our Lambda code there.\n";
-        $bucketName = "test-example-bucket-$uniqid";
+        $bucketName = "amzn-s3-demo-bucket-$uniqid";
         $s3client->createBucket([
             'Bucket' => $bucketName,
         ]);

--- a/php/example_code/lambda/tests/LambdaTest.php
+++ b/php/example_code/lambda/tests/LambdaTest.php
@@ -53,7 +53,7 @@ class LambdaTest extends TestCase
                 }
             ]
         }";
-        $bucketName = "test-example-bucket-$uniqid";
+        $bucketName = "amzn-s3-demo-bucket-$uniqid";
         $this->s3client->createBucket([
             'Bucket' => $bucketName,
         ]);

--- a/php/example_code/s3/CreateBucket.php
+++ b/php/example_code/s3/CreateBucket.php
@@ -46,7 +46,7 @@ function createTheBucket()
         'version' => '2006-03-01'
     ]);
 
-    echo createBucket($s3Client, 'my-bucket');
+    echo createBucket($s3Client, 'amzn-s3-demo-bucket');
 }
 
 // Uncomment the following line to run this code in an AWS account.

--- a/php/example_code/s3/ErrorHandling.php
+++ b/php/example_code/s3/ErrorHandling.php
@@ -33,7 +33,7 @@ $sdk = new Aws\Sdk([
 $s3Client = $sdk->createS3();
 
 try {
-    $s3Client->createBucket(['Bucket' => 'my-bucket']);
+    $s3Client->createBucket(['Bucket' => 'amzn-s3-demo-bucket']);
 } catch (S3Exception $e) {
     // Catch an S3 specific exception.
     echo $e->getMessage();
@@ -53,7 +53,7 @@ try {
 // snippet-start:[s3.php.error_handling.async]
 //Asynchronous Error Handling
 // snippet-start:[s3.php.error_handling.promise]
-$promise = $s3Client->createBucketAsync(['Bucket' => 'my-bucket']);
+$promise = $s3Client->createBucketAsync(['Bucket' => 'amzn-s3-demo-bucket']);
 // snippet-end:[s3.php.error_handling.promise]
 $promise->otherwise(function ($reason) {
     var_dump($reason);

--- a/php/example_code/s3/PutObjectServiceOperations.php
+++ b/php/example_code/s3/PutObjectServiceOperations.php
@@ -36,14 +36,14 @@ $s3Client = $sdk->createS3();
 
 // Send a PutObject request and get the result object.
 $result = $s3Client->putObject([
-    'Bucket' => 'my-bucket',
+    'Bucket' => 'amzn-s3-demo-bucket',
     'Key' => 'my-key',
     'Body' => 'this is the body!'
 ]);
 
 // Download the contents of the object.
 $result = $s3Client->getObject([
-    'Bucket' => 'my-bucket',
+    'Bucket' => 'amzn-s3-demo-bucket',
     'Key' => 'my-key'
 ]);
 

--- a/php/example_code/s3/s3BucketAcl.php
+++ b/php/example_code/s3/s3BucketAcl.php
@@ -26,7 +26,7 @@ $s3Client = new S3Client([
 ]);
 
 // Gets the access control policy for a bucket
-$bucket = 'my-s3-bucket';
+$bucket = 'amzn-s3-demo-bucket';
 try {
     $resp = $s3Client->getBucketAcl([
         'Bucket' => $bucket

--- a/php/example_code/s3/s3BucketPolicy.php
+++ b/php/example_code/s3/s3BucketPolicy.php
@@ -25,7 +25,7 @@ $s3Client = new S3Client([
     'version' => '2006-03-01'
 ]);
 
-$bucket = 'my-s3-bucket';
+$bucket = 'amzn-s3-demo-bucket';
 
 // Get the policy of a specific bucket
 try {

--- a/php/example_code/s3/s3ObjectAcl.php
+++ b/php/example_code/s3/s3ObjectAcl.php
@@ -19,7 +19,7 @@ $s3Client = new S3Client([
 ]);
 
 // Gets the access control list (ACL) of an object.
-$bucket = 'my-s3-bucket';
+$bucket = 'amzn-s3-demo-bucket';
 $key = 'my-object';
 try {
     $resp = $s3Client->getObjectAcl([

--- a/php/example_code/s3/s3WebHost.php
+++ b/php/example_code/s3/s3WebHost.php
@@ -26,7 +26,7 @@ $s3Client = new S3Client([
 ]);
 
 // Retrieving the Bucket Website Configuration
-$bucket = 'my-s3-bucket';
+$bucket = 'amzn-s3-demo-bucket';
 try {
     $resp = $s3Client->getBucketWebsite([
         'Bucket' => $bucket


### PR DESCRIPTION
This pull request updates the last few s3 bucket names in PHP examples to the TCX required change. It replaces bucket names like "my-bucket" to TCX approved names like "amzn-s3-demo-bucket".

The [scan report](https://quip-amazon.com/SWySAZ9a5vIy/RCC-Replace-hard-coded-S3-bucket-names#temp:C:CEO2e418cd3eafa4a97a4c82a1c8) of the bad bucket names, flagged pages in the PHP Developer guide, and these final changes appear to affect code examples that only appear in the guide, not in the Code Library itself.

For safe measure, as I worked through updating the changes, I found a few other "bad" bucket names, that I fixed anyway, even though I did not see them as flagged.

Ticket this PR addresses: https://taskei.amazon.dev/tasks/PHP-3162

I did a C[DD build of the Code Library](http://tkhill2-clouddesk.aka.corp.amazon.com/sos-metadata/build/AWSCodeExampleUsageDocs/AWSCodeExampleUsageDocs-3.0/AL2_x86_64/DEV.STD.PTHREAD/build/server-root/code-library/latest/ug/what-is-code-library.html), but since these updates won't appear there, it's not very useful.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
