### PR TITLE
fix: Add Python-v1 to allowed-labels for label creation

### DIFF
--- a/.github/allowed-labels.yml
+++ b/.github/allowed-labels.yml
@@ -75,6 +75,9 @@
 - name: Python
   color: "f5f7f9"
   description: "This issue relates to the AWS SDK for Python (boto3)"
+- name: Python-v1
+  color: "f5f7f9"
+  description: "This issue relates to the AWS SDK for Python"
 - name: Ruby
   color: "f5f7f9"
   description: "This issue relates to the AWS SDK for Ruby"


### PR DESCRIPTION
The Python-v1 label was added to label-ruleset.yml in #8074 but not to allowed-labels.yml, so the label was never created in the repo and could not be selected or auto-applied. Add the matching label definition so the label-auditor workflow creates it.

<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request...

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
