### PR TITLE
Update LSI code to Javav2

### DIFF
--- a/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/document/DocumentAPILocalSecondaryIndexExample.java
+++ b/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/document/DocumentAPILocalSecondaryIndexExample.java
@@ -326,4 +326,4 @@ public class DocumentAPILocalSecondaryIndexExample {
 
 }
 
-// snippet-end:[dynamodb.java.codeexample.DocumentAPILocalSecondaryIndexExample]
+// snippet-end:[dynamodb.java.codeexample.DocumentAPILocalSecondaryIndexExampleV1]

--- a/javav2/example_code/dynamodb/src/main/java/com/example/dynamodb/DocumentAPILocalSecondaryIndexExample.java
+++ b/javav2/example_code/dynamodb/src/main/java/com/example/dynamodb/DocumentAPILocalSecondaryIndexExample.java
@@ -239,3 +239,5 @@ public class DocumentAPILocalSecondaryIndexExample {
         client.putItem(PutItemRequest.builder().tableName(tableName).item(item).build());
     }
 }
+
+// snippet-end:[dynamodb.java.codeexample.DocumentAPILocalSecondaryIndexExample]


### PR DESCRIPTION
Java: Add SDK v2 version of DocumentAPILocalSecondaryIndexExample in DynamoDB

This pull request adds an AWS SDK for Java v2 version of the DocumentAPILocalSecondaryIndexExample to the javav2 directory. The example demonstrates how to:
- Create a DynamoDB table with local secondary indexes
- Load data into the table
- Query the table with and without indexes
- Use projection expressions to limit returned attributes
- Delete the table

The v2 implementation uses the low-level DynamoDbClient API with builder patterns, replacing the v1 Document API which has no direct equivalent in SDK v2.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
