### PR TITLE
Add S3 basics to Python premium examples KB

### DIFF
--- a/python/premium-ex.md
+++ b/python/premium-ex.md
@@ -3,6 +3,7 @@
 
 ## basics:
 /example_code/controltower
+/example_code/s3/s3_basics
 
 ## feature-scenario:
 /example_code/s3/scenarios/conditional_requests


### PR DESCRIPTION
Adds /example_code/s3/s3_basics to the Python premium examples list. This will include the S3 basics scenario (bucket operations, object operations, presigned URLs) in the Python KB, giving the AI PR reviewer more reference material for S3-related PRs.
The actions to update the KBs have been updated, and this PR is for testing they work. It will be reverted once we establish that the actions work as intended.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
