### PR TITLE
.NET v4: Add appsettings example to CloudWatch scenario

### DIFF
--- a/.doc_gen/metadata/cloudwatch_metadata.yaml
+++ b/.doc_gen/metadata/cloudwatch_metadata.yaml
@@ -1097,6 +1097,9 @@ cloudwatch_GetStartedMetricsDashboardsAlarms:
             - description: Wrapper methods used by the scenario for &CW; actions.
               snippet_tags:
                 - CloudWatch.dotnetv4.CloudWatchWrapper
+            - description: Example settings.json values for the scenario.
+            - snippet_files:
+                - dotnetv4/CloudWatch/Scenarios/settings.json
   services:
     cloudwatch: {ListMetrics, GetMetricStatistics, PutDashboard, PutMetricData, GetMetricData, PutMetricAlarm, DescribeAlarms,
                  DescribeAlarmsForMetric, DescribeAlarmHistory, DeleteAlarms, PutAnomalyDetector, GetMetricWidgetImage, DescribeAnomalyDetectors,


### PR DESCRIPTION

This pull request adds the example appsettings in settings.json to the displayed code example. Resolves a customer ticket.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
