### PR TITLE
Fix incorrect queue name in getRequestSource (Fixes #4971)

### DIFF
--- a/javav2/example_code/sqs/src/main/java/com/example/sqs/DeadLetterQueues.java
+++ b/javav2/example_code/sqs/src/main/java/com/example/sqs/DeadLetterQueues.java
@@ -62,7 +62,7 @@ public class DeadLetterQueues {
 
                         // Set dead letter queue with redrive policy on source queue.
                         GetQueueUrlRequest getRequestSource = GetQueueUrlRequest.builder()
-                                        .queueName(DLQueueName)
+                                        .queueName(QueueName)
                                         .build();
 
                         String srcQueueUrl = sqs.getQueueUrl(getRequestSource).queueUrl();


### PR DESCRIPTION
Line 65 used DLQueueName when building getRequestSource, which is meant to retrieve the source queue's URL. Changed to QueueName to match the intended logic.

Fixes #4971 

<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
