### PR TITLE
SAP ABAP: Add IoT, SESv2, and S3 Control examples

### DIFF
--- a/.doc_gen/metadata/iot_metadata.yaml
+++ b/.doc_gen/metadata/iot_metadata.yaml
@@ -54,6 +54,15 @@ iot_Hello:
     iot: {listThings}
 iot_DescribeEndpoint:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.describe_endpoint
     Kotlin:
       versions:
         - sdk_version: 1
@@ -108,6 +117,15 @@ iot_DescribeEndpoint:
     iot: {DescribeEndpoint}
 iot_ListThings:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.list_things
     .NET:
       versions:
         - sdk_version: 4
@@ -137,6 +155,15 @@ iot_ListThings:
     iot: {ListThings}
 iot_ListCertificates:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.list_certificates
     Kotlin:
       versions:
         - sdk_version: 1
@@ -183,6 +210,15 @@ iot_ListCertificates:
     iot: {ListCertificates}
 iot_CreateKeysAndCertificate:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.create_keys_and_certificate
     Kotlin:
       versions:
         - sdk_version: 1
@@ -229,6 +265,15 @@ iot_CreateKeysAndCertificate:
     iot: {CreateKeysAndCertificate}
 iot_DeleteCertificate:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.delete_certificate
     Kotlin:
       versions:
         - sdk_version: 1
@@ -275,6 +320,15 @@ iot_DeleteCertificate:
     iot: {DeleteCertificate}
 iot_SearchIndex:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.search_index
     Kotlin:
       versions:
         - sdk_version: 1
@@ -321,6 +375,15 @@ iot_SearchIndex:
     iot: {SearchIndex}
 iot_UpdateIndexingConfiguration:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.update_indexing_configuration
     C++:
       versions:
         - sdk_version: 1
@@ -342,6 +405,15 @@ iot_UpdateIndexingConfiguration:
     iot: {UpdateIndexingConfiguration}
 iot_DeleteThing:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.delete_thing
     Kotlin:
       versions:
         - sdk_version: 1
@@ -417,6 +489,15 @@ iot_DescribeThing:
     iot: {DescribeThing}
 iot_AttachThingPrincipal:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.attach_thing_principal
     Kotlin:
       versions:
         - sdk_version: 1
@@ -463,6 +544,15 @@ iot_AttachThingPrincipal:
     iot: {AttachThingPrincipal}
 iot_DetachThingPrincipal:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.detach_thing_principal
     Kotlin:
       versions:
         - sdk_version: 1
@@ -538,6 +628,15 @@ iot_UpdateThing:
     iot: {UpdateThing}
 iot_CreateTopicRule:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.create_topic_rule
     Kotlin:
       versions:
         - sdk_version: 1
@@ -584,6 +683,15 @@ iot_CreateTopicRule:
     iot: {CreateTopicRule}
 iot_DeleteTopicRule:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.delete_topic_rule
     C++:
       versions:
         - sdk_version: 1
@@ -605,6 +713,15 @@ iot_DeleteTopicRule:
     iot: {DeleteTopicRule}
 iot_CreateThing:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/iot
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - iot.abapv1.create_thing
     Kotlin:
       versions:
         - sdk_version: 1

--- a/.doc_gen/metadata/s3-control_metadata.yaml
+++ b/.doc_gen/metadata/s3-control_metadata.yaml
@@ -27,6 +27,15 @@ s3-control_Hello:
 
 s3-control_CreateJob:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/s3c
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - s3c.abapv1.create_job
     Java:
       versions:
         - sdk_version: 2
@@ -58,6 +67,15 @@ s3-control_CreateJob:
     s3-control: {CreateJob}
 s3-control_PutJobTagging:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/s3c
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - s3c.abapv1.put_job_tagging
     Java:
       versions:
         - sdk_version: 2
@@ -80,6 +98,15 @@ s3-control_PutJobTagging:
     s3-control: {PutJobTagging}
 s3-control_DescribeJob:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/s3c
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - s3c.abapv1.describe_job
     Java:
       versions:
         - sdk_version: 2
@@ -102,6 +129,15 @@ s3-control_DescribeJob:
     s3-control: {DescribeJob}
 s3-control_DeleteJobTagging:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/s3c
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - s3c.abapv1.delete_job_tagging
     Java:
       versions:
         - sdk_version: 2
@@ -124,6 +160,15 @@ s3-control_DeleteJobTagging:
     s3-control: {DeleteJobTagging}
 s3-control_GetJobTagging:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/s3c
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - s3c.abapv1.get_job_tagging
     Java:
       versions:
         - sdk_version: 2
@@ -146,6 +191,15 @@ s3-control_GetJobTagging:
     s3-control: {GetJobTagging}
 s3-control_UpdateJobStatus:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/s3c
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - s3c.abapv1.update_job_status
     Java:
       versions:
         - sdk_version: 2
@@ -168,6 +222,15 @@ s3-control_UpdateJobStatus:
     s3-control: {UpdateJobStatus}
 s3-control_UpdateJobPriority:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/s3c
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - s3c.abapv1.update_job_priority
     Java:
       versions:
         - sdk_version: 2

--- a/.doc_gen/metadata/sesv2_metadata.yaml
+++ b/.doc_gen/metadata/sesv2_metadata.yaml
@@ -101,6 +101,15 @@ sesv2_CreateContact:
     sesv2: {CreateContact}
 sesv2_GetEmailIdentity:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/se2
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - se2.abapv1.get_email_identity
     Python:
       versions:
         - sdk_version: 3
@@ -644,6 +653,15 @@ sesv2_Hello:
     sesv2: {ListEmailIdentities}
 sesv2_SendBulkEmail:
   languages:
+    SAP ABAP:
+      versions:
+        - sdk_version: 1
+          github: sap-abap/services/se2
+          excerpts:
+            - description:
+              genai: most
+              snippet_tags:
+                - se2.abapv1.send_bulk_email
     Python:
       versions:
         - sdk_version: 3

--- a/.tools/readmes/config.py
+++ b/.tools/readmes/config.py
@@ -229,6 +229,7 @@ language = {
                 "sagemaker": "sap-abap/services/sgm",
                 "scheduler": "sap-abap/services/scd",
                 "secrets-manager": "sap-abap/services/smr",
+                "s3-control": "sap-abap/services/s3c",
                 "sesv2": "sap-abap/services/se2",
                 "textract": "sap-abap/services/tex",
                 "transcribe": "sap-abap/services/tnb",

--- a/sap-abap/services/iot/#awsex#cl_iot_actions.clas.abap
+++ b/sap-abap/services/iot/#awsex#cl_iot_actions.clas.abap
@@ -1,0 +1,492 @@
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
+CLASS /awsex/cl_iot_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    " Creates an AWS IoT thing.
+    " @parameter iv_thing_name | The name of the thing to create (e.g., 'MyIoTThing')
+    " @parameter oo_result | The result object containing thing name, ARN, and ID
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS create_thing
+      IMPORTING
+        !iv_thing_name   TYPE /aws1/iotthingname
+      RETURNING
+        VALUE(oo_result) TYPE REF TO /aws1/cl_iotcreatethingrsp
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Lists all AWS IoT things, paginating through all pages.
+    " @parameter oo_result | The result object from the final page
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS list_things
+      RETURNING
+        VALUE(oo_result) TYPE REF TO /aws1/cl_iotlistthingsresponse
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Creates keys and a certificate for an AWS IoT thing.
+    " @parameter oo_result | The result object containing certificate ARN, ID, and PEM
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS create_keys_and_certificate
+      RETURNING
+        VALUE(oo_result) TYPE REF TO /aws1/cl_iotcrekeysandcertrsp
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Attaches a certificate to an AWS IoT thing.
+    " @parameter iv_thing_name | The name of the thing (e.g., 'MyIoTThing')
+    " @parameter iv_principal  | The ARN of the certificate
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS attach_thing_principal
+      IMPORTING
+        !iv_thing_name TYPE /aws1/iotthingname
+        !iv_principal  TYPE /aws1/iotprincipal
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Gets the AWS IoT endpoint address.
+    " @parameter iv_endpoint_type | The endpoint type (e.g., 'iot:Data-ATS')
+    " @parameter ov_endpoint_address | The endpoint address
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS describe_endpoint
+      IMPORTING
+        !iv_endpoint_type          TYPE /aws1/iotendpointtype
+                                   DEFAULT 'iot:Data-ATS'
+      RETURNING
+        VALUE(ov_endpoint_address) TYPE /aws1/iotendpointaddress
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Lists all AWS IoT certificates, paginating through all pages.
+    " @parameter oo_result | The result object from the final page
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS list_certificates
+      RETURNING
+        VALUE(oo_result) TYPE REF TO /aws1/cl_iotlistcertsresponse
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Detaches a certificate from an AWS IoT thing.
+    " @parameter iv_thing_name | The name of the thing (e.g., 'MyIoTThing')
+    " @parameter iv_principal  | The ARN of the certificate
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS detach_thing_principal
+      IMPORTING
+        !iv_thing_name TYPE /aws1/iotthingname
+        !iv_principal  TYPE /aws1/iotprincipal
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Deactivates and deletes an AWS IoT certificate.
+    " @parameter iv_certificate_id | The ID of the certificate to delete
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS delete_certificate
+      IMPORTING
+        !iv_certificate_id TYPE /aws1/iotcertificateid
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Creates an AWS IoT topic rule with an SNS action.
+    " @parameter iv_rule_name      | The name of the rule (e.g., 'MyTopicRule')
+    " @parameter iv_topic          | The MQTT topic to subscribe to (e.g., 'my/topic')
+    " @parameter iv_sns_action_arn | The ARN of the SNS topic to publish to
+    " @parameter iv_role_arn       | The ARN of the IAM role
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS create_topic_rule
+      IMPORTING
+        !iv_rule_name      TYPE /aws1/iotrulename
+        !iv_topic          TYPE /aws1/iottopic
+        !iv_sns_action_arn TYPE /aws1/iotstring
+        !iv_role_arn       TYPE /aws1/iotstring
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Lists all AWS IoT topic rules, paginating through all pages.
+    " @parameter oo_result | The result object from the final page
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS list_topic_rules
+      RETURNING
+        VALUE(oo_result) TYPE REF TO /aws1/cl_iotlisttopicrulesrsp
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Searches the AWS IoT index.
+    " @parameter iv_query_string | The search query string (e.g., 'thingName:MyThing*')
+    " @parameter oo_result       | The result object containing the list of matching things
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS search_index
+      IMPORTING
+        !iv_query_string TYPE /aws1/iotquerystring
+      RETURNING
+        VALUE(oo_result) TYPE REF TO /aws1/cl_iotsearchindexrsp
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Enables thing indexing in AWS IoT.
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS update_indexing_configuration
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Deletes an AWS IoT thing.
+    " @parameter iv_thing_name | The name of the thing to delete (e.g., 'MyIoTThing')
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS delete_thing
+      IMPORTING
+        !iv_thing_name TYPE /aws1/iotthingname
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Deletes an AWS IoT topic rule.
+    " @parameter iv_rule_name | The name of the rule to delete (e.g., 'MyTopicRule')
+    " @raising /aws1/cx_rt_generic | Thrown when operation fails
+    METHODS delete_topic_rule
+      IMPORTING
+        !iv_rule_name TYPE /aws1/iotrulename
+      RAISING
+        /aws1/cx_rt_generic.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS /awsex/cl_iot_actions IMPLEMENTATION.
+
+  METHOD create_thing.
+    " snippet-start:[iot.abapv1.create_thing]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        oo_result = lo_iot->creatething(
+          iv_thingname = iv_thing_name ).
+        MESSAGE |IoT thing created: { oo_result->get_thingname( ) } ARN: { oo_result->get_thingarn( ) }| TYPE 'I'.
+      CATCH /aws1/cx_iotresrcalrdyexistsex.
+        MESSAGE |IoT thing '{ iv_thing_name }' already exists.| TYPE 'I'.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_ex).
+        MESSAGE lo_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.create_thing]
+  ENDMETHOD.
+
+
+  METHOD list_things.
+    " snippet-start:[iot.abapv1.list_things]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        " Collect all things by following the pagination token.
+        DATA lv_nexttoken TYPE /aws1/iotnexttoken.
+        DATA lv_count     TYPE i.
+
+        DO.
+          oo_result    = lo_iot->listthings( iv_nexttoken = lv_nexttoken ).
+          lv_count     = lv_count + lines( oo_result->get_things( ) ).
+          lv_nexttoken = oo_result->get_nexttoken( ).
+          IF lv_nexttoken IS INITIAL.
+            EXIT.
+          ENDIF.
+        ENDDO.
+
+        MESSAGE |Retrieved { lv_count } IoT things.| TYPE 'I'.
+      CATCH /aws1/cx_iotthrottlingex INTO DATA(lo_throttle_ex).
+        MESSAGE 'Request throttled. Please try again later.' TYPE 'I'.
+        RAISE EXCEPTION lo_throttle_ex.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_ex).
+        MESSAGE lo_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.list_things]
+  ENDMETHOD.
+
+
+  METHOD create_keys_and_certificate.
+    " snippet-start:[iot.abapv1.create_keys_and_certificate]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        oo_result = lo_iot->createkeysandcertificate( iv_setasactive = abap_true ).
+        MESSAGE |Certificate created: { oo_result->get_certificateid( ) }| TYPE 'I'.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_ex).
+        MESSAGE lo_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.create_keys_and_certificate]
+  ENDMETHOD.
+
+
+  METHOD attach_thing_principal.
+    " snippet-start:[iot.abapv1.attach_thing_principal]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        lo_iot->attachthingprincipal(
+          iv_thingname = iv_thing_name
+          iv_principal = iv_principal ).
+        MESSAGE |Principal attached to IoT thing '{ iv_thing_name }'.| TYPE 'I'.
+      CATCH /aws1/cx_iotresourcenotfoundex INTO DATA(lo_ex).
+        MESSAGE |Resource not found when attaching principal to '{ iv_thing_name }'.| TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_svc_ex).
+        MESSAGE lo_svc_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_svc_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.attach_thing_principal]
+  ENDMETHOD.
+
+
+  METHOD describe_endpoint.
+    " snippet-start:[iot.abapv1.describe_endpoint]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    " iv_endpoint_type = 'iot:Data-ATS' - Endpoint type for data operations
+    TRY.
+        DATA(lo_result) = lo_iot->describeendpoint( iv_endpointtype = iv_endpoint_type ).
+        ov_endpoint_address = lo_result->get_endpointaddress( ).
+        MESSAGE |Endpoint address: { ov_endpoint_address }| TYPE 'I'.
+      CATCH /aws1/cx_iotthrottlingex INTO DATA(lo_throttle_ex).
+        MESSAGE 'Request throttled. Please try again later.' TYPE 'I'.
+        RAISE EXCEPTION lo_throttle_ex.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_ex).
+        MESSAGE lo_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.describe_endpoint]
+  ENDMETHOD.
+
+
+  METHOD list_certificates.
+    " snippet-start:[iot.abapv1.list_certificates]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        " Collect all certificates by following the pagination marker.
+        DATA lv_marker TYPE /aws1/iotmarker.
+        DATA lv_count  TYPE i.
+
+        DO.
+          oo_result = lo_iot->listcertificates( iv_marker = lv_marker ).
+          lv_count  = lv_count + lines( oo_result->get_certificates( ) ).
+          lv_marker = oo_result->get_nextmarker( ).
+          IF lv_marker IS INITIAL.
+            EXIT.
+          ENDIF.
+        ENDDO.
+
+        MESSAGE |Retrieved { lv_count } IoT certificates.| TYPE 'I'.
+      CATCH /aws1/cx_iotthrottlingex INTO DATA(lo_throttle_ex).
+        MESSAGE 'Request throttled. Please try again later.' TYPE 'I'.
+        RAISE EXCEPTION lo_throttle_ex.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_ex).
+        MESSAGE lo_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.list_certificates]
+  ENDMETHOD.
+
+
+  METHOD detach_thing_principal.
+    " snippet-start:[iot.abapv1.detach_thing_principal]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        lo_iot->detachthingprincipal(
+          iv_thingname = iv_thing_name
+          iv_principal = iv_principal ).
+        MESSAGE |Principal detached from IoT thing '{ iv_thing_name }'.| TYPE 'I'.
+      CATCH /aws1/cx_iotresourcenotfoundex INTO DATA(lo_ex).
+        MESSAGE |Resource not found when detaching principal from '{ iv_thing_name }'.| TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_svc_ex).
+        MESSAGE lo_svc_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_svc_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.detach_thing_principal]
+  ENDMETHOD.
+
+
+  METHOD delete_certificate.
+    " snippet-start:[iot.abapv1.delete_certificate]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        " Certificates must be deactivated before they can be deleted.
+        lo_iot->updatecertificate(
+          iv_certificateid = iv_certificate_id
+          iv_newstatus     = 'INACTIVE' ).
+        lo_iot->deletecertificate( iv_certificateid = iv_certificate_id ).
+        MESSAGE |Certificate deleted: { iv_certificate_id }| TYPE 'I'.
+      CATCH /aws1/cx_iotresourcenotfoundex INTO DATA(lo_ex).
+        MESSAGE |Certificate '{ iv_certificate_id }' not found.| TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_svc_ex).
+        MESSAGE lo_svc_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_svc_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.delete_certificate]
+  ENDMETHOD.
+
+
+  METHOD create_topic_rule.
+    " snippet-start:[iot.abapv1.create_topic_rule]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        " Build the SNS action that will receive messages matching the rule.
+        DATA lo_sns_action TYPE REF TO /aws1/cl_iotsnsaction.
+        CREATE OBJECT lo_sns_action
+          EXPORTING
+            iv_targetarn = iv_sns_action_arn
+            iv_rolearn   = iv_role_arn.
+
+        DATA lo_action TYPE REF TO /aws1/cl_iotaction.
+        CREATE OBJECT lo_action
+          EXPORTING
+            io_sns = lo_sns_action.
+
+        DATA lt_actions TYPE /aws1/cl_iotaction=>tt_actionlist.
+        APPEND lo_action TO lt_actions.
+
+        " iv_topic = 'my/iot/topic' - The MQTT topic pattern to match
+        DATA lo_payload TYPE REF TO /aws1/cl_iottopicrulepayload.
+        CREATE OBJECT lo_payload
+          EXPORTING
+            iv_sql     = |SELECT * FROM '{ iv_topic }'|
+            it_actions = lt_actions.
+
+        lo_iot->createtopicrule(
+          iv_rulename         = iv_rule_name
+          io_topicrulepayload = lo_payload ).
+        MESSAGE |IoT topic rule created: { iv_rule_name }| TYPE 'I'.
+      CATCH /aws1/cx_iotresrcalrdyexistsex.
+        MESSAGE |Topic rule '{ iv_rule_name }' already exists.| TYPE 'I'.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_ex).
+        MESSAGE lo_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.create_topic_rule]
+  ENDMETHOD.
+
+
+  METHOD list_topic_rules.
+    " snippet-start:[iot.abapv1.list_topic_rules]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        " Collect all topic rules by following the pagination token.
+        DATA lv_nexttoken TYPE /aws1/iotnexttoken.
+        DATA lv_count     TYPE i.
+
+        DO.
+          oo_result    = lo_iot->listtopicrules( iv_nexttoken = lv_nexttoken ).
+          lv_count     = lv_count + lines( oo_result->get_rules( ) ).
+          lv_nexttoken = oo_result->get_nexttoken( ).
+          IF lv_nexttoken IS INITIAL.
+            EXIT.
+          ENDIF.
+        ENDDO.
+
+        MESSAGE |Retrieved { lv_count } IoT topic rules.| TYPE 'I'.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_ex).
+        MESSAGE lo_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.list_topic_rules]
+  ENDMETHOD.
+
+
+  METHOD search_index.
+    " snippet-start:[iot.abapv1.search_index]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    " iv_query_string = 'thingName:MyThing*' - Fleet indexing query string
+    TRY.
+        oo_result = lo_iot->searchindex( iv_querystring = iv_query_string ).
+        MESSAGE |Found { lines( oo_result->get_things( ) ) } IoT things matching query.| TYPE 'I'.
+      CATCH /aws1/cx_iotindexnotreadyex INTO DATA(lo_idx_ex).
+        MESSAGE 'Fleet indexing is not ready. Enable indexing with UpdateIndexingConfiguration first.' TYPE 'I'.
+        RAISE EXCEPTION lo_idx_ex.
+      CATCH /aws1/cx_iotthrottlingex INTO DATA(lo_throttle_ex).
+        MESSAGE 'Request throttled. Please try again later.' TYPE 'I'.
+        RAISE EXCEPTION lo_throttle_ex.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_ex).
+        MESSAGE lo_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.search_index]
+  ENDMETHOD.
+
+
+  METHOD update_indexing_configuration.
+    " snippet-start:[iot.abapv1.update_indexing_configuration]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        DATA lo_idx_conf TYPE REF TO /aws1/cl_iotthingindexingconf.
+        CREATE OBJECT lo_idx_conf
+          EXPORTING
+            iv_thingindexingmode = 'REGISTRY'.
+        lo_iot->updateindexingconfiguration(
+          io_thingindexingconf = lo_idx_conf ).
+        MESSAGE 'IoT thing indexing configuration updated to REGISTRY mode.' TYPE 'I'.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_ex).
+        MESSAGE lo_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.update_indexing_configuration]
+  ENDMETHOD.
+
+
+  METHOD delete_thing.
+    " snippet-start:[iot.abapv1.delete_thing]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        lo_iot->deletething( iv_thingname = iv_thing_name ).
+        MESSAGE |IoT thing deleted: { iv_thing_name }| TYPE 'I'.
+      CATCH /aws1/cx_iotresourcenotfoundex INTO DATA(lo_ex).
+        MESSAGE |IoT thing '{ iv_thing_name }' not found.| TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_svc_ex).
+        MESSAGE lo_svc_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_svc_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.delete_thing]
+  ENDMETHOD.
+
+
+  METHOD delete_topic_rule.
+    " snippet-start:[iot.abapv1.delete_topic_rule]
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_iot) = /aws1/cl_iot_factory=>create( lo_session ).
+    TRY.
+        lo_iot->deletetopicrule( iv_rulename = iv_rule_name ).
+        MESSAGE |IoT topic rule deleted: { iv_rule_name }| TYPE 'I'.
+      CATCH /aws1/cx_rt_service_generic INTO DATA(lo_ex).
+        MESSAGE lo_ex->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION lo_ex.
+    ENDTRY.
+    " snippet-end:[iot.abapv1.delete_topic_rule]
+  ENDMETHOD.
+
+ENDCLASS.

--- a/sap-abap/services/iot/#awsex#cl_iot_actions.clas.testclasses.abap
+++ b/sap-abap/services/iot/#awsex#cl_iot_actions.clas.testclasses.abap
@@ -1,0 +1,880 @@
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
+CLASS ltc_awsex_cl_iot_actions DEFINITION DEFERRED.
+CLASS /awsex/cl_iot_actions DEFINITION LOCAL FRIENDS ltc_awsex_cl_iot_actions.
+
+CLASS ltc_awsex_cl_iot_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL DANGEROUS.
+
+  PRIVATE SECTION.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+
+    CLASS-DATA ao_iot         TYPE REF TO /aws1/if_iot.
+    CLASS-DATA ao_iam         TYPE REF TO /aws1/if_iam.
+    CLASS-DATA ao_sns         TYPE REF TO /aws1/if_sns.
+    CLASS-DATA ao_session     TYPE REF TO /aws1/cl_rt_session_base.
+    CLASS-DATA ao_iot_actions TYPE REF TO /awsex/cl_iot_actions.
+
+    " ── Resources shared by non-destructive tests ────────────────────────
+    " Shared IoT thing (used by list_things, attach/detach, list_certs, etc.)
+    CLASS-DATA av_thing_name    TYPE /aws1/iotthingname.
+    " Shared certificate attached to the shared thing
+    CLASS-DATA av_cert_id       TYPE /aws1/iotcertificateid.
+    CLASS-DATA av_cert_arn      TYPE /aws1/iotcertificatearn.
+    " Shared SNS topic + IAM role for topic-rule tests
+    CLASS-DATA av_sns_topic_arn TYPE /aws1/snstopicarn.
+    CLASS-DATA av_iam_role_name TYPE /aws1/iamrolenametype.
+    CLASS-DATA av_iam_role_arn  TYPE /aws1/iamarntype.
+    " Shared topic rule (used by list_topic_rules)
+    CLASS-DATA av_rule_name     TYPE /aws1/iotrulename.
+
+    " ── Dedicated resources for destructive (delete) tests ───────────────
+    CLASS-DATA av_del_thing_name TYPE /aws1/iotthingname.
+    CLASS-DATA av_del_cert_id    TYPE /aws1/iotcertificateid.
+    CLASS-DATA av_del_rule_name  TYPE /aws1/iotrulename.
+
+    " ── Test methods ─────────────────────────────────────────────────────
+    METHODS: create_thing              FOR TESTING RAISING /aws1/cx_rt_generic,
+             list_things               FOR TESTING RAISING /aws1/cx_rt_generic,
+             create_keys_and_cert      FOR TESTING RAISING /aws1/cx_rt_generic,
+             attach_thing_principal    FOR TESTING RAISING /aws1/cx_rt_generic,
+             describe_endpoint         FOR TESTING RAISING /aws1/cx_rt_generic,
+             list_certificates         FOR TESTING RAISING /aws1/cx_rt_generic,
+             detach_thing_principal    FOR TESTING RAISING /aws1/cx_rt_generic,
+             delete_certificate        FOR TESTING RAISING /aws1/cx_rt_generic,
+             create_topic_rule         FOR TESTING RAISING /aws1/cx_rt_generic,
+             list_topic_rules          FOR TESTING RAISING /aws1/cx_rt_generic,
+             update_indexing_conf      FOR TESTING RAISING /aws1/cx_rt_generic,
+             search_index              FOR TESTING RAISING /aws1/cx_rt_generic,
+             delete_thing              FOR TESTING RAISING /aws1/cx_rt_generic,
+             delete_topic_rule         FOR TESTING RAISING /aws1/cx_rt_generic.
+
+    CLASS-METHODS class_setup    RAISING /aws1/cx_rt_generic.
+    CLASS-METHODS class_teardown RAISING /aws1/cx_rt_generic.
+
+    CLASS-METHODS build_iot_tags
+      RETURNING
+        VALUE(rt_tags) TYPE /aws1/cl_iottag=>tt_taglist.
+
+ENDCLASS.
+
+
+CLASS ltc_awsex_cl_iot_actions IMPLEMENTATION.
+
+  METHOD class_setup.
+
+    " ── Session and clients ──────────────────────────────────────────────
+    ao_session    = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    ao_iot        = /aws1/cl_iot_factory=>create( ao_session ).
+    ao_iam        = /aws1/cl_iam_factory=>create( ao_session ).
+    ao_sns        = /aws1/cl_sns_factory=>create( ao_session ).
+    CREATE OBJECT ao_iot_actions.
+
+    DATA lv_uuid TYPE string.
+    lv_uuid = /awsex/cl_utils=>get_random_string( ).
+    CONDENSE lv_uuid NO-GAPS.
+
+    " ── Shared IoT thing ─────────────────────────────────────────────────
+    av_thing_name = |sap-abap-iot-{ lv_uuid }|.
+    DATA(lo_thing) = ao_iot->creatething( iv_thingname = av_thing_name ).
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_thing
+      msg = |class_setup: failed to create shared thing { av_thing_name }| ).
+
+    " Note: IoT things do not support TagResource. Things are tracked by
+    " naming convention (sap-abap-iot-*) for identification and cleanup.
+
+    " ── Shared certificate ───────────────────────────────────────────────
+    DATA(lo_cert) = ao_iot->createkeysandcertificate( iv_setasactive = abap_true ).
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_cert
+      msg = 'class_setup: failed to create shared certificate' ).
+    av_cert_id  = lo_cert->get_certificateid( ).
+    av_cert_arn = lo_cert->get_certificatearn( ).
+
+    " Attach certificate to the shared thing so detach_thing_principal and
+    " list_certificates tests have a known principal already in place.
+    ao_iot->attachthingprincipal(
+      iv_thingname = av_thing_name
+      iv_principal = av_cert_arn ).
+
+    " ── SNS topic for topic-rule tests ───────────────────────────────────
+    DATA lt_sns_tags TYPE /aws1/cl_snstag=>tt_taglist.
+    DATA lo_sns_tag  TYPE REF TO /aws1/cl_snstag.
+    lo_sns_tag = NEW /aws1/cl_snstag( iv_key = 'convert_test' iv_value = 'true' ).
+    APPEND lo_sns_tag TO lt_sns_tags.
+    DATA(lo_sns_result) = ao_sns->createtopic(
+      iv_name = |sap-abap-iot-sns-{ lv_uuid }|
+      it_tags = lt_sns_tags ).
+    av_sns_topic_arn = lo_sns_result->get_topicarn( ).
+    cl_abap_unit_assert=>assert_not_initial(
+      act = av_sns_topic_arn
+      msg = 'class_setup: failed to create SNS topic' ).
+
+    " ── IAM role that IoT rules use to publish to SNS ────────────────────
+    " Trust policy: IoT service may assume this role.
+    DATA(lv_trust) =
+      `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` &&
+      `"Principal":{"Service":"iot.amazonaws.com"},` &&
+      `"Action":"sts:AssumeRole"}]}`.
+
+    av_iam_role_name = |sap-abap-iot-role-{ lv_uuid }|.
+
+    DATA lt_iam_tags TYPE /aws1/cl_iamtag=>tt_taglisttype.
+    DATA lo_iam_tag  TYPE REF TO /aws1/cl_iamtag.
+    lo_iam_tag = NEW /aws1/cl_iamtag( iv_key = 'convert_test' iv_value = 'true' ).
+    APPEND lo_iam_tag TO lt_iam_tags.
+    DATA(lo_role) = ao_iam->createrole(
+      iv_rolename                = av_iam_role_name
+      iv_assumerolepolicydocument = lv_trust
+      it_tags = lt_iam_tags ).
+    av_iam_role_arn = lo_role->get_role( )->get_arn( ).
+    cl_abap_unit_assert=>assert_not_initial(
+      act = av_iam_role_arn
+      msg = 'class_setup: failed to create IAM role' ).
+
+    " Inline policy: allow SNS Publish to any topic.
+    DATA(lv_policy) =
+      `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` &&
+      `"Action":["sns:Publish"],"Resource":"*"}]}`.
+    ao_iam->putrolepolicy(
+      iv_rolename       = av_iam_role_name
+      iv_policyname     = 'IoTSNSPublish'
+      iv_policydocument = lv_policy ).
+
+    " ── Shared topic rule (used by list_topic_rules test) ────────────────
+    " IoT rule names allow only letters, numbers, and underscores.
+    av_rule_name = |sap_abap_iot_rule_{ lv_uuid }|.
+    REPLACE ALL OCCURRENCES OF '-' IN av_rule_name WITH '_'.
+
+    DATA lt_actions TYPE /aws1/cl_iotaction=>tt_actionlist.
+    DATA lo_sns_act TYPE REF TO /aws1/cl_iotsnsaction.
+    DATA lo_action  TYPE REF TO /aws1/cl_iotaction.
+    DATA lo_payload TYPE REF TO /aws1/cl_iottopicrulepayload.
+    CREATE OBJECT lo_sns_act
+      EXPORTING
+        iv_targetarn = av_sns_topic_arn
+        iv_rolearn   = av_iam_role_arn.
+    CREATE OBJECT lo_action
+      EXPORTING
+        io_sns = lo_sns_act.
+    APPEND lo_action TO lt_actions.
+    CREATE OBJECT lo_payload
+      EXPORTING
+        iv_sql     = |SELECT * FROM 'test/sap/abap/shared'|
+        it_actions = lt_actions.
+
+    " Poll until IoT can assume the newly created IAM role (eventual consistency).
+    " InvalidRequestException with 'unable to assume role' means the role is not
+    " yet propagated — retry with backoff for up to 60 seconds.
+    DATA lv_rule_created TYPE abap_bool VALUE abap_false.
+    DATA lv_retries      TYPE i         VALUE 0.
+    WHILE lv_retries < 12 AND lv_rule_created = abap_false.
+      TRY.
+          ao_iot->createtopicrule(
+            iv_rulename         = av_rule_name
+            io_topicrulepayload = lo_payload ).
+          lv_rule_created = abap_true.
+        CATCH /aws1/cx_iotinvalidrequestex.
+          lv_retries = lv_retries + 1.
+          WAIT UP TO 5 SECONDS.
+        CATCH /aws1/cx_iotresrcalrdyexistsex.
+          lv_rule_created = abap_true.
+      ENDTRY.
+    ENDWHILE.
+
+    IF lv_rule_created = abap_false.
+      cl_abap_unit_assert=>fail(
+        msg = |class_setup: IAM role { av_iam_role_name } not assumable by IoT after 60s| ).
+    ENDIF.
+
+    " Derive the rule ARN so we can tag it.
+    DATA(lv_acct)   = ao_session->get_account_id( ).
+    DATA(lv_region) = ao_session->get_region( ).
+    DATA(lv_rule_arn) = |arn:aws:iot:{ lv_region }:{ lv_acct }:rule/{ av_rule_name }|.
+
+    ao_iot->tagresource(
+      iv_resourcearn = lv_rule_arn
+      it_tags        = build_iot_tags( ) ).
+
+    " ── Dedicated thing for delete_thing test ────────────────────────────
+    av_del_thing_name = |sap-abap-iot-del-{ lv_uuid }|.
+    DATA(lo_del_thing) = ao_iot->creatething( iv_thingname = av_del_thing_name ).
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_del_thing
+      msg = |class_setup: failed to create dedicated delete-thing { av_del_thing_name }| ).
+    " Note: IoT things do not support TagResource. Tracked by name convention.
+
+    " ── Dedicated certificate for delete_certificate test ────────────────
+    DATA(lo_del_cert) = ao_iot->createkeysandcertificate( iv_setasactive = abap_true ).
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_del_cert
+      msg = 'class_setup: failed to create dedicated delete-certificate' ).
+    av_del_cert_id = lo_del_cert->get_certificateid( ).
+
+    " ── Dedicated topic rule for delete_topic_rule test ──────────────────
+    av_del_rule_name = |sap_abap_iot_del_{ lv_uuid }|.
+    REPLACE ALL OCCURRENCES OF '-' IN av_del_rule_name WITH '_'.
+
+    DATA lt_del_actions  TYPE /aws1/cl_iotaction=>tt_actionlist.
+    DATA lo_del_sns_act  TYPE REF TO /aws1/cl_iotsnsaction.
+    DATA lo_del_action   TYPE REF TO /aws1/cl_iotaction.
+    DATA lo_del_payload  TYPE REF TO /aws1/cl_iottopicrulepayload.
+    CREATE OBJECT lo_del_sns_act
+      EXPORTING
+        iv_targetarn = av_sns_topic_arn
+        iv_rolearn   = av_iam_role_arn.
+    CREATE OBJECT lo_del_action
+      EXPORTING
+        io_sns = lo_del_sns_act.
+    APPEND lo_del_action TO lt_del_actions.
+    CREATE OBJECT lo_del_payload
+      EXPORTING
+        iv_sql     = |SELECT * FROM 'test/sap/abap/del'|
+        it_actions = lt_del_actions.
+
+    " Same IAM propagation retry for the dedicated delete rule.
+    DATA lv_del_rule_created TYPE abap_bool VALUE abap_false.
+    DATA lv_del_retries      TYPE i         VALUE 0.
+    WHILE lv_del_retries < 12 AND lv_del_rule_created = abap_false.
+      TRY.
+          ao_iot->createtopicrule(
+            iv_rulename         = av_del_rule_name
+            io_topicrulepayload = lo_del_payload ).
+          lv_del_rule_created = abap_true.
+        CATCH /aws1/cx_iotinvalidrequestex.
+          lv_del_retries = lv_del_retries + 1.
+          WAIT UP TO 5 SECONDS.
+        CATCH /aws1/cx_iotresrcalrdyexistsex.
+          lv_del_rule_created = abap_true.
+      ENDTRY.
+    ENDWHILE.
+
+    IF lv_del_rule_created = abap_false.
+      cl_abap_unit_assert=>fail(
+        msg = |class_setup: del rule { av_del_rule_name } could not be created after 60s| ).
+    ENDIF.
+
+    DATA(lv_del_rule_arn) =
+      |arn:aws:iot:{ lv_region }:{ lv_acct }:rule/{ av_del_rule_name }|.
+    ao_iot->tagresource(
+      iv_resourcearn = lv_del_rule_arn
+      it_tags        = build_iot_tags( ) ).
+
+  ENDMETHOD.
+
+
+  METHOD class_teardown.
+
+    " ── Shared thing: detach cert first, then delete ─────────────────────
+    IF av_cert_arn IS NOT INITIAL AND av_thing_name IS NOT INITIAL.
+      TRY.
+          ao_iot->detachthingprincipal(
+            iv_thingname = av_thing_name
+            iv_principal = av_cert_arn ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+    ENDIF.
+
+    IF av_cert_id IS NOT INITIAL.
+      TRY.
+          ao_iot->updatecertificate(
+            iv_certificateid = av_cert_id
+            iv_newstatus     = 'INACTIVE' ).
+          ao_iot->deletecertificate( iv_certificateid = av_cert_id ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+    ENDIF.
+
+    IF av_thing_name IS NOT INITIAL.
+      TRY.
+          ao_iot->deletething( iv_thingname = av_thing_name ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+    ENDIF.
+
+    " ── Shared topic rule ────────────────────────────────────────────────
+    IF av_rule_name IS NOT INITIAL.
+      TRY.
+          ao_iot->deletetopicrule( iv_rulename = av_rule_name ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+    ENDIF.
+
+    " ── Dedicated delete-thing (may already be gone) ─────────────────────
+    IF av_del_thing_name IS NOT INITIAL.
+      TRY.
+          ao_iot->deletething( iv_thingname = av_del_thing_name ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+    ENDIF.
+
+    " ── Dedicated delete-certificate (may already be gone) ───────────────
+    IF av_del_cert_id IS NOT INITIAL.
+      TRY.
+          ao_iot->updatecertificate(
+            iv_certificateid = av_del_cert_id
+            iv_newstatus     = 'INACTIVE' ).
+          ao_iot->deletecertificate( iv_certificateid = av_del_cert_id ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+    ENDIF.
+
+    " ── Dedicated delete-topic-rule (may already be gone) ────────────────
+    IF av_del_rule_name IS NOT INITIAL.
+      TRY.
+          ao_iot->deletetopicrule( iv_rulename = av_del_rule_name ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+    ENDIF.
+
+    " ── IAM role: remove inline policy then delete role ──────────────────
+    IF av_iam_role_name IS NOT INITIAL.
+      TRY.
+          ao_iam->deleterolepolicy(
+            iv_rolename   = av_iam_role_name
+            iv_policyname = 'IoTSNSPublish' ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+      TRY.
+          ao_iam->deleterole( iv_rolename = av_iam_role_name ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+    ENDIF.
+
+    " ── SNS topic ────────────────────────────────────────────────────────
+    IF av_sns_topic_arn IS NOT INITIAL.
+      TRY.
+          ao_sns->deletetopic( iv_topicarn = av_sns_topic_arn ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD build_iot_tags.
+    DATA lo_tag TYPE REF TO /aws1/cl_iottag.
+    lo_tag = NEW /aws1/cl_iottag( iv_key = 'convert_test' iv_value = 'true' ).
+    APPEND lo_tag TO rt_tags.
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: create_thing
+  " Creates a fresh thing via the action, validates ARN + name, cleans up.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD create_thing.
+    DATA lv_uuid TYPE string.
+    lv_uuid = /awsex/cl_utils=>get_random_string( ).
+    CONDENSE lv_uuid NO-GAPS.
+    DATA(lv_name) = CONV /aws1/iotthingname( |sap-abap-iot-new-{ lv_uuid }| ).
+
+    DATA(lo_result) = ao_iot_actions->create_thing( iv_thing_name = lv_name ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = |create_thing: result not bound for { lv_name }| ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_result->get_thingname( )
+      exp = lv_name
+      msg = |create_thing: thing name mismatch| ).
+
+    cl_abap_unit_assert=>assert_not_initial(
+      act = lo_result->get_thingarn( )
+      msg = |create_thing: ARN is empty| ).
+
+    " Clean up the newly created thing.
+    TRY.
+        ao_iot->deletething( iv_thingname = lv_name ).
+      CATCH /aws1/cx_rt_generic.
+    ENDTRY.
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: list_things
+  " The shared thing must appear in the full accumulated result table.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD list_things.
+    DATA(lo_result) = ao_iot_actions->list_things( ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = 'list_things: result not bound' ).
+
+    " The action paginates all pages; oo_result is the last-page object.
+    " We call get_things() which returns items on that page only.
+    " To find the shared thing across all pages we re-paginate here.
+    DATA lv_found     TYPE abap_bool VALUE abap_false.
+    DATA lv_nexttoken TYPE /aws1/iotnexttoken.
+    DO.
+      DATA(lo_page) = ao_iot->listthings( iv_nexttoken = lv_nexttoken ).
+      LOOP AT lo_page->get_things( ) INTO DATA(lo_thing).
+        IF lo_thing->get_thingname( ) = av_thing_name.
+          lv_found = abap_true.
+        ENDIF.
+      ENDLOOP.
+      lv_nexttoken = lo_page->get_nexttoken( ).
+      IF lv_nexttoken IS INITIAL OR lv_found = abap_true.
+        EXIT.
+      ENDIF.
+    ENDDO.
+
+    cl_abap_unit_assert=>assert_true(
+      act = lv_found
+      msg = |list_things: shared thing { av_thing_name } not found in result| ).
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: create_keys_and_certificate
+  " Creates a real certificate, validates all returned fields, cleans up.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD create_keys_and_cert.
+    DATA(lo_result) = ao_iot_actions->create_keys_and_certificate( ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = 'create_keys_and_cert: result not bound' ).
+
+    cl_abap_unit_assert=>assert_not_initial(
+      act = lo_result->get_certificateid( )
+      msg = 'create_keys_and_cert: certificate ID is empty' ).
+
+    cl_abap_unit_assert=>assert_not_initial(
+      act = lo_result->get_certificatearn( )
+      msg = 'create_keys_and_cert: certificate ARN is empty' ).
+
+    cl_abap_unit_assert=>assert_not_initial(
+      act = lo_result->get_certificatepem( )
+      msg = 'create_keys_and_cert: certificate PEM is empty' ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result->get_keypair( )
+      msg = 'create_keys_and_cert: key pair is not bound' ).
+
+    cl_abap_unit_assert=>assert_not_initial(
+      act = lo_result->get_keypair( )->get_publickey( )
+      msg = 'create_keys_and_cert: public key is empty' ).
+
+    " Clean up.
+    TRY.
+        ao_iot->updatecertificate(
+          iv_certificateid = lo_result->get_certificateid( )
+          iv_newstatus     = 'INACTIVE' ).
+        ao_iot->deletecertificate(
+          iv_certificateid = lo_result->get_certificateid( ) ).
+      CATCH /aws1/cx_rt_generic.
+    ENDTRY.
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: attach_thing_principal
+  " Creates a fresh certificate, attaches it to the shared thing via the
+  " action, verifies it appears in ListThingPrincipals, then cleans up.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD attach_thing_principal.
+    " Create a dedicated certificate for this test.
+    DATA(lo_cert)     = ao_iot->createkeysandcertificate( iv_setasactive = abap_true ).
+    DATA(lv_cert_arn) = lo_cert->get_certificatearn( ).
+    DATA(lv_cert_id)  = lo_cert->get_certificateid( ).
+
+    ao_iot_actions->attach_thing_principal(
+      iv_thing_name = av_thing_name
+      iv_principal  = lv_cert_arn ).
+
+    " Verify: certificate must appear in the thing's principal list.
+    DATA(lo_principals) =
+      ao_iot->listthingprincipals( iv_thingname = av_thing_name ).
+    DATA lv_found TYPE abap_bool VALUE abap_false.
+    LOOP AT lo_principals->get_principals( ) INTO DATA(lo_p).
+      IF lo_p->get_value( ) = lv_cert_arn.
+        lv_found = abap_true.
+      ENDIF.
+    ENDLOOP.
+
+    cl_abap_unit_assert=>assert_true(
+      act = lv_found
+      msg = |attach_thing_principal: cert { lv_cert_arn } not found in principals| ).
+
+    " Clean up.
+    TRY.
+        ao_iot->detachthingprincipal(
+          iv_thingname = av_thing_name
+          iv_principal = lv_cert_arn ).
+        ao_iot->updatecertificate(
+          iv_certificateid = lv_cert_id
+          iv_newstatus     = 'INACTIVE' ).
+        ao_iot->deletecertificate( iv_certificateid = lv_cert_id ).
+      CATCH /aws1/cx_rt_generic.
+    ENDTRY.
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: describe_endpoint
+  " Retrieves the ATS data endpoint; validates it looks like a real URL.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD describe_endpoint.
+    DATA(lv_endpoint) = ao_iot_actions->describe_endpoint(
+      iv_endpoint_type = 'iot:Data-ATS' ).
+
+    cl_abap_unit_assert=>assert_not_initial(
+      act = lv_endpoint
+      msg = 'describe_endpoint: endpoint address is empty' ).
+
+    " A real ATS endpoint always contains 'amazonaws.com'.
+    DATA(lv_ep_str) = CONV string( lv_endpoint ).
+    cl_abap_unit_assert=>assert_differs(
+      act = find( val = lv_ep_str sub = 'amazonaws.com' )
+      exp = -1
+      msg = |describe_endpoint: address looks invalid: { lv_endpoint }| ).
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: list_certificates
+  " The shared certificate (created in class_setup) must appear in results.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD list_certificates.
+    DATA(lo_result) = ao_iot_actions->list_certificates( ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = 'list_certificates: result not bound' ).
+
+    " The action paginates all pages; oo_result is the last-page object.
+    " Re-paginate here to search all pages for the shared certificate.
+    DATA lv_found  TYPE abap_bool VALUE abap_false.
+    DATA lv_marker TYPE /aws1/iotmarker.
+    DO.
+      DATA(lo_page) = ao_iot->listcertificates( iv_marker = lv_marker ).
+      LOOP AT lo_page->get_certificates( ) INTO DATA(lo_cert).
+        IF lo_cert->get_certificateid( ) = av_cert_id.
+          lv_found = abap_true.
+        ENDIF.
+      ENDLOOP.
+      lv_marker = lo_page->get_nextmarker( ).
+      IF lv_marker IS INITIAL OR lv_found = abap_true.
+        EXIT.
+      ENDIF.
+    ENDDO.
+
+    cl_abap_unit_assert=>assert_true(
+      act = lv_found
+      msg = |list_certificates: shared cert { av_cert_id } not found| ).
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: detach_thing_principal
+  " Creates a fresh certificate, attaches it directly, then detaches via
+  " the action; verifies it no longer appears in ListThingPrincipals.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD detach_thing_principal.
+    DATA(lo_cert)     = ao_iot->createkeysandcertificate( iv_setasactive = abap_true ).
+    DATA(lv_cert_arn) = lo_cert->get_certificatearn( ).
+    DATA(lv_cert_id)  = lo_cert->get_certificateid( ).
+
+    " Attach directly (bypassing the action method under test).
+    ao_iot->attachthingprincipal(
+      iv_thingname = av_thing_name
+      iv_principal = lv_cert_arn ).
+
+    " Now use the action to detach.
+    ao_iot_actions->detach_thing_principal(
+      iv_thing_name = av_thing_name
+      iv_principal  = lv_cert_arn ).
+
+    " Verify: certificate must NOT appear in principal list any more.
+    DATA(lo_principals) =
+      ao_iot->listthingprincipals( iv_thingname = av_thing_name ).
+    DATA lv_found TYPE abap_bool VALUE abap_false.
+    LOOP AT lo_principals->get_principals( ) INTO DATA(lo_p).
+      IF lo_p->get_value( ) = lv_cert_arn.
+        lv_found = abap_true.
+      ENDIF.
+    ENDLOOP.
+
+    cl_abap_unit_assert=>assert_false(
+      act = lv_found
+      msg = |detach_thing_principal: cert { lv_cert_arn } still in principals| ).
+
+    " Clean up.
+    TRY.
+        ao_iot->updatecertificate(
+          iv_certificateid = lv_cert_id
+          iv_newstatus     = 'INACTIVE' ).
+        ao_iot->deletecertificate( iv_certificateid = lv_cert_id ).
+      CATCH /aws1/cx_rt_generic.
+    ENDTRY.
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: delete_certificate
+  " Uses the dedicated certificate from class_setup. After the action
+  " succeeds, DescribeCertificate must raise ResourceNotFoundException.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD delete_certificate.
+    " Fail fast if the dedicated resource was never created.
+    cl_abap_unit_assert=>assert_not_initial(
+      act = av_del_cert_id
+      msg = 'delete_certificate: dedicated certificate ID not set in class_setup' ).
+
+    ao_iot_actions->delete_certificate( iv_certificate_id = av_del_cert_id ).
+
+    " Verify: DescribeCertificate must now raise ResourceNotFoundException.
+    DATA lv_deleted TYPE abap_bool VALUE abap_false.
+    TRY.
+        ao_iot->describecertificate( iv_certificateid = av_del_cert_id ).
+      CATCH /aws1/cx_iotresourcenotfoundex.
+        lv_deleted = abap_true.
+    ENDTRY.
+
+    cl_abap_unit_assert=>assert_true(
+      act = lv_deleted
+      msg = |delete_certificate: cert { av_del_cert_id } still exists after deletion| ).
+
+    " Prevent class_teardown from trying to delete it again.
+    CLEAR av_del_cert_id.
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: create_topic_rule
+  " Creates a fresh rule via the action, verifies it appears in
+  " ListTopicRules, then cleans up.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD create_topic_rule.
+    DATA lv_uuid TYPE string.
+    lv_uuid = /awsex/cl_utils=>get_random_string( ).
+    CONDENSE lv_uuid NO-GAPS.
+    DATA(lv_rule) = CONV /aws1/iotrulename( |sap_abap_iot_new_{ lv_uuid }| ).
+    REPLACE ALL OCCURRENCES OF '-' IN lv_rule WITH '_'.
+
+    ao_iot_actions->create_topic_rule(
+      iv_rule_name      = lv_rule
+      iv_topic          = 'test/sap/abap/create'
+      iv_sns_action_arn = av_sns_topic_arn
+      iv_role_arn       = av_iam_role_arn ).
+
+    " Tag the newly created rule.
+    DATA(lv_acct)   = ao_session->get_account_id( ).
+    DATA(lv_region) = ao_session->get_region( ).
+    TRY.
+        ao_iot->tagresource(
+          iv_resourcearn =
+            |arn:aws:iot:{ lv_region }:{ lv_acct }:rule/{ lv_rule }|
+          it_tags = build_iot_tags( ) ).
+      CATCH /aws1/cx_rt_generic.
+    ENDTRY.
+
+    " Verify: rule must appear in paginated list.
+    DATA lv_found     TYPE abap_bool VALUE abap_false.
+    DATA lv_nexttoken TYPE /aws1/iotnexttoken.
+    DO.
+      DATA(lo_rules) = ao_iot->listtopicrules( iv_nexttoken = lv_nexttoken ).
+      LOOP AT lo_rules->get_rules( ) INTO DATA(lo_rule).
+        IF lo_rule->get_rulename( ) = lv_rule.
+          lv_found = abap_true.
+        ENDIF.
+      ENDLOOP.
+      lv_nexttoken = lo_rules->get_nexttoken( ).
+      IF lv_nexttoken IS INITIAL OR lv_found = abap_true.
+        EXIT.
+      ENDIF.
+    ENDDO.
+
+    cl_abap_unit_assert=>assert_true(
+      act = lv_found
+      msg = |create_topic_rule: rule { lv_rule } not found after creation| ).
+
+    " Clean up.
+    TRY.
+        ao_iot->deletetopicrule( iv_rulename = lv_rule ).
+      CATCH /aws1/cx_rt_generic.
+    ENDTRY.
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: list_topic_rules
+  " The shared rule created in class_setup must appear in results.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD list_topic_rules.
+    DATA(lo_result) = ao_iot_actions->list_topic_rules( ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = 'list_topic_rules: result not bound' ).
+
+    " The action paginates all pages; oo_result is the last-page object.
+    " Re-paginate here to search all pages for the shared rule.
+    DATA lv_found     TYPE abap_bool VALUE abap_false.
+    DATA lv_nexttoken TYPE /aws1/iotnexttoken.
+    DO.
+      DATA(lo_page) = ao_iot->listtopicrules( iv_nexttoken = lv_nexttoken ).
+      LOOP AT lo_page->get_rules( ) INTO DATA(lo_rule).
+        IF lo_rule->get_rulename( ) = av_rule_name.
+          lv_found = abap_true.
+        ENDIF.
+      ENDLOOP.
+      lv_nexttoken = lo_page->get_nexttoken( ).
+      IF lv_nexttoken IS INITIAL OR lv_found = abap_true.
+        EXIT.
+      ENDIF.
+    ENDDO.
+
+    cl_abap_unit_assert=>assert_true(
+      act = lv_found
+      msg = |list_topic_rules: shared rule { av_rule_name } not found| ).
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: update_indexing_configuration
+  " Enables REGISTRY-mode indexing, then reads it back to confirm.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD update_indexing_conf.
+    ao_iot_actions->update_indexing_configuration( ).
+
+    DATA(lo_conf) = ao_iot->getindexingconfiguration( ).
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_conf
+      msg = 'update_indexing_conf: getindexingconfiguration returned unbound' ).
+
+    DATA(lo_thing_conf) = lo_conf->get_thingindexingconf( ).
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_thing_conf
+      msg = 'update_indexing_conf: thingindexingconf not bound' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_thing_conf->get_thingindexingmode( )
+      exp = 'REGISTRY'
+      msg = |update_indexing_conf: mode is { lo_thing_conf->get_thingindexingmode( ) }, expected REGISTRY| ).
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: search_index
+  " Fleet indexing must be enabled first; poll until it is ready (up to
+  " 60 s).  Then call the action and confirm the shared thing is found.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD search_index.
+    " Ensure indexing is enabled (idempotent – safe to call again here).
+    DATA lo_idx_conf TYPE REF TO /aws1/cl_iotthingindexingconf.
+    CREATE OBJECT lo_idx_conf
+      EXPORTING
+        iv_thingindexingmode = 'REGISTRY'.
+    ao_iot->updateindexingconfiguration(
+      io_thingindexingconf = lo_idx_conf ).
+
+    " Poll SearchIndex until the index is ready (IndexNotReadyException resolves).
+    DATA lv_ready   TYPE abap_bool VALUE abap_false.
+    DATA lv_retries TYPE i        VALUE 0.
+    WHILE lv_retries < 20 AND lv_ready = abap_false.
+      TRY.
+          ao_iot->searchindex(
+            iv_querystring = |thingName:{ av_thing_name }| ).
+          lv_ready = abap_true.
+        CATCH /aws1/cx_iotindexnotreadyex.
+          lv_retries = lv_retries + 1.
+          WAIT UP TO 3 SECONDS.
+        CATCH /aws1/cx_rt_generic INTO DATA(lo_poll_ex).
+          cl_abap_unit_assert=>fail(
+            msg = |search_index: polling failed: { lo_poll_ex->get_text( ) }| ).
+      ENDTRY.
+    ENDWHILE.
+
+    IF lv_ready = abap_false.
+      cl_abap_unit_assert=>fail(
+        msg = 'search_index: fleet index not ready after 60 s of polling' ).
+    ENDIF.
+
+    " Now exercise the action method under test.
+    DATA(lo_result) = ao_iot_actions->search_index(
+      iv_query_string = |thingName:{ av_thing_name }| ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = 'search_index: result not bound' ).
+
+    DATA lv_found TYPE abap_bool VALUE abap_false.
+    LOOP AT lo_result->get_things( ) INTO DATA(lo_thing).
+      IF lo_thing->get_thingname( ) = av_thing_name.
+        lv_found = abap_true.
+      ENDIF.
+    ENDLOOP.
+
+    cl_abap_unit_assert=>assert_true(
+      act = lv_found
+      msg = |search_index: shared thing { av_thing_name } not found in result| ).
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: delete_thing
+  " Uses the dedicated thing from class_setup; verifies DescribeThing
+  " raises ResourceNotFoundException after deletion.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD delete_thing.
+    cl_abap_unit_assert=>assert_not_initial(
+      act = av_del_thing_name
+      msg = 'delete_thing: dedicated thing name not set in class_setup' ).
+
+    ao_iot_actions->delete_thing( iv_thing_name = av_del_thing_name ).
+
+    DATA lv_deleted TYPE abap_bool VALUE abap_false.
+    TRY.
+        ao_iot->describething( iv_thingname = av_del_thing_name ).
+      CATCH /aws1/cx_iotresourcenotfoundex.
+        lv_deleted = abap_true.
+    ENDTRY.
+
+    cl_abap_unit_assert=>assert_true(
+      act = lv_deleted
+      msg = |delete_thing: thing { av_del_thing_name } still exists after deletion| ).
+
+    CLEAR av_del_thing_name.
+  ENDMETHOD.
+
+
+  " ════════════════════════════════════════════════════════════════════════
+  " Test: delete_topic_rule
+  " Uses the dedicated rule from class_setup; verifies it no longer
+  " appears in ListTopicRules after deletion.
+  " ════════════════════════════════════════════════════════════════════════
+  METHOD delete_topic_rule.
+    cl_abap_unit_assert=>assert_not_initial(
+      act = av_del_rule_name
+      msg = 'delete_topic_rule: dedicated rule name not set in class_setup' ).
+
+    ao_iot_actions->delete_topic_rule( iv_rule_name = av_del_rule_name ).
+
+    " Verify: rule must NOT appear in paginated list.
+    DATA lv_found     TYPE abap_bool VALUE abap_false.
+    DATA lv_nexttoken TYPE /aws1/iotnexttoken.
+    DO.
+      DATA(lo_rules) = ao_iot->listtopicrules( iv_nexttoken = lv_nexttoken ).
+      LOOP AT lo_rules->get_rules( ) INTO DATA(lo_rule).
+        IF lo_rule->get_rulename( ) = av_del_rule_name.
+          lv_found = abap_true.
+        ENDIF.
+      ENDLOOP.
+      lv_nexttoken = lo_rules->get_nexttoken( ).
+      IF lv_nexttoken IS INITIAL.
+        EXIT.
+      ENDIF.
+    ENDDO.
+
+    cl_abap_unit_assert=>assert_false(
+      act = lv_found
+      msg = |delete_topic_rule: rule { av_del_rule_name } still exists after deletion| ).
+
+    CLEAR av_del_rule_name.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/sap-abap/services/iot/#awsex#cl_iot_actions.clas.xml
+++ b/sap-abap/services/iot/#awsex#cl_iot_actions.clas.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>/AWSEX/CL_IOT_ACTIONS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Iot Code Example</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/sap-abap/services/iot/README.md
+++ b/sap-abap/services/iot/README.md
@@ -1,13 +1,13 @@
-# Amazon SES v2 API code examples for the SDK for SAP ABAP
+# AWS IoT code examples for the SDK for SAP ABAP
 
 ## Overview
 
-Shows how to use the AWS SDK for SAP ABAP to work with Amazon Simple Email Service v2 API.
+Shows how to use the AWS SDK for SAP ABAP to work with AWS IoT.
 
 <!--custom.overview.start-->
 <!--custom.overview.end-->
 
-_Amazon SES v2 API is a reliable, scalable, and cost-effective email service._
+_AWS IoT provides secure, bi-directional communication for Internet-connected devices (such as sensors, actuators, embedded devices, wireless devices, and smart appliances) to connect to the AWS Cloud over MQTT, HTTPS, and LoRaWAN._
 
 ## ⚠ Important
 
@@ -33,17 +33,19 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `sap-a
 
 Code excerpts that show you how to call individual service functions.
 
-- [CreateContact](%23awsex%23cl_se2_actions.clas.abap#L189)
-- [CreateContactList](%23awsex%23cl_se2_actions.clas.abap#L137)
-- [CreateEmailIdentity](%23awsex%23cl_se2_actions.clas.abap#L116)
-- [CreateEmailTemplate](%23awsex%23cl_se2_actions.clas.abap#L162)
-- [DeleteContactList](%23awsex%23cl_se2_actions.clas.abap#L326)
-- [DeleteEmailIdentity](%23awsex%23cl_se2_actions.clas.abap#L366)
-- [DeleteEmailTemplate](%23awsex%23cl_se2_actions.clas.abap#L346)
-- [GetEmailIdentity](%23awsex%23cl_se2_actions.clas.abap#L386)
-- [ListContacts](%23awsex%23cl_se2_actions.clas.abap#L304)
-- [SendBulkEmail](%23awsex%23cl_se2_actions.clas.abap#L407)
-- [SendEmail](%23awsex%23cl_se2_actions.clas.abap#L211)
+- [AttachThingPrincipal](%23awsex%23cl_iot_actions.clas.abap#L228)
+- [CreateKeysAndCertificate](%23awsex%23cl_iot_actions.clas.abap#L212)
+- [CreateThing](%23awsex%23cl_iot_actions.clas.abap#L162)
+- [CreateTopicRule](%23awsex%23cl_iot_actions.clas.abap#L345)
+- [DeleteCertificate](%23awsex%23cl_iot_actions.clas.abap#L322)
+- [DeleteThing](%23awsex%23cl_iot_actions.clas.abap#L459)
+- [DeleteTopicRule](%23awsex%23cl_iot_actions.clas.abap#L478)
+- [DescribeEndpoint](%23awsex%23cl_iot_actions.clas.abap#L249)
+- [DetachThingPrincipal](%23awsex%23cl_iot_actions.clas.abap#L301)
+- [ListCertificates](%23awsex%23cl_iot_actions.clas.abap#L270)
+- [ListThings](%23awsex%23cl_iot_actions.clas.abap#L181)
+- [SearchIndex](%23awsex%23cl_iot_actions.clas.abap#L415)
+- [UpdateIndexingConfiguration](%23awsex%23cl_iot_actions.clas.abap#L438)
 
 
 <!--custom.examples.start-->
@@ -74,9 +76,9 @@ in the `sap-abap` folder.
 
 ## Additional resources
 
-- [Amazon SES v2 API Developer Guide](https://docs.aws.amazon.com/ses/latest/dg/Welcome.html)
-- [Amazon SES v2 API API Reference](https://docs.aws.amazon.com/ses/latest/APIReference-V2/Welcome.html)
-- [SDK for SAP ABAP Amazon SES v2 API reference](https://docs.aws.amazon.com/sdk-for-sap-abap/v1/api/latest/sesv2/index.html)
+- [AWS IoT Developer Guide](https://docs.aws.amazon.com/iot/latest/developerguide/what-is-aws-iot.html)
+- [AWS IoT API Reference](https://docs.aws.amazon.com/iot/latest/apireference/Welcome.html)
+- [SDK for SAP ABAP AWS IoT reference](https://docs.aws.amazon.com/sdk-for-sap-abap/v1/api/latest/iot/index.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/sap-abap/services/iot/package.devc.xml
+++ b/sap-abap/services/iot/package.devc.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DEVC>
+    <CTEXT>Package for Iot</CTEXT>
+   </DEVC>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/sap-abap/services/s3c/#awsex#cl_s3c_actions.clas.abap
+++ b/sap-abap/services/s3c/#awsex#cl_s3c_actions.clas.abap
@@ -1,0 +1,403 @@
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
+CLASS /awsex/cl_s3c_actions DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    METHODS create_job
+      IMPORTING
+        !iv_account_id       TYPE /aws1/s3caccountid
+        !iv_role_arn         TYPE /aws1/s3ciamrolearn
+        !iv_manifest_arn     TYPE /aws1/s3cs3keyarnstring
+        !iv_manifest_etag    TYPE string
+        !iv_report_bucket    TYPE /aws1/s3cs3bucketarnstring
+      RETURNING
+        VALUE(ov_job_id)     TYPE /aws1/s3cjobid
+      RAISING
+        /aws1/cx_rt_generic.
+
+    METHODS describe_job
+      IMPORTING
+        !iv_account_id       TYPE /aws1/s3caccountid
+        !iv_job_id           TYPE /aws1/s3cjobid
+      RETURNING
+        VALUE(oo_result)     TYPE REF TO /aws1/cl_s3cdescribejobresult
+      RAISING
+        /aws1/cx_rt_generic.
+
+    METHODS update_job_priority
+      IMPORTING
+        !iv_account_id       TYPE /aws1/s3caccountid
+        !iv_job_id           TYPE /aws1/s3cjobid
+      RETURNING
+        VALUE(oo_result)     TYPE REF TO /aws1/cl_s3cupdjobpriorityrslt
+      RAISING
+        /aws1/cx_rt_generic.
+
+    METHODS update_job_status
+      IMPORTING
+        !iv_account_id       TYPE /aws1/s3caccountid
+        !iv_job_id           TYPE /aws1/s3cjobid
+        !iv_requested_status TYPE /aws1/s3crequestedjobstatus
+      RETURNING
+        VALUE(oo_result)     TYPE REF TO /aws1/cl_s3cupdjobstatusrslt
+      RAISING
+        /aws1/cx_rt_generic.
+
+    METHODS get_job_tagging
+      IMPORTING
+        !iv_account_id       TYPE /aws1/s3caccountid
+        !iv_job_id           TYPE /aws1/s3cjobid
+      RETURNING
+        VALUE(oo_result)     TYPE REF TO /aws1/cl_s3cgetjobtagresult
+      RAISING
+        /aws1/cx_rt_generic.
+
+    METHODS put_job_tagging
+      IMPORTING
+        !iv_account_id       TYPE /aws1/s3caccountid
+        !iv_job_id           TYPE /aws1/s3cjobid
+      RAISING
+        /aws1/cx_rt_generic.
+
+    METHODS list_jobs
+      IMPORTING
+        !iv_account_id       TYPE /aws1/s3caccountid
+      RETURNING
+        VALUE(oo_result)     TYPE REF TO /aws1/cl_s3clistjobsresult
+      RAISING
+        /aws1/cx_rt_generic.
+
+    METHODS delete_job_tagging
+      IMPORTING
+        !iv_account_id       TYPE /aws1/s3caccountid
+        !iv_job_id           TYPE /aws1/s3cjobid
+      RAISING
+        /aws1/cx_rt_generic.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS /awsex/cl_s3c_actions IMPLEMENTATION.
+
+
+  METHOD create_job.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_s3c) = /aws1/cl_s3c_factory=>create( lo_session ).
+
+    " snippet-start:[s3c.abapv1.create_job]
+    TRY.
+        " iv_manifest_arn  = 'arn:aws:s3:::my-bucket/job-manifest.csv'
+        " iv_manifest_etag = 'abc123def456'
+        " iv_report_bucket = 'arn:aws:s3:::my-report-bucket'
+        DATA(lo_result) = lo_s3c->createjob(
+          iv_accountid            = iv_account_id
+          iv_rolearn              = iv_role_arn
+          iv_confirmationrequired = abap_true
+          iv_priority             = 10
+          iv_description          = 'Batch job for tagging objects'
+          io_operation            = NEW /aws1/cl_s3cjoboperation(
+            io_s3putobjecttagging = NEW /aws1/cl_s3cs3setobjecttagop(
+              it_tagset = VALUE /aws1/cl_s3cs3tag=>tt_s3tagset(
+                ( NEW /aws1/cl_s3cs3tag(
+                    iv_key   = 'BatchTag'
+                    iv_value = 'BatchValue' ) )
+              )
+            )
+          )
+          io_manifest             = NEW /aws1/cl_s3cjobmanifest(
+            io_spec     = NEW /aws1/cl_s3cjobmanifestspec(
+              iv_format = 'S3BatchOperations_CSV_20180820'
+              it_fields = VALUE /aws1/cl_s3cjobmanifestfield00=>tt_jobmanifestfieldlist(
+                ( NEW /aws1/cl_s3cjobmanifestfield00( 'Bucket' ) )
+                ( NEW /aws1/cl_s3cjobmanifestfield00( 'Key' ) )
+              )
+            )
+            io_location = NEW /aws1/cl_s3cjobmanifestloc(
+              iv_objectarn = iv_manifest_arn
+              iv_etag      = iv_manifest_etag
+            )
+          )
+          io_report               = NEW /aws1/cl_s3cjobreport(
+            iv_bucket      = iv_report_bucket
+            iv_format      = 'Report_CSV_20180820'
+            iv_enabled     = abap_true
+            iv_prefix      = 'batch-op-reports'
+            iv_reportscope = 'AllTasks'
+          )
+        ).
+        ov_job_id = lo_result->get_jobid( ).
+        MESSAGE |S3 Batch Operations job created: { ov_job_id }| TYPE 'I'.
+      CATCH /aws1/cx_s3cbadrequestex INTO DATA(lo_ex_bad).
+        MESSAGE lo_ex_bad->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_bad.
+      CATCH /aws1/cx_s3cclientexc INTO DATA(lo_ex_cli).
+        MESSAGE lo_ex_cli->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_cli.
+      CATCH /aws1/cx_s3cserverexc INTO DATA(lo_ex_srv).
+        MESSAGE lo_ex_srv->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_srv.
+    ENDTRY.
+    " snippet-end:[s3c.abapv1.create_job]
+  ENDMETHOD.
+
+
+  METHOD describe_job.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_s3c) = /aws1/cl_s3c_factory=>create( lo_session ).
+
+    " snippet-start:[s3c.abapv1.describe_job]
+    TRY.
+        oo_result = lo_s3c->describejob(         " oo_result is returned for testing purposes.
+          iv_accountid = iv_account_id
+          iv_jobid     = iv_job_id
+        ).
+        DATA(lo_job) = oo_result->get_job( ).
+        DATA(lv_status) = lo_job->get_status( ).
+        DATA(lv_priority) = lo_job->get_priority( ).
+        DATA(lo_progress) = lo_job->get_progresssummary( ).
+        IF lo_progress IS NOT INITIAL.
+          MESSAGE |Job { iv_job_id }: status={ lv_status }, priority={ lv_priority }, | &&
+                  |total={ lo_progress->get_totalnumberoftasks( ) }, | &&
+                  |succeeded={ lo_progress->get_numberoftaskssucceeded( ) }, | &&
+                  |failed={ lo_progress->get_numberoftasksfailed( ) }| TYPE 'I'.
+        ELSE.
+          MESSAGE |Job { iv_job_id }: status={ lv_status }, priority={ lv_priority }| TYPE 'I'.
+        ENDIF.
+      CATCH /aws1/cx_s3cnotfoundexception INTO DATA(lo_ex_nf).
+        MESSAGE lo_ex_nf->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_nf.
+      CATCH /aws1/cx_s3cclientexc INTO DATA(lo_ex_cli).
+        MESSAGE lo_ex_cli->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_cli.
+      CATCH /aws1/cx_s3cserverexc INTO DATA(lo_ex_srv).
+        MESSAGE lo_ex_srv->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_srv.
+    ENDTRY.
+    " snippet-end:[s3c.abapv1.describe_job]
+  ENDMETHOD.
+
+
+  METHOD update_job_priority.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_s3c) = /aws1/cl_s3c_factory=>create( lo_session ).
+
+    " snippet-start:[s3c.abapv1.update_job_priority]
+    TRY.
+        oo_result = lo_s3c->updatejobpriority(   " oo_result is returned for testing purposes.
+          iv_accountid = iv_account_id
+          iv_jobid     = iv_job_id
+          iv_priority  = 60
+        ).
+        MESSAGE |Job { oo_result->get_jobid( ) } priority updated to { oo_result->get_priority( ) }| TYPE 'I'.
+      CATCH /aws1/cx_s3cnotfoundexception INTO DATA(lo_ex_nf).
+        MESSAGE lo_ex_nf->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_nf.
+      CATCH /aws1/cx_s3cbadrequestex INTO DATA(lo_ex_bad).
+        MESSAGE lo_ex_bad->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_bad.
+      CATCH /aws1/cx_s3cclientexc INTO DATA(lo_ex_cli).
+        MESSAGE lo_ex_cli->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_cli.
+      CATCH /aws1/cx_s3cserverexc INTO DATA(lo_ex_srv).
+        MESSAGE lo_ex_srv->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_srv.
+    ENDTRY.
+    " snippet-end:[s3c.abapv1.update_job_priority]
+  ENDMETHOD.
+
+
+  METHOD update_job_status.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_s3c) = /aws1/cl_s3c_factory=>create( lo_session ).
+
+    " snippet-start:[s3c.abapv1.update_job_status]
+    TRY.
+        " iv_requested_status = 'Cancelled'
+        oo_result = lo_s3c->updatejobstatus(     " oo_result is returned for testing purposes.
+          iv_accountid          = iv_account_id
+          iv_jobid              = iv_job_id
+          iv_requestedjobstatus = iv_requested_status
+        ).
+        MESSAGE |Job { oo_result->get_jobid( ) } status updated to { oo_result->get_status( ) }| TYPE 'I'.
+      CATCH /aws1/cx_s3cjobstatusexception INTO DATA(lo_ex_js).
+        MESSAGE lo_ex_js->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_js.
+      CATCH /aws1/cx_s3cnotfoundexception INTO DATA(lo_ex_nf).
+        MESSAGE lo_ex_nf->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_nf.
+      CATCH /aws1/cx_s3cclientexc INTO DATA(lo_ex_cli).
+        MESSAGE lo_ex_cli->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_cli.
+      CATCH /aws1/cx_s3cserverexc INTO DATA(lo_ex_srv).
+        MESSAGE lo_ex_srv->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_srv.
+    ENDTRY.
+    " snippet-end:[s3c.abapv1.update_job_status]
+  ENDMETHOD.
+
+
+  METHOD get_job_tagging.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_s3c) = /aws1/cl_s3c_factory=>create( lo_session ).
+
+    " snippet-start:[s3c.abapv1.get_job_tagging]
+    TRY.
+        oo_result = lo_s3c->getjobtagging(       " oo_result is returned for testing purposes.
+          iv_accountid = iv_account_id
+          iv_jobid     = iv_job_id
+        ).
+        DATA(lt_tags) = oo_result->get_tags( ).
+        MESSAGE |Retrieved { lines( lt_tags ) } tag(s) for job { iv_job_id }| TYPE 'I'.
+      CATCH /aws1/cx_s3cnotfoundexception INTO DATA(lo_ex_nf).
+        MESSAGE lo_ex_nf->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_nf.
+      CATCH /aws1/cx_s3cclientexc INTO DATA(lo_ex_cli).
+        MESSAGE lo_ex_cli->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_cli.
+      CATCH /aws1/cx_s3cserverexc INTO DATA(lo_ex_srv).
+        MESSAGE lo_ex_srv->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_srv.
+    ENDTRY.
+    " snippet-end:[s3c.abapv1.get_job_tagging]
+  ENDMETHOD.
+
+
+  METHOD put_job_tagging.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_s3c) = /aws1/cl_s3c_factory=>create( lo_session ).
+
+    " snippet-start:[s3c.abapv1.put_job_tagging]
+    TRY.
+        lo_s3c->putjobtagging(
+          iv_accountid = iv_account_id
+          iv_jobid     = iv_job_id
+          it_tags      = VALUE /aws1/cl_s3cs3tag=>tt_s3tagset(
+            ( NEW /aws1/cl_s3cs3tag(
+                iv_key   = 'Environment'
+                iv_value = 'Development' ) )
+            ( NEW /aws1/cl_s3cs3tag(
+                iv_key   = 'Team'
+                iv_value = 'DataProcessing' ) )
+          )
+        ).
+        MESSAGE |Tags added to job { iv_job_id }| TYPE 'I'.
+      CATCH /aws1/cx_s3cnotfoundexception INTO DATA(lo_ex_nf).
+        MESSAGE lo_ex_nf->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_nf.
+      CATCH /aws1/cx_s3ctoomanytagsex INTO DATA(lo_ex_tags).
+        MESSAGE lo_ex_tags->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_tags.
+      CATCH /aws1/cx_s3cclientexc INTO DATA(lo_ex_cli).
+        MESSAGE lo_ex_cli->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_cli.
+      CATCH /aws1/cx_s3cserverexc INTO DATA(lo_ex_srv).
+        MESSAGE lo_ex_srv->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_srv.
+    ENDTRY.
+    " snippet-end:[s3c.abapv1.put_job_tagging]
+  ENDMETHOD.
+
+
+  METHOD list_jobs.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_s3c) = /aws1/cl_s3c_factory=>create( lo_session ).
+
+    " snippet-start:[s3c.abapv1.list_jobs]
+    TRY.
+        oo_result = lo_s3c->listjobs(            " oo_result is returned for testing purposes.
+          iv_accountid    = iv_account_id
+          it_jobstatuses  = VALUE /aws1/cl_s3cjobstatuslist_w=>tt_jobstatuslist(
+            ( NEW /aws1/cl_s3cjobstatuslist_w( 'Active' ) )
+            ( NEW /aws1/cl_s3cjobstatuslist_w( 'Complete' ) )
+            ( NEW /aws1/cl_s3cjobstatuslist_w( 'Cancelled' ) )
+            ( NEW /aws1/cl_s3cjobstatuslist_w( 'Failed' ) )
+            ( NEW /aws1/cl_s3cjobstatuslist_w( 'New' ) )
+            ( NEW /aws1/cl_s3cjobstatuslist_w( 'Paused' ) )
+            ( NEW /aws1/cl_s3cjobstatuslist_w( 'Pausing' ) )
+            ( NEW /aws1/cl_s3cjobstatuslist_w( 'Preparing' ) )
+            ( NEW /aws1/cl_s3cjobstatuslist_w( 'Ready' ) )
+            ( NEW /aws1/cl_s3cjobstatuslist_w( 'Suspended' ) )
+          )
+        ).
+        MESSAGE |Retrieved { lines( oo_result->get_jobs( ) ) } S3 Batch Operations job(s)| TYPE 'I'.
+      CATCH /aws1/cx_s3cinternalserviceex INTO DATA(lo_ex_int).
+        MESSAGE lo_ex_int->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_int.
+      CATCH /aws1/cx_s3cclientexc INTO DATA(lo_ex_cli).
+        MESSAGE lo_ex_cli->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_cli.
+      CATCH /aws1/cx_s3cserverexc INTO DATA(lo_ex_srv).
+        MESSAGE lo_ex_srv->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_srv.
+    ENDTRY.
+    " snippet-end:[s3c.abapv1.list_jobs]
+  ENDMETHOD.
+
+
+  METHOD delete_job_tagging.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_s3c) = /aws1/cl_s3c_factory=>create( lo_session ).
+
+    " snippet-start:[s3c.abapv1.delete_job_tagging]
+    TRY.
+        lo_s3c->deletejobtagging(
+          iv_accountid = iv_account_id
+          iv_jobid     = iv_job_id
+        ).
+        MESSAGE |Tags deleted from job { iv_job_id }| TYPE 'I'.
+      CATCH /aws1/cx_s3cnotfoundexception INTO DATA(lo_ex_nf).
+        MESSAGE lo_ex_nf->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_nf.
+      CATCH /aws1/cx_s3cclientexc INTO DATA(lo_ex_cli).
+        MESSAGE lo_ex_cli->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_cli.
+      CATCH /aws1/cx_s3cserverexc INTO DATA(lo_ex_srv).
+        MESSAGE lo_ex_srv->get_text( ) TYPE 'I'.
+        RAISE EXCEPTION TYPE /aws1/cx_rt_generic
+          EXPORTING previous = lo_ex_srv.
+    ENDTRY.
+    " snippet-end:[s3c.abapv1.delete_job_tagging]
+  ENDMETHOD.
+
+ENDCLASS.

--- a/sap-abap/services/s3c/#awsex#cl_s3c_actions.clas.testclasses.abap
+++ b/sap-abap/services/s3c/#awsex#cl_s3c_actions.clas.testclasses.abap
@@ -1,0 +1,590 @@
+" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+" SPDX-License-Identifier: Apache-2.0
+CLASS ltc_awsex_cl_s3c_actions DEFINITION DEFERRED.
+CLASS /awsex/cl_s3c_actions DEFINITION LOCAL FRIENDS ltc_awsex_cl_s3c_actions.
+
+CLASS ltc_awsex_cl_s3c_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL DANGEROUS.
+
+  PRIVATE SECTION.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+
+    CLASS-DATA ao_s3        TYPE REF TO /aws1/if_s3.
+    CLASS-DATA ao_s3c       TYPE REF TO /aws1/if_s3c.
+    CLASS-DATA ao_sts       TYPE REF TO /aws1/if_sts.
+    CLASS-DATA ao_iam       TYPE REF TO /aws1/if_iam.
+    CLASS-DATA ao_session   TYPE REF TO /aws1/cl_rt_session_base.
+    CLASS-DATA ao_s3c_acts  TYPE REF TO /awsex/cl_s3c_actions.
+
+    " Shared resources created once in class_setup
+    CLASS-DATA gv_account_id    TYPE /aws1/s3caccountid.
+    CLASS-DATA gv_bucket_name   TYPE /aws1/s3_bucketname.
+    CLASS-DATA gv_role_arn      TYPE /aws1/s3ciamrolearn.
+    CLASS-DATA gv_role_name     TYPE /aws1/iamrolenametype.
+    CLASS-DATA gv_manifest_arn  TYPE /aws1/s3cs3keyarnstring.
+    CLASS-DATA gv_manifest_etag TYPE string.
+    CLASS-DATA gv_report_bucket TYPE /aws1/s3cs3bucketarnstring.
+    CLASS-DATA gv_uuid          TYPE string.
+
+    " Shared job used by read-only tests (describe, list, get_job_tagging)
+    CLASS-DATA gv_shared_job_id TYPE /aws1/s3cjobid.
+
+    " All dedicated jobs created by mutation tests are tracked here and
+    " cancelled in class_teardown, guaranteeing cleanup even when a test
+    " throws before reaching its own inline cancel.
+    CLASS-DATA gt_cleanup_jobs  TYPE TABLE OF /aws1/s3cjobid.
+
+    CLASS-METHODS class_setup    RAISING /aws1/cx_rt_generic.
+    CLASS-METHODS class_teardown RAISING /aws1/cx_rt_generic.
+
+    METHODS create_job          FOR TESTING RAISING /aws1/cx_rt_generic.
+    METHODS describe_job        FOR TESTING RAISING /aws1/cx_rt_generic.
+    METHODS update_job_priority FOR TESTING RAISING /aws1/cx_rt_generic.
+    METHODS update_job_status   FOR TESTING RAISING /aws1/cx_rt_generic.
+    METHODS get_job_tagging     FOR TESTING RAISING /aws1/cx_rt_generic.
+    METHODS put_job_tagging     FOR TESTING RAISING /aws1/cx_rt_generic.
+    METHODS list_jobs           FOR TESTING RAISING /aws1/cx_rt_generic.
+    METHODS delete_job_tagging  FOR TESTING RAISING /aws1/cx_rt_generic.
+
+    " Creates a fresh S3 Batch job in Suspended state and registers it for
+    " teardown cleanup.  ConfirmationRequired=true keeps it Suspended.
+    CLASS-METHODS create_fresh_job
+      RETURNING
+        VALUE(rv_job_id) TYPE /aws1/s3cjobid
+      RAISING
+        /aws1/cx_rt_generic.
+
+    " Polls DescribeJob until the job reaches iv_desired_status or a terminal state.
+    CLASS-METHODS wait_for_job
+      IMPORTING
+        iv_job_id         TYPE /aws1/s3cjobid
+        iv_desired_status TYPE string
+      RAISING
+        /aws1/cx_rt_generic.
+
+ENDCLASS.
+
+CLASS ltc_awsex_cl_s3c_actions IMPLEMENTATION.
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD class_setup.
+* ─────────────────────────────────────────────────────────────────────────────
+    DATA lv_uuid_string   TYPE string.
+    DATA lv_trust_policy  TYPE string.
+    DATA lv_inline_policy TYPE string.
+    DATA lv_file_xstr     TYPE xstring.
+    DATA lv_manifest_body TYPE string.
+    DATA lv_manifest_xstr TYPE xstring.
+    DATA lv_etag_raw      TYPE string.
+
+    ao_session  = /aws1/cl_rt_session_aws=>create( iv_profile_id = cv_pfl ).
+    ao_s3       = /aws1/cl_s3_factory=>create( ao_session ).
+    ao_s3c      = /aws1/cl_s3c_factory=>create( ao_session ).
+    ao_sts      = /aws1/cl_sts_factory=>create( ao_session ).
+    ao_iam      = /aws1/cl_iam_factory=>create( ao_session ).
+    ao_s3c_acts = NEW /awsex/cl_s3c_actions( ).
+
+    " ── Unique suffix for all resource names ───────────────────────────────
+    lv_uuid_string = /awsex/cl_utils=>get_random_string( ).
+    CONDENSE lv_uuid_string NO-GAPS.
+    gv_uuid = to_lower( lv_uuid_string(10) ).
+
+    " ── Resolve AWS account ID via STS ────────────────────────────────────
+    DATA(lo_sts_result) = ao_sts->getcalleridentity( ).
+    gv_account_id = lo_sts_result->get_account( ).
+    IF gv_account_id IS INITIAL.
+      cl_abap_unit_assert=>fail( msg = 'Could not determine AWS account ID' ).
+    ENDIF.
+
+    " ── Create test S3 bucket (respects us-east-1 constraint rule) ─────────
+    gv_bucket_name = |s3c-test-{ gv_uuid }|.
+    /awsex/cl_utils=>create_bucket(
+      iv_bucket  = gv_bucket_name
+      io_s3      = ao_s3
+      io_session = ao_session ).
+
+    " Tag bucket with convert_test
+    TRY.
+        ao_s3->putbuckettagging(
+          iv_bucket  = gv_bucket_name
+          io_tagging = NEW /aws1/cl_s3_tagging(
+            it_tagset = VALUE /aws1/cl_s3_tag=>tt_tagset(
+              ( NEW /aws1/cl_s3_tag( iv_key = 'convert_test' iv_value = 'true' ) )
+            ) ) ).
+      CATCH /aws1/cx_rt_generic.
+        " Tagging failure is non-fatal here
+    ENDTRY.
+
+    " ── Upload three sample objects ────────────────────────────────────────
+    lv_file_xstr = cl_abap_codepage=>convert_to( 'Content for object1.txt' ).
+    ao_s3->putobject( iv_bucket = gv_bucket_name iv_key = 'object1.txt' iv_body = lv_file_xstr ).
+    lv_file_xstr = cl_abap_codepage=>convert_to( 'Content for object2.txt' ).
+    ao_s3->putobject( iv_bucket = gv_bucket_name iv_key = 'object2.txt' iv_body = lv_file_xstr ).
+    lv_file_xstr = cl_abap_codepage=>convert_to( 'Content for object3.txt' ).
+    ao_s3->putobject( iv_bucket = gv_bucket_name iv_key = 'object3.txt' iv_body = lv_file_xstr ).
+
+    " ── Build and upload the job manifest CSV ─────────────────────────────
+    lv_manifest_body = |{ gv_bucket_name },object1.txt\n| &&
+                       |{ gv_bucket_name },object2.txt\n| &&
+                       |{ gv_bucket_name },object3.txt\n|.
+    lv_manifest_xstr = cl_abap_codepage=>convert_to( lv_manifest_body ).
+    ao_s3->putobject(
+      iv_bucket = gv_bucket_name
+      iv_key    = 'job-manifest.csv'
+      iv_body   = lv_manifest_xstr ).
+
+    " ── Retrieve the manifest ETag (strip surrounding quotes) ─────────────
+    DATA(lo_head) = ao_s3->headobject(
+      iv_bucket = gv_bucket_name
+      iv_key    = 'job-manifest.csv' ).
+    lv_etag_raw = lo_head->get_etag( ).
+    REPLACE ALL OCCURRENCES OF '"' IN lv_etag_raw WITH ''.
+    gv_manifest_etag = lv_etag_raw.
+    IF gv_manifest_etag IS INITIAL.
+      cl_abap_unit_assert=>fail( msg = 'Could not retrieve manifest ETag' ).
+    ENDIF.
+
+    gv_manifest_arn  = |arn:aws:s3:::{ gv_bucket_name }/job-manifest.csv|.
+    gv_report_bucket = |arn:aws:s3:::{ gv_bucket_name }|.
+
+    " ── Create IAM role that S3 Batch Operations will assume ───────────────
+    gv_role_name = |s3c-test-role-{ gv_uuid }|.
+    lv_trust_policy =
+      '{"Version":"2012-10-17","Statement":[{"Effect":"Allow",' &&
+      '"Principal":{"Service":"batchoperations.s3.amazonaws.com"},' &&
+      '"Action":"sts:AssumeRole"}]}'.
+
+    DATA(lo_iam_result) = ao_iam->createrole(
+      iv_rolename                 = gv_role_name
+      iv_assumerolepolicydocument = lv_trust_policy
+      iv_description              = 'Role for S3 Batch Operations ABAP test'
+      it_tags                     = VALUE /aws1/cl_iamtag=>tt_taglisttype(
+        ( NEW /aws1/cl_iamtag( iv_key = 'convert_test' iv_value = 'true' ) )
+      ) ).
+    gv_role_arn = lo_iam_result->get_role( )->get_arn( ).
+    IF gv_role_arn IS INITIAL.
+      cl_abap_unit_assert=>fail( msg = 'Failed to create IAM role' ).
+    ENDIF.
+
+    " ── Attach inline policy granting all permissions required by
+    "    S3 Batch Operations for PutObjectTagging jobs:
+    "      ReadObjects  – read objects listed in the manifest
+    "      TagObjects   – apply tags to those objects
+    "      BucketAccess – resolve bucket location / versioning state
+    "      WriteReports – write the per-job completion report
+    " ─────────────────────────────────────────────────────────────────────────
+    lv_inline_policy =
+      '{"Version":"2012-10-17","Statement":[' &&
+        '{"Sid":"ReadObjects","Effect":"Allow",' &&
+          '"Action":["s3:GetObject","s3:GetObjectVersion",' &&
+                   '"s3:GetObjectTagging","s3:GetObjectVersionTagging"],' &&
+          '"Resource":"arn:aws:s3:::' && gv_bucket_name && '/*"},' &&
+        '{"Sid":"TagObjects","Effect":"Allow",' &&
+          '"Action":["s3:PutObjectTagging","s3:PutObjectVersionTagging"],' &&
+          '"Resource":"arn:aws:s3:::' && gv_bucket_name && '/*"},' &&
+        '{"Sid":"BucketAccess","Effect":"Allow",' &&
+          '"Action":["s3:GetBucketLocation","s3:GetBucketObjectLockConfiguration",' &&
+                   '"s3:GetBucketVersioning","s3:ListBucket","s3:ListBucketVersions"],' &&
+          '"Resource":"arn:aws:s3:::' && gv_bucket_name && '"},' &&
+        '{"Sid":"WriteReports","Effect":"Allow",' &&
+          '"Action":["s3:PutObject","s3:GetObject","s3:GetBucketLocation"],' &&
+          '"Resource":["arn:aws:s3:::' && gv_bucket_name && '/batch-op-reports/*",' &&
+                      '"arn:aws:s3:::' && gv_bucket_name && '"]}' &&
+      ']}' .
+
+    ao_iam->putrolepolicy(
+      iv_rolename       = gv_role_name
+      iv_policyname     = 's3c-batch-policy'
+      iv_policydocument = lv_inline_policy ).
+
+    " IAM changes take a few seconds to propagate globally
+    WAIT UP TO 15 SECONDS.
+
+    " ── Create the shared job used by read-only tests ──────────────────────
+    "    ConfirmationRequired=true → job lands in Suspended state, a stable
+    "    state that supports describe/list/tag operations without risk of
+    "    the job actually executing and consuming resources.
+    gv_shared_job_id = create_fresh_job( ).
+    IF gv_shared_job_id IS INITIAL.
+      cl_abap_unit_assert=>fail( msg = 'Failed to create shared S3 Batch Operations job' ).
+    ENDIF.
+    wait_for_job( iv_job_id = gv_shared_job_id iv_desired_status = 'Suspended' ).
+  ENDMETHOD.
+
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD class_teardown.
+* ─────────────────────────────────────────────────────────────────────────────
+
+    " ── Cancel ALL tracked jobs (shared + dedicated) ───────────────────────
+    "    Each cancel is in its own TRY/CATCH so one failure does not block the
+    "    rest.  Jobs in terminal states (Complete/Failed/Cancelled) are
+    "    silently skipped by the SDK; jobs that cannot be deleted via API are
+    "    tagged convert_test=true for manual identification.
+    LOOP AT gt_cleanup_jobs INTO DATA(lv_jid).
+      TRY.
+          DATA(lo_d) = ao_s3c->describejob(
+            iv_accountid = gv_account_id iv_jobid = lv_jid ).
+          DATA(lv_st) = lo_d->get_job( )->get_status( ).
+          IF lv_st = 'Suspended' OR lv_st = 'Ready'
+             OR lv_st = 'New'    OR lv_st = 'Active'.
+            ao_s3c->updatejobstatus(
+              iv_accountid          = gv_account_id
+              iv_jobid              = lv_jid
+              iv_requestedjobstatus = 'Cancelled' ).
+          ENDIF.
+        CATCH /aws1/cx_rt_generic.
+          " Job already terminal or not found – ignore
+      ENDTRY.
+    ENDLOOP.
+
+    " ── Empty and delete the test bucket ──────────────────────────────────
+    IF gv_bucket_name IS NOT INITIAL.
+      TRY.
+          /awsex/cl_utils=>cleanup_bucket( iv_bucket = gv_bucket_name io_s3 = ao_s3 ).
+        CATCH /aws1/cx_rt_generic.
+          " Ignore – bucket may already be gone
+      ENDTRY.
+    ENDIF.
+
+    " ── Remove IAM inline policy then the role itself ─────────────────────
+    IF gv_role_name IS NOT INITIAL.
+      TRY.
+          ao_iam->deleterolepolicy(
+            iv_rolename   = gv_role_name
+            iv_policyname = 's3c-batch-policy' ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+      TRY.
+          ao_iam->deleterole( iv_rolename = gv_role_name ).
+        CATCH /aws1/cx_rt_generic.
+      ENDTRY.
+    ENDIF.
+  ENDMETHOD.
+
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD create_fresh_job.
+* ─────────────────────────────────────────────────────────────────────────────
+    " Creates a brand-new job with ConfirmationRequired=true (→ Suspended) and
+    " immediately appends its ID to gt_cleanup_jobs so class_teardown always
+    " cancels it, regardless of whether the calling test succeeds or fails.
+    DATA(lo_result) = ao_s3c->createjob(
+      iv_accountid            = gv_account_id
+      iv_rolearn              = gv_role_arn
+      iv_confirmationrequired = abap_true
+      iv_priority             = 10
+      iv_description          = |s3c-test-{ gv_uuid }|
+      io_operation            = NEW /aws1/cl_s3cjoboperation(
+        io_s3putobjecttagging = NEW /aws1/cl_s3cs3setobjecttagop(
+          it_tagset = VALUE /aws1/cl_s3cs3tag=>tt_s3tagset(
+            ( NEW /aws1/cl_s3cs3tag( iv_key = 'convert_test' iv_value = 'true' ) )
+          )
+        )
+      )
+      io_manifest             = NEW /aws1/cl_s3cjobmanifest(
+        io_spec     = NEW /aws1/cl_s3cjobmanifestspec(
+          iv_format = 'S3BatchOperations_CSV_20180820'
+          it_fields = VALUE /aws1/cl_s3cjobmanifestfield00=>tt_jobmanifestfieldlist(
+            ( NEW /aws1/cl_s3cjobmanifestfield00( 'Bucket' ) )
+            ( NEW /aws1/cl_s3cjobmanifestfield00( 'Key' ) )
+          )
+        )
+        io_location = NEW /aws1/cl_s3cjobmanifestloc(
+          iv_objectarn = gv_manifest_arn
+          iv_etag      = gv_manifest_etag
+        )
+      )
+      io_report               = NEW /aws1/cl_s3cjobreport(
+        iv_bucket      = gv_report_bucket
+        iv_format      = 'Report_CSV_20180820'
+        iv_enabled     = abap_true
+        iv_prefix      = 'batch-op-reports'
+        iv_reportscope = 'AllTasks'
+      )
+    ).
+    rv_job_id = lo_result->get_jobid( ).
+    " Register for guaranteed teardown cleanup
+    APPEND rv_job_id TO gt_cleanup_jobs.
+  ENDMETHOD.
+
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD wait_for_job.
+* ─────────────────────────────────────────────────────────────────────────────
+    " Polls DescribeJob up to ~2.5 minutes (30 × 5 s) until the job reaches
+    " iv_desired_status or enters a terminal state (Failed/Cancelled/Complete).
+    DATA lv_max TYPE i VALUE 30.
+    DATA lv_i   TYPE i VALUE 0.
+    DATA lv_cur TYPE string.
+
+    WHILE lv_i < lv_max.
+      TRY.
+          DATA(lo_d) = ao_s3c->describejob(
+            iv_accountid = gv_account_id
+            iv_jobid     = iv_job_id ).
+          lv_cur = lo_d->get_job( )->get_status( ).
+          IF lv_cur = iv_desired_status
+             OR lv_cur = 'Failed' OR lv_cur = 'Cancelled' OR lv_cur = 'Complete'.
+            RETURN.
+          ENDIF.
+        CATCH /aws1/cx_rt_generic.
+          " Job not visible yet – retry
+      ENDTRY.
+      WAIT UP TO 5 SECONDS.
+      lv_i = lv_i + 1.
+    ENDWHILE.
+  ENDMETHOD.
+
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD create_job.
+* ─────────────────────────────────────────────────────────────────────────────
+    " Calls the action method and asserts a non-empty Job ID is returned.
+    " The new job is registered for teardown via create_fresh_job's append to
+    " gt_cleanup_jobs, so it is always cancelled even if the test fails mid-way.
+    DATA(lv_new_job_id) = ao_s3c_acts->create_job(
+      iv_account_id    = gv_account_id
+      iv_role_arn      = gv_role_arn
+      iv_manifest_arn  = gv_manifest_arn
+      iv_manifest_etag = gv_manifest_etag
+      iv_report_bucket = gv_report_bucket ).
+
+    cl_abap_unit_assert=>assert_not_initial(
+      act = lv_new_job_id
+      msg = 'create_job must return a non-empty Job ID' ).
+
+    " Register the new job for teardown (the action method itself calls the
+    " SDK directly, so it is NOT registered via create_fresh_job).
+    APPEND lv_new_job_id TO gt_cleanup_jobs.
+  ENDMETHOD.
+
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD describe_job.
+* ─────────────────────────────────────────────────────────────────────────────
+    " Verifies the RETURNING value contains the expected job ID and a non-empty
+    " status — confirming the result object is correctly populated and returned.
+    DATA(lo_result) = ao_s3c_acts->describe_job(
+      iv_account_id = gv_account_id
+      iv_job_id     = gv_shared_job_id ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = 'describe_job must return a bound result object' ).
+
+    DATA(lo_job) = lo_result->get_job( ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = gv_shared_job_id
+      act = lo_job->get_jobid( )
+      msg = 'Returned job ID must match the shared job ID' ).
+
+    cl_abap_unit_assert=>assert_not_initial(
+      act = lo_job->get_status( )
+      msg = 'Returned job status must not be initial' ).
+  ENDMETHOD.
+
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD update_job_priority.
+* ─────────────────────────────────────────────────────────────────────────────
+    " Uses a dedicated fresh job to avoid order-dependency with other tests.
+    " Asserts via the RETURNING value that the priority was applied as requested.
+    DATA(lv_job_id) = create_fresh_job( ).
+    wait_for_job( iv_job_id = lv_job_id iv_desired_status = 'Suspended' ).
+
+    DATA(lo_result) = ao_s3c_acts->update_job_priority(
+      iv_account_id = gv_account_id
+      iv_job_id     = lv_job_id ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = 'update_job_priority must return a bound result object' ).
+
+    " The action hard-codes priority=60; verify via the returned value
+    cl_abap_unit_assert=>assert_equals(
+      exp = 60
+      act = lo_result->get_priority( )
+      msg = 'Returned priority must be 60' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = lv_job_id
+      act = lo_result->get_jobid( )
+      msg = 'Returned job ID must match the job that was updated' ).
+  ENDMETHOD.
+
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD update_job_status.
+* ─────────────────────────────────────────────────────────────────────────────
+    " Uses a dedicated fresh job so cancellation does not affect the shared job
+    " or any other test.  Asserts via the RETURNING value.
+    DATA(lv_job_id) = create_fresh_job( ).
+    wait_for_job( iv_job_id = lv_job_id iv_desired_status = 'Suspended' ).
+
+    " Guard: verify the job is actually cancellable before proceeding
+    DATA(lo_pre) = ao_s3c->describejob(
+      iv_accountid = gv_account_id iv_jobid = lv_job_id ).
+    DATA(lv_pre_status) = lo_pre->get_job( )->get_status( ).
+    IF lv_pre_status <> 'Suspended' AND lv_pre_status <> 'Ready'
+       AND lv_pre_status <> 'New'.
+      cl_abap_unit_assert=>fail(
+        msg = |Job reached unexpected state '{ lv_pre_status }' – cannot cancel| ).
+    ENDIF.
+
+    DATA(lo_result) = ao_s3c_acts->update_job_status(
+      iv_account_id       = gv_account_id
+      iv_job_id           = lv_job_id
+      iv_requested_status = 'Cancelled' ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = 'update_job_status must return a bound result object' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'Cancelled'
+      act = lo_result->get_status( )
+      msg = 'Returned status must be Cancelled' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = lv_job_id
+      act = lo_result->get_jobid( )
+      msg = 'Returned job ID must match the job that was updated' ).
+  ENDMETHOD.
+
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD get_job_tagging.
+* ─────────────────────────────────────────────────────────────────────────────
+    " Pre-loads a known tag on the shared job, then asserts the RETURNING value
+    " contains that tag — verifying the result object is correctly populated.
+    ao_s3c->putjobtagging(
+      iv_accountid = gv_account_id
+      iv_jobid     = gv_shared_job_id
+      it_tags      = VALUE /aws1/cl_s3cs3tag=>tt_s3tagset(
+        ( NEW /aws1/cl_s3cs3tag( iv_key = 'convert_test' iv_value = 'true' ) )
+      ) ).
+
+    DATA(lo_result) = ao_s3c_acts->get_job_tagging(
+      iv_account_id = gv_account_id
+      iv_job_id     = gv_shared_job_id ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = 'get_job_tagging must return a bound result object' ).
+
+    DATA(lt_tags) = lo_result->get_tags( ).
+    cl_abap_unit_assert=>assert_true(
+      act  = xsdbool( lines( lt_tags ) >= 1 )
+      msg  = 'get_job_tagging: at least 1 tag must be present' ).
+
+    DATA lv_found TYPE abap_bool.
+    LOOP AT lt_tags INTO DATA(lo_tag).
+      IF lo_tag->get_key( ) = 'convert_test'.
+        lv_found = abap_true.
+        EXIT.
+      ENDIF.
+    ENDLOOP.
+    cl_abap_unit_assert=>assert_true(
+      act = lv_found
+      msg = 'Tag convert_test must be present in the returned tag list' ).
+  ENDMETHOD.
+
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD put_job_tagging.
+* ─────────────────────────────────────────────────────────────────────────────
+    " Uses a dedicated fresh job so tag mutations are isolated.
+    " Verifies via a direct SDK call that the correct tags were stored.
+    DATA(lv_job_id) = create_fresh_job( ).
+    wait_for_job( iv_job_id = lv_job_id iv_desired_status = 'Suspended' ).
+
+    " Ensure the job starts with no tags
+    ao_s3c->deletejobtagging(
+      iv_accountid = gv_account_id iv_jobid = lv_job_id ).
+
+    ao_s3c_acts->put_job_tagging(
+      iv_account_id = gv_account_id
+      iv_job_id     = lv_job_id ).
+
+    " Verify exactly 2 tags (Environment + Team) via direct SDK call
+    DATA(lo_tags) = ao_s3c->getjobtagging(
+      iv_accountid = gv_account_id iv_jobid = lv_job_id ).
+    DATA(lt_tags) = lo_tags->get_tags( ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = 2
+      act = lines( lt_tags )
+      msg = 'put_job_tagging must store exactly 2 tags' ).
+
+    DATA lv_found_env  TYPE abap_bool.
+    DATA lv_found_team TYPE abap_bool.
+    LOOP AT lt_tags INTO DATA(lo_tag).
+      IF lo_tag->get_key( ) = 'Environment'. lv_found_env  = abap_true. ENDIF.
+      IF lo_tag->get_key( ) = 'Team'.        lv_found_team = abap_true. ENDIF.
+    ENDLOOP.
+    cl_abap_unit_assert=>assert_true(
+      act = lv_found_env  msg = 'Tag key ''Environment'' must be present' ).
+    cl_abap_unit_assert=>assert_true(
+      act = lv_found_team msg = 'Tag key ''Team'' must be present' ).
+  ENDMETHOD.
+
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD list_jobs.
+* ─────────────────────────────────────────────────────────────────────────────
+    " Verifies the RETURNING value contains the shared job, confirming the
+    " result object is correctly populated and returned.
+    DATA(lo_result) = ao_s3c_acts->list_jobs( iv_account_id = gv_account_id ).
+
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = 'list_jobs must return a bound result object' ).
+
+    DATA lv_found TYPE abap_bool.
+    LOOP AT lo_result->get_jobs( ) INTO DATA(lo_job).
+      IF lo_job->get_jobid( ) = gv_shared_job_id.
+        lv_found = abap_true.
+        EXIT.
+      ENDIF.
+    ENDLOOP.
+    cl_abap_unit_assert=>assert_true(
+      act = lv_found
+      msg = 'list_jobs: the shared test job must appear in the returned job list' ).
+  ENDMETHOD.
+
+
+* ─────────────────────────────────────────────────────────────────────────────
+  METHOD delete_job_tagging.
+* ─────────────────────────────────────────────────────────────────────────────
+    " Uses a dedicated fresh job so deletion does not affect the shared job.
+    DATA(lv_job_id) = create_fresh_job( ).
+    wait_for_job( iv_job_id = lv_job_id iv_desired_status = 'Suspended' ).
+
+    " Put a tag on the job first
+    ao_s3c->putjobtagging(
+      iv_accountid = gv_account_id
+      iv_jobid     = lv_job_id
+      it_tags      = VALUE /aws1/cl_s3cs3tag=>tt_s3tagset(
+        ( NEW /aws1/cl_s3cs3tag( iv_key = 'ToDelete' iv_value = 'yes' ) )
+      ) ).
+
+    " Confirm the tag exists before deleting
+    DATA(lo_before) = ao_s3c->getjobtagging(
+      iv_accountid = gv_account_id iv_jobid = lv_job_id ).
+    cl_abap_unit_assert=>assert_true(
+      act  = xsdbool( lines( lo_before->get_tags( ) ) >= 1 )
+      msg  = 'delete_job_tagging pre-condition: tag must exist before deletion' ).
+
+    ao_s3c_acts->delete_job_tagging(
+      iv_account_id = gv_account_id
+      iv_job_id     = lv_job_id ).
+
+    " Verify all tags are gone
+    DATA(lo_after) = ao_s3c->getjobtagging(
+      iv_accountid = gv_account_id iv_jobid = lv_job_id ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = 0
+      act = lines( lo_after->get_tags( ) )
+      msg = 'delete_job_tagging must remove all tags' ).
+  ENDMETHOD.
+
+ENDCLASS.

--- a/sap-abap/services/s3c/#awsex#cl_s3c_actions.clas.xml
+++ b/sap-abap/services/s3c/#awsex#cl_s3c_actions.clas.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>/AWSEX/CL_S3C_ACTIONS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>S3-control Code Example</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/sap-abap/services/s3c/README.md
+++ b/sap-abap/services/s3c/README.md
@@ -1,13 +1,13 @@
-# Amazon SES v2 API code examples for the SDK for SAP ABAP
+# Amazon S3 Control code examples for the SDK for SAP ABAP
 
 ## Overview
 
-Shows how to use the AWS SDK for SAP ABAP to work with Amazon Simple Email Service v2 API.
+Shows how to use the AWS SDK for SAP ABAP to work with Amazon S3 Control.
 
 <!--custom.overview.start-->
 <!--custom.overview.end-->
 
-_Amazon SES v2 API is a reliable, scalable, and cost-effective email service._
+_Amazon S3 Control lets you manage S3 resources._
 
 ## ⚠ Important
 
@@ -33,17 +33,13 @@ For prerequisites, see the [README](../../README.md#Prerequisites) in the `sap-a
 
 Code excerpts that show you how to call individual service functions.
 
-- [CreateContact](%23awsex%23cl_se2_actions.clas.abap#L189)
-- [CreateContactList](%23awsex%23cl_se2_actions.clas.abap#L137)
-- [CreateEmailIdentity](%23awsex%23cl_se2_actions.clas.abap#L116)
-- [CreateEmailTemplate](%23awsex%23cl_se2_actions.clas.abap#L162)
-- [DeleteContactList](%23awsex%23cl_se2_actions.clas.abap#L326)
-- [DeleteEmailIdentity](%23awsex%23cl_se2_actions.clas.abap#L366)
-- [DeleteEmailTemplate](%23awsex%23cl_se2_actions.clas.abap#L346)
-- [GetEmailIdentity](%23awsex%23cl_se2_actions.clas.abap#L386)
-- [ListContacts](%23awsex%23cl_se2_actions.clas.abap#L304)
-- [SendBulkEmail](%23awsex%23cl_se2_actions.clas.abap#L407)
-- [SendEmail](%23awsex%23cl_se2_actions.clas.abap#L211)
+- [CreateJob](%23awsex%23cl_s3c_actions.clas.abap#L95)
+- [DeleteJobTagging](%23awsex%23cl_s3c_actions.clas.abap#L380)
+- [DescribeJob](%23awsex%23cl_s3c_actions.clas.abap#L160)
+- [GetJobTagging](%23awsex%23cl_s3c_actions.clas.abap#L269)
+- [PutJobTagging](%23awsex%23cl_s3c_actions.clas.abap#L299)
+- [UpdateJobPriority](%23awsex%23cl_s3c_actions.clas.abap#L200)
+- [UpdateJobStatus](%23awsex%23cl_s3c_actions.clas.abap#L234)
 
 
 <!--custom.examples.start-->
@@ -74,9 +70,9 @@ in the `sap-abap` folder.
 
 ## Additional resources
 
-- [Amazon SES v2 API Developer Guide](https://docs.aws.amazon.com/ses/latest/dg/Welcome.html)
-- [Amazon SES v2 API API Reference](https://docs.aws.amazon.com/ses/latest/APIReference-V2/Welcome.html)
-- [SDK for SAP ABAP Amazon SES v2 API reference](https://docs.aws.amazon.com/sdk-for-sap-abap/v1/api/latest/sesv2/index.html)
+- [Amazon S3 Control User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
+- [Amazon S3 Control API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html)
+- [SDK for SAP ABAP Amazon S3 Control reference](https://docs.aws.amazon.com/sdk-for-sap-abap/v1/api/latest/s3-control/index.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/sap-abap/services/s3c/package.devc.xml
+++ b/sap-abap/services/s3c/package.devc.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DEVC>
+    <CTEXT>Package for S3 control</CTEXT>
+   </DEVC>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/sap-abap/services/se2/#awsex#cl_se2_actions.clas.abap
+++ b/sap-abap/services/se2/#awsex#cl_se2_actions.clas.abap
@@ -80,6 +80,25 @@ CLASS /awsex/cl_se2_actions DEFINITION
       RAISING
         /aws1/cx_rt_generic.
 
+    METHODS get_email_identity
+      IMPORTING
+        !iv_email_identity TYPE /aws1/se2identity
+      RETURNING
+        VALUE(oo_result)   TYPE REF TO /aws1/cl_se2getemailidresponse
+      RAISING
+        /aws1/cx_rt_generic.
+
+    METHODS send_bulk_email
+      IMPORTING
+        !iv_from_address       TYPE /aws1/se2emailaddress
+        !iv_template_name      TYPE /aws1/se2emailtemplatename
+        !iv_template_data      TYPE /aws1/se2emailtemplatedata
+        !it_bulk_entries       TYPE /aws1/cl_se2bulkemailentry=>tt_bulkemailentrylist
+      RETURNING
+        VALUE(ot_results)      TYPE /aws1/cl_se2bulkemailentryrslt=>tt_bulkemailentryresultlist
+      RAISING
+        /aws1/cx_rt_generic.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -356,6 +375,66 @@ CLASS /awsex/cl_se2_actions IMPLEMENTATION.
         RAISE EXCEPTION lo_bad_request.
     ENDTRY.
     " snippet-end:[se2.abapv1.delete_email_identity]
+  ENDMETHOD.
+
+  METHOD get_email_identity.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_se2) = /aws1/cl_se2_factory=>create( lo_session ).
+
+    " snippet-start:[se2.abapv1.get_email_identity]
+    TRY.
+        oo_result = lo_se2->getemailidentity(
+          iv_emailidentity = iv_email_identity ).
+        MESSAGE |Identity type: { oo_result->get_identitytype( ) }, | &&
+                |verified for sending: { oo_result->get_verifiedforsendingstatus( ) }| TYPE 'I'.
+      CATCH /aws1/cx_se2notfoundexception.
+        MESSAGE |Email identity { iv_email_identity } not found.| TYPE 'I'.
+      CATCH /aws1/cx_se2badrequestex INTO DATA(lo_bad_request).
+        MESSAGE lo_bad_request TYPE 'I' DISPLAY LIKE 'E'.
+        RAISE EXCEPTION lo_bad_request.
+    ENDTRY.
+    " snippet-end:[se2.abapv1.get_email_identity]
+  ENDMETHOD.
+
+  METHOD send_bulk_email.
+    CONSTANTS cv_pfl TYPE /aws1/rt_profile_id VALUE 'ZCODE_DEMO'.
+
+    DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
+    DATA(lo_se2) = /aws1/cl_se2_factory=>create( lo_session ).
+
+    " snippet-start:[se2.abapv1.send_bulk_email]
+    TRY.
+        " Build the default template content used for all bulk recipients
+        DATA(lo_template) = NEW /aws1/cl_se2template(
+          iv_templatename = iv_template_name
+          iv_templatedata = iv_template_data ).
+
+        DATA(lo_default_content) = NEW /aws1/cl_se2bulkemailcontent(
+          io_template = lo_template ).
+
+        DATA(lo_result) = lo_se2->sendbulkemail(
+          iv_fromemailaddress = iv_from_address
+          io_defaultcontent   = lo_default_content
+          it_bulkemailentries = it_bulk_entries ).
+
+        ot_results = lo_result->get_bulkemailentryresults( ).
+        MESSAGE |Bulk email sent to { lines( it_bulk_entries ) } recipient(s).| TYPE 'I'.
+      CATCH /aws1/cx_se2messagerejected INTO DATA(lo_rejected).
+        MESSAGE lo_rejected TYPE 'I' DISPLAY LIKE 'E'.
+        RAISE EXCEPTION lo_rejected.
+      CATCH /aws1/cx_se2mailfrmdomnotver00 INTO DATA(lo_not_verified).
+        MESSAGE lo_not_verified TYPE 'I' DISPLAY LIKE 'E'.
+        RAISE EXCEPTION lo_not_verified.
+      CATCH /aws1/cx_se2notfoundexception INTO DATA(lo_not_found).
+        MESSAGE lo_not_found TYPE 'I' DISPLAY LIKE 'E'.
+        RAISE EXCEPTION lo_not_found.
+      CATCH /aws1/cx_se2badrequestex INTO DATA(lo_bad_request).
+        MESSAGE lo_bad_request TYPE 'I' DISPLAY LIKE 'E'.
+        RAISE EXCEPTION lo_bad_request.
+    ENDTRY.
+    " snippet-end:[se2.abapv1.send_bulk_email]
   ENDMETHOD.
 
 ENDCLASS.

--- a/sap-abap/services/se2/#awsex#cl_se2_actions.clas.testclasses.abap
+++ b/sap-abap/services/se2/#awsex#cl_se2_actions.clas.testclasses.abap
@@ -26,7 +26,9 @@ CLASS ltc_awsex_cl_se2_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL D
       list_contacts FOR TESTING RAISING /aws1/cx_rt_generic,
       delete_contact_list FOR TESTING RAISING /aws1/cx_rt_generic,
       delete_email_template FOR TESTING RAISING /aws1/cx_rt_generic,
-      delete_email_identity FOR TESTING RAISING /aws1/cx_rt_generic.
+      delete_email_identity FOR TESTING RAISING /aws1/cx_rt_generic,
+      get_email_identity FOR TESTING RAISING /aws1/cx_rt_generic,
+      send_bulk_email FOR TESTING RAISING /aws1/cx_rt_generic.
 
     CLASS-METHODS class_setup RAISING /aws1/cx_rt_generic.
     CLASS-METHODS class_teardown RAISING /aws1/cx_rt_generic.
@@ -36,7 +38,7 @@ CLASS ltc_awsex_cl_se2_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL D
         iv_resource_arn TYPE /aws1/se2amazonresourcename
       RAISING
         /aws1/cx_rt_generic.
-    
+
     CLASS-METHODS wait_for_identity_verification
       IMPORTING
         iv_email_identity TYPE /aws1/se2identity
@@ -45,6 +47,10 @@ CLASS ltc_awsex_cl_se2_actions DEFINITION FOR TESTING DURATION LONG RISK LEVEL D
         VALUE(rv_verified) TYPE abap_bool
       RAISING
         /aws1/cx_rt_generic.
+
+    " New class-data for get_email_identity and send_bulk_email tests.
+    CLASS-DATA av_del_tmpl_name TYPE /aws1/se2emailtemplatename.
+    CLASS-DATA av_del_identity  TYPE /aws1/se2identity.
 
 ENDCLASS.
 
@@ -94,6 +100,10 @@ CLASS ltc_awsex_cl_se2_actions IMPLEMENTATION.
     " 2. We can still test the API operations without verified identity
     " 3. Send tests will handle MessageRejected exception appropriately
 
+    " Pause between management API calls: SES v2 allows ~1 TPS for
+    " CreateEmailIdentity, CreateEmailTemplate, and similar operations.
+    WAIT UP TO 2 SECONDS.
+
     " Create contact list for tests
     " Note: SES Sandbox allows only 1 contact list per account
     " If limit is reached, find and use existing list
@@ -122,7 +132,7 @@ CLASS ltc_awsex_cl_se2_actions IMPLEMENTATION.
                 EXIT.
               ENDLOOP.
               MESSAGE |Using existing contact list: { av_contact_list_name }| TYPE 'I'.
-              
+
               " Try to tag the existing list (best effort)
               TRY.
                   DATA(lv_existing_arn) = |arn:aws:ses:{ ao_session->get_region( ) }:{ ao_session->get_account_id( ) }:contact-list/{ av_contact_list_name }|.
@@ -144,6 +154,8 @@ CLASS ltc_awsex_cl_se2_actions IMPLEMENTATION.
         cl_abap_unit_assert=>fail(
           msg = |Failed to create contact list: { lo_list_ex2->get_text( ) }| ).
     ENDTRY.
+
+    WAIT UP TO 2 SECONDS.
 
     " Create email template for tests
     TRY.
@@ -167,6 +179,42 @@ CLASS ltc_awsex_cl_se2_actions IMPLEMENTATION.
       CATCH /aws1/cx_rt_generic INTO DATA(lo_template_ex).
         cl_abap_unit_assert=>fail(
           msg = |Failed to create email template: { lo_template_ex->get_text( ) }| ).
+    ENDTRY.
+
+    " Create dedicated template for delete_email_template test (new)
+    WAIT UP TO 2 SECONDS.
+    av_del_tmpl_name = |del-tmpl-{ av_uuid }|.
+    TRY.
+        DATA(lo_del_tmpl_content) = NEW /aws1/cl_se2emailtmplcontent(
+          iv_subject = 'Delete-me template'
+          iv_html    = '<p>delete</p>'
+          iv_text    = 'delete' ).
+        ao_se2->createemailtemplate(
+          iv_templatename    = av_del_tmpl_name
+          io_templatecontent = lo_del_tmpl_content ).
+        DATA(lv_del_tmpl_arn) = |arn:aws:ses:{ ao_session->get_region( ) }:{ ao_session->get_account_id( ) }:template/{ av_del_tmpl_name }|.
+        tag_resource( lv_del_tmpl_arn ).
+        MESSAGE |Created delete-target template { av_del_tmpl_name }| TYPE 'I'.
+      CATCH /aws1/cx_se2alreadyexistsex.
+        MESSAGE |Delete-target template { av_del_tmpl_name } already exists| TYPE 'I'.
+      CATCH /aws1/cx_rt_generic INTO DATA(lo_dt_ex).
+        cl_abap_unit_assert=>fail(
+          msg = |Failed to create delete-target template: { lo_dt_ex->get_text( ) }| ).
+    ENDTRY.
+
+    " Create dedicated identity for delete_email_identity test (new)
+    WAIT UP TO 2 SECONDS.
+    av_del_identity = |se2del-{ av_uuid }@example.com|.
+    TRY.
+        ao_se2->createemailidentity( iv_emailidentity = av_del_identity ).
+        DATA(lv_del_id_arn) = |arn:aws:ses:{ ao_session->get_region( ) }:{ ao_session->get_account_id( ) }:identity/{ av_del_identity }|.
+        tag_resource( lv_del_id_arn ).
+        MESSAGE |Created delete-target identity { av_del_identity }| TYPE 'I'.
+      CATCH /aws1/cx_se2alreadyexistsex.
+        MESSAGE |Delete-target identity { av_del_identity } already exists| TYPE 'I'.
+      CATCH /aws1/cx_rt_generic INTO DATA(lo_di_ex).
+        cl_abap_unit_assert=>fail(
+          msg = |Failed to create delete-target identity: { lo_di_ex->get_text( ) }| ).
     ENDTRY.
 
   ENDMETHOD.
@@ -216,6 +264,26 @@ CLASS ltc_awsex_cl_se2_actions IMPLEMENTATION.
       CATCH /aws1/cx_rt_generic INTO DATA(lo_id_del_ex).
         MESSAGE |Could not delete email identity: { lo_id_del_ex->get_text( ) }| TYPE 'I'.
     ENDTRY.
+
+    " Clean up delete-target template (may already be deleted by test)
+    TRY.
+        ao_se2->deleteemailtemplate( iv_templatename = av_del_tmpl_name ).
+        MESSAGE |Deleted delete-target template { av_del_tmpl_name }| TYPE 'I'.
+      CATCH /aws1/cx_se2notfoundexception.
+        " Already deleted by the test - expected.
+      CATCH /aws1/cx_rt_generic INTO DATA(lo_dt_del_ex).
+        MESSAGE |Could not delete delete-target template: { lo_dt_del_ex->get_text( ) }| TYPE 'I'.
+    ENDTRY.
+
+    " Clean up delete-target identity (may already be deleted by test)
+    TRY.
+        ao_se2->deleteemailidentity( iv_emailidentity = av_del_identity ).
+        MESSAGE |Deleted delete-target identity { av_del_identity }| TYPE 'I'.
+      CATCH /aws1/cx_se2notfoundexception.
+        " Already deleted by the test - expected.
+      CATCH /aws1/cx_rt_generic INTO DATA(lo_di_del_ex).
+        MESSAGE |Could not delete delete-target identity: { lo_di_del_ex->get_text( ) }| TYPE 'I'.
+    ENDTRY.
   ENDMETHOD.
 
   METHOD tag_resource.
@@ -233,30 +301,30 @@ CLASS ltc_awsex_cl_se2_actions IMPLEMENTATION.
   METHOD wait_for_identity_verification.
     DATA lv_elapsed_seconds TYPE i VALUE 0.
     DATA lv_wait_interval TYPE i VALUE 5.
-    
+
     rv_verified = abap_false.
-    
+
     WHILE lv_elapsed_seconds < iv_max_wait_seconds.
       TRY.
           DATA(lo_identity) = ao_se2->getemailidentity(
             iv_emailidentity = iv_email_identity ).
-          
+
           IF lo_identity->get_verifiedforsendingstatus( ) = abap_true.
             rv_verified = abap_true.
             MESSAGE |Email identity verified after { lv_elapsed_seconds } seconds| TYPE 'I'.
             RETURN.
           ENDIF.
-          
+
           " Wait before checking again
           WAIT UP TO lv_wait_interval SECONDS.
           lv_elapsed_seconds = lv_elapsed_seconds + lv_wait_interval.
-          
+
         CATCH /aws1/cx_rt_generic INTO DATA(lo_ex).
           MESSAGE |Error checking verification status: { lo_ex->get_text( ) }| TYPE 'I'.
           RETURN.
       ENDTRY.
     ENDWHILE.
-    
+
     MESSAGE |Email identity not verified after { iv_max_wait_seconds } seconds| TYPE 'I'.
   ENDMETHOD.
 
@@ -328,6 +396,9 @@ CLASS ltc_awsex_cl_se2_actions IMPLEMENTATION.
   METHOD create_email_template.
     DATA(lv_test_uuid) = /awsex/cl_utils=>get_random_string( ).
     DATA(lv_test_template) = |tst-tmp-{ lv_test_uuid(8) }|.
+
+    " Brief pause to avoid TooManyRequestsException after rapid class_setup calls.
+    WAIT UP TO 2 SECONDS.
 
     " Call the action method
     ao_se2_actions->create_email_template(
@@ -543,6 +614,9 @@ CLASS ltc_awsex_cl_se2_actions IMPLEMENTATION.
     DATA(lv_test_uuid) = /awsex/cl_utils=>get_random_string( ).
     DATA(lv_test_template) = |tst-del-{ lv_test_uuid(8) }|.
 
+    " Brief pause to avoid TooManyRequestsException after rapid class_setup calls.
+    WAIT UP TO 2 SECONDS.
+
     " Create the template
     DATA(lo_template_content) = NEW /aws1/cl_se2emailtmplcontent(
       iv_subject = 'Test Delete'
@@ -575,6 +649,9 @@ CLASS ltc_awsex_cl_se2_actions IMPLEMENTATION.
     DATA(lv_test_uuid) = /awsex/cl_utils=>get_random_string( ).
     DATA(lv_test_identity) = |test{ lv_test_uuid }@example.com|.
 
+    " Brief pause to avoid TooManyRequestsException after rapid class_setup calls.
+    WAIT UP TO 2 SECONDS.
+
     " Create the identity
     ao_se2->createemailidentity( iv_emailidentity = lv_test_identity ).
 
@@ -592,6 +669,83 @@ CLASS ltc_awsex_cl_se2_actions IMPLEMENTATION.
           msg = |Email identity { lv_test_identity } should have been deleted| ).
       CATCH /aws1/cx_se2notfoundexception.
         " Expected - identity was successfully deleted
+    ENDTRY.
+  ENDMETHOD.
+
+  METHOD get_email_identity.
+    " Use the email identity already created in class_setup
+    DATA(lo_result) = ao_se2_actions->get_email_identity( av_verified_email ).
+
+    " Verify the result is bound and contains the expected identity type
+    cl_abap_unit_assert=>assert_bound(
+      act = lo_result
+      msg = 'GetEmailIdentity result should not be null' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_result->get_identitytype( )
+      exp = 'EMAIL_ADDRESS'
+      msg = |Identity { av_verified_email } should be of type EMAIL_ADDRESS| ).
+  ENDMETHOD.
+
+  METHOD send_bulk_email.
+    " Build two bulk entries using SES mailbox simulator addresses.
+    " Unique subaddress tags distinguish the two recipients.
+    " lv_uid is declared as string first so the fallback assignment from
+    " get_random_string() is type-safe (no sysuuid_x16 intermediate needed).
+    DATA lv_uid  TYPE string.
+    DATA lv_uuid TYPE sysuuid_x16.
+    TRY.
+        lv_uuid = cl_system_uuid=>create_uuid_x16_static( ).
+        lv_uid  = lv_uuid.
+      CATCH cx_uuid_error.
+        " Fallback: get_random_string() returns string; assign directly to string var.
+        lv_uid = /awsex/cl_utils=>get_random_string( ).
+    ENDTRY.
+    TRANSLATE lv_uid TO LOWER CASE.
+
+    " 'success' simulator address accepts all mail without bouncing.
+    DATA(lv_recipient1) = |success+b1{ lv_uid(6) }@simulator.amazonses.com|.
+    DATA(lv_recipient2) = |success+b2{ lv_uid(6) }@simulator.amazonses.com|.
+
+    DATA lt_entries TYPE /aws1/cl_se2bulkemailentry=>tt_bulkemailentrylist.
+
+    DATA lt_to1 TYPE /aws1/cl_se2emailaddresslist_w=>tt_emailaddresslist.
+    APPEND NEW /aws1/cl_se2emailaddresslist_w( iv_value = lv_recipient1 ) TO lt_to1.
+    APPEND NEW /aws1/cl_se2bulkemailentry(
+      io_destination = NEW /aws1/cl_se2destination( it_toaddresses = lt_to1 ) )
+      TO lt_entries.
+
+    DATA lt_to2 TYPE /aws1/cl_se2emailaddresslist_w=>tt_emailaddresslist.
+    APPEND NEW /aws1/cl_se2emailaddresslist_w( iv_value = lv_recipient2 ) TO lt_to2.
+    APPEND NEW /aws1/cl_se2bulkemailentry(
+      io_destination = NEW /aws1/cl_se2destination( it_toaddresses = lt_to2 ) )
+      TO lt_entries.
+
+    " av_verified_email is registered but not click-verified in sandbox, so
+    " SendBulkEmail may raise MessageRejected or MailFromDomainNotVerified.
+    " Both are re-raised by the action method; handle them here as acceptable
+    " outcomes, consistent with the send_email and send_email_template tests.
+    TRY.
+        DATA(lt_results) = ao_se2_actions->send_bulk_email(
+          iv_from_address  = av_verified_email
+          iv_template_name = av_template_name
+          " Empty JSON object is valid default template data.
+          iv_template_data = '{}'
+          it_bulk_entries  = lt_entries ).
+
+        " If the send succeeded, validate one result per submitted entry.
+        cl_abap_unit_assert=>assert_equals(
+          act = lines( lt_results )
+          exp = 2
+          msg = 'send_bulk_email: must receive one result per bulk entry' ).
+
+      CATCH /aws1/cx_se2messagerejected INTO DATA(lo_rejected).
+        " Expected in sandbox with unverified sender — action executed correctly.
+        MESSAGE |send_bulk_email: expected MessageRejected in sandbox: { lo_rejected->get_text( ) }| TYPE 'I'.
+
+      CATCH /aws1/cx_se2mailfrmdomnotver00 INTO DATA(lo_not_verified).
+        " Expected in sandbox when mail-from domain is not verified.
+        MESSAGE |send_bulk_email: expected MailFromDomainNotVerified: { lo_not_verified->get_text( ) }| TYPE 'I'.
     ENDTRY.
   ENDMETHOD.
 


### PR DESCRIPTION
Adds AWS SDK for SAP ABAP code examples for three services, generated by the ABAPyCodeConverter tool and validated on a live SAP system (AAE).

## Services

| Service | Scope | Operations |
|---------|-------|------------|
| **IoT** (new) | New service | CreateThing, ListThings, CreateKeysAndCertificate, AttachThingPrincipal, DescribeEndpoint, ListCertificates, DetachThingPrincipal, DeleteCertificate, CreateTopicRule, SearchIndex, UpdateIndexingConfiguration, DeleteThing, DeleteTopicRule (13) |
| **S3 Control** (new) | New service | CreateJob, DescribeJob, UpdateJobPriority, UpdateJobStatus, GetJobTagging, PutJobTagging, DeleteJobTagging (7) |
| **SESv2** (update) | Existing service | Adds GetEmailIdentity, SendBulkEmail (existing operations preserved) |

## What's included
- Actions classes with snippet tags for each operation
- Unit test classes (`testclasses.abap`) with resource setup/teardown
- Package and class XML metadata
- `.doc_gen/metadata` SAP ABAP entries for each new example
- Regenerated service READMEs
- A `service_folder_overrides` entry in `.tools/readmes/config.py` mapping `s3-control` to the `s3c` TLA folder

## Testing
All examples pass syntax checks and unit tests on the SAP ABAP test system (AAE). Test evidence is documented in the originating fork PRs.

## Notes
- The `list_topic_rules` (IoT) and `list_jobs` (S3 Control) helper methods used by the tests are intentionally not surfaced as standalone metadata examples, consistent with how other SDKs document these operations only within scenarios.

Generated by ABAPyCodeConverter.