### PR TITLE
Add exclamation mark to README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![GitHub Super-Linter](https://github.com/awsdocs/aws-doc-sdk-examples/actions/workflows/super-linter.yml/badge.svg)](https://github.com/marketplace/actions/super-linter)
 ![[]](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)
 
-# AWS SDK Code Examples
+# AWS SDK Code Examples!
 
 This repository contains code examples that demonstrate how to use the [AWS SDKs](https://aws.amazon.com/developer/tools/) to interact with [AWS services](https://aws.amazon.com/products).
 


### PR DESCRIPTION
This PR adds an exclamation mark to the main title in the README to make it more enthusiastic and welcoming for developers exploring AWS SDK examples.