### PR TITLE
Restrict AI PR Review to example code paths only

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,6 +2,9 @@ name: AI PR Review
 on:
   pull_request_target:
     types: [opened, synchronize]
+    paths:
+      - '*/example_code/**'
+      - '*/scenarios/**'
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
Add paths filter so the workflow only triggers on PRs that touch files under */example_code/** or */scenarios/**. This avoids unnecessary workflow runs on dependency bumps, CI changes, and documentation updates where there's no example code to review.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
