### PR TITLE
Improve PR review action: dedicated role, hardcoded KBs, better retrieval

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,6 +1,6 @@
 name: AI PR Review
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
   workflow_dispatch:
     inputs:
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
+          role-to-assume: ${{ secrets.AWS_PR_REVIEW_ROLE }}
           aws-region: us-west-2
 
       - name: Set up Python

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,67 @@
+name: AI PR Review
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review (for manual testing)'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  ai-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install boto3
+
+      - name: Get PR diff
+        id: diff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+        run: |
+          gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/files \
+            --paginate --jq '.[].patch // empty' > /tmp/pr_diff.txt
+          gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/files \
+            --paginate --jq '.[].filename' > /tmp/pr_files.txt
+
+      - name: Run AI Review
+        id: review
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          PR_TITLE: ${{ github.event.pull_request.title || 'Manual review' }}
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+        run: python .tools/scripts/pr_review.py
+
+      - name: Post review comment
+        if: steps.review.outputs.has_review == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+        run: |
+          gh pr comment ${PR_NUMBER} \
+            --repo ${{ github.repository }} \
+            --body-file /tmp/review_comment.md

--- a/.tools/scripts/pr_review.py
+++ b/.tools/scripts/pr_review.py
@@ -85,47 +85,38 @@ def detect_service(files):
 
 def retrieve_comparables(bedrock_agent_runtime, kb_id, language, service, diff_summary):
     """Retrieve comparable examples from the Knowledge Base."""
-    queries = [
-        ("service-specific", f"{service} example scenario in {language}"),
-        ("general pattern", f"premium example demonstrating best practices in {language}"),
-    ]
+    query = f"{service} example scenario in {language}"
 
     try:
+        response = bedrock_agent_runtime.retrieve(
+            knowledgeBaseId=kb_id,
+            retrievalQuery={"text": query},
+            retrievalConfiguration={
+                "vectorSearchConfiguration": {"numberOfResults": 10}
+            },
+        )
+
+        # Group chunks by source file and filter by relevance score
         MIN_SCORE = 0.3
         source_chunks = {}
-        source_labels = {}
-
-        for label, query in queries:
-            response = bedrock_agent_runtime.retrieve(
-                knowledgeBaseId=kb_id,
-                retrievalQuery={"text": query},
-                retrievalConfiguration={
-                    "vectorSearchConfiguration": {"numberOfResults": 10}
-                },
+        for result in response.get("retrievalResults", []):
+            score = result.get("score", 0)
+            source = (
+                result.get("location", {}).get("s3Location", {}).get("uri", "unknown")
             )
-
-            for result in response.get("retrievalResults", []):
-                score = result.get("score", 0)
-                source = (
-                    result.get("location", {}).get("s3Location", {}).get("uri", "unknown")
-                )
-                print(f"  KB result: score={score:.3f} source={source} query=\"{query}\"")
-                if score < MIN_SCORE:
-                    continue
-                content = result.get("content", {}).get("text", "")
-                if source not in source_chunks:
-                    source_chunks[source] = []
-                    source_labels[source] = label
-                # Avoid duplicate chunks from the same source
-                if content not in source_chunks[source]:
-                    source_chunks[source].append(content)
+            print(f"  KB result: score={score:.3f} source={source}")
+            if score < MIN_SCORE:
+                continue
+            content = result.get("content", {}).get("text", "")
+            if source not in source_chunks:
+                source_chunks[source] = []
+            source_chunks[source].append(content)
 
         # Concatenate chunks from the same source file
         results = []
         for source, chunks in source_chunks.items():
             combined = "\n\n".join(chunks)
-            label = source_labels.get(source, "reference")
-            results.append(f"### {label.title()} reference: {source}\n```\n{combined}\n```")
+            results.append(f"### Source: {source}\n```\n{combined}\n```")
 
         return "\n\n".join(results) if results else "No comparable examples found."
     except Exception as e:

--- a/.tools/scripts/pr_review.py
+++ b/.tools/scripts/pr_review.py
@@ -1,0 +1,267 @@
+Is this# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+AI-powered PR review script for aws-doc-sdk-examples.
+
+Retrieves comparable examples from Bedrock Knowledge Bases,
+then uses Claude to review the PR against quality criteria.
+"""
+
+import boto3
+import json
+import os
+import subprocess
+import sys
+
+REGION = "us-west-2"
+MODEL_ID = "anthropic.claude-sonnet-4-20250514-v1:0"
+
+# Map directory prefixes to language KB names
+LANGUAGE_MAP = {
+    "python": "python",
+    "javav2": "java",
+    "javascriptv3": "javascript",
+    "dotnetv4": "dotnet",
+    "rustv1": "rust",
+    "gov2": "go",
+    "swift": "swift",
+    "ruby": "ruby",
+    "php": "php",
+    "cpp": "cpp",
+    "kotlin": "kotlin",
+}
+
+REVIEW_CRITERIA = """
+You are reviewing a code example PR for the AWS SDK documentation repository.
+Evaluate the code against these criteria:
+
+1. **Tested**: Does the PR include test files? Do the tests appear to cover the scenario adequately?
+2. **Runnable**: Do imports resolve? Are dependencies declared? Is there anything obviously missing that would prevent execution?
+3. **Guidelines conformance**: Does the code follow AWS SDK example best practices?
+   - Clear comments explaining each step
+   - Proper error handling
+   - Resource cleanup
+   - Minimal hardcoded values
+   - Appropriate use of waiters/polling where needed
+4. **Quality relative to comparables**: How does this example compare to similar examples in other languages? Is it as clear, complete, and idiomatic?
+
+Be specific and actionable. Reference line numbers where possible.
+If the PR looks good overall, say so briefly — don't invent issues.
+Keep your review concise: no more than 10 points.
+"""
+
+
+def detect_language(files: list[str]) -> str | None:
+    """Detect the SDK language from PR file paths."""
+    for file_path in files:
+        for prefix, language in LANGUAGE_MAP.items():
+            if file_path.startswith(prefix + "/"):
+                return language
+    return None
+
+
+def detect_service(files: list[str]) -> str | None:
+    """Detect the AWS service from PR file paths."""
+    for file_path in files:
+        parts = file_path.split("/")
+        # Pattern: {sdk}/example_code/{service}/...
+        if len(parts) >= 3 and parts[1] == "example_code":
+            return parts[2]
+        # Pattern: {sdk}/scenarios/{service}/...
+        if len(parts) >= 3 and parts[1] == "scenarios":
+            return parts[2]
+    return None
+
+
+def get_kb_id(bedrock_agent, kb_name: str) -> str | None:
+    """Look up a Knowledge Base ID by name."""
+    try:
+        response = bedrock_agent.list_knowledge_bases()
+        for kb in response["knowledgeBaseSummaries"]:
+            if kb["name"] == kb_name:
+                return kb["knowledgeBaseId"]
+    except Exception as e:
+        print(f"Warning: Could not list knowledge bases: {e}")
+    return None
+
+
+def retrieve_comparables(
+    bedrock_agent_runtime, kb_id: str, language: str, service: str, diff_summary: str
+) -> str:
+    """Retrieve comparable examples from the Knowledge Base."""
+    query = f"{service} example scenario"
+    if language:
+        query += f" (looking for examples in languages other than {language})"
+
+    try:
+        response = bedrock_agent_runtime.retrieve(
+            knowledgeBaseId=kb_id,
+            retrievalQuery={"text": query},
+            retrievalConfiguration={
+                "vectorSearchConfiguration": {"numberOfResults": 5}
+            },
+        )
+        results = []
+        for result in response.get("retrievalResults", []):
+            content = result.get("content", {}).get("text", "")
+            source = result.get("location", {}).get("s3Location", {}).get("uri", "unknown")
+            results.append(f"### Source: {source}\n```\n{content[:2000]}\n```")
+
+        return "\n\n".join(results) if results else "No comparable examples found."
+    except Exception as e:
+        print(f"Warning: KB retrieval failed: {e}")
+        return "Could not retrieve comparable examples."
+
+
+def retrieve_guidelines(bedrock_agent_runtime, kb_id: str) -> str:
+    """Retrieve coding guidelines from the guidelines KB."""
+    try:
+        response = bedrock_agent_runtime.retrieve(
+            knowledgeBaseId=kb_id,
+            retrievalQuery={"text": "code example guidelines and standards"},
+            retrievalConfiguration={
+                "vectorSearchConfiguration": {"numberOfResults": 3}
+            },
+        )
+        results = []
+        for result in response.get("retrievalResults", []):
+            content = result.get("content", {}).get("text", "")
+            results.append(content[:1500])
+        return "\n\n".join(results) if results else ""
+    except Exception as e:
+        print(f"Warning: Guidelines retrieval failed: {e}")
+        return ""
+
+
+def invoke_claude(bedrock_runtime, diff: str, comparables: str, guidelines: str, pr_title: str, pr_body: str) -> str:
+    """Send the review request to Claude."""
+    user_message = f"""## PR: {pr_title}
+
+### PR Description
+{pr_body or "No description provided."}
+
+### Code Changes (diff)
+```diff
+{diff[:30000]}
+```
+
+### Comparable Examples from Other Languages
+{comparables}
+
+### Coding Guidelines
+{guidelines}
+"""
+
+    response = bedrock_runtime.invoke_model(
+        modelId=MODEL_ID,
+        body=json.dumps(
+            {
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 4096,
+                "system": REVIEW_CRITERIA,
+                "messages": [{"role": "user", "content": user_message}],
+            }
+        ),
+        contentType="application/json",
+    )
+
+    response_body = json.loads(response["body"].read())
+    return response_body["content"][0]["text"]
+
+
+def set_output(name: str, value: str):
+    """Set a GitHub Actions output variable."""
+    output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{name}={value}\n")
+
+
+def main():
+    # Read PR metadata
+    pr_title = os.environ.get("PR_TITLE", "")
+    pr_body = os.environ.get("PR_BODY", "")
+
+    # Read diff and file list
+    try:
+        with open("/tmp/pr_diff.txt", "r") as f:
+            diff = f.read()
+        with open("/tmp/pr_files.txt", "r") as f:
+            files = [line.strip() for line in f.readlines() if line.strip()]
+    except FileNotFoundError:
+        print("Error: PR diff files not found.")
+        set_output("has_review", "false")
+        sys.exit(0)
+
+    if not diff.strip():
+        print("No diff content found. Skipping review.")
+        set_output("has_review", "false")
+        sys.exit(0)
+
+    # Detect language and service
+    language = detect_language(files)
+    service = detect_service(files)
+
+    print(f"Detected language: {language}")
+    print(f"Detected service: {service}")
+
+    if not service:
+        print("Could not detect AWS service from file paths. Skipping review.")
+        set_output("has_review", "false")
+        sys.exit(0)
+
+    # Initialize Bedrock clients
+    bedrock_agent = boto3.client("bedrock-agent", region_name=REGION)
+    bedrock_agent_runtime = boto3.client("bedrock-agent-runtime", region_name=REGION)
+    bedrock_runtime = boto3.client("bedrock-runtime", region_name=REGION)
+
+    # Retrieve comparable examples
+    comparables = "No comparable examples found."
+    if language:
+        # Try language-specific KB first
+        kb_name = f"{language}-premium-KB"
+        kb_id = get_kb_id(bedrock_agent, kb_name)
+        if kb_id:
+            print(f"Retrieving comparables from {kb_name}...")
+            comparables = retrieve_comparables(
+                bedrock_agent_runtime, kb_id, language, service, diff[:1000]
+            )
+
+    # Retrieve guidelines
+    guidelines = ""
+    guidelines_kb_id = get_kb_id(bedrock_agent, "coding-standards-KB")
+    if guidelines_kb_id:
+        print("Retrieving coding guidelines...")
+        guidelines = retrieve_guidelines(bedrock_agent_runtime, guidelines_kb_id)
+
+    # Also try steering docs
+    steering_kb_id = get_kb_id(bedrock_agent, "steering-docs-KB")
+    if steering_kb_id:
+        print("Retrieving steering docs...")
+        steering = retrieve_guidelines(bedrock_agent_runtime, steering_kb_id)
+        if steering:
+            guidelines += "\n\n" + steering
+
+    # Invoke Claude for review
+    print("Generating AI review...")
+    review = invoke_claude(bedrock_runtime, diff, comparables, guidelines, pr_title, pr_body)
+
+    # Write review comment
+    comment = f"""## 🤖 AI Code Example Review
+
+{review}
+
+---
+<sub>This review was generated automatically using Amazon Bedrock. It compares your changes against existing examples and coding guidelines. Please use your judgment — this is advisory, not authoritative.</sub>
+"""
+
+    with open("/tmp/review_comment.md", "w") as f:
+        f.write(comment)
+
+    set_output("has_review", "true")
+    print("Review generated successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.tools/scripts/pr_review.py
+++ b/.tools/scripts/pr_review.py
@@ -1,4 +1,4 @@
-Is this# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -11,7 +11,6 @@ then uses Claude to review the PR against quality criteria.
 import boto3
 import json
 import os
-import subprocess
 import sys
 
 REGION = "us-west-2"
@@ -52,7 +51,7 @@ Keep your review concise: no more than 10 points.
 """
 
 
-def detect_language(files: list[str]) -> str | None:
+def detect_language(files):
     """Detect the SDK language from PR file paths."""
     for file_path in files:
         for prefix, language in LANGUAGE_MAP.items():
@@ -61,7 +60,7 @@ def detect_language(files: list[str]) -> str | None:
     return None
 
 
-def detect_service(files: list[str]) -> str | None:
+def detect_service(files):
     """Detect the AWS service from PR file paths."""
     for file_path in files:
         parts = file_path.split("/")
@@ -74,7 +73,7 @@ def detect_service(files: list[str]) -> str | None:
     return None
 
 
-def get_kb_id(bedrock_agent, kb_name: str) -> str | None:
+def get_kb_id(bedrock_agent, kb_name):
     """Look up a Knowledge Base ID by name."""
     try:
         response = bedrock_agent.list_knowledge_bases()
@@ -86,9 +85,7 @@ def get_kb_id(bedrock_agent, kb_name: str) -> str | None:
     return None
 
 
-def retrieve_comparables(
-    bedrock_agent_runtime, kb_id: str, language: str, service: str, diff_summary: str
-) -> str:
+def retrieve_comparables(bedrock_agent_runtime, kb_id, language, service, diff_summary):
     """Retrieve comparable examples from the Knowledge Base."""
     query = f"{service} example scenario"
     if language:
@@ -105,7 +102,9 @@ def retrieve_comparables(
         results = []
         for result in response.get("retrievalResults", []):
             content = result.get("content", {}).get("text", "")
-            source = result.get("location", {}).get("s3Location", {}).get("uri", "unknown")
+            source = (
+                result.get("location", {}).get("s3Location", {}).get("uri", "unknown")
+            )
             results.append(f"### Source: {source}\n```\n{content[:2000]}\n```")
 
         return "\n\n".join(results) if results else "No comparable examples found."
@@ -114,7 +113,7 @@ def retrieve_comparables(
         return "Could not retrieve comparable examples."
 
 
-def retrieve_guidelines(bedrock_agent_runtime, kb_id: str) -> str:
+def retrieve_guidelines(bedrock_agent_runtime, kb_id):
     """Retrieve coding guidelines from the guidelines KB."""
     try:
         response = bedrock_agent_runtime.retrieve(
@@ -134,7 +133,7 @@ def retrieve_guidelines(bedrock_agent_runtime, kb_id: str) -> str:
         return ""
 
 
-def invoke_claude(bedrock_runtime, diff: str, comparables: str, guidelines: str, pr_title: str, pr_body: str) -> str:
+def invoke_claude(bedrock_runtime, diff, comparables, guidelines, pr_title, pr_body):
     """Send the review request to Claude."""
     user_message = f"""## PR: {pr_title}
 
@@ -170,7 +169,7 @@ def invoke_claude(bedrock_runtime, diff: str, comparables: str, guidelines: str,
     return response_body["content"][0]["text"]
 
 
-def set_output(name: str, value: str):
+def set_output(name, value):
     """Set a GitHub Actions output variable."""
     output_file = os.environ.get("GITHUB_OUTPUT", "")
     if output_file:
@@ -245,7 +244,9 @@ def main():
 
     # Invoke Claude for review
     print("Generating AI review...")
-    review = invoke_claude(bedrock_runtime, diff, comparables, guidelines, pr_title, pr_body)
+    review = invoke_claude(
+        bedrock_runtime, diff, comparables, guidelines, pr_title, pr_body
+    )
 
     # Write review comment
     comment = f"""## 🤖 AI Code Example Review

--- a/.tools/scripts/pr_review.py
+++ b/.tools/scripts/pr_review.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 REGION = "us-west-2"
-MODEL_ID = "anthropic.claude-sonnet-4-20250514-v1:0"
+MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
 # Map directory prefixes to language KB names
 LANGUAGE_MAP = {

--- a/.tools/scripts/pr_review.py
+++ b/.tools/scripts/pr_review.py
@@ -14,9 +14,10 @@ import os
 import sys
 
 REGION = "us-west-2"
-MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
-# Map directory prefixes to language KB names
+MODEL_ID = "us.anthropic.claude-sonnet-4-6"
+
+# Map directory prefixes to language identifiers
 LANGUAGE_MAP = {
     "python": "python",
     "javav2": "java",
@@ -31,6 +32,15 @@ LANGUAGE_MAP = {
     "kotlin": "kotlin",
 }
 
+# Bedrock Knowledge Base IDs (account 415879937535, us-west-2)
+LANGUAGE_KB_IDS = {
+    "python": "VJYPXZTSXT",
+    "java": "64P3VU9OAD",
+    "dotnet": "CRSPSCYZIX",
+}
+CODING_STANDARDS_KB_ID = "Q2ZUWJJOIN"
+STEERING_DOCS_KB_ID = "63A2M1LZ2E"
+
 REVIEW_CRITERIA = """
 You are reviewing a code example PR for the AWS SDK documentation repository.
 Evaluate the code against these criteria:
@@ -43,7 +53,7 @@ Evaluate the code against these criteria:
    - Resource cleanup
    - Minimal hardcoded values
    - Appropriate use of waiters/polling where needed
-4. **Quality relative to comparables**: How does this example compare to similar examples in other languages? Is it as clear, complete, and idiomatic?
+4. **Quality relative to comparables**: How does this example compare to the premium reference examples for this language? Does it follow the same structure, patterns, and idioms?
 
 Be specific and actionable. Reference line numbers where possible.
 If the PR looks good overall, say so briefly — don't invent issues.
@@ -73,39 +83,49 @@ def detect_service(files):
     return None
 
 
-def get_kb_id(bedrock_agent, kb_name):
-    """Look up a Knowledge Base ID by name."""
-    try:
-        response = bedrock_agent.list_knowledge_bases()
-        for kb in response["knowledgeBaseSummaries"]:
-            if kb["name"] == kb_name:
-                return kb["knowledgeBaseId"]
-    except Exception as e:
-        print(f"Warning: Could not list knowledge bases: {e}")
-    return None
-
-
 def retrieve_comparables(bedrock_agent_runtime, kb_id, language, service, diff_summary):
     """Retrieve comparable examples from the Knowledge Base."""
-    query = f"{service} example scenario"
-    if language:
-        query += f" (looking for examples in languages other than {language})"
+    queries = [
+        ("service-specific", f"{service} example scenario in {language}"),
+        ("general pattern", f"premium example demonstrating best practices in {language}"),
+    ]
 
     try:
-        response = bedrock_agent_runtime.retrieve(
-            knowledgeBaseId=kb_id,
-            retrievalQuery={"text": query},
-            retrievalConfiguration={
-                "vectorSearchConfiguration": {"numberOfResults": 5}
-            },
-        )
-        results = []
-        for result in response.get("retrievalResults", []):
-            content = result.get("content", {}).get("text", "")
-            source = (
-                result.get("location", {}).get("s3Location", {}).get("uri", "unknown")
+        MIN_SCORE = 0.3
+        source_chunks = {}
+        source_labels = {}
+
+        for label, query in queries:
+            response = bedrock_agent_runtime.retrieve(
+                knowledgeBaseId=kb_id,
+                retrievalQuery={"text": query},
+                retrievalConfiguration={
+                    "vectorSearchConfiguration": {"numberOfResults": 10}
+                },
             )
-            results.append(f"### Source: {source}\n```\n{content[:2000]}\n```")
+
+            for result in response.get("retrievalResults", []):
+                score = result.get("score", 0)
+                source = (
+                    result.get("location", {}).get("s3Location", {}).get("uri", "unknown")
+                )
+                print(f"  KB result: score={score:.3f} source={source} query=\"{query}\"")
+                if score < MIN_SCORE:
+                    continue
+                content = result.get("content", {}).get("text", "")
+                if source not in source_chunks:
+                    source_chunks[source] = []
+                    source_labels[source] = label
+                # Avoid duplicate chunks from the same source
+                if content not in source_chunks[source]:
+                    source_chunks[source].append(content)
+
+        # Concatenate chunks from the same source file
+        results = []
+        for source, chunks in source_chunks.items():
+            combined = "\n\n".join(chunks)
+            label = source_labels.get(source, "reference")
+            results.append(f"### {label.title()} reference: {source}\n```\n{combined}\n```")
 
         return "\n\n".join(results) if results else "No comparable examples found."
     except Exception as e:
@@ -211,34 +231,29 @@ def main():
         sys.exit(0)
 
     # Initialize Bedrock clients
-    bedrock_agent = boto3.client("bedrock-agent", region_name=REGION)
     bedrock_agent_runtime = boto3.client("bedrock-agent-runtime", region_name=REGION)
     bedrock_runtime = boto3.client("bedrock-runtime", region_name=REGION)
 
     # Retrieve comparable examples
     comparables = "No comparable examples found."
     if language:
-        # Try language-specific KB first
-        kb_name = f"{language}-premium-KB"
-        kb_id = get_kb_id(bedrock_agent, kb_name)
+        kb_id = LANGUAGE_KB_IDS.get(language)
         if kb_id:
-            print(f"Retrieving comparables from {kb_name}...")
+            print(f"Retrieving comparables from {language} KB ({kb_id})...")
             comparables = retrieve_comparables(
                 bedrock_agent_runtime, kb_id, language, service, diff[:1000]
             )
 
     # Retrieve guidelines
     guidelines = ""
-    guidelines_kb_id = get_kb_id(bedrock_agent, "coding-standards-KB")
-    if guidelines_kb_id:
+    if CODING_STANDARDS_KB_ID:
         print("Retrieving coding guidelines...")
-        guidelines = retrieve_guidelines(bedrock_agent_runtime, guidelines_kb_id)
+        guidelines = retrieve_guidelines(bedrock_agent_runtime, CODING_STANDARDS_KB_ID)
 
     # Also try steering docs
-    steering_kb_id = get_kb_id(bedrock_agent, "steering-docs-KB")
-    if steering_kb_id:
+    if STEERING_DOCS_KB_ID:
         print("Retrieving steering docs...")
-        steering = retrieve_guidelines(bedrock_agent_runtime, steering_kb_id)
+        steering = retrieve_guidelines(bedrock_agent_runtime, STEERING_DOCS_KB_ID)
         if steering:
             guidelines += "\n\n" + steering
 


### PR DESCRIPTION
Migrates the PR review workflow to a dedicated IAM role in internal production account and improves the KB retrieval logic.

 Changes
  
  Infrastructure:
  
  - New AWS_PR_REVIEW_ROLE secret (least-privilege, only Bedrock permissions)
  - Separates PR review auth from sync/updater workflows
  
  Script improvements:
  
  - Hardcoded KB IDs instead of ListKnowledgeBases lookup on every run (faster, more reliable)
  - Updated to active Claude Sonnet 4 model (us.anthropic.claude-sonnet-4-6)
  - Dual-query retrieval: service-specific + general best-practice patterns
  - Chunks grouped by source file with deduplication (more coherent context for Claude)
  - Relevance score filtering (drops low-quality matches) with logging for calibration
  - Results labeled as service-specific vs general pattern to reduce Claude confusion
  
  Testing
  
  - IAM role, OIDC provider, and policy created in internal production account
  - KB IDs verified against existing Bedrock Knowledge Bases
  - Model availability confirmed (auto-enabled in commercial regions)

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
