### PR TITLE
Fixing Redshift README and EMR naming issue

### DIFF
--- a/sap-abap/services/emr/#awsex#cl_emr_actions.clas.abap
+++ b/sap-abap/services/emr/#awsex#cl_emr_actions.clas.abap
@@ -15,8 +15,8 @@ CLASS /awsex/cl_emr_actions DEFINITION
         !it_applications       TYPE /aws1/cl_emrapplication=>tt_applicationlist
         !iv_job_flow_role      TYPE /aws1/emrxmlstring
         !iv_service_role       TYPE /aws1/emrxmlstring
-        !iv_master_sec_grp     TYPE /aws1/emrxmlstringmaxlen256
-        !iv_slave_sec_grp      TYPE /aws1/emrxmlstringmaxlen256
+        !iv_primary_sec_grp    TYPE /aws1/emrxmlstringmaxlen256
+        !iv_secondary_sec_grp  TYPE /aws1/emrxmlstringmaxlen256
         !it_steps              TYPE /aws1/cl_emrstepconfig=>tt_stepconfiglist
       RETURNING
         VALUE(ov_cluster_id)   TYPE /aws1/emrxmlstringmaxlen256
@@ -88,8 +88,8 @@ CLASS /AWSEX/CL_EMR_ACTIONS IMPLEMENTATION.
           iv_slaveinstancetype = 'm5.xlarge'
           iv_instancecount = 3
           iv_keepjobflowalivewhennos00 = iv_keep_alive
-          iv_emrmanagedmastersecgroup = iv_master_sec_grp
-          iv_emrmanagedslavesecgroup = iv_slave_sec_grp
+          iv_emrmanagedmastersecgroup = iv_primary_sec_grp
+          iv_emrmanagedslavesecgroup = iv_secondary_sec_grp
         ).
 
         DATA(lo_result) = lo_emr->runjobflow(

--- a/sap-abap/services/rsh/README.md
+++ b/sap-abap/services/rsh/README.md
@@ -33,14 +33,14 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `sap-a
 
 Code excerpts that show you how to call individual service functions.
 
-- [CreateCluster](#awsex#cl_rsh_actions.clas.abap#L63)
-- [DeleteCluster](#awsex#cl_rsh_actions.clas.abap#L99)
-- [DescribeClusters](#awsex#cl_rsh_actions.clas.abap#L156)
-- [DescribeStatement](../rsd/#awsex#cl_rsd_actions.clas.abap#L150)
-- [ExecuteStatement](../rsd/#awsex#cl_rsd_actions.clas.abap#L102)
-- [GetStatementResult](../rsd/#awsex#cl_rsd_actions.clas.abap#L182)
-- [ListDatabases](../rsd/#awsex#cl_rsd_actions.clas.abap#L69)
-- [ModifyCluster](#awsex#cl_rsh_actions.clas.abap#L126)
+- [CreateCluster](%23awsex%23cl_rsh_actions.clas.abap#L63)
+- [DeleteCluster](%23awsex%23cl_rsh_actions.clas.abap#L99)
+- [DescribeClusters](%23awsex%23cl_rsh_actions.clas.abap#L156)
+- [DescribeStatement](../rsd/%23awsex%23cl_rsd_actions.clas.abap#L150)
+- [ExecuteStatement](../rsd/%23awsex%23cl_rsd_actions.clas.abap#L102)
+- [GetStatementResult](../rsd/%23awsex%23cl_rsd_actions.clas.abap#L182)
+- [ListDatabases](../rsd/%23awsex%23cl_rsd_actions.clas.abap#L69)
+- [ModifyCluster](%23awsex%23cl_rsh_actions.clas.abap#L126)
 
 
 <!--custom.examples.start-->


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request contains fixes for Redshift's README which was generated incorrectly. It also fixes a syntax issue with the EMR examples that was caught by a syntax check ran on the ABAP system

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
