### PR TITLE
PHP: Modernize Bedrock Runtime example models

### DIFF
--- a/.doc_gen/metadata/bedrock-runtime_metadata.yaml
+++ b/.doc_gen/metadata/bedrock-runtime_metadata.yaml
@@ -703,7 +703,7 @@ bedrock-runtime_InvokeModel_AnthropicClaude:
         - sdk_version: 3
           github: php/example_code/bedrock-runtime
           excerpts:
-            - description: Invoke the Anthropic Claude 2 foundation model to generate text.
+            - description: Use the Invoke Model API to send a text message.
               snippet_tags:
                 - php.example_code.bedrock-runtime.service.invokeClaude
     SAP ABAP:
@@ -1116,21 +1116,13 @@ bedrock-runtime_InvokeModel_TitanImageGenerator:
               snippet_tags:
                 - gov2.bedrock-runtime.InvokeModelWrapper.struct
                 - gov2.bedrock-runtime.InvokeTitanImage
-    PHP:
-      versions:
-        - sdk_version: 3
-          github: php/example_code/bedrock-runtime
-          excerpts:
-            - description: Create an image with the Amazon Titan Image Generator.
-              snippet_tags:
-                - php.example_code.bedrock-runtime.service.invokeTitanImage
   services:
     bedrock-runtime: {InvokeModel}
 
 bedrock-runtime_InvokeModel_StableDiffusion:
-  title: Invoke Stability.ai Stable Diffusion XL on &BR; to generate an image
+  title: Invoke Stability.ai Stable Diffusion on &BR; to generate an image
   title_abbrev: "InvokeModel"
-  synopsis: invoke Stability.ai Stable Diffusion XL on &BR; to generate an image.
+  synopsis: invoke Stability.ai Stable Diffusion on &BR; to generate an image.
   category: Stable Diffusion
   languages:
     Java:

--- a/php/example_code/aws_utilities/AWSServiceClass.php
+++ b/php/example_code/aws_utilities/AWSServiceClass.php
@@ -59,8 +59,8 @@ abstract class AWSServiceClass
      */
     public function createRole(
         string $roleName,
-        string $rolePolicyDocument = null,
-        array $clientArgs = null,
+        ?string $rolePolicyDocument = null,
+        ?array $clientArgs = null,
         bool $verbose = false
     ): string {
         $clientArgs = $clientArgs ?: [

--- a/php/example_code/bedrock-runtime/BedrockRuntimeService.php
+++ b/php/example_code/bedrock-runtime/BedrockRuntimeService.php
@@ -11,13 +11,15 @@ use Exception;
 
 class BedrockRuntimeService extends AWSServiceClass
 {
-    public function __construct(BedrockRuntimeClient $client = null)
+    protected BedrockRuntimeClient $bedrockRuntimeClient;
+
+    public function __construct(?BedrockRuntimeClient $client = null)
     {
         if ($client) {
             $this->bedrockRuntimeClient = $client;
         } else {
             $this->bedrockRuntimeClient = new BedrockRuntimeClient([
-                'region' => 'us-east-1',
+                'region' => 'us-west-2',
                 'profile' => 'default'
             ]);
         }
@@ -37,7 +39,7 @@ class BedrockRuntimeService extends AWSServiceClass
 
         $completion = "";
         try {
-            $modelId = 'anthropic.claude-3-haiku-20240307-v1:0';
+            $modelId = 'global.anthropic.claude-haiku-4-5-20251001-v1:0';
         // Claude requires you to enclose the prompt as follows:
             $body = [
                 'anthropic_version' => 'bedrock-2023-05-31',
@@ -64,69 +66,25 @@ class BedrockRuntimeService extends AWSServiceClass
     // snippet-end:[php.example_code.bedrock-runtime.service.invokeClaude]
 
     // snippet-start:[php.example_code.bedrock-runtime.service.invokeStableDiffusion]
-    public function invokeStableDiffusion(string $prompt, int $seed, string $style_preset)
+    public function invokeStableDiffusion(string $prompt, int $seed = 0, string $aspect_ratio = '1:1')
     {
         // The different model providers have individual request and response formats.
-        // For the format, ranges, and available style_presets of Stable Diffusion models refer to:
+        // For the format, ranges, and available parameters of Stable Diffusion models refer to:
         // https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-stability-diffusion.html
 
         $base64_image_data = "";
         try {
-            $modelId = 'stability.stable-diffusion-xl-v1';
+            $modelId = 'stability.stable-image-core-v1:1';
             $body = [
-                'text_prompts' => [
-                    ['text' => $prompt]
-                ],
+                'prompt' => $prompt,
+                'aspect_ratio' => $aspect_ratio,
                 'seed' => $seed,
-                'cfg_scale' => 10,
-                'steps' => 30
+                'output_format' => 'png',
             ];
-            if ($style_preset) {
-                $body['style_preset'] = $style_preset;
-            }
 
             $result = $this->bedrockRuntimeClient->invokeModel([
                 'contentType' => 'application/json',
                 'body' => json_encode($body),
-                'modelId' => $modelId,
-            ]);
-            $response_body = json_decode($result['body']);
-            $base64_image_data = $response_body->artifacts[0]->base64;
-        } catch (Exception $e) {
-            echo "Error: ({$e->getCode()}) - {$e->getMessage()}\n";
-        }
-
-        return $base64_image_data;
-    }
-    // snippet-end:[php.example_code.bedrock-runtime.service.invokeStableDiffusion]
-
-    // snippet-start:[php.example_code.bedrock-runtime.service.invokeTitanImage]
-    public function invokeTitanImage(string $prompt, int $seed)
-    {
-        // The different model providers have individual request and response formats.
-        // For the format, ranges, and default values for Titan Image models refer to:
-        // https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-image.html
-
-        $base64_image_data = "";
-        try {
-            $modelId = 'amazon.titan-image-generator-v2:0';
-            $request = json_encode([
-                'taskType' => 'TEXT_IMAGE',
-                'textToImageParams' => [
-                    'text' => $prompt
-                ],
-                'imageGenerationConfig' => [
-                    'numberOfImages' => 1,
-                    'quality' => 'standard',
-                    'cfgScale' => 8.0,
-                    'height' => 512,
-                    'width' => 512,
-                    'seed' => $seed
-                ]
-            ]);
-            $result = $this->bedrockRuntimeClient->invokeModel([
-                'contentType' => 'application/json',
-                'body' => $request,
                 'modelId' => $modelId,
             ]);
             $response_body = json_decode($result['body']);
@@ -137,6 +95,6 @@ class BedrockRuntimeService extends AWSServiceClass
 
         return $base64_image_data;
     }
-    // snippet-end:[php.example_code.bedrock-runtime.service.invokeTitanImage]
+    // snippet-end:[php.example_code.bedrock-runtime.service.invokeStableDiffusion]
 }
 // snippet-end:[php.example_code.bedrock-runtime.service]

--- a/php/example_code/bedrock-runtime/GettingStartedWithBedrockRuntime.php
+++ b/php/example_code/bedrock-runtime/GettingStartedWithBedrockRuntime.php
@@ -28,16 +28,10 @@ class GettingStartedWithBedrockRuntime
         echo "\n---------------------------------------------------------------------\n";
         $image_prompt = 'stylized picture of a cute old steampunk robot';
         echo "\nImage prompt: " . $image_prompt;
-        echo "\n\nStability.ai Stable Diffusion XL:\n";
+        echo "\n\nStability.ai Stable Image Core:\n";
         $diffusionSeed = rand(0, 4294967295);
-        $style_preset = 'photographic';
-        $base64 = $bedrockRuntimeService->invokeStableDiffusion($image_prompt, $diffusionSeed, $style_preset);
-        $image_path = $this->saveImage($base64, 'stability.stable-diffusion-xl');
-        echo "The generated image has been saved to $image_path";
-        echo "\n\nAmazon Titan Image Generation:\n";
-        $titanSeed = rand(0, 2147483647);
-        $base64 = $bedrockRuntimeService->invokeTitanImage($image_prompt, $titanSeed);
-        $image_path = $this->saveImage($base64, 'amazon.titan-image-generator-v2');
+        $base64 = $bedrockRuntimeService->invokeStableDiffusion($image_prompt, $diffusionSeed);
+        $image_path = $this->saveImage($base64, 'stability.stable-image-core');
         echo "The generated image has been saved to $image_path";
     }
 

--- a/php/example_code/bedrock-runtime/README.md
+++ b/php/example_code/bedrock-runtime/README.md
@@ -46,17 +46,13 @@ functions within the same service.
 
 - [Converse](Models/AmazonNova/Text/Converse.php#L9)
 
-### Amazon Titan Image Generator
-
-- [InvokeModel](BedrockRuntimeService.php#L103)
-
 ### Anthropic Claude
 
-- [InvokeModel](BedrockRuntimeService.php#L31)
+- [InvokeModel](BedrockRuntimeService.php#L33)
 
 ### Stable Diffusion
 
-- [InvokeModel](BedrockRuntimeService.php#L66)
+- [InvokeModel](BedrockRuntimeService.php#L68)
 
 
 <!--custom.examples.start-->

--- a/php/example_code/bedrock-runtime/composer.json
+++ b/php/example_code/bedrock-runtime/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
-        "aws/aws-sdk-php": "^3.343",
+        "php": "^8.5",
+        "aws/aws-sdk-php": "^3.388",
         "guzzlehttp/guzzle": "^7.9.2"
     },
     "autoload": {

--- a/php/example_code/bedrock-runtime/composer.lock
+++ b/php/example_code/bedrock-runtime/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f11b6cff262e6d51913b7a1931fede96",
+    "content-hash": "be667c3ba3edded1bfc8a0767fde2eaf",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.368.0",
+            "version": "3.388.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "c1189f8e4ba3268d6306e515f6f65611c671d033"
+                "reference": "b89b2b0e0741900c9e25d12302ed8300fa50f22b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c1189f8e4ba3268d6306e515f6f65611c671d033",
-                "reference": "c1189f8e4ba3268d6306e515f6f65611c671d033",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b89b2b0e0741900c9e25d12302ed8300fa50f22b",
+                "reference": "b89b2b0e0741900c9e25d12302ed8300fa50f22b",
                 "shasum": ""
             },
             "require": {
@@ -82,22 +82,22 @@
                 "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/promises": "^2.0",
                 "guzzlehttp/psr7": "^2.4.5",
-                "mtdowling/jmespath.php": "^2.8.0",
+                "mtdowling/jmespath.php": "^2.9.1",
                 "php": ">=8.1",
                 "psr/http-message": "^1.0 || ^2.0",
-                "symfony/filesystem": "^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
             },
             "require-dev": {
                 "andrewsville/php-token-reflection": "^1.4",
                 "aws/aws-php-sns-message-validator": "~1.0",
                 "behat/behat": "~3.0",
                 "composer/composer": "^2.7.8",
-                "dms/phpunit-arraysubset-asserts": "^0.4.0",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-openssl": "*",
                 "ext-sockets": "*",
-                "phpunit/phpunit": "^9.6",
+                "phpunit/phpunit": "^10.0",
                 "psr/cache": "^2.0 || ^3.0",
                 "psr/simple-cache": "^2.0 || ^3.0",
                 "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
@@ -135,11 +135,11 @@
             "authors": [
                 {
                     "name": "Amazon Web Services",
-                    "homepage": "http://aws.amazon.com"
+                    "homepage": "https://aws.amazon.com"
                 }
             ],
             "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
-            "homepage": "http://aws.amazon.com/sdkforphp",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
             "keywords": [
                 "amazon",
                 "aws",
@@ -153,31 +153,32 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.368.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.388.6"
             },
-            "time": "2025-12-16T20:11:32+00:00"
+            "time": "2026-07-14T18:07:03+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "fa88c57803501ad0770f5cddb1e60525d49da9a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/fa88c57803501ad0770f5cddb1e60525d49da9a1",
+                "reference": "fa88c57803501ad0770f5cddb1e60525d49da9a1",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.12.5",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -185,9 +186,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -265,7 +267,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.14.2"
             },
             "funding": [
                 {
@@ -281,28 +283,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-07-14T18:15:01+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -348,7 +351,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -364,27 +367,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9365d578a9fd1552ad6ca9c3cb530708526feb09",
+                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -392,8 +397,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -464,7 +470,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.5"
             },
             "funding": [
                 {
@@ -480,20 +486,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-07-13T01:27:20+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
-            "version": "2.8.0",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
                 "shasum": ""
             },
             "require": {
@@ -502,7 +508,7 @@
             },
             "require-dev": {
                 "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.33"
+                "phpunit/phpunit": "^8.5.52"
             },
             "bin": [
                 "bin/jp.php"
@@ -510,7 +516,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "2.9-dev"
                 }
             },
             "autoload": {
@@ -544,9 +550,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
             },
-            "time": "2024-09-04T18:46:31+00:00"
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "psr/http-client",
@@ -754,16 +760,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -776,7 +782,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -801,7 +807,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -813,28 +819,33 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v8.0.1",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d937d400b980523dc9ee946bb69972b5e619058d"
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d937d400b980523dc9ee946bb69972b5e619058d",
-                "reference": "d937d400b980523dc9ee946bb69972b5e619058d",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -867,7 +878,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.0.1"
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -887,20 +898,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-01T09:13:36+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -950,7 +961,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -970,20 +981,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -1035,7 +1046,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -1055,7 +1066,91 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
         }
     ],
     "packages-dev": [],
@@ -1064,7 +1159,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": "^8.5"
+    },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/php/example_code/bedrock-runtime/tests/BedrockRuntimeTests.php
+++ b/php/example_code/bedrock-runtime/tests/BedrockRuntimeTests.php
@@ -28,7 +28,7 @@ class BedrockRuntimeTests extends TestCase
     {
         $service = new BedrockRuntimeService();
         self::assertNotNull($service->getClient());
-        self::assertEquals('us-east-1', $service->getClient()->getRegion());
+        self::assertEquals('us-west-2', $service->getClient()->getRegion());
     }
 
     public function test_constructor_uses_injected_client()
@@ -50,15 +50,7 @@ class BedrockRuntimeTests extends TestCase
     public function test_stable_diffusion_can_be_invoked()
     {
         $seed = 0;
-        $style_preset = "photographic";
-        $base64_image_data = $this->bedrockRuntimeService->invokeStableDiffusion($this->prompt, $seed, $style_preset);
-        self::assertNotEmpty($base64_image_data);
-    }
-
-    public function test_titan_image_can_be_invoked()
-    {
-        $seed = 0;
-        $base64_image_data = $this->bedrockRuntimeService->invokeTitanImage($this->prompt, $seed);
+        $base64_image_data = $this->bedrockRuntimeService->invokeStableDiffusion($this->prompt, $seed);
         self::assertNotEmpty($base64_image_data);
     }
 }


### PR DESCRIPTION
Updates the PHP Bedrock Runtime example to current, non-deprecated models.

- Stable Diffusion XL -> Stable Image Core (`stability.stable-image-core-v1:1`)
- Claude -> Claude Haiku 4.5 via the `global.` inference profile
- Default Region set to `us-west-2` where the models are available
- Removed `invokeTitanImage` (Titan Image v2 reached end of life)
- PHP 8.5 compatibility fixes; pinned `php ^8.5` / `aws-sdk-php ^3.388`
- Regenerated README and updated metadata

Verified: phpcs, yamllint, doc-metadata validation, and WRITEME `--check` all pass. Integration tests pass against live Bedrock.