### PR TITLE
JavaScript: fixed link to Nodemailer docs page

### DIFF
--- a/.doc_gen/metadata/ses_metadata.yaml
+++ b/.doc_gen/metadata/ses_metadata.yaml
@@ -79,7 +79,7 @@ ses_SendRawEmail:
           github: javascriptv3/example_code/ses
           sdkguide:
           excerpts:
-            - description: Use <ulink url="https://nodemailer.com/transports/ses/">nodemailer</ulink> to send an email with
+            - description: Use <ulink url="https://nodemailer.com/transports/ses">nodemailer</ulink> to send an email with
                 an attachment.
               snippet_tags:
                 - javascript.v3.ses.attachment

--- a/javascriptv3/example_code/ses/src/send-with-attachments.js
+++ b/javascriptv3/example_code/ses/src/send-with-attachments.js
@@ -9,7 +9,7 @@ import sesClientModule from "@aws-sdk/client-ses";
  * nodemailer wraps the SES SDK and calls SendRawEmail. Use this for more advanced
  * functionality like adding attachments to your email.
  *
- * https://nodemailer.com/transports/ses/
+ * https://nodemailer.com/transports/ses
  */
 import nodemailer from "nodemailer";
 


### PR DESCRIPTION
This pull request fixes some broken links to the Nodemailer SES transport docs page. The trailing slash gives a 404 error.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
