### PR TITLE
Fix AI review limit check to use pulls/reviews endpoint

### DIFF
--- a/.github/workflows/pr-review-collect.yml
+++ b/.github/workflows/pr-review-collect.yml
@@ -46,8 +46,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Count existing AI review comments on this PR
-          REVIEW_COUNT=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --paginate --jq '[.[] | select(.body | startswith("## 🤖 AI Code Example Review"))] | length')
+          REVIEW_COUNT=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
+            --paginate --jq '[.[] | select(.body | contains("🤖 AI Code Example Review"))] | length')
 
           echo "Auto-reviews posted so far: ${REVIEW_COUNT}"
 


### PR DESCRIPTION
The count check was querying issues/comments, but AI reviews are posted as PR reviews. Switch to the pulls/reviews endpoint to correctly count and enforce the 3-review limit.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
