### PR TITLE
Bedrock Runtime: modernize Stability AI examples to Stable Image Core (Python, Java v2, SAP ABAP)

### DIFF
--- a/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/models/stabilityAi/InvokeModel.java
+++ b/javav2/example_code/bedrock-runtime/src/main/java/com/example/bedrockruntime/models/stabilityAi/InvokeModel.java
@@ -27,11 +27,11 @@ public class InvokeModel {
         // Replace the DefaultCredentialsProvider with your preferred credentials provider.
         var client = BedrockRuntimeClient.builder()
                 .credentialsProvider(DefaultCredentialsProvider.create())
-                .region(Region.US_EAST_1)
+                .region(Region.US_WEST_2)
                 .build();
 
         // Set the model ID, e.g., Stable Image Core.
-        var modelId = "stability.stable-image-core-v1:0";
+        var modelId = "stability.stable-image-core-v1:1";
 
         // The InvokeModel API uses the model's native payload.
         // Learn more about the available inference parameters and response fields at:
@@ -39,7 +39,9 @@ public class InvokeModel {
         var nativeRequestTemplate = """
                 {
                     "prompt": "{{prompt}}",
-                    "seed": {{seed}}
+                    "aspect_ratio": "1:1",
+                    "seed": {{seed}},
+                    "output_format": "png"
                 }""";
 
         // Define the prompt for the image generation.

--- a/python/example_code/bedrock-runtime/models/stability_ai/invoke_model.py
+++ b/python/example_code/bedrock-runtime/models/stability_ai/invoke_model.py
@@ -11,10 +11,10 @@ import os
 import random
 
 # Create a Bedrock Runtime client in the AWS Region of your choice.
-client = boto3.client("bedrock-runtime", region_name="us-east-1")
+client = boto3.client("bedrock-runtime", region_name="us-west-2")
 
-# Set the model ID, e.g., Stable Diffusion XL 1.
-model_id = "stability.stable-diffusion-xl-v1"
+# Set the model ID, e.g., Stable Image Core.
+model_id = "stability.stable-image-core-v1:1"
 
 # Define the image generation prompt for the model.
 prompt = "A stylized picture of a cute old steampunk robot."
@@ -24,11 +24,10 @@ seed = random.randint(0, 4294967295)
 
 # Format the request payload using the model's native structure.
 native_request = {
-    "text_prompts": [{"text": prompt}],
-    "style_preset": "photographic",
+    "prompt": prompt,
+    "aspect_ratio": "1:1",
     "seed": seed,
-    "cfg_scale": 10,
-    "steps": 30,
+    "output_format": "png",
 }
 
 # Convert the native request to JSON.
@@ -41,7 +40,7 @@ response = client.invoke_model(modelId=model_id, body=request)
 model_response = json.loads(response["body"].read())
 
 # Extract the image data.
-base64_image_data = model_response["artifacts"][0]["base64"]
+base64_image_data = model_response["images"][0]
 
 # Save the generated image to a local folder.
 i, output_dir = 1, "output"

--- a/python/example_code/bedrock-runtime/models/stability_ai/invoke_model.py
+++ b/python/example_code/bedrock-runtime/models/stability_ai/invoke_model.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # snippet-start:[python.example_code.bedrock-runtime.InvokeModel_StableDiffusion]
-# Use the native inference API to create an image with Stability.ai Stable Diffusion
+# Use the native inference API to create an image with Stability AI Stable Image Core
 
 import base64
 import boto3

--- a/python/test_tools/bedrock_runtime_stubber.py
+++ b/python/test_tools/bedrock_runtime_stubber.py
@@ -246,10 +246,11 @@ class BedrockRuntimeStubber(ExampleStubber):
         self._stub_bifurcator(
             "invoke_model", expected_params, response, error_code=error_code
         )
+
     def stub_converse(self, expected_params, response, error_code=None):
         """
         Adds a stub for the converse function.
-        
+
         :param expected_params: The parameters that are expected to be passed to the function.
         :param response: The response to return when the expected parameters are passed.
         :param error_code: The error code to raise when the expected parameters are passed.

--- a/python/test_tools/bedrock_runtime_stubber.py
+++ b/python/test_tools/bedrock_runtime_stubber.py
@@ -123,24 +123,21 @@ class BedrockRuntimeStubber(ExampleStubber):
             error_code=error_code,
         )
 
-    def stub_invoke_stable_diffusion(self, prompt, style_preset, seed, error_code=None):
+    def stub_invoke_stable_diffusion(self, prompt, seed, error_code=None):
         expected_params = {
-            "modelId": "stability.stable-diffusion-xl",
+            "modelId": "stability.stable-image-core-v1:1",
             "body": json.dumps(
                 {
-                    "text_prompts": [{"text": prompt}],
+                    "prompt": prompt,
+                    "aspect_ratio": "1:1",
                     "seed": seed,
-                    "cfg_scale": 10,
-                    "steps": 30,
-                    "style_preset": style_preset,
+                    "output_format": "png",
                 }
             ),
         }
 
         response_body = io.BytesIO(
-            json.dumps({"artifacts": [{"base64": "FakeBase64String=="}]}).encode(
-                "utf-8"
-            )
+            json.dumps({"images": ["FakeBase64String=="]}).encode("utf-8")
         )
 
         response = {"body": response_body, "contentType": ""}

--- a/sap-abap/services/bdr/#awsex#cl_bdr_actions.clas.abap
+++ b/sap-abap/services/bdr/#awsex#cl_bdr_actions.clas.abap
@@ -218,31 +218,24 @@ CLASS /AWSEX/CL_BDR_ACTIONS IMPLEMENTATION.
     DATA(lo_session) = /aws1/cl_rt_session_aws=>create( cv_pfl ).
     DATA(lo_bdr) = /aws1/cl_bdr_factory=>create( lo_session ).
     "snippet-start:[bdr.abapv1.invokemodel_stable_diffusion]
-    "Stable Diffusion Input Parameters should be in a format like this:
+    "Stable Image Core Input Parameters should be in a format like this:
 *   {
-*     "text_prompts": [
-*       {"text":"Draw a dolphin with a mustache"},
-*       {"text":"Make it photorealistic"}
-*     ],
-*     "cfg_scale":10,
-*     "seed":0,
-*     "steps":50
+*     "prompt": "Draw a dolphin with a mustache, photorealistic",
+*     "aspect_ratio": "1:1",
+*     "seed": 0,
+*     "output_format": "png"
 *   }
-    TYPES: BEGIN OF prompt_ts,
-             text TYPE /aws1/rt_shape_string,
-           END OF prompt_ts.
-
     DATA: BEGIN OF ls_input,
-            text_prompts TYPE STANDARD TABLE OF prompt_ts,
-            cfg_scale    TYPE /aws1/rt_shape_integer,
-            seed         TYPE /aws1/rt_shape_integer,
-            steps        TYPE /aws1/rt_shape_integer,
+            prompt        TYPE /aws1/rt_shape_string,
+            aspect_ratio  TYPE /aws1/rt_shape_string,
+            seed          TYPE /aws1/rt_shape_integer,
+            output_format TYPE /aws1/rt_shape_string,
           END OF ls_input.
 
-    APPEND VALUE prompt_ts( text = iv_prompt ) TO ls_input-text_prompts.
-    ls_input-cfg_scale = 10.
+    ls_input-prompt = iv_prompt.
+    ls_input-aspect_ratio = '1:1'.
     ls_input-seed = 0. "or better, choose a random integer.
-    ls_input-steps = 50.
+    ls_input-output_format = 'png'.
 
     DATA(lv_json) = /ui2/cl_json=>serialize(
       data = ls_input
@@ -251,38 +244,26 @@ CLASS /AWSEX/CL_BDR_ACTIONS IMPLEMENTATION.
     TRY.
         DATA(lo_response) = lo_bdr->invokemodel(
           iv_body = /aws1/cl_rt_util=>string_to_xstring( lv_json )
-          iv_modelid = 'stability.stable-diffusion-xl-v1'
+          iv_modelid = 'stability.stable-image-core-v1:1'
           iv_accept = 'application/json'
           iv_contenttype = 'application/json' ).
 
-        "Stable Diffusion Result Format:
+        "Stable Image Core Result Format:
 *       {
-*         "result": "success",
-*         "artifacts": [
-*           {
-*             "seed": 0,
-*             "base64": "iVBORw0KGgoAAAANSUhEUgAAAgAAA....
-*             "finishReason": "SUCCESS"
-*           }
-*         ]
+*         "seeds": ["0"],
+*         "finish_reasons": [null],
+*         "images": ["iVBORw0KGgoAAAANSUhEUgAAAgAAA...."]
 *       }
-        TYPES: BEGIN OF artifact_ts,
-                 seed         TYPE /aws1/rt_shape_integer,
-                 base64       TYPE /aws1/rt_shape_string,
-                 finishreason TYPE /aws1/rt_shape_string,
-               END OF artifact_ts.
-
         DATA: BEGIN OF ls_response,
-                result    TYPE /aws1/rt_shape_string,
-                artifacts TYPE STANDARD TABLE OF artifact_ts,
+                images TYPE STANDARD TABLE OF /aws1/rt_shape_string,
               END OF ls_response.
 
         /ui2/cl_json=>deserialize(
           EXPORTING jsonx = lo_response->get_body( )
                     pretty_name = /ui2/cl_json=>pretty_mode-camel_case
           CHANGING  data  = ls_response ).
-        IF ls_response-artifacts IS NOT INITIAL.
-          DATA(lv_image) = cl_http_utility=>if_http_utility~decode_x_base64( ls_response-artifacts[ 1 ]-base64 ).
+        IF ls_response-images IS NOT INITIAL.
+          DATA(lv_image) = cl_http_utility=>if_http_utility~decode_x_base64( ls_response-images[ 1 ] ).
         ENDIF.
       CATCH /aws1/cx_bdraccessdeniedex INTO DATA(lo_ex).
         WRITE / lo_ex->get_text( ).


### PR DESCRIPTION
Closes #7988.

Migrates the Stability AI image-generation examples off the deprecated Stable Diffusion XL model onto **Stable Image Core** (`stability.stable-image-core-v1:1`), aligning them with the PHP reference implementation.

## What changed

Every migrated example now uses the same model, request schema, response shape, and Region:

- **Model:** `stability.stable-image-core-v1:1`
- **Request:** `{ prompt, aspect_ratio: "1:1", seed, output_format: "png" }` (was `text_prompts`/`cfg_scale`/`steps`/`style_preset`)
- **Response:** first element of the `images` array (was `artifacts[0].base64`)
- **Region:** `us-west-2`

| Language | Change |
|---|---|
| **Python (v3)** | Full swap from SDXL + old schema; header/comment and orphaned stubber refreshed. |
| **Java (v2)** | Bumped `:0` → `:1`, expanded the minimal `{prompt, seed}` request to the full schema, Region → `us-west-2`. |
| **SAP ABAP (v1) — L1** | `prompt_stable_diffusion` migrated to the new schema; empty-response guard preserved. |

## Verification

- **Live invoke:** the Python example was run against the real model — `stable-image-core-v1:1` is ACTIVE in `us-west-2`, invoke succeeded, produced a 1536×1536 PNG. All three languages send the same schema to the same model/Region.
- **Java:** `mvn compile` clean.
- **Python:** `black` + `pylint` (errors-only) clean.
- **Metadata/READMEs:** `yamllint`, doc-metadata validation, and `writeme.py --check --diff` all pass — no drift (snippet tags and descriptions unchanged).

## Deliberately out of scope (tracked in #7988)

- **SAP ABAP L2** (`l2_prompt_stable_diffusion`) stays on SDXL — it uses a hard-wired `create_stable_diffusion_xl_1` factory; migrating it depends on whether the ABAP SDK ships a Stable Image Core L2 factory. Left unchanged, with its metadata description accurately still naming SDXL.
- **.NET (v3/v4)** has a Stability SDXL example that is absent from the metadata `StableDiffusion` block — separate follow-up.

Snippet-tag IDs (`*_StableDiffusion`, `*_stable_diffusion`) are intentionally left unchanged to avoid breaking published doc cross-references.