### PR TITLE
Python: Update to use unquote_plus for parsing instead of unquote.

### DIFF
--- a/python/cross_service/apigateway_covid-19_tracker/app.py
+++ b/python/cross_service/apigateway_covid-19_tracker/app.py
@@ -106,7 +106,7 @@ def state_cases(state):
     logger.info("Got %s to /states/%s.", app.current_request.method, state)
     logger.info("JSON body: %s", app.current_request.json_body)
 
-    state = urllib.parse.unquote(state)
+    state = urllib.parse.unquote_plus(state)
     verify_input(state, data=app.current_request.json_body)
 
     response = None
@@ -145,8 +145,8 @@ def state_date_cases(state, date):
     """
     logger.info("Got %s to /states/%s/%s.", app.current_request.method, state, date)
 
-    state = urllib.parse.unquote(state)
-    date = urllib.parse.unquote(date)
+    state = urllib.parse.unquote_plus(state)
+    date = urllib.parse.unquote_plus(date)
     verify_input(state, date=date)
 
     response = None

--- a/python/cross_service/aurora_rest_lending_library/library_api/app.py
+++ b/python/cross_service/aurora_rest_lending_library/library_api/app.py
@@ -93,7 +93,7 @@ def list_books_by_author(author_id):
     :param author_id: The ID of the author to query.
     :return: The list of books written by the specified author.
     """
-    author_id = int(urllib.parse.unquote(author_id))
+    author_id = int(urllib.parse.unquote_plus(author_id))
     return {"books": get_storage().get_books(author_id=author_id)}
 
 
@@ -151,7 +151,7 @@ def delete_patron(patron_id):
 
     :param patron_id: The ID of the patron to remove.
     """
-    patron_id = int(urllib.parse.unquote(patron_id))
+    patron_id = int(urllib.parse.unquote_plus(patron_id))
     get_storage().delete_patron(patron_id)
 
 
@@ -185,8 +185,8 @@ def book_lending(book_id, patron_id):
     :param book_id: The ID of the book.
     :param patron_id: The ID of the patron.
     """
-    book_id = int(urllib.parse.unquote(book_id))
-    patron_id = int(urllib.parse.unquote(patron_id))
+    book_id = int(urllib.parse.unquote_plus(book_id))
+    patron_id = int(urllib.parse.unquote_plus(patron_id))
     if app.current_request.method == "PUT":
         get_storage().borrow_book(book_id, patron_id)
     elif app.current_request.method == "DELETE":

--- a/python/example_code/s3/s3_versioning/remove_delete_marker.py
+++ b/python/example_code/s3/s3_versioning/remove_delete_marker.py
@@ -41,7 +41,7 @@ def lambda_handler(event, context):
     task_id = task["taskId"]
 
     try:
-        obj_key = parse.unquote(task["s3Key"], encoding="utf-8")
+        obj_key = parse.unquote_plus(task["s3Key"], encoding="utf-8")
         obj_version_id = task["s3VersionId"]
         bucket_name = task["s3BucketArn"].split(":")[-1]
 

--- a/python/example_code/s3/s3_versioning/revise_stanza.py
+++ b/python/example_code/s3/s3_versioning/revise_stanza.py
@@ -39,7 +39,7 @@ def lambda_handler(event, context):
     task = event["tasks"][0]
     task_id = task["taskId"]
     # The revision type is packed with the object key as a pipe-delimited string.
-    obj_key, revision = parse.unquote(task["s3Key"], encoding="utf-8").split("|")
+    obj_key, revision = parse.unquote_plus(task["s3Key"], encoding="utf-8").split("|")
     bucket_name = task["s3BucketArn"].split(":")[-1]
 
     logger.info("Got task: apply revision %s to %s.", revision, obj_key)


### PR DESCRIPTION

This pull request changes the parse methods to use unquote_plus for parsing instead of unquote as best practice.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
