### PR TITLE
remove hard-coded region from Bedrock-Runtime examples (#7993)

### DIFF
--- a/swift/example_code/bedrock-runtime/models/amazon-nova/amazon-nova-canvas/Sources/main.swift
+++ b/swift/example_code/bedrock-runtime/models/amazon-nova/amazon-nova-canvas/Sources/main.swift
@@ -15,9 +15,7 @@ struct NovaImageOutput: Decodable {
 func generateImage(_ textPrompt: String) async throws {
     // Create a Bedrock Runtime client in the AWS Region you want to use.
     let config =
-        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration(
-            region: "us-east-1"
-        )
+        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration()
     config.awsCredentialIdentityResolver = try SSOAWSCredentialIdentityResolver()
 
     let client = BedrockRuntimeClient(config: config)

--- a/swift/example_code/bedrock-runtime/models/amazon-nova/amazon-nova-reel/Sources/main.swift
+++ b/swift/example_code/bedrock-runtime/models/amazon-nova/amazon-nova-reel/Sources/main.swift
@@ -61,9 +61,7 @@ func queryJobStatus(
 func main() async throws {
     // Create a Bedrock Runtime client
     let config =
-        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration(
-            region: "us-east-1"
-        )
+        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration()
     let client = BedrockRuntimeClient(config: config)
 
     // Specify the S3 location for the output video

--- a/swift/example_code/bedrock-runtime/models/amazon-nova/amazon-nova-text/Sources/Converse/main.swift
+++ b/swift/example_code/bedrock-runtime/models/amazon-nova/amazon-nova-text/Sources/Converse/main.swift
@@ -11,9 +11,7 @@ func converse(_ textPrompt: String) async throws -> String {
 
     // Create a Bedrock Runtime client in the AWS Region you want to use.
     let config =
-        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration(
-            region: "us-east-1"
-        )
+        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration()
     let client = BedrockRuntimeClient(config: config)
 
     // Set the model ID.

--- a/swift/example_code/bedrock-runtime/models/amazon-nova/amazon-nova-text/Sources/ConverseStream/main.swift
+++ b/swift/example_code/bedrock-runtime/models/amazon-nova/amazon-nova-text/Sources/ConverseStream/main.swift
@@ -11,9 +11,7 @@ func printConverseStream(_ textPrompt: String) async throws {
 
     // Create a Bedrock Runtime client in the AWS Region you want to use.
     let config =
-        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration(
-            region: "us-east-1"
-        )
+        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration()
     let client = BedrockRuntimeClient(config: config)
 
     // Set the model ID.

--- a/swift/example_code/bedrock-runtime/models/anthropic_claude/Sources/Converse/main.swift
+++ b/swift/example_code/bedrock-runtime/models/anthropic_claude/Sources/Converse/main.swift
@@ -11,9 +11,7 @@ func converse(_ textPrompt: String) async throws -> String {
 
     // Create a Bedrock Runtime client in the AWS Region you want to use.
     let config =
-        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration(
-            region: "us-east-1"
-        )
+        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration()
     let client = BedrockRuntimeClient(config: config)
 
     // Set the model ID.

--- a/swift/example_code/bedrock-runtime/models/anthropic_claude/Sources/ConverseStream/main.swift
+++ b/swift/example_code/bedrock-runtime/models/anthropic_claude/Sources/ConverseStream/main.swift
@@ -11,9 +11,7 @@ func printConverseStream(_ textPrompt: String) async throws {
 
     // Create a Bedrock Runtime client in the AWS Region you want to use.
     let config =
-        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration(
-            region: "us-east-1"
-        )
+        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration()
     let client = BedrockRuntimeClient(config: config)
 
     // Set the model ID.

--- a/swift/example_code/bedrock-runtime/models/meta_llama/Sources/Converse/main.swift
+++ b/swift/example_code/bedrock-runtime/models/meta_llama/Sources/Converse/main.swift
@@ -11,9 +11,7 @@ func converse(_ textPrompt: String) async throws -> String {
 
     // Create a Bedrock Runtime client in the AWS Region you want to use.
     let config =
-        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration(
-            region: "us-east-1"
-        )
+        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration()
     let client = BedrockRuntimeClient(config: config)
 
     // Set the model ID.

--- a/swift/example_code/bedrock-runtime/models/meta_llama/Sources/ConverseStream/main.swift
+++ b/swift/example_code/bedrock-runtime/models/meta_llama/Sources/ConverseStream/main.swift
@@ -11,9 +11,7 @@ func printConverseStream(_ textPrompt: String) async throws {
 
     // Create a Bedrock Runtime client in the AWS Region you want to use.
     let config =
-        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration(
-            region: "us-east-1"
-        )
+        try await BedrockRuntimeClient.BedrockRuntimeClientConfiguration()
     let client = BedrockRuntimeClient(config: config)
 
     // Set the model ID.


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

Resolves #7993

### Description of Changes
- Removed unnecessary hard-coded `region: "us-east-1"` parameter from Bedrock-Runtime Swift examples across the 3 affected package subdirectories.

### Testing
- Ran `swift build` across all affected package directories containing `Package.swift`.
- Confirmed all packages compile cleanly without errors or region deprecation warnings.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
