### PR TITLE
Use DynamoDBDocumentClient to send DeleteCommand for consistency

### DIFF
--- a/javascriptv3/example_code/dynamodb/scenarios/basic.js
+++ b/javascriptv3/example_code/dynamodb/scenarios/basic.js
@@ -1,4 +1,4 @@
-U789// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
This change sends DeleteCommand using DynamoDBDocumentClient instead of
DynamoDBClient for consistency with other CRUD operations in the example.

DeleteCommand is imported from @aws-sdk/lib-dynamodb and is intended to be
used with the document client, matching Put/Get/Update usage earlier in
the scenario.