### PR TITLE
Add doesObjectExist convenience method

### DIFF
--- a/.doc_gen/metadata/s3_metadata.yaml
+++ b/.doc_gen/metadata/s3_metadata.yaml
@@ -3940,6 +3940,24 @@ s3_Scenario_DoesBucketExist:
   services:
     s3: {GetBucketAcl}
     
+s3_Scenario_DoesObjectExist:
+  title: Check if an object exists
+  title_abbrev: Check if an object exists
+  synopsis: check if an object exists.
+  category: Scenarios
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/s3
+          sdkguide:
+          excerpts:
+            - description: You can use the following <code>doesObjectExist</code> method as a replacement for the &Java; V1 <ulink url="https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Client.html#doesObjectExist-java.lang.String-java.lang.String-">AmazonS3Client#doesObjectExist(String, String)</ulink> method.
+              snippet_tags:
+                - s3.java2.does-object-exist-main
+  services:
+    s3: {HeadObject}
+    
 s3_CreatePresignedPost:
   languages:
     .NET:

--- a/javav2/example_code/s3/README.md
+++ b/javav2/example_code/s3/README.md
@@ -85,6 +85,7 @@ Code examples that show you how to accomplish a specific task by calling multipl
 functions within the same service.
 
 - [Check if a bucket exists](src/main/java/com/example/s3/DoesBucketExist.java)
+- [Check if an object exists](src/main/java/com/example/s3/DoesObjectExist.java)
 - [Delete incomplete multipart uploads](src/main/java/com/example/s3/AbortMultipartUploadExamples.java)
 - [Download S3 'directories'](src/main/java/com/example/s3/transfermanager/S3DirectoriesDownloader.java)
 - [Download objects to a local directory](src/main/java/com/example/s3/transfermanager/DownloadToDirectory.java)
@@ -148,6 +149,18 @@ This example shows you how to check if a bucket exists.
 
 <!--custom.scenarios.s3_Scenario_DoesBucketExist.start-->
 <!--custom.scenarios.s3_Scenario_DoesBucketExist.end-->
+
+#### Check if an object exists
+
+This example shows you how to check if an object exists.
+
+
+<!--custom.scenario_prereqs.s3_Scenario_DoesObjectExist.start-->
+<!--custom.scenario_prereqs.s3_Scenario_DoesObjectExist.end-->
+
+
+<!--custom.scenarios.s3_Scenario_DoesObjectExist.start-->
+<!--custom.scenarios.s3_Scenario_DoesObjectExist.end-->
 
 #### Delete incomplete multipart uploads
 

--- a/javav2/example_code/s3/src/main/java/com/example/s3/DoesObjectExist.java
+++ b/javav2/example_code/s3/src/main/java/com/example/s3/DoesObjectExist.java
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.example.s3;
+// snippet-start:[s3.java2.does-object-exist-main]
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.utils.Validate;
+
+public class DoesObjectExist {
+    private static final Logger logger = LoggerFactory.getLogger(DoesObjectExist.class);
+
+    public static void main(String[] args) {
+        DoesObjectExist doesObjectExist = new DoesObjectExist();
+
+        final S3Client s3SyncClient = S3Client.builder().build();
+        final String bucketName = "amzn-s3-demo-bucket"; // Replace with your bucket name.
+        final String key = "my-key"; // Replace with your object key.
+
+        boolean exists = doesObjectExist.doesObjectExist(bucketName, key, s3SyncClient);
+        logger.info("Object exists: {}", exists);
+    }
+
+    /**
+     * Checks if the specified object exists in the specified bucket.
+     * <p>
+     * Internally this method uses the
+     * <a href="https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#headObject(java.util.function.Consumer)">S3Client.headObject</a>
+     * operation to determine whether the object exists.
+     * <p>
+     * This method is equivalent to the AWS SDK for Java V1's
+     * <a href="https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Client.html#doesObjectExist-java.lang.String-java.lang.String-">AmazonS3Client#doesObjectExist(String, String)</a>.
+     * <p>
+     * <b>Note:</b> This method returns {@code false} only when S3 responds with 404 (NoSuchKey). If the caller
+     * does not have {@code s3:ListBucket} permission on the bucket, S3 may return 403 instead of 404 for
+     * non-existent objects, which will be thrown as an exception.
+     *
+     * @param bucketName   The name of the bucket containing the object.
+     * @param key          The key of the object to check.
+     * @param s3SyncClient An {@code S3Client} instance.
+     * @return {@code true} if the object exists; {@code false} if it does not exist.
+     */
+    public boolean doesObjectExist(String bucketName, String key, S3Client s3SyncClient) {
+        try {
+            Validate.notEmpty(bucketName, "The bucket name must not be null or an empty string.", "");
+            Validate.notEmpty(key, "The object key must not be null or an empty string.", "");
+            s3SyncClient.headObject(HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        }
+    }
+}
+// snippet-end:[s3.java2.does-object-exist-main]

--- a/javav2/example_code/s3/src/test/java/com/example/s3/DoesObjectExistTest.java
+++ b/javav2/example_code/s3/src/test/java/com/example/s3/DoesObjectExistTest.java
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.example.s3;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DoesObjectExistTest {
+
+    private final S3Client s3Client = mock(S3Client.class);
+    private final DoesObjectExist doesObjectExist = new DoesObjectExist();
+
+    @Test
+    void doesObjectExist_objectExists_returnsTrue() {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenReturn(HeadObjectResponse.builder().build());
+
+        assertTrue(doesObjectExist.doesObjectExist("bucket", "key", s3Client));
+    }
+
+    @Test
+    void doesObjectExist_objectDoesNotExist_returnsFalse() {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenThrow(NoSuchKeyException.builder().build());
+
+        assertFalse(doesObjectExist.doesObjectExist("bucket", "key", s3Client));
+    }
+
+    @Test
+    void doesObjectExist_accessDenied_throwsS3Exception() {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenThrow((S3Exception) S3Exception.builder().statusCode(403).message("Forbidden").build());
+
+        assertThrows(S3Exception.class, () ->
+                doesObjectExist.doesObjectExist("bucket", "key", s3Client));
+    }
+}


### PR DESCRIPTION
Related https://github.com/aws/aws-sdk-java-v2/issues/392
### Background
The v1 Java SDK provided `doesObjectExist(bucket, key)` as a convenience method on the S3 client. The v2 SDK does not have this. Customers must call `headObject` and catch `NoSuchKeyException` manually. The existing code examples repo has a `DoesBucketExist` example showing the bucket equivalent, but no object example exists.
This fills that gap so customers migrating from v1 have a reference for the object case.
  
### Changes
  
- Added code example file demonstrating how to check if an object exists in S3 using `headObject`. Returns true on success, false on `NoSuchKeyException`, and throws on any other error (including 403).
This matches v1's doesObjectExist behavior.

- Added stubbed integ test. Unlike the integ test for `doesBucketExist` that uses real S3, this test uses a mock to avoid having to setup and clean resources. (I wrote a one-off integ test using real s3 just to make sure the test passes) The existing stubbed integ test should be enough to cover the behavior we are trying to showcase.