### PR TITLE
DynamoDB: fix String comparison in Java v1 GSI Document API example

### DIFF
--- a/.tools/readmes/requirements_freeze.txt
+++ b/.tools/readmes/requirements_freeze.txt
@@ -1,4 +1,4 @@
-aws_doc_sdk_examples_tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools@2025.41.0
+aws_doc_sdk_examples_tools @ git+https://github.com/awsdocs/aws-doc-sdk-examples-tools@2026.10.0
 black==25.11.0
 certifi==2025.1.31
 charset-normalizer==3.4.1

--- a/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/document/DocumentAPIGlobalSecondaryIndexExample.java
+++ b/java/example_code/dynamodb/src/main/java/com/amazonaws/codesamples/document/DocumentAPIGlobalSecondaryIndexExample.java
@@ -125,18 +125,18 @@ public class DocumentAPIGlobalSecondaryIndexExample {
 
         QuerySpec querySpec = new QuerySpec();
 
-        if (indexName == "CreateDateIndex") {
+        if ("CreateDateIndex".equals(indexName)) {
             System.out.println("Issues filed on 2013-11-01");
             querySpec.withKeyConditionExpression("CreateDate = :v_date and begins_with(IssueId, :v_issue)")
                     .withValueMap(new ValueMap().withString(":v_date", "2013-11-01").withString(":v_issue", "A-"));
             items = index.query(querySpec);
-        } else if (indexName == "TitleIndex") {
+        } else if ("TitleIndex".equals(indexName)) {
             System.out.println("Compilation errors");
             querySpec.withKeyConditionExpression("Title = :v_title and begins_with(IssueId, :v_issue)")
                     .withValueMap(
                             new ValueMap().withString(":v_title", "Compilation error").withString(":v_issue", "A-"));
             items = index.query(querySpec);
-        } else if (indexName == "DueDateIndex") {
+        } else if ("DueDateIndex".equals(indexName)) {
             System.out.println("Items that are due on 2013-11-30");
             querySpec.withKeyConditionExpression("DueDate = :v_date")
                     .withValueMap(new ValueMap().withString(":v_date", "2013-11-30"));

--- a/python/README.md
+++ b/python/README.md
@@ -1,11 +1,11 @@
-# AWS SDK for Python code examples
+# AWS SDK for Python (Boto3) code examples
 
 ## Overview
 
 The code examples in this topic show you how to use the AWS SDK for Python (Boto3) 
 with AWS. 
 
-The AWS SDK for Python provides a Python API for AWS infrastructure services.
+The AWS SDK for Python (Boto3) provides a Python API for AWS infrastructure services.
 Using the SDK, you can build applications on top of AWS services such as Amazon Simple 
 Storage Service (Amazon S3), Amazon Elastic Compute Cloud (Amazon EC2), and Amazon DynamoDB.
 
@@ -169,7 +169,7 @@ hosted on [Amazon Elastic Container Registry (Amazon ECR)](https://docs.aws.amaz
 The image is preloaded with all Python examples, with dependencies pre-resolved. 
 That way, you can explore the examples in an isolated environment.
 
-See [SDK for Python image](https://gallery.ecr.aws/b4v4v1s0/python) for more information.
+See [SDK for Python (Boto3) image](https://gallery.ecr.aws/b4v4v1s0/python) for more information.
 
 ### Build the Docker image
 

--- a/python/example_code/acm/README.md
+++ b/python/example_code/acm/README.md
@@ -1,4 +1,4 @@
-# ACM code examples for the SDK for Python
+# ACM code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -109,7 +109,7 @@ in the `python` folder.
 
 - [ACM User Guide](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)
 - [ACM API Reference](https://docs.aws.amazon.com/acm/latest/APIReference/Welcome.html)
-- [SDK for Python ACM reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/acm.html)
+- [SDK for Python (Boto3) ACM reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/acm.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/api-gateway/README.md
+++ b/python/example_code/api-gateway/README.md
@@ -1,4 +1,4 @@
-# API Gateway code examples for the SDK for Python
+# API Gateway code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -163,7 +163,7 @@ in the `python` folder.
 
 - [API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html)
 - [API Gateway API Reference](https://docs.aws.amazon.com/apigateway/latest/api/API_Operations.html)
-- [SDK for Python API Gateway reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/apigateway.html)
+- [SDK for Python (Boto3) API Gateway reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/api-gateway.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/auditmanager/README.md
+++ b/python/example_code/auditmanager/README.md
@@ -1,4 +1,4 @@
-# Audit Manager code examples for the SDK for Python
+# Audit Manager code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -148,7 +148,7 @@ in the `python` folder.
 
 - [Audit Manager User Guide](https://docs.aws.amazon.com/audit-manager/latest/userguide/what-is.html)
 - [Audit Manager API Reference](https://docs.aws.amazon.com/audit-manager/latest/APIReference/Welcome.html)
-- [SDK for Python Audit Manager reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/auditmanager.html)
+- [SDK for Python (Boto3) Audit Manager reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/auditmanager.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/aurora/README.md
+++ b/python/example_code/aurora/README.md
@@ -1,4 +1,4 @@
-# Aurora code examples for the SDK for Python
+# Aurora code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -158,7 +158,7 @@ in the `python` folder.
 
 - [Aurora User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/CHAP_AuroraOverview.html)
 - [Aurora API Reference](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/Welcome.html)
-- [SDK for Python Aurora reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html)
+- [SDK for Python (Boto3) Aurora reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/aurora.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/auto-scaling/README.md
+++ b/python/example_code/auto-scaling/README.md
@@ -1,4 +1,4 @@
-# Auto Scaling code examples for the SDK for Python
+# Auto Scaling code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -157,7 +157,7 @@ in the `python` folder.
 
 - [Auto Scaling User Guide](https://docs.aws.amazon.com/autoscaling/ec2/userguide/what-is-amazon-ec2-auto-scaling.html)
 - [Auto Scaling API Reference](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/Welcome.html)
-- [SDK for Python Auto Scaling reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/autoscaling.html)
+- [SDK for Python (Boto3) Auto Scaling reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/auto-scaling.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/bedrock-agent-runtime/README.md
+++ b/python/example_code/bedrock-agent-runtime/README.md
@@ -1,4 +1,4 @@
-# Amazon Bedrock Agents Runtime code examples for the SDK for Python
+# Amazon Bedrock Agents Runtime code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -127,7 +127,7 @@ in the `python` folder.
 
 - [Amazon Bedrock Agents Runtime User Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html)
 - [Amazon Bedrock Agents Runtime API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Agents_for_Amazon_Bedrock_Runtime.html)
-- [SDK for Python Amazon Bedrock Agents Runtime reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-agent-runtime.html)
+- [SDK for Python (Boto3) Amazon Bedrock Agents Runtime reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-agent-runtime.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/bedrock-agent/README.md
+++ b/python/example_code/bedrock-agent/README.md
@@ -1,4 +1,4 @@
-# Amazon Bedrock Agents code examples for the SDK for Python
+# Amazon Bedrock Agents code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -188,7 +188,7 @@ in the `python` folder.
 
 - [Amazon Bedrock Agents User Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html)
 - [Amazon Bedrock Agents API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Agents_for_Amazon_Bedrock.html)
-- [SDK for Python Amazon Bedrock Agents reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-agent.html)
+- [SDK for Python (Boto3) Amazon Bedrock Agents reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-agent.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/bedrock-runtime/README.md
+++ b/python/example_code/bedrock-runtime/README.md
@@ -1,4 +1,4 @@
-# Amazon Bedrock Runtime code examples for the SDK for Python
+# Amazon Bedrock Runtime code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -199,7 +199,7 @@ in the `python` folder.
 
 - [Amazon Bedrock Runtime User Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html)
 - [Amazon Bedrock Runtime API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/welcome.html)
-- [SDK for Python Amazon Bedrock Runtime reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime.html)
+- [SDK for Python (Boto3) Amazon Bedrock Runtime reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/bedrock/README.md
+++ b/python/example_code/bedrock/README.md
@@ -1,4 +1,4 @@
-# Amazon Bedrock code examples for the SDK for Python
+# Amazon Bedrock code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -96,7 +96,7 @@ in the `python` folder.
 
 - [Amazon Bedrock User Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html)
 - [Amazon Bedrock API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/welcome.html)
-- [SDK for Python Amazon Bedrock reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock.html)
+- [SDK for Python (Boto3) Amazon Bedrock reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/cloudfront/README.md
+++ b/python/example_code/cloudfront/README.md
@@ -1,4 +1,4 @@
-# CloudFront code examples for the SDK for Python
+# CloudFront code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -78,7 +78,7 @@ in the `python` folder.
 
 - [CloudFront Developer Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html)
 - [CloudFront API Reference](https://docs.aws.amazon.com/cloudfront/latest/APIReference/Welcome.html)
-- [SDK for Python CloudFront reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html)
+- [SDK for Python (Boto3) CloudFront reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/cloudwatch-logs/README.md
+++ b/python/example_code/cloudwatch-logs/README.md
@@ -1,4 +1,4 @@
-# CloudWatch Logs code examples for the SDK for Python
+# CloudWatch Logs code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -110,7 +110,7 @@ in the `python` folder.
 
 - [CloudWatch Logs User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html)
 - [CloudWatch Logs API Reference](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/Welcome.html)
-- [SDK for Python CloudWatch Logs reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch-logs.html)
+- [SDK for Python (Boto3) CloudWatch Logs reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch-logs.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/cloudwatch/README.md
+++ b/python/example_code/cloudwatch/README.md
@@ -1,4 +1,4 @@
-# CloudWatch code examples for the SDK for Python
+# CloudWatch code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -107,7 +107,7 @@ in the `python` folder.
 
 - [CloudWatch User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html)
 - [CloudWatch API Reference](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/Welcome.html)
-- [SDK for Python CloudWatch reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html)
+- [SDK for Python (Boto3) CloudWatch reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/cognito/README.md
+++ b/python/example_code/cognito/README.md
@@ -1,4 +1,4 @@
-# Amazon Cognito Identity Provider code examples for the SDK for Python
+# Amazon Cognito Identity Provider code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -144,7 +144,7 @@ in the `python` folder.
 
 - [Amazon Cognito Identity Provider Developer Guide](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html)
 - [Amazon Cognito Identity Provider API Reference](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/Welcome.html)
-- [SDK for Python Amazon Cognito Identity Provider reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp.html)
+- [SDK for Python (Boto3) Amazon Cognito Identity Provider reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-identity-provider.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/comprehend/README.md
+++ b/python/example_code/comprehend/README.md
@@ -1,4 +1,4 @@
-# Amazon Comprehend code examples for the SDK for Python
+# Amazon Comprehend code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -173,7 +173,7 @@ in the `python` folder.
 
 - [Amazon Comprehend Developer Guide](https://docs.aws.amazon.com/comprehend/latest/dg/what-is.html)
 - [Amazon Comprehend API Reference](https://docs.aws.amazon.com/comprehend/latest/APIReference/welcome.html)
-- [SDK for Python Amazon Comprehend reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/comprehend.html)
+- [SDK for Python (Boto3) Amazon Comprehend reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/comprehend.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/config/README.md
+++ b/python/example_code/config/README.md
@@ -1,4 +1,4 @@
-# AWS Config code examples for the SDK for Python
+# AWS Config code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -73,7 +73,7 @@ in the `python` folder.
 
 - [AWS Config Developer Guide](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html)
 - [AWS Config API Reference](https://docs.aws.amazon.com/config/latest/APIReference/Welcome.html)
-- [SDK for Python AWS Config reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/config-service.html)
+- [SDK for Python (Boto3) AWS Config reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/config-service.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/controltower/README.md
+++ b/python/example_code/controltower/README.md
@@ -1,4 +1,4 @@
-# AWS Control Tower code examples for the SDK for Python
+# AWS Control Tower code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -123,7 +123,7 @@ in the `python` folder.
 
 - [AWS Control Tower User Guide](https://docs.aws.amazon.com/controltower/latest/userguide/what-is-control-tower.html)
 - [AWS Control Tower API Reference](https://docs.aws.amazon.com/controltower/latest/APIReference/Welcome.html)
-- [SDK for Python AWS Control Tower reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp.html)
+- [SDK for Python (Boto3) AWS Control Tower reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/controltower.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/devicefarm/README.md
+++ b/python/example_code/devicefarm/README.md
@@ -1,4 +1,4 @@
-# Device Farm code examples for the SDK for Python
+# Device Farm code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -108,7 +108,7 @@ in the `python` folder.
 
 - [Device Farm Developer Guide](https://docs.aws.amazon.com/devicefarm/latest/developerguide/welcome.html)
 - [Device Farm API Reference](https://docs.aws.amazon.com/devicefarm/latest/APIReference/Welcome.html)
-- [SDK for Python Device Farm reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/devicefarm.html)
+- [SDK for Python (Boto3) Device Farm reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/device-farm.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/dynamodb/README.md
+++ b/python/example_code/dynamodb/README.md
@@ -1,4 +1,4 @@
-# DynamoDB code examples for the SDK for Python
+# DynamoDB code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -302,7 +302,7 @@ in the `python` folder.
 
 - [DynamoDB Developer Guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html)
 - [DynamoDB API Reference](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/Welcome.html)
-- [SDK for Python DynamoDB reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html)
+- [SDK for Python (Boto3) DynamoDB reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/ec2/README.md
+++ b/python/example_code/ec2/README.md
@@ -1,4 +1,4 @@
-# Amazon EC2 code examples for the SDK for Python
+# Amazon EC2 code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -176,7 +176,7 @@ in the `python` folder.
 
 - [Amazon EC2 User Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html)
 - [Amazon EC2 API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html)
-- [SDK for Python Amazon EC2 reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html)
+- [SDK for Python (Boto3) Amazon EC2 reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/ecr/README.md
+++ b/python/example_code/ecr/README.md
@@ -1,4 +1,4 @@
-# Amazon ECR code examples for the SDK for Python
+# Amazon ECR code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -124,7 +124,7 @@ in the `python` folder.
 
 - [Amazon ECR User Guide](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html)
 - [Amazon ECR API Reference](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/Welcome.html)
-- [SDK for Python Amazon ECR reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/scheduler.html)
+- [SDK for Python (Boto3) Amazon ECR reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecr.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/elastic-load-balancing/README.md
+++ b/python/example_code/elastic-load-balancing/README.md
@@ -1,4 +1,4 @@
-# Elastic Load Balancing - Version 2 code examples for the SDK for Python
+# Elastic Load Balancing - Version 2 code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -126,7 +126,7 @@ in the `python` folder.
 
 - [Elastic Load Balancing - Version 2 User Guide](https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/what-is-load-balancing.html)
 - [Elastic Load Balancing - Version 2 API Reference](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/Welcome.html)
-- [SDK for Python Elastic Load Balancing - Version 2 reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html)
+- [SDK for Python (Boto3) Elastic Load Balancing - Version 2 reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elastic-load-balancing-v2.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/emr/README.md
+++ b/python/example_code/emr/README.md
@@ -1,4 +1,4 @@
-# Amazon EMR code examples for the SDK for Python
+# Amazon EMR code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -132,7 +132,7 @@ in the `python` folder.
 
 - [Amazon EMR Management Guide](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-what-is-emr.html)
 - [Amazon EMR API Reference](https://docs.aws.amazon.com/emr/latest/APIReference/Welcome.html)
-- [SDK for Python Amazon EMR reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html)
+- [SDK for Python (Boto3) Amazon EMR reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/firehose/README.md
+++ b/python/example_code/firehose/README.md
@@ -1,4 +1,4 @@
-# Data Firehose code examples for the SDK for Python
+# Data Firehose code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -98,7 +98,7 @@ in the `python` folder.
 
 - [Data Firehose User Guide](https://docs.aws.amazon.com/firehose/latest/dev/what-is-this-service.html)
 - [Data Firehose API Reference](https://docs.aws.amazon.com/firehose/latest/APIReference/Welcome.html)
-- [SDK for Python Data Firehose reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kinesis-firehose.html)
+- [SDK for Python (Boto3) Data Firehose reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/firehose.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/glacier/README.md
+++ b/python/example_code/glacier/README.md
@@ -1,4 +1,4 @@
-# Amazon Glacier code examples for the SDK for Python
+# Amazon Glacier code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -136,7 +136,7 @@ in the `python` folder.
 
 - [Amazon Glacier Developer Guide](https://docs.aws.amazon.com/amazonglacier/latest/dev/introduction.html)
 - [Amazon Glacier API Reference](https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-api.html)
-- [SDK for Python Amazon Glacier reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glacier.html)
+- [SDK for Python (Boto3) Amazon Glacier reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glacier.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/glue/README.md
+++ b/python/example_code/glue/README.md
@@ -1,4 +1,4 @@
-# AWS Glue code examples for the SDK for Python
+# AWS Glue code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -156,7 +156,7 @@ in the `python` folder.
 
 - [AWS Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html)
 - [AWS Glue API Reference](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api.html)
-- [SDK for Python AWS Glue reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html)
+- [SDK for Python (Boto3) AWS Glue reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/healthlake/README.md
+++ b/python/example_code/healthlake/README.md
@@ -1,4 +1,4 @@
-# HealthLake code examples for the SDK for Python
+# HealthLake code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -83,7 +83,7 @@ in the `python` folder.
 
 - [HealthLake Developer Guide](https://docs.aws.amazon.com/healthlake/latest/devguide/what-is-amazon-health-lake.html)
 - [HealthLake API Reference](https://docs.aws.amazon.com/healthlake/latest/APIReference/Welcome.html)
-- [SDK for Python HealthLake reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/medical-imaging.html)
+- [SDK for Python (Boto3) HealthLake reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/healthlake.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/iam/README.md
+++ b/python/example_code/iam/README.md
@@ -1,4 +1,4 @@
-# IAM code examples for the SDK for Python
+# IAM code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -318,7 +318,7 @@ in the `python` folder.
 
 - [IAM User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html)
 - [IAM API Reference](https://docs.aws.amazon.com/IAM/latest/APIReference/welcome.html)
-- [SDK for Python IAM reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html)
+- [SDK for Python (Boto3) IAM reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/iot/README.md
+++ b/python/example_code/iot/README.md
@@ -1,4 +1,4 @@
-# AWS IoT code examples for the SDK for Python
+# AWS IoT code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -131,7 +131,7 @@ in the `python` folder.
 
 - [AWS IoT Developer Guide](https://docs.aws.amazon.com/iot/latest/developerguide/what-is-aws-iot.html)
 - [AWS IoT API Reference](https://docs.aws.amazon.com/iot/latest/apireference/Welcome.html)
-- [SDK for Python AWS IoT reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iot.html)
+- [SDK for Python (Boto3) AWS IoT reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iot.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/iotsitewise/README.md
+++ b/python/example_code/iotsitewise/README.md
@@ -1,4 +1,4 @@
-# AWS IoT SiteWise code examples for the SDK for Python
+# AWS IoT SiteWise code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -126,7 +126,7 @@ in the `python` folder.
 
 - [AWS IoT SiteWise Developer Guide](https://docs.aws.amazon.com/iot-sitewise/latest/userguide/what-is-sitewise.html)
 - [AWS IoT SiteWise API Reference](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/Welcome.html)
-- [SDK for Python AWS IoT SiteWise reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iotsitewise.html)
+- [SDK for Python (Boto3) AWS IoT SiteWise reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iotsitewise.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/keyspaces/README.md
+++ b/python/example_code/keyspaces/README.md
@@ -1,4 +1,4 @@
-# Amazon Keyspaces code examples for the SDK for Python
+# Amazon Keyspaces code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -122,7 +122,7 @@ in the `python` folder.
 
 - [Amazon Keyspaces Developer Guide](https://docs.aws.amazon.com/keyspaces/latest/devguide/what-is-keyspaces.html)
 - [Amazon Keyspaces API Reference](https://docs.aws.amazon.com/keyspaces/latest/APIReference/Welcome.html)
-- [SDK for Python Amazon Keyspaces reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/keyspaces.html)
+- [SDK for Python (Boto3) Amazon Keyspaces reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/keyspaces.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/kinesis-analytics-v2/README.md
+++ b/python/example_code/kinesis-analytics-v2/README.md
@@ -1,4 +1,4 @@
-# Managed Service for Apache Flink code examples for the SDK for Python
+# Managed Service for Apache Flink code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -100,7 +100,7 @@ in the `python` folder.
 
 - [Managed Service for Apache Flink Developer Guide](https://docs.aws.amazon.com/managed-flink/latest/java/what-is.html)
 - [Managed Service for Apache Flink API Reference](https://docs.aws.amazon.com/managed-flink/latest/apiv2/Welcome.html)
-- [SDK for Python Managed Service for Apache Flink reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kinesisanalyticsv2.html)
+- [SDK for Python (Boto3) Managed Service for Apache Flink reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kinesis-analytics-v2.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/kinesis/README.md
+++ b/python/example_code/kinesis/README.md
@@ -1,4 +1,4 @@
-# Kinesis code examples for the SDK for Python
+# Kinesis code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -83,7 +83,7 @@ in the `python` folder.
 
 - [Kinesis Developer Guide](https://docs.aws.amazon.com/streams/latest/dev/introduction.html)
 - [Kinesis API Reference](https://docs.aws.amazon.com/kinesis/latest/APIReference/Welcome.html)
-- [SDK for Python Kinesis reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kinesisanalyticsv2.html)
+- [SDK for Python (Boto3) Kinesis reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kinesis.html)
 
 <!--custom.resources.start-->
 * [SDK for Python Kinesis Data Analytics reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kinesisanalyticsv2.html)

--- a/python/example_code/kms/README.md
+++ b/python/example_code/kms/README.md
@@ -1,4 +1,4 @@
-# AWS KMS code examples for the SDK for Python
+# AWS KMS code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -127,7 +127,7 @@ in the `python` folder.
 
 - [AWS KMS Developer Guide](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html)
 - [AWS KMS API Reference](https://docs.aws.amazon.com/kms/latest/APIReference/Welcome.html)
-- [SDK for Python AWS KMS reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms.html)
+- [SDK for Python (Boto3) AWS KMS reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/lambda/README.md
+++ b/python/example_code/lambda/README.md
@@ -1,4 +1,4 @@
-# Lambda code examples for the SDK for Python
+# Lambda code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -203,7 +203,7 @@ in the `python` folder.
 
 - [Lambda Developer Guide](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html)
 - [Lambda API Reference](https://docs.aws.amazon.com/lambda/latest/dg/API_Reference.html)
-- [SDK for Python Lambda reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html)
+- [SDK for Python (Boto3) Lambda reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/medical-imaging/README.md
+++ b/python/example_code/medical-imaging/README.md
@@ -1,4 +1,4 @@
-# HealthImaging code examples for the SDK for Python
+# HealthImaging code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -172,7 +172,7 @@ in the `python` folder.
 
 - [HealthImaging Developer Guide](https://docs.aws.amazon.com/healthimaging/latest/devguide/what-is.html)
 - [HealthImaging API Reference](https://docs.aws.amazon.com/healthimaging/latest/APIReference/Welcome.html)
-- [SDK for Python HealthImaging reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/medical-imaging.html)
+- [SDK for Python (Boto3) HealthImaging reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/medical-imaging.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/neptune/README.md
+++ b/python/example_code/neptune/README.md
@@ -1,4 +1,4 @@
-# Neptune code examples for the SDK for Python
+# Neptune code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -130,7 +130,7 @@ in the `python` folder.
 
 - [Neptune User Guide](https://docs.aws.amazon.com/neptune/latest/userguide/intro.html)
 - [Neptune API Reference](https://docs.aws.amazon.com/neptune/latest/apiref/Welcome.html)
-- [SDK for Python Neptune reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html)
+- [SDK for Python (Boto3) Neptune reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/neptune.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/organizations/README.md
+++ b/python/example_code/organizations/README.md
@@ -1,4 +1,4 @@
-# Organizations code examples for the SDK for Python
+# Organizations code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -85,7 +85,7 @@ in the `python` folder.
 
 - [Organizations User Guide](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html)
 - [Organizations API Reference](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html)
-- [SDK for Python Organizations reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/organizations.html)
+- [SDK for Python (Boto3) Organizations reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/organizations.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/pinpoint-sms-voice/README.md
+++ b/python/example_code/pinpoint-sms-voice/README.md
@@ -1,4 +1,4 @@
-# Amazon Pinpoint SMS and Voice code examples for the SDK for Python
+# Amazon Pinpoint SMS and Voice code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -76,7 +76,7 @@ in the `python` folder.
 
 - [Amazon Pinpoint SMS and Voice Developer Guide](https://docs.aws.amazon.com/pinpoint/latest/developerguide/welcome.html)
 - [Amazon Pinpoint SMS and Voice API Reference](https://docs.aws.amazon.com/pinpoint-sms-voice/latest/APIReference/welcome.html)
-- [SDK for Python Amazon Pinpoint SMS and Voice reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/pinpoint-sms-voice.html)
+- [SDK for Python (Boto3) Amazon Pinpoint SMS and Voice reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/pinpoint-sms-voice.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/pinpoint/README.md
+++ b/python/example_code/pinpoint/README.md
@@ -1,4 +1,4 @@
-# Amazon Pinpoint code examples for the SDK for Python
+# Amazon Pinpoint code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -77,7 +77,7 @@ in the `python` folder.
 
 - [Amazon Pinpoint Developer Guide](https://docs.aws.amazon.com/pinpoint/latest/developerguide/welcome.html)
 - [Amazon Pinpoint API Reference](https://docs.aws.amazon.com/pinpoint/latest/apireference/welcome.html)
-- [SDK for Python Amazon Pinpoint reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/pinpoint.html)
+- [SDK for Python (Boto3) Amazon Pinpoint reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/pinpoint.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/polly/README.md
+++ b/python/example_code/polly/README.md
@@ -1,4 +1,4 @@
-# Amazon Polly code examples for the SDK for Python
+# Amazon Polly code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -115,7 +115,7 @@ in the `python` folder.
 
 - [Amazon Polly Developer Guide](https://docs.aws.amazon.com/polly/latest/dg/what-is.html)
 - [Amazon Polly API Reference](https://docs.aws.amazon.com/polly/latest/dg/API_Reference.html)
-- [SDK for Python Amazon Polly reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/polly.html)
+- [SDK for Python (Boto3) Amazon Polly reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/polly.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/rds/README.md
+++ b/python/example_code/rds/README.md
@@ -1,4 +1,4 @@
-# Amazon RDS code examples for the SDK for Python
+# Amazon RDS code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -142,7 +142,7 @@ in the `python` folder.
 
 - [Amazon RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html)
 - [Amazon RDS API Reference](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/Welcome.html)
-- [SDK for Python Amazon RDS reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html)
+- [SDK for Python (Boto3) Amazon RDS reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/redshift/README.md
+++ b/python/example_code/redshift/README.md
@@ -1,4 +1,4 @@
-# Amazon Redshift code examples for the SDK for Python
+# Amazon Redshift code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -120,7 +120,7 @@ in the `python` folder.
 
 - [Amazon Redshift Management Guide](https://docs.aws.amazon.com/redshift/latest/mgmt/welcome.html)
 - [Amazon Redshift API Reference](https://docs.aws.amazon.com/redshift/latest/APIReference/Welcome.html)
-- [SDK for Python Amazon Redshift reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/redshift.html)
+- [SDK for Python (Boto3) Amazon Redshift reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/redshift.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/rekognition/README.md
+++ b/python/example_code/rekognition/README.md
@@ -1,4 +1,4 @@
-# Amazon Rekognition code examples for the SDK for Python
+# Amazon Rekognition code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -163,7 +163,7 @@ in the `python` folder.
 
 - [Amazon Rekognition Developer Guide](https://docs.aws.amazon.com/rekognition/latest/dg/what-is.html)
 - [Amazon Rekognition API Reference](https://docs.aws.amazon.com/rekognition/latest/APIReference/Welcome.html)
-- [SDK for Python Amazon Rekognition reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rekognition.html)
+- [SDK for Python (Boto3) Amazon Rekognition reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rekognition.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/route53-recovery-cluster/README.md
+++ b/python/example_code/route53-recovery-cluster/README.md
@@ -1,4 +1,4 @@
-# Route 53 ARC code examples for the SDK for Python
+# Route 53 ARC code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -100,7 +100,7 @@ in the `python` folder.
 
 - [Route 53 ARC Developer Guide](https://docs.aws.amazon.com/r53recovery/latest/dg/what-is-route53-recovery.html)
 - [Route 53 ARC API Reference](https://docs.aws.amazon.com/routing-control/latest/APIReference/Welcome.html)
-- [SDK for Python Route 53 ARC reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/route53-recovery-cluster.html)
+- [SDK for Python (Boto3) Route 53 ARC reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/route53-recovery-cluster.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/s3-directory-buckets/README.md
+++ b/python/example_code/s3-directory-buckets/README.md
@@ -1,4 +1,4 @@
-# S3 Directory Buckets code examples for the SDK for Python
+# S3 Directory Buckets code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -104,7 +104,7 @@ in the `python` folder.
 
 - [S3 Directory Buckets User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-overview.html)
 - [S3 Directory Buckets API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html)
-- [SDK for Python S3 Directory Buckets reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3-directory-buckets.html)
+- [SDK for Python (Boto3) S3 Directory Buckets reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3-directory-buckets.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/s3/README.md
+++ b/python/example_code/s3/README.md
@@ -1,4 +1,4 @@
-# Amazon S3 code examples for the SDK for Python
+# Amazon S3 code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -294,7 +294,7 @@ in the `python` folder.
 
 - [Amazon S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
 - [Amazon S3 API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html)
-- [SDK for Python Amazon S3 reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html)
+- [SDK for Python (Boto3) Amazon S3 reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/scheduler/README.md
+++ b/python/example_code/scheduler/README.md
@@ -1,4 +1,4 @@
-# EventBridge Scheduler code examples for the SDK for Python
+# EventBridge Scheduler code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -117,7 +117,7 @@ in the `python` folder.
 
 - [EventBridge Scheduler User Guide](https://docs.aws.amazon.com/scheduler/latest/userguide/intro.html)
 - [EventBridge Scheduler API Reference](https://docs.aws.amazon.com/scheduler/latest/apireference/Welcome.html)
-- [SDK for Python EventBridge Scheduler reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/scheduler.html)
+- [SDK for Python (Boto3) EventBridge Scheduler reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/scheduler.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/secretsmanager/README.md
+++ b/python/example_code/secretsmanager/README.md
@@ -1,4 +1,4 @@
-# Secrets Manager code examples for the SDK for Python
+# Secrets Manager code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -96,7 +96,7 @@ in the `python` folder.
 
 - [Secrets Manager User Guide](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html)
 - [Secrets Manager API Reference](https://docs.aws.amazon.com/secretsmanager/latest/apireference/Welcome.html)
-- [SDK for Python Secrets Manager reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager.html)
+- [SDK for Python (Boto3) Secrets Manager reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secrets-manager.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/ses/README.md
+++ b/python/example_code/ses/README.md
@@ -1,4 +1,4 @@
-# Amazon SES code examples for the SDK for Python
+# Amazon SES code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -209,7 +209,7 @@ in the `python` folder.
 
 - [Amazon SES Developer Guide](https://docs.aws.amazon.com/ses/latest/dg/Welcome.html)
 - [Amazon SES API Reference](https://docs.aws.amazon.com/ses/latest/APIReference/Welcome.html)
-- [SDK for Python Amazon SES reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html)
+- [SDK for Python (Boto3) Amazon SES reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/sesv2/README.md
+++ b/python/example_code/sesv2/README.md
@@ -1,4 +1,4 @@
-# Amazon SES v2 API code examples for the SDK for Python
+# Amazon SES v2 API code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -149,7 +149,7 @@ in the `python` folder.
 
 - [Amazon SES v2 API Developer Guide](https://docs.aws.amazon.com/ses/latest/dg/Welcome.html)
 - [Amazon SES v2 API API Reference](https://docs.aws.amazon.com/ses/latest/APIReference-V2/Welcome.html)
-- [SDK for Python Amazon SES v2 API reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sesv2.html)
+- [SDK for Python (Boto3) Amazon SES v2 API reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sesv2.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/sns/README.md
+++ b/python/example_code/sns/README.md
@@ -1,4 +1,4 @@
-# Amazon SNS code examples for the SDK for Python
+# Amazon SNS code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -202,7 +202,7 @@ in the `python` folder.
 
 - [Amazon SNS Developer Guide](https://docs.aws.amazon.com/sns/latest/dg/welcome.html)
 - [Amazon SNS API Reference](https://docs.aws.amazon.com/sns/latest/api/welcome.html)
-- [SDK for Python Amazon SNS reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html)
+- [SDK for Python (Boto3) Amazon SNS reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/sqs/README.md
+++ b/python/example_code/sqs/README.md
@@ -1,4 +1,4 @@
-# Amazon SQS code examples for the SDK for Python
+# Amazon SQS code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -191,7 +191,7 @@ in the `python` folder.
 
 - [Amazon SQS Developer Guide](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/welcome.html)
 - [Amazon SQS API Reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/Welcome.html)
-- [SDK for Python Amazon SQS reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html)
+- [SDK for Python (Boto3) Amazon SQS reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/ssm/README.md
+++ b/python/example_code/ssm/README.md
@@ -1,4 +1,4 @@
-# Systems Manager code examples for the SDK for Python
+# Systems Manager code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -125,7 +125,7 @@ in the `python` folder.
 
 - [Systems Manager User Guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/what-is-systems-manager.html)
 - [Systems Manager API Reference](https://docs.aws.amazon.com/systems-manager/latest/APIReference/Welcome.html)
-- [SDK for Python Systems Manager reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm.html)
+- [SDK for Python (Boto3) Systems Manager reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/sts/README.md
+++ b/python/example_code/sts/README.md
@@ -1,4 +1,4 @@
-# AWS STS code examples for the SDK for Python
+# AWS STS code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -146,7 +146,7 @@ in the `python` folder.
 
 - [AWS STS User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html)
 - [AWS STS API Reference](https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html)
-- [SDK for Python AWS STS reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts.html)
+- [SDK for Python (Boto3) AWS STS reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/support/README.md
+++ b/python/example_code/support/README.md
@@ -1,4 +1,4 @@
-# Support code examples for the SDK for Python
+# Support code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -124,7 +124,7 @@ in the `python` folder.
 
 - [Support User Guide](https://docs.aws.amazon.com/awssupport/latest/user/getting-started.html)
 - [Support API Reference](https://docs.aws.amazon.com/awssupport/latest/APIReference/welcome.html)
-- [SDK for Python Support reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/support.html)
+- [SDK for Python (Boto3) Support reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/support.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/textract/README.md
+++ b/python/example_code/textract/README.md
@@ -1,4 +1,4 @@
-# Amazon Textract code examples for the SDK for Python
+# Amazon Textract code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -107,7 +107,7 @@ in the `python` folder.
 
 - [Amazon Textract Developer Guide](https://docs.aws.amazon.com/textract/latest/dg/what-is.html)
 - [Amazon Textract API Reference](https://docs.aws.amazon.com/textract/latest/dg/API_Reference.html)
-- [SDK for Python Amazon Textract reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/textract.html)
+- [SDK for Python (Boto3) Amazon Textract reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/textract.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->

--- a/python/example_code/transcribe/README.md
+++ b/python/example_code/transcribe/README.md
@@ -1,4 +1,4 @@
-# Amazon Transcribe code examples for the SDK for Python
+# Amazon Transcribe code examples for the SDK for Python (Boto3)
 
 ## Overview
 
@@ -134,7 +134,7 @@ in the `python` folder.
 
 - [Amazon Transcribe Developer Guide](https://docs.aws.amazon.com/transcribe/latest/dg/what-is.html)
 - [Amazon Transcribe API Reference](https://docs.aws.amazon.com/transcribe/latest/APIReference/Welcome.html)
-- [SDK for Python Amazon Transcribe reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/transcribe.html)
+- [SDK for Python (Boto3) Amazon Transcribe reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/transcribe.html)
 
 <!--custom.resources.start-->
 <!--custom.resources.end-->


### PR DESCRIPTION
Use String.equals() instead of == to compare indexName in DocumentAPIGlobalSecondaryIndexExample. Comparing Strings with == checks reference identity, not value equality, which is a bug.

<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request...

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
