### PR TITLE
    Migrate sync-S3-KB and KB_Updater workflows to new account

### DIFF
--- a/.github/workflows/KB_Updater.yml
+++ b/.github/workflows/KB_Updater.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
+          role-to-assume: ${{ secrets.AWS_SYNC_ROLE }}
           aws-region: us-west-2
 
       - name: Deploy Lambda

--- a/.github/workflows/sync-S3-KB.yml
+++ b/.github/workflows/sync-S3-KB.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5 
         with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}     # once merged, update trust policy of the role to point to main branch
+          role-to-assume: ${{ secrets.AWS_SYNC_ROLE }}
           aws-region: us-west-2
 
       - name: Set SDK and language mapping for S3
@@ -134,7 +134,7 @@ jobs:
         run: |
           for level in "basics" "feature-scenario" "complex-feature-scenario"; do
             if [ -d "./extracted_snippets/$level" ]; then
-              aws s3 sync "./extracted_snippets/$level/" "s3://$S3_LANGUAGE-premium-bucket/$level/" --delete
+              aws s3 sync "./extracted_snippets/$level/" "s3://codeloom-$S3_LANGUAGE-premium-codeloomdev/$level/" --delete
               echo "Uploaded $level examples to S3"
             fi
           done
@@ -143,11 +143,11 @@ jobs:
         if: ${{ contains(fromJSON('["steering_docs","coding-standards","specs"]'), github.event.inputs.sdk_name) }}
         run: |
           if [ "$sdk_name" == "steering_docs" ]; then
-            aws s3 sync "./$sdk_name/" "s3://$S3_LANGUAGE-bucket/" --delete
+            aws s3 sync "./$sdk_name/" "s3://codeloom-$S3_LANGUAGE-codeloomdev/" --delete
           elif [ "$sdk_name" == "coding-standards" ]; then
-            aws s3 sync "./filtered-wiki/" "s3://$S3_LANGUAGE-bucket/" --delete
+            aws s3 sync "./filtered-wiki/" "s3://codeloom-$S3_LANGUAGE-codeloomdev/" --delete
           else
-            aws s3 sync "./filtered_specs/" "s3://$S3_LANGUAGE-bucket/" --delete
+            aws s3 sync "./filtered_specs/" "s3://codeloom-$S3_LANGUAGE-codeloomdev/" --delete
           fi
 
       - name: Sync Knowledge Base Data Source

--- a/.tools/lambda/KB_Updater/lambda_function.py
+++ b/.tools/lambda/KB_Updater/lambda_function.py
@@ -12,12 +12,15 @@ class DateTimeEncoder(json.JSONEncoder):
             return obj.isoformat()
         return super().default(obj)
 
-def get_knowledge_base_id(knowledge_base_name, region_name, bedrock_agent):
-    response = bedrock_agent.list_knowledge_bases()
-    for kb in response['knowledgeBaseSummaries']:
-        if kb['name'] == knowledge_base_name:
-            return kb['knowledgeBaseId']
-    raise ValueError(f"Knowledge base '{knowledge_base_name}' not found")
+# Bedrock Knowledge Base IDs (account 415879937535, us-west-2)
+KB_IDS = {
+    "python": "VJYPXZTSXT",
+    "java": "64P3VU9OAD",
+    "dotnet": "CRSPSCYZIX",
+    "coding-standards": "Q2ZUWJJOIN",
+    "steering-docs": "63A2M1LZ2E",
+    "final-specs": "3KVUHEFDHK",
+}
 
 def get_or_create_data_source(knowledge_base_id, language, region_name, bedrock_agent):
     # List existing data sources
@@ -30,10 +33,10 @@ def get_or_create_data_source(knowledge_base_id, language, region_name, bedrock_
             return ds['dataSourceId'], ds['name'], False  # Found existing
     if language in ["steering-docs", "final-specs"]:
         ds_name=f"{language}-data-source"
-        bucket_name = f"{language}-bucket"
+        bucket_name = f"codeloom-{language}-codeloomdev"
     else:
         ds_name=f"{language}-premium-data-source"
-        bucket_name = f"{language}-premium-bucket"
+        bucket_name = f"codeloom-{language}-premium-codeloomdev"
     # Create new data source if none found
     response = bedrock_agent.create_data_source(
         knowledgeBaseId=knowledge_base_id,
@@ -95,14 +98,17 @@ def monitor_ingestion_job(knowledge_base_id, data_source_id, ingestion_job_id, r
 def lambda_handler(event, context):
     language = event.get('language', 'python')
     region_name = event.get('region_name', 'us-west-2')
-    if language in ["steering-docs", "final-specs","coding-standards"]:
-        knowledge_base_name = f"{language}-KB"
-    else:
-        knowledge_base_name = f"{language}-premium-KB"
-    
+
+    # Look up KB ID from hardcoded mapping
+    kb_key = language if language in ["steering-docs", "final-specs", "coding-standards"] else language
+    knowledge_base_id = KB_IDS.get(kb_key)
+    if not knowledge_base_id:
+        return {
+            'statusCode': 400,
+            'body': json.dumps({"error": f"No Knowledge Base configured for language: {language}"})
+        }
+
     bedrock_agent = boto3.client('bedrock-agent', region_name=region_name)
-    
-    knowledge_base_id = get_knowledge_base_id(knowledge_base_name, region_name, bedrock_agent)
     
     # Get or create data source
     data_source_id, data_source_name, is_new = get_or_create_data_source(


### PR DESCRIPTION
Migrates the S3 sync and KB_Updater workflows from the shared AWS_ASSUME_ROLE to a dedicated AWS_SYNC_ROLE with least-privilege permissions.
  
**Changes**
  
  - sync-S3-KB.yml — uses AWS_SYNC_ROLE, updated S3 bucket names to codeloom-{language}-premium-codeloomdev convention
  - KB_Updater.yml — uses AWS_SYNC_ROLE
  - KB_Updater/lambda_function.py — hardcoded KB IDs (removes ListKnowledgeBases call), updated bucket naming
  
 ** Infrastructure**
  
  New resources in the target account:
  
  - 8 S3 buckets for languages not previously provisioned
  - KB_Updater Lambda (already deployed with updated code)
  - GitHubSyncKB IAM policy (S3 sync + Lambda invoke/deploy)
  - GitHubSyncKBRole (OIDC trust scoped to main branch only)
  
  **Notes**
  
  - The old AWS_ASSUME_ROLE secret is no longer referenced by any workflow after this merges
  - OIDC trust is restricted to ref:refs/heads/main since both workflows only trigger on push to main

This pull request...

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
