### PR TITLE
Update Swift lambda runtime example

### DIFF
--- a/swift/example_code/lambda/using-lambda-runtime/Package.swift
+++ b/swift/example_code/lambda/using-lambda-runtime/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     // before building the project.
     dependencies: [
         .package(
-            url: "https://github.com/swift-server/swift-aws-lambda-runtime.git",
-            from: "2.0.0-beta.1"),
+            url: "https://github.com/awslabs/swift-aws-lambda-runtime.git",
+            from: "2.0.0"),
         .package(url: "https://github.com/awslabs/aws-sdk-swift.git",
             from: "1.0.0"),
     ],


### PR DESCRIPTION
This PR updates the `Package.swift` file for the Swift Lambda Runtime for AWS example so that it pulls the 2.0.0 version or newer from the `awslabs` organization instead of from the `swift-server` organization.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
