### PR TITLE
Restrict AI PR Review to example code paths only

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,6 +2,27 @@ name: AI PR Review
 on:
   pull_request_target:
     types: [opened, synchronize]
+    paths:
+      - 'python/example_code/**'
+      - 'python/cross_service/**'
+      - 'javav2/example_code/**'
+      - 'javav2/usecases/**'
+      - 'javascriptv3/example_code/**'
+      - 'dotnetv3/**'
+      - 'dotnetv4/**'
+      - 'rustv1/examples/**'
+      - 'rustv1/cross_service/**'
+      - 'gov2/**'
+      - 'swift/example_code/**'
+      - 'ruby/example_code/**'
+      - 'ruby/cross_service_examples/**'
+      - 'php/example_code/**'
+      - 'php/cross_service/**'
+      - 'cpp/example_code/**'
+      - 'kotlin/services/**'
+      - 'kotlin/usecases/**'
+      - 'scenarios/**'
+      - 'aws-cli/**'
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
Add paths filter so the workflow only triggers on PRs that touch files under */example_code/** or */scenarios/**. This avoids unnecessary workflow runs on dependency bumps, CI changes, and documentation updates where there's no example code to review.


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
